### PR TITLE
Fix autoquoting of and/or/xor keywords before =>

### DIFF
--- a/src/main/java/org/perlonjava/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/parser/ParseInfix.java
@@ -95,7 +95,7 @@ public class ParseInfix {
                     left = new StringNode(((IdentifierNode) left).name, ((IdentifierNode) left).tokenIndex);
                 }
                 token = peek(parser);
-                if (token.type == LexerTokenType.EOF || ParserTables.LIST_TERMINATORS.contains(token.text) || token.text.equals(",") || token.text.equals("=>")) {
+                if (token.type == LexerTokenType.EOF || ListParser.isListTerminator(parser, token) || token.text.equals(",") || token.text.equals("=>")) {
                     // "postfix" comma
                     return ListNode.makeList(left);
                 }

--- a/src/main/java/org/perlonjava/parser/ParsePrimary.java
+++ b/src/main/java/org/perlonjava/parser/ParsePrimary.java
@@ -214,6 +214,16 @@ public class ParsePrimary {
      * @throws PerlCompilerException if the operator is not recognized or used incorrectly
      */
     static Node parseOperator(Parser parser, LexerToken token, String operator) {
+        // Check for autoquoting: keyword operators before => should be treated as barewords
+        // This handles cases like: and => {...}, or => {...}, xor => {...}
+        if (operator.equals("and") || operator.equals("or") || operator.equals("xor")) {
+            String peekTokenText = peek(parser).text;
+            if (peekTokenText.equals("=>")) {
+                // Autoquote: convert operator keyword to string literal
+                return new StringNode(token.text, parser.tokenIndex);
+            }
+        }
+        
         Node operand = null;
         switch (token.text) {
             case "(":

--- a/src/main/java/org/perlonjava/parser/PrototypeArgs.java
+++ b/src/main/java/org/perlonjava/parser/PrototypeArgs.java
@@ -87,7 +87,7 @@ public class PrototypeArgs {
     private static boolean isArgumentTerminator(Parser parser) {
         var next = TokenUtils.peek(parser);
         return next.type == LexerTokenType.EOF ||
-                ParserTables.LIST_TERMINATORS.contains(next.text) ||
+                ListParser.isListTerminator(parser, next) ||
                 Parser.isExpressionTerminator(next) ||
                 // Assignment operators should terminate argument parsing
                 next.text.equals("=") ||


### PR DESCRIPTION
The parser was incorrectly treating 'and', 'or', and 'xor' as list terminators even when they appeared before '=>' in hash literals. This caused syntax errors in valid Perl code like:

  my %h = ( and => 1, or => 2, xor => 3 );

The fix adds special handling in:
1. ListParser.isListTerminator() - checks if and/or/xor are followed by '=>' and if so, doesn't treat them as terminators
2. ParsePrimary.parseOperator() - handles autoquoting when these keywords appear as OPERATOR tokens before '=>'
3. ParsePrimary.parseIdentifier() - already handled autoquoting for IDENTIFIER tokens (unchanged)

This allows these keywords to be used as hash keys with fat comma syntax while still functioning as operators in other contexts.