### PR TITLE
Fix filehandle.t: Add DESTROY method to IO::Handle

### DIFF
--- a/src/main/perl/lib/IO/Handle.pm
+++ b/src/main/perl/lib/IO/Handle.pm
@@ -449,6 +449,13 @@ sub untaint {
     return -1;
 }
 
+# DESTROY method - called when handle is being destroyed
+# In PerlOnJava, this is called by JVM garbage collector
+sub DESTROY {
+    # Empty DESTROY is fine - the actual cleanup happens in Java
+    # This just needs to exist so FileHandle can import it
+}
+
 1;
 
 __END__


### PR DESCRIPTION
## Summary
FileHandle.pm expects to import IO::Handle::DESTROY, but it wasn't defined.

## Changes
- Added an empty DESTROY method to IO::Handle.pm
- The actual cleanup happens in Java when the JVM garbage collects the object
- This DESTROY method just needs to exist so FileHandle can import it

## Test Results
✅ **t/op/filehandle.t**: 4/4 tests now pass (was 0/4)

## Details
The error was:
```
IO::Handle::DESTROY missing at file:/Users/fglock/projects/PerlOnJava/target/perlonjava-3.0.0.jar!/lib/FileHandle.pm line 73
```

FileHandle.pm line 63-64 explicitly imports DESTROY from IO::Handle, but the method wasn't defined in IO::Handle.pm.