### PR TITLE
Fix file test operators on uppercase filenames and restructure test d…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,23 +30,29 @@ test-unit:
 	@echo "Running fast unit tests..."
 	perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 10 src/test/resources/unit
 
-# Perl 5 core test suite (t/ directory)
-# Run 'perl dev/import-perl5/sync.pl' first to populate t/
+# Perl 5 core test suite (perl5_t/t/ directory)
+# Run 'perl dev/import-perl5/sync.pl' first to populate perl5_t/
 test-perl5:
 	@echo "Running Perl 5 core test suite..."
-	@if [ -d t ]; then \
-		perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 60 --output test_results.json t; \
+	@if [ -d perl5_t/t ]; then \
+		perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 60 --output test_results.json perl5_t/t; \
 	else \
-		echo "Error: t/ directory not found. Run 'perl dev/import-perl5/sync.pl' first."; \
+		echo "Error: perl5_t/t/ directory not found. Run 'perl dev/import-perl5/sync.pl' first."; \
 		exit 1; \
 	fi
 
-# Perl 5 module tests (perl5_t/ directory)
+# Perl 5 module tests (auto-discovers all subdirectories in perl5_t/ except t/)
 # Run 'perl dev/import-perl5/sync.pl' first to populate perl5_t/
 test-modules:
 	@echo "Running Perl 5 module tests..."
 	@if [ -d perl5_t ]; then \
-		perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 60 --output test_modules_results.json perl5_t; \
+		MODULE_DIRS=$$(find perl5_t -maxdepth 1 -type d ! -name perl5_t ! -name t -name '[A-Z]*' 2>/dev/null | sort); \
+		if [ -n "$$MODULE_DIRS" ]; then \
+			echo "Found module test directories: $$MODULE_DIRS"; \
+			perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 60 --output test_modules_results.json $$MODULE_DIRS; \
+		else \
+			echo "Warning: No module test directories found in perl5_t/. Run 'perl dev/import-perl5/sync.pl' first."; \
+		fi \
 	else \
 		echo "Error: perl5_t/ directory not found. Run 'perl dev/import-perl5/sync.pl' first."; \
 		exit 1; \

--- a/dev/import-perl5/README.md
+++ b/dev/import-perl5/README.md
@@ -187,13 +187,17 @@ dev/import-perl5/
 └── README.md           # This file
 
 Project root after sync:
-├── t/                  # Perl 5 core test suite (NOT IN GIT)
-├── perl5_t/            # Module tests from perl5/lib/*.t (NOT IN GIT)
+├── perl5_t/            # Complete Perl 5 test environment (NOT IN GIT)
+│   ├── t/              # Core test suite from perl5/t/
+│   ├── TestInit.pm     # Test infrastructure from perl5/
+│   ├── MANIFEST        # Manifest file from perl5/
+│   ├── Porting/        # Porting tools and tests from perl5/
+│   └── Benchmark/      # Module tests from perl5/lib/*.t
 ├── src/main/perl/lib/  # Imported Perl modules (IN GIT)
 └── src/test/resources/unit/  # PerlOnJava unit tests (IN GIT)
 ```
 
-**Important**: Both `t/` and `perl5_t/` directories are excluded from git and must be synced using `sync.pl` before running comprehensive tests.
+**Important**: The `perl5_t/` directory is excluded from git and must be synced using `sync.pl` before running comprehensive tests. This directory contains a complete Perl 5 test environment with all necessary infrastructure files.
 
 ## Examples
 

--- a/dev/import-perl5/config.yaml
+++ b/dev/import-perl5/config.yaml
@@ -20,18 +20,30 @@ imports:
   - source: perl5/lib/Benchmark.t
     target: perl5_t/Benchmark/Benchmark.t
 
-  # Bulk import all test files from perl5/t/ to t/
+  # Perl 5 test infrastructure files
+  - source: perl5/TestInit.pm
+    target: perl5_t/TestInit.pm
+
+  - source: perl5/MANIFEST
+    target: perl5_t/MANIFEST
+
+  - source: perl5/Porting
+    target: perl5_t/Porting
+    type: directory
+
+  # Bulk import all core test files from perl5/t/ to perl5_t/t/
+  # This creates a complete Perl 5 test environment under perl5_t/
   - source: perl5/t
-    target: t
+    target: perl5_t/t
     type: directory
 
   # Specific patched files (applied after directory import above)
   - source: perl5/t/test.pl
-    target: t/test.pl
+    target: perl5_t/t/test.pl
     patch: test.pl.patch
 
   - source: perl5/t/re/pat.t
-    target: t/re/pat.t
+    target: perl5_t/t/re/pat.t
     patch: pat.t.patch
 
   # Pod modules from CPAN distributions

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -303,14 +303,17 @@ To import Perl test files and verify their behavior under PerlOnJava:
    perl dev/import-perl5/sync.pl
    ```
 
-This will copy all files from `perl5/t/` to `t/` and apply any necessary patches for PerlOnJava compatibility.
+This will copy all files from `perl5/` to `perl5_t/`, creating a complete Perl 5 test environment including:
+- Core tests (`perl5_t/t/`)
+- Test infrastructure (`TestInit.pm`, `MANIFEST`)
+- Supporting files (`Porting/` directory)
 
 ### Running Imported Tests
 
 To run the imported Perl5 tests:
 
 ```bash
-perl dev/tools/perl_test_runner.pl --output out.json t
+perl dev/tools/perl_test_runner.pl --output out.json perl5_t/t
 ```
 
 See `dev/import-perl5/README.md` for more details on:

--- a/src/main/java/org/perlonjava/operators/FileTestOperator.java
+++ b/src/main/java/org/perlonjava/operators/FileTestOperator.java
@@ -155,12 +155,11 @@ public class FileTestOperator {
                     return fileTest(operator, globVar);
                 }
             } catch (Exception e) {
-                // Ignore, treat as non-existent filehandle
+                // Ignore, treat as filename
             }
 
-            // It looks like a filehandle but isn't one, return EBADF and appropriate result
-            getGlobalVariable("main::!").set(9);
-            return operator.equals("-l") ? scalarFalse : scalarUndef;
+            // It looks like a filehandle but isn't one - fall through to treat as filename
+            // Don't return error here, as it could be a legitimate uppercase filename
         }
 
         // Handle string filenames


### PR DESCRIPTION
…irectories

This commit fixes a critical bug where file test operators (-f, -e, -r, etc.) were failing on all uppercase filenames (MANIFEST, README, LICENSE, etc.) and restructures the test directory layout for better organization.

Changes:

1. FileTestOperator.java (lines 147-163):
   - Fixed logic to fall through to filesystem checks instead of returning error for uppercase filenames that look like filehandles but aren't
   - Now correctly handles both actual filehandles AND uppercase filenames

2. Test Directory Restructuring:
   - Moved all Perl 5 test infrastructure under perl5_t/
   - New structure: perl5_t/t/, perl5_t/TestInit.pm, perl5_t/MANIFEST, etc.
   - Better separation: Perl 5 tests in perl5_t/, PerlOnJava tests in src/test/

3. dev/import-perl5/config.yaml:
   - Added imports for TestInit.pm, MANIFEST, Porting/
   - Changed test paths from t/ to perl5_t/t/
   - Updated patch targets to new structure

4. dev/tools/perl_test_runner.pl:
   - Fixed chdir logic to correctly handle perl5_t/t/ tests
   - Added support for multiple test directories in one run
   - Auto-discovers test directories for better scalability

5. Makefile:
   - Updated test-perl5 to use perl5_t/t/
   - Updated test-modules to auto-discover module directories
   - No hardcoding - automatically finds new modules

6. Documentation:
   - Updated docs/TESTING.md with new directory structure
   - Updated dev/import-perl5/README.md with complete structure diagram

Impact:
- Fixes all file test operations on uppercase filenames (systematic fix)
- Unlocks perl5_t/t/porting/readme.t (78/78 tests pass)
- Enables proper Perl 5 test infrastructure
- Scalable module testing without hardcoding

Tested:
- perl5_t/t/porting/readme.t: 78/78 pass (100%)
- perl5_t/t/op/index.t: 415/415 pass (100%)
- File test operators work correctly on uppercase files