### PR TITLE
Implement threads.pm to match standard Perl behavior

### DIFF
--- a/src/main/perl/lib/threads.pm
+++ b/src/main/perl/lib/threads.pm
@@ -1,11 +1,52 @@
 package threads;
 
-# placeholder
+use strict;
+use warnings;
+
+# Stub implementation matching standard Perl behavior
+# Standard Perl's threads.pm checks useithreads and dies if not available
+
+# Verify this Perl supports threads (mimicking standard Perl behavior)
+require Config;
+if (!$Config::Config{useithreads}) {
+    die("This Perl not built to support threads\n");
+}
+
+# Declare that we have been loaded (standard Perl sets this)
+our $threads = 1;
 
 # tid() is needed by t/loc_tools.pl
 sub tid {
     return 0;
 }
+
+# create() is called by watchdog() in t/test.pl
+# Returns a dummy thread object
+sub create {
+    my ($class, $code) = @_;
+    # Don't actually create a thread, just return a dummy object
+    return bless {}, 'threads::DummyThread';
+}
+
+# Stub for threads::DummyThread
+package threads::DummyThread;
+
+sub detach {
+    # Do nothing - we're not actually running a thread
+    return 1;
+}
+
+sub kill {
+    # Do nothing - we're not actually running a thread
+    return 1;
+}
+
+sub is_running {
+    # Always return false - thread is not running
+    return 0;
+}
+
+package threads;
 
 1;
 


### PR DESCRIPTION
Match standard Perl's threads.pm behavior:
- Check $Config{useithreads} on load
- Die with 'This Perl not built to support threads' if not available
- Set $threads::threads = 1 when loaded (for compatibility checks)
- Add stub methods (tid, create, detach, kill, is_running)

This matches how standard Perl 5 handles threads when not compiled with threading support. Tests use eval { require threads; } to gracefully handle the unavailability.

Result:
- t/re/subst.t now runs 27 additional tests (202 -> 229)
- Tests stop at line 966 with '(?{...}) code blocks not implemented' instead of crashing at line 857

Verified behavior matches standard Perl:
$ perl -e 'eval { require threads; }; print "Error: $@" if $@' (on non-threaded Perl: dies with same message)