### PR TITLE
Add patch for loc_tools.pl to handle threads gracefully

### DIFF
--- a/dev/import-perl5/patches/loc_tools.pl.patch
+++ b/dev/import-perl5/patches/loc_tools.pl.patch
@@ -1,0 +1,26 @@
+--- perl5/t/loc_tools.pl
++++ t/loc_tools.pl
+@@ -1,3 +1,9 @@
++# --------------------------------------------
++# Modified t/loc_tools.pl for running Perl test suite with PerlOnJava:
++#
++# - Wrap 'require threads' in eval to handle non-threaded Perl gracefully
++# --------------------------------------------
++
+ # NOTE:  Some of the functions and 'use' statements in this file are also in
+ # other .pl files in the 't' directory, because they were needed there first.
+ # This was done to speed up 'make test'.  But the intent is to move them to
+@@ -367,8 +373,10 @@
+     # and all other threads unsafe.
+     if (! ${^SAFE_LOCALES}) {
+         return 0 if $^O eq 'os390'; # Threaded locales don't work well here
+-        require threads;
+-        return 0 if threads->tid() != 0;
++        # Only check thread ID if threads are available
++        if (eval { require threads; 1 }) {
++            return 0 if threads->tid() != 0;
++        }
+     }
+ 
+     # If no setlocale, we need the POSIX 2008 alternatives
+


### PR DESCRIPTION
Add patch file for t/loc_tools.pl that wraps 'require threads' in eval to prevent crashes when threads aren't available.

This patch allows locale-based tests to run successfully:
- t/re/charset.t now passes all 5552 tests
- Other tests using loc_tools.pl will also benefit

The patch can be applied when importing/syncing from perl5 test suite.