### PR TITLE
Fix smart chunking package context preservation

### DIFF
--- a/src/main/java/org/perlonjava/codegen/EmitSubroutine.java
+++ b/src/main/java/org/perlonjava/codegen/EmitSubroutine.java
@@ -45,7 +45,16 @@ public class EmitSubroutine {
         ctx.logDebug("AnonSub ctx.symbolTable.getAllVisibleVariables");
 
         // Create a new symbol table for the subroutine
-        ScopedSymbolTable newSymbolTable = ctx.symbolTable.snapShot();
+        // For smart chunking, use the pre-made snapshot that captures the correct package context
+        ScopedSymbolTable newSymbolTable;
+        Object chunkSnapshot = node.getAnnotation("chunkSnapshot");
+        if (chunkSnapshot instanceof ScopedSymbolTable snapshot) {
+            // Smart chunking: use the pre-made snapshot with correct package context
+            newSymbolTable = snapshot;
+        } else {
+            // Normal anonymous subroutine - create snapshot from current context
+            newSymbolTable = ctx.symbolTable.snapShot();
+        }
 
         String[] newEnv = newSymbolTable.getVariableNames();
         ctx.logDebug("AnonSub " + newSymbolTable);


### PR DESCRIPTION
Root Cause:
Smart chunking creates closures at codegen time, when the package context in the symbol table may no longer match the source location. This caused function resolution to look in the wrong package, leading to "Undefined subroutine" errors for imported functions.

Solution:
1. Track package changes through the AST during chunking
2. Create symbol table snapshots with correct package context
3. Store snapshots in SubroutineNode annotations
4. Use pre-made snapshots in EmitSubroutine for chunked closures

This mimics how normal anonymous subroutines capture their parse-time context, ensuring imported functions are resolved correctly.

Smart chunking remains disabled by default pending full test suite validation. To re-enable, uncomment lines 66-69 in LargeBlockRefactorer.java.