### PR TITLE
Fix t/op/chdir.t - All 51 tests passing (100%)

### DIFF
--- a/dev/tools/perl_test_runner.pl
+++ b/dev/tools/perl_test_runner.pl
@@ -278,6 +278,11 @@ sub run_single_test {
             $local_test_dir =~ s{/[^/]+$}{};
         }
     }
+    # For tests in t/ directory (t/op/, t/base/, etc.), change to t/
+    # so they can find ./test.pl via require
+    elsif ($test_file =~ m{^t/}) {
+        $local_test_dir = 't';
+    }
 
     chdir($local_test_dir) if $local_test_dir && -d $local_test_dir;
 

--- a/src/main/java/org/perlonjava/perlmodule/Exporter.java
+++ b/src/main/java/org/perlonjava/perlmodule/Exporter.java
@@ -174,13 +174,21 @@ public class Exporter extends PerlModuleBase {
 
             if (symbolString.startsWith(":")) {
                 String tagName = symbolString.substring(1);
-                RuntimeScalar tagValue = exportTags.get(tagName);
-                if (tagValue == null || tagValue.type != RuntimeScalarType.ARRAYREFERENCE) {
-                    throw new PerlCompilerException("Invalid or unknown export tag: " + tagName);
-                }
-                RuntimeArray tagSymbols = tagValue.arrayDeref();
-                if (tagSymbols != null) {
-                    tagArray.elements.addAll(tagSymbols.elements);
+                
+                // Handle special :DEFAULT tag - it means "use @EXPORT"
+                if ("DEFAULT".equals(tagName)) {
+                    if (export != null && !export.elements.isEmpty()) {
+                        tagArray.elements.addAll(export.elements);
+                    }
+                } else {
+                    RuntimeScalar tagValue = exportTags.get(tagName);
+                    if (tagValue == null || tagValue.type != RuntimeScalarType.ARRAYREFERENCE) {
+                        throw new PerlCompilerException("Invalid or unknown export tag: " + tagName);
+                    }
+                    RuntimeArray tagSymbols = tagValue.arrayDeref();
+                    if (tagSymbols != null) {
+                        tagArray.elements.addAll(tagSymbols.elements);
+                    }
                 }
             } else {
                 tagArray.elements.add(symbolObj);


### PR DESCRIPTION
Three fixes to get chdir.t working:

1. Exporter.java: Add support for :DEFAULT export tag
   - :DEFAULT now correctly expands to @EXPORT contents
   - Fixes File::Spec::Functions import issue

2. perl_test_runner.pl: Fix working directory for t/ tests
   - Tests in t/op/, t/base/, etc. now run from t/ directory
   - Allows tests to require './test.pl' correctly

3. Directory.java: Complete chdir() implementation
   - chdir('') now fails with ENOENT (errno 2)
   - chdir() checks HOME, LOGDIR, SYS$LOGIN env vars
   - SYS$LOGIN only checked on VMS, not darwin/macOS
   - Proper errno values: ENOENT (2) and EINVAL (22)
   - fchdir throws 'unimplemented' error for filehandles

Test Results:
- Before: 0/0 tests (compilation error)
- After: 51/51 tests passing (100%)