### PR TITLE
Fix bitwise operators: reference stringification, shift edge cases, a…

### DIFF
--- a/src/main/java/org/perlonjava/codegen/EmitBinaryOperator.java
+++ b/src/main/java/org/perlonjava/codegen/EmitBinaryOperator.java
@@ -48,7 +48,7 @@ public class EmitBinaryOperator {
             right = new StringNode(identifierNode.name, node.tokenIndex);
         }
 
-        // Special case for modulus and division operators under "use integer"
+        // Special case for modulus, division, and shift operators under "use integer"
         if (emitterVisitor.ctx.symbolTable.isStrictOptionEnabled(Strict.HINT_INTEGER)) {
             if (node.operator.equals("%")) {
                 // Use integer modulus when "use integer" is in effect
@@ -70,6 +70,30 @@ public class EmitBinaryOperator {
                         Opcodes.INVOKESTATIC,
                         "org/perlonjava/operators/MathOperators",
                         "integerDivide",
+                        "(Lorg/perlonjava/runtime/RuntimeScalar;Lorg/perlonjava/runtime/RuntimeScalar;)Lorg/perlonjava/runtime/RuntimeScalar;",
+                        false);
+                EmitOperator.handleVoidContext(emitterVisitor);
+                return;
+            } else if (node.operator.equals("<<")) {
+                // Use integer left shift when "use integer" is in effect
+                node.left.accept(scalarVisitor); // left parameter
+                right.accept(scalarVisitor); // right parameter
+                emitterVisitor.ctx.mv.visitMethodInsn(
+                        Opcodes.INVOKESTATIC,
+                        "org/perlonjava/operators/BitwiseOperators",
+                        "integerShiftLeft",
+                        "(Lorg/perlonjava/runtime/RuntimeScalar;Lorg/perlonjava/runtime/RuntimeScalar;)Lorg/perlonjava/runtime/RuntimeScalar;",
+                        false);
+                EmitOperator.handleVoidContext(emitterVisitor);
+                return;
+            } else if (node.operator.equals(">>")) {
+                // Use integer right shift when "use integer" is in effect
+                node.left.accept(scalarVisitor); // left parameter
+                right.accept(scalarVisitor); // right parameter
+                emitterVisitor.ctx.mv.visitMethodInsn(
+                        Opcodes.INVOKESTATIC,
+                        "org/perlonjava/operators/BitwiseOperators",
+                        "integerShiftRight",
                         "(Lorg/perlonjava/runtime/RuntimeScalar;Lorg/perlonjava/runtime/RuntimeScalar;)Lorg/perlonjava/runtime/RuntimeScalar;",
                         false);
                 EmitOperator.handleVoidContext(emitterVisitor);

--- a/src/main/java/org/perlonjava/codegen/EmitBinaryOperatorNode.java
+++ b/src/main/java/org/perlonjava/codegen/EmitBinaryOperatorNode.java
@@ -81,8 +81,8 @@ public class EmitBinaryOperatorNode {
                  "==", "!=", "eq", "ne" -> EmitOperatorChained.emitChainedComparison(emitterVisitor, node);
 
             // Binary operators
-            case "%", "&", "&.", "*", "**", "+", "-", "/", "^^", "xor",
-                 "<<", "<=>", ">>", "^", "^.", "|", "|.",
+            case "%", "&", "&.", "binary&", "*", "**", "+", "-", "/", "^^", "xor",
+                 "<<", "<=>", ">>", "^", "^.", "binary^", "|", "|.", "binary|",
                  "bless", "cmp", "isa" -> EmitBinaryOperator.handleBinaryOperator(emitterVisitor, node,
                     OperatorHandler.get(node.operator));
 


### PR DESCRIPTION
…nd integer shifts

Fixes t/op/bop.t from 68% to 89% passing (356→465 tests)

Major improvements:
- Add binary&, binary|, binary^ operator support for 'use feature bitwise'
- Fix reference stringification in bitwise operators (& | ^ ~)
  - Non-numeric values now properly stringify instead of numify
  - Uses ScalarUtils.looksLikeNumber() to detect numeric vs string ops
- Implement proper shift operator semantics
  - Handle negative shifts (reverse direction)
  - Implement 32-bit UV semantics for unsigned shifts
  - Add integerShiftLeft/Right for 'use integer' pragma
  - Shifts >= 32 properly return 0 (or -1/0 for signed)
- Detect 'use integer' pragma in EmitBinaryOperator for shifts

Files modified:
- BitwiseOperators.java: Enhanced operators, added integer shift methods
- EmitBinaryOperator.java: Added 'use integer' detection for shifts
- EmitBinaryOperatorNode.java: Added binary& | ^ operator cases

Remaining edge cases (57/522 tests): tied variable magic, extreme shift values, and minor error message differences.