### PR TITLE
Add partial \G anchor support for regex matching and substitution

### DIFF
--- a/src/main/java/org/perlonjava/regex/RegexPreprocessorHelper.java
+++ b/src/main/java/org/perlonjava/regex/RegexPreprocessorHelper.java
@@ -198,6 +198,13 @@ public class RegexPreprocessorHelper {
             sb.setLength(sb.length() - 1); // Remove the backslash
             sb.append("[^\\n\\x0B\\f\\r\\x85\\x{2028}\\x{2029}]");
             return offset;
+        } else if (nextChar == 'G') {
+            // \G - matches at the position where the last match ended
+            // Java regex doesn't support \G, so we remove it and handle it manually in RuntimeRegex
+            // The useGAssertion flag will be set and we'll validate match positions manually
+            sb.setLength(sb.length() - 1); // Remove the backslash
+            // Don't add anything - \G is handled in RuntimeRegex.matchRegex/replaceRegex
+            return offset;
         } else if (nextChar == 'K') {
             // \K - keep assertion (reset start of match)
             // Convert to positive lookbehind for everything before this point


### PR DESCRIPTION
- Add \G escape sequence handling in RegexPreprocessorHelper to remove \G from patterns (since Java regex doesn't support it natively)
- Set useGAssertion flag in RuntimeRegex based on pattern contents
- Implement position validation for patterns starting with \G in matchRegex
- Implement position validation for patterns starting/ending with \G in replaceRegex
- Add matcher.region() support for patterns starting with \G

This is a partial implementation that improves \G support but does not fully handle all edge cases, particularly:
- Patterns ending with \G (e.g., \d\d\G) need more work
- Complex interactions with pos() and string modification during substitution

Contributes to fixing t/re/subst.t tests 96-99 and 165-188.