### PR TITLE
Fix 'no strict refs' not being honored in hash/array dereferences

### DIFF
--- a/src/main/java/org/perlonjava/runtime/RuntimeBaseProxy.java
+++ b/src/main/java/org/perlonjava/runtime/RuntimeBaseProxy.java
@@ -200,6 +200,70 @@ public abstract class RuntimeBaseProxy extends RuntimeScalar {
         return ret;
     }
 
+    // Method to implement `$v->{key}`, when "no strict refs" is in effect
+    @Override
+    public RuntimeScalar hashDerefGetNonStrict(RuntimeScalar index, String packageName) {
+        vivify();
+        RuntimeScalar ret = lvalue.hashDerefGetNonStrict(index, packageName);
+        this.type = lvalue.type;
+        this.value = lvalue.value;
+        return ret;
+    }
+
+    // Method to implement `delete $v->{key}`, when "no strict refs" is in effect
+    @Override
+    public RuntimeScalar hashDerefDeleteNonStrict(RuntimeScalar index, String packageName) {
+        vivify();
+        RuntimeScalar ret = lvalue.hashDerefDeleteNonStrict(index, packageName);
+        this.type = lvalue.type;
+        this.value = lvalue.value;
+        return ret;
+    }
+
+    // Method to implement `exists $v->{key}`, when "no strict refs" is in effect
+    @Override
+    public RuntimeScalar hashDerefExistsNonStrict(RuntimeScalar index, String packageName) {
+        vivify();
+        RuntimeScalar ret = lvalue.hashDerefExistsNonStrict(index, packageName);
+        this.type = lvalue.type;
+        this.value = lvalue.value;
+        return ret;
+    }
+
+    // Method to implement `$v->[index]`, when "no strict refs" is in effect
+    @Override
+    public RuntimeScalar arrayDerefGetNonStrict(RuntimeScalar index, String packageName) {
+        // Don't vivify read-only scalars (like constants from constant subroutines)
+        if (lvalue == null && this instanceof RuntimeScalarReadOnly) {
+            return RuntimeScalarCache.scalarUndef;
+        }
+        vivify();
+        RuntimeScalar ret = lvalue.arrayDerefGetNonStrict(index, packageName);
+        this.type = lvalue.type;
+        this.value = lvalue.value;
+        return ret;
+    }
+
+    // Method to implement `delete $v->[index]`, when "no strict refs" is in effect
+    @Override
+    public RuntimeScalar arrayDerefDeleteNonStrict(RuntimeScalar index, String packageName) {
+        vivify();
+        RuntimeScalar ret = lvalue.arrayDerefDeleteNonStrict(index, packageName);
+        this.type = lvalue.type;
+        this.value = lvalue.value;
+        return ret;
+    }
+
+    // Method to implement `exists $v->[index]`, when "no strict refs" is in effect
+    @Override
+    public RuntimeScalar arrayDerefExistsNonStrict(RuntimeScalar index, String packageName) {
+        vivify();
+        RuntimeScalar ret = lvalue.arrayDerefExistsNonStrict(index, packageName);
+        this.type = lvalue.type;
+        this.value = lvalue.value;
+        return ret;
+    }
+
     /**
      * Performs a pre-increment operation on the underlying scalar.
      *

--- a/src/main/java/org/perlonjava/runtime/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/RuntimeScalar.java
@@ -730,9 +730,19 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         return this.hashDeref().delete(index);
     }
 
+    // Method to implement `delete $v->{key}`, when "no strict refs" is in effect
+    public RuntimeScalar hashDerefDeleteNonStrict(RuntimeScalar index, String packageName) {
+        return this.hashDerefNonStrict(packageName).delete(index);
+    }
+
     // Method to implement `exists $v->{key}`
     public RuntimeScalar hashDerefExists(RuntimeScalar index) {
         return this.hashDeref().exists(index);
+    }
+
+    // Method to implement `exists $v->{key}`, when "no strict refs" is in effect
+    public RuntimeScalar hashDerefExistsNonStrict(RuntimeScalar index, String packageName) {
+        return this.hashDerefNonStrict(packageName).exists(index);
     }
 
     // Method to implement `$v->[10]`
@@ -740,9 +750,19 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         return this.arrayDeref().get(index);
     }
 
+    // Method to implement `$v->[10]`, when "no strict refs" is in effect
+    public RuntimeScalar arrayDerefGetNonStrict(RuntimeScalar index, String packageName) {
+        return this.arrayDerefNonStrict(packageName).get(index);
+    }
+
     // Method to implement `$v->[10, 20]` (slice)
     public RuntimeList arrayDerefGetSlice(RuntimeList indices) {
         return this.arrayDeref().getSlice(indices);
+    }
+
+    // Method to implement `$v->[10, 20]` (slice), when "no strict refs" is in effect
+    public RuntimeList arrayDerefGetSliceNonStrict(RuntimeList indices, String packageName) {
+        return this.arrayDerefNonStrict(packageName).getSlice(indices);
     }
 
     // Method to implement `delete $v->[10]`
@@ -750,9 +770,19 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         return this.arrayDeref().delete(index);
     }
 
+    // Method to implement `delete $v->[10]`, when "no strict refs" is in effect
+    public RuntimeScalar arrayDerefDeleteNonStrict(RuntimeScalar index, String packageName) {
+        return this.arrayDerefNonStrict(packageName).delete(index);
+    }
+
     // Method to implement `exists $v->[10]`
     public RuntimeScalar arrayDerefExists(RuntimeScalar index) {
         return this.arrayDeref().exists(index);
+    }
+
+    // Method to implement `exists $v->[10]`, when "no strict refs" is in effect
+    public RuntimeScalar arrayDerefExistsNonStrict(RuntimeScalar index, String packageName) {
+        return this.arrayDerefNonStrict(packageName).exists(index);
     }
 
     // Method to implement `@$v`


### PR DESCRIPTION
The issue was that Dereference.handleArrowHashDeref() and handleArrowArrayDeref() were not checking the HINT_STRICT_REFS flag at compile time. They always used the strict versions of dereference methods, even when 'no strict refs' was active.

Changes:
- RuntimeScalar.java: Added 8 new *NonStrict methods for hash/array operations (hashDerefDeleteNonStrict, hashDerefExistsNonStrict, arrayDerefGetNonStrict, arrayDerefDeleteNonStrict, arrayDerefExistsNonStrict, arrayDerefGetSliceNonStrict)

- RuntimeBaseProxy.java: Added 6 NonStrict method overrides to delegate to lvalue

- Dereference.java: Updated handleArrowHashDeref() and handleArrowArrayDeref() to check isStrictOptionEnabled(HINT_STRICT_REFS) and call appropriate methods

Test Results:
- t/op/multideref.t: Now passes 56/65 tests (was 2/65)
- The first 3 strict refs tests now pass
- Remaining failures are unrelated (local/autovivification issues)

Fixes symbolic references like: $a[0]{k} where $a[0] = 'foo' creates $foo{k}