### PR TITLE
Fix parsing of not(...) with and/or (issue #93)

### DIFF
--- a/src/main/java/org/perlonjava/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/parser/OperatorParser.java
@@ -668,7 +668,8 @@ public class OperatorParser {
             if (TokenUtils.peek(parser).text.equals(")")) {
                 operand = new OperatorNode("undef", null, currentIndex);
             } else {
-                operand = parser.parseExpression(parser.getPrecedence(token.text) + 1);
+                // Parentheses group a full expression; allow low-precedence operators like `and`/`or`.
+                operand = parser.parseExpression(0);
             }
             TokenUtils.consume(parser, OPERATOR, ")");
             return new OperatorNode(token.text, operand, currentIndex);


### PR DESCRIPTION
Fixes parsing of parenthesized `not ( ... )` expressions so low-precedence logical operators like `and`/`or` are handled correctly.

Refs: https://github.com/fglock/PerlOnJava/issues/93

Repro:
- `jperl --parse -e "my $dir; not (IsPC() and $dir)"`