### PR TITLE
Implement $^P debugger flags support for eval source line retention

### DIFF
--- a/src/main/java/org/perlonjava/runtime/GlobalContext.java
+++ b/src/main/java/org/perlonjava/runtime/GlobalContext.java
@@ -94,6 +94,7 @@ public class GlobalContext {
         // GlobalVariable.globalVariables.put(encodeSpecialVar("R"), new ScalarSpecialVariable(ScalarSpecialVariable.Id.LAST_REGEXP_CODE_RESULT)); // $^R
         GlobalVariable.getGlobalVariable(encodeSpecialVar("R"));    // initialize $^R to "undef" - writable variable
         GlobalVariable.getGlobalVariable(encodeSpecialVar("A")).set("");    // initialize $^A to "" - format accumulator variable
+        GlobalVariable.getGlobalVariable(encodeSpecialVar("P")).set(0);    // initialize $^P to 0 - debugger flags
         GlobalVariable.globalVariables.put(encodeSpecialVar("LAST_SUCCESSFUL_PATTERN"), new ScalarSpecialVariable(ScalarSpecialVariable.Id.LAST_SUCCESSFUL_PATTERN));
         GlobalVariable.globalVariables.put(encodeSpecialVar("LAST_FH"), new ScalarSpecialVariable(ScalarSpecialVariable.Id.LAST_FH)); // $^LAST_FH
 

--- a/src/main/java/org/perlonjava/runtime/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/RuntimeScalar.java
@@ -776,6 +776,11 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 yield AutovivificationArray.createAutovivifiedArray(this);
             }
             case ARRAYREFERENCE -> (RuntimeArray) value;
+            case GLOB -> {
+                // When dereferencing a typeglob as an array, return the array slot
+                RuntimeGlob glob = (RuntimeGlob) value;
+                yield GlobalVariable.getGlobalArray(glob.globName);
+            }
             case STRING, BYTE_STRING ->
                     throw new PerlCompilerException("Can't use string (\"" + this + "\") as an ARRAY ref while \"strict refs\" in use");
             case TIED_SCALAR -> tiedFetch().arrayDeref();
@@ -836,6 +841,11 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             case HASHREFERENCE ->
                 // Simple case: already a hash reference, just return the hash
                     (RuntimeHash) value;
+            case GLOB -> {
+                // When dereferencing a typeglob as a hash, return the hash slot
+                RuntimeGlob glob = (RuntimeGlob) value;
+                yield GlobalVariable.getGlobalHash(glob.globName);
+            }
             case STRING, BYTE_STRING ->
                 // Strict refs violation: attempting to use a string as a hash ref
                     throw new PerlCompilerException("Can't use string (\"" + this + "\") as a HASH ref while \"strict refs\" in use");


### PR DESCRIPTION
- Add $^P variable initialization in GlobalContext (debugger flags)
- Implement typeglob dereferencing for arrays and hashes in RuntimeScalar
- Store eval'd source lines in symbol table when $^P is set
- Disable eval caching when $^P is active to ensure unique eval numbers
- Add runtime eval counter for unique filename generation
- Use regex heuristic to detect subroutine definitions in eval strings
- Store source lines in @{"_<(eval N)"} format for debugger access

Fixes t/comp/retainedlines.t (86/89 tests pass before LinkageError)

This enables Perl debugger support by retaining eval'd source code when debugging flags are set, allowing debuggers to access the source lines through the symbol table.