### PR TITLE
Add generic LargeNodeRefactorer for large array/hash/list literals

### DIFF
--- a/src/main/java/org/perlonjava/astnode/ArrayLiteralNode.java
+++ b/src/main/java/org/perlonjava/astnode/ArrayLiteralNode.java
@@ -1,29 +1,67 @@
 package org.perlonjava.astnode;
 
 import org.perlonjava.astvisitor.Visitor;
+import org.perlonjava.codegen.LargeNodeRefactorer;
 
 import java.util.List;
 
 /**
- * The ArrayLiteralNode class represents a node in the abstract syntax tree (AST) that holds
- * a list of other nodes surrounded by `[` `]`.
+ * Represents an array literal in the AST, corresponding to Perl's {@code [...]} syntax.
+ * <p>
+ * Examples:
+ * <ul>
+ *   <li>{@code [1, 2, 3]} - simple array literal</li>
+ *   <li>{@code [$a, @b, %c]} - array with mixed elements</li>
+ *   <li>{@code [[1,2], [3,4]]} - nested array literals</li>
+ * </ul>
+ * <p>
+ * <b>Large Literal Handling:</b> The constructor automatically invokes
+ * {@link LargeNodeRefactorer#maybeRefactorElements} to split very large arrays
+ * into chunks when {@code JPERL_LARGECODE=refactor} is set. This prevents
+ * JVM "method too large" errors for arrays with thousands of elements.
+ *
+ * @see LargeNodeRefactorer
+ * @see HashLiteralNode
+ * @see ListNode
  */
 public class ArrayLiteralNode extends AbstractNode {
     /**
-     * The list of child nodes contained in this Node
+     * The list of element nodes contained in this array literal.
+     * <p>
+     * Each element is evaluated in LIST context when the array is constructed.
+     * Elements may be scalars, arrays (which flatten), hashes (which flatten to key-value pairs),
+     * or any expression.
+     * <p>
+     * Note: This field is non-final because {@link LargeNodeRefactorer} may replace
+     * the original list with a refactored version containing chunk wrappers.
      */
-    public final List<Node> elements;
+    public List<Node> elements;
 
     /**
      * Constructs a new ArrayLiteralNode with the specified list of child nodes.
+     * <p>
+     * <b>Large Literal Refactoring:</b> When {@code JPERL_LARGECODE=refactor} environment
+     * variable is set and the elements list is large enough to potentially exceed JVM's
+     * 64KB method size limit, the constructor automatically splits the elements into
+     * chunks wrapped in anonymous subroutines.
      *
-     * @param elements the list of child nodes to be stored in this ArrayLiteralNode
+     * @param elements   the list of child nodes to be stored in this ArrayLiteralNode
+     * @param tokenIndex the token index in the source for error reporting
+     * @see LargeNodeRefactorer#maybeRefactorElements
      */
     public ArrayLiteralNode(List<Node> elements, int tokenIndex) {
-        this.elements = elements;
         this.tokenIndex = tokenIndex;
+        this.elements = LargeNodeRefactorer.maybeRefactorElements(elements, tokenIndex, LargeNodeRefactorer.NodeType.ARRAY);
     }
 
+    /**
+     * Converts this array literal to a ListNode containing the same elements.
+     * <p>
+     * This is useful when the array elements need to be processed as a flat list
+     * rather than as an array reference.
+     *
+     * @return a new ListNode containing this array's elements
+     */
     public ListNode asListNode() {
         return new ListNode(elements, tokenIndex);
     }

--- a/src/main/java/org/perlonjava/astnode/HashLiteralNode.java
+++ b/src/main/java/org/perlonjava/astnode/HashLiteralNode.java
@@ -1,29 +1,69 @@
 package org.perlonjava.astnode;
 
 import org.perlonjava.astvisitor.Visitor;
+import org.perlonjava.codegen.LargeNodeRefactorer;
 
 import java.util.List;
 
 /**
- * The HashLiteralNode class represents a node in the abstract syntax tree (AST) that holds
- * a list of other nodes surrounded by `{` `}`.
+ * Represents a hash literal in the AST, corresponding to Perl's {@code {...}} syntax.
+ * <p>
+ * Examples:
+ * <ul>
+ *   <li>{@code {a => 1, b => 2}} - simple hash literal with fat comma</li>
+ *   <li>{@code {$key => $value}} - hash with variable key/value</li>
+ *   <li>{@code {nested => {inner => 1}}} - nested hash literals</li>
+ * </ul>
+ * <p>
+ * The elements list contains key-value pairs in sequence: key1, value1, key2, value2, etc.
+ * <p>
+ * <b>Large Literal Handling:</b> The constructor automatically invokes
+ * {@link LargeNodeRefactorer#maybeRefactorElements} to split very large hashes
+ * into chunks when {@code JPERL_LARGECODE=refactor} is set. For hashes, chunk
+ * sizes are forced to be even to preserve key-value pairing.
+ *
+ * @see LargeNodeRefactorer
+ * @see ArrayLiteralNode
+ * @see ListNode
  */
 public class HashLiteralNode extends AbstractNode {
     /**
-     * The list of child nodes contained in this Node
+     * The list of element nodes contained in this hash literal.
+     * <p>
+     * Elements are stored as alternating key-value pairs: [key1, value1, key2, value2, ...].
+     * Each element is evaluated in LIST context when the hash is constructed.
+     * <p>
+     * Note: This field is non-final because {@link LargeNodeRefactorer} may replace
+     * the original list with a refactored version containing chunk wrappers.
      */
-    public final List<Node> elements;
+    public List<Node> elements;
 
     /**
      * Constructs a new HashLiteralNode with the specified list of child nodes.
+     * <p>
+     * <b>Large Literal Refactoring:</b> When {@code JPERL_LARGECODE=refactor} environment
+     * variable is set and the elements list is large enough to potentially exceed JVM's
+     * 64KB method size limit, the constructor automatically splits the elements into
+     * chunks wrapped in anonymous subroutines. Chunk sizes are forced to be even
+     * to preserve key-value pairing.
      *
-     * @param elements the list of child nodes to be stored in this HashLiteralNode
+     * @param elements   the list of key-value pairs (alternating keys and values)
+     * @param tokenIndex the token index in the source for error reporting
+     * @see LargeNodeRefactorer#maybeRefactorElements
      */
     public HashLiteralNode(List<Node> elements, int tokenIndex) {
-        this.elements = elements;
         this.tokenIndex = tokenIndex;
+        this.elements = LargeNodeRefactorer.maybeRefactorElements(elements, tokenIndex, LargeNodeRefactorer.NodeType.HASH);
     }
 
+    /**
+     * Converts this hash literal to a ListNode containing the same elements.
+     * <p>
+     * This is useful when the hash elements need to be processed as a flat list
+     * of key-value pairs rather than as a hash reference.
+     *
+     * @return a new ListNode containing this hash's key-value pairs
+     */
     public ListNode asListNode() {
         return new ListNode(elements, tokenIndex);
     }

--- a/src/main/java/org/perlonjava/astnode/ListNode.java
+++ b/src/main/java/org/perlonjava/astnode/ListNode.java
@@ -1,44 +1,100 @@
 package org.perlonjava.astnode;
 
 import org.perlonjava.astvisitor.Visitor;
+import org.perlonjava.codegen.LargeNodeRefactorer;
 
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The ListNode class represents a node in the abstract syntax tree (AST) that holds
- * a list of other nodes. This class implements the Node interface, allowing it to be
- * visited by a Visitor.
+ * Represents a list expression in the AST, corresponding to Perl's {@code (...)} syntax.
+ * <p>
+ * ListNode is used for:
+ * <ul>
+ *   <li>Parenthesized lists: {@code (1, 2, 3)}</li>
+ *   <li>Function arguments: {@code foo($a, $b, $c)}</li>
+ *   <li>Assignment targets: {@code ($x, $y) = @array}</li>
+ *   <li>qw// lists: {@code qw(a b c)}</li>
+ * </ul>
+ * <p>
+ * Unlike {@link ArrayLiteralNode} which creates an array reference, ListNode represents
+ * a flat list that can be assigned to arrays or used in list context.
+ * <p>
+ * <b>Large Literal Handling:</b> The constructor automatically invokes
+ * {@link LargeNodeRefactorer#maybeRefactorElements} to split very large lists
+ * into chunks when {@code JPERL_LARGECODE=refactor} is set.
+ *
+ * @see LargeNodeRefactorer
+ * @see ArrayLiteralNode
+ * @see HashLiteralNode
  */
 public class ListNode extends AbstractNode {
     /**
-     * The list of child nodes contained in this ListNode.
+     * The list of element nodes contained in this list expression.
+     * <p>
+     * Each element is an AST node representing an expression. Elements are evaluated
+     * in the context determined by how the list is used (list context for assignments,
+     * scalar context for the last element in scalar context, etc.).
+     * <p>
+     * Note: This field is non-final because {@link LargeNodeRefactorer} may replace
+     * the original list with a refactored version containing chunk wrappers.
      */
-    public final List<Node> elements;
+    public List<Node> elements;
 
     /**
-     * Optional fileHandle or block.
-     * Used in: print, say, map, grep, sort
+     * Optional handle node for I/O operations or block for list transformations.
+     * <p>
+     * This field is used in several contexts:
+     * <ul>
+     *   <li>{@code print HANDLE @list} - HANDLE is stored here</li>
+     *   <li>{@code say HANDLE @list} - HANDLE is stored here</li>
+     *   <li>{@code map BLOCK @list} - BLOCK is stored here</li>
+     *   <li>{@code grep BLOCK @list} - BLOCK is stored here</li>
+     *   <li>{@code sort BLOCK @list} - BLOCK is stored here</li>
+     * </ul>
      */
     public Node handle;
 
     /**
      * Constructs a new ListNode with the specified list of child nodes.
+     * <p>
+     * <b>Large Literal Refactoring:</b> When {@code JPERL_LARGECODE=refactor} environment
+     * variable is set and the elements list is large enough to potentially exceed JVM's
+     * 64KB method size limit, the constructor automatically splits the elements into
+     * chunks wrapped in anonymous subroutines.
      *
-     * @param elements the list of child nodes to be stored in this ListNode
+     * @param elements   the list of child nodes to be stored in this ListNode
+     * @param tokenIndex the token index in the source for error reporting
+     * @see LargeNodeRefactorer#maybeRefactorElements
      */
     public ListNode(List<Node> elements, int tokenIndex) {
-        this.elements = elements;
         this.tokenIndex = tokenIndex;
+        this.elements = LargeNodeRefactorer.maybeRefactorElements(elements, tokenIndex, LargeNodeRefactorer.NodeType.LIST);
         this.handle = null;
     }
 
+    /**
+     * Constructs an empty ListNode.
+     * <p>
+     * This constructor creates a list with no elements, useful for building
+     * lists incrementally or representing empty argument lists.
+     *
+     * @param tokenIndex the token index in the source for error reporting
+     */
     public ListNode(int tokenIndex) {
         this.elements = new ArrayList<>();
         this.tokenIndex = tokenIndex;
         this.handle = null;
     }
 
+    /**
+     * Creates a ListNode from a single node, or returns the node if it's already a ListNode.
+     * <p>
+     * This is a convenience method for normalizing nodes to list form.
+     *
+     * @param left the node to wrap in a list (or return as-is if already a ListNode)
+     * @return a ListNode containing the input node
+     */
     public static ListNode makeList(Node left) {
         if (left instanceof ListNode) {
             return (ListNode) left;
@@ -48,6 +104,16 @@ public class ListNode extends AbstractNode {
         return new ListNode(list, left.getIndex());
     }
 
+    /**
+     * Creates a ListNode by concatenating two nodes.
+     * <p>
+     * Both nodes are first converted to ListNodes (if not already), then their
+     * elements are combined into a single list.
+     *
+     * @param left  the first node (or list of nodes)
+     * @param right the second node (or list of nodes)
+     * @return a ListNode containing all elements from both inputs
+     */
     public static ListNode makeList(Node left, Node right) {
         ListNode leftList = ListNode.makeList(left);
         ListNode rightList = ListNode.makeList(right);
@@ -58,12 +124,29 @@ public class ListNode extends AbstractNode {
         return leftList;
     }
 
+    /**
+     * Creates a ListNode by concatenating two nodes and appending a third.
+     *
+     * @param left  the first node (or list of nodes)
+     * @param right the second node (or list of nodes)
+     * @param more  an additional node to append
+     * @return a ListNode containing all elements
+     */
     public static ListNode makeList(Node left, Node right, Node more) {
         ListNode leftList = ListNode.makeList(left, right);
         leftList.elements.add(more);
         return leftList;
     }
 
+    /**
+     * Creates a ListNode by concatenating two nodes and appending two more.
+     *
+     * @param left  the first node (or list of nodes)
+     * @param right the second node (or list of nodes)
+     * @param more  an additional node to append
+     * @param more2 another additional node to append
+     * @return a ListNode containing all elements
+     */
     public static ListNode makeList(Node left, Node right, Node more, Node more2) {
         ListNode leftList = ListNode.makeList(left, right);
         leftList.elements.add(more);

--- a/src/main/java/org/perlonjava/codegen/LargeNodeRefactorer.java
+++ b/src/main/java/org/perlonjava/codegen/LargeNodeRefactorer.java
@@ -1,0 +1,269 @@
+package org.perlonjava.codegen;
+
+import org.perlonjava.astnode.*;
+import org.perlonjava.astvisitor.BytecodeSizeEstimator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Generic helper class for refactoring large AST node lists to avoid JVM's "Method too large" error.
+ * <p>
+ * <b>Problem:</b> The JVM has a hard limit of 65535 bytes per method. Large Perl literals
+ * (arrays, hashes, lists with thousands of elements) can exceed this limit when compiled.
+ * <p>
+ * <b>Solution:</b> This class splits large element lists into chunks, each wrapped in an
+ * anonymous subroutine. The chunks are then dereferenced and merged back together.
+ * <p>
+ * <b>Supported Node Types:</b>
+ * <ul>
+ *   <li>{@link ArrayLiteralNode} - e.g., [1, 2, 3, ... thousands of elements]</li>
+ *   <li>{@link HashLiteralNode} - e.g., {a =&gt; 1, b =&gt; 2, ... thousands of pairs}</li>
+ *   <li>{@link ListNode} - e.g., (1, 2, 3, ... thousands of elements)</li>
+ *   <li>{@link org.perlonjava.astnode.BlockNode} - handled by {@link LargeBlockRefactorer} for control flow safety</li>
+ * </ul>
+ * <p>
+ * <b>Chunk Wrapping Strategy:</b>
+ * <ul>
+ *   <li>Arrays: {@code [@{sub{[chunk1]}->()}, @{sub{[chunk2]}->()}, ...]}</li>
+ *   <li>Hashes: {@code {%{sub{{chunk1}}->()}, %{sub{{chunk2}}->()}, ...}}</li>
+ *   <li>Lists: {@code (sub{(chunk1)}->(), sub{(chunk2)}->(), ...)}</li>
+ * </ul>
+ * <p>
+ * <b>Integration:</b> Called automatically from AST node constructors when enabled.
+ * This ensures the AST is always the right size from creation time.
+ * <p>
+ * <b>Activation:</b> Set environment variable {@code JPERL_LARGECODE=refactor} to enable.
+ * <p>
+ * <b>Recursion Safety:</b> The circular dependency (constructor calls refactorer which
+ * creates new nodes) breaks naturally when chunks become small enough (below MIN_CHUNK_SIZE).
+ *
+ * @see BytecodeSizeEstimator#estimateSnippetSize(Node)
+ * @see LargeBlockRefactorer
+ */
+public class LargeNodeRefactorer {
+
+    /**
+     * Minimum number of elements before considering refactoring.
+     * Lists smaller than this are never refactored, regardless of bytecode size.
+     */
+    private static final int LARGE_ELEMENT_COUNT = 500;
+
+    /**
+     * Target maximum bytecode size per chunk (in bytes).
+     * When total estimated bytecode exceeds this, refactoring is triggered.
+     */
+    private static final int LARGE_BYTECODE_SIZE = 30000;
+
+    /**
+     * Minimum elements per chunk. Chunks smaller than this are inlined directly
+     * rather than wrapped in a subroutine. This also breaks the recursion.
+     */
+    private static final int MIN_CHUNK_SIZE = 50;
+
+    /**
+     * Maximum elements per chunk. Limits chunk size even if bytecode estimates
+     * suggest larger chunks would fit.
+     */
+    private static final int MAX_CHUNK_SIZE = 200;
+
+    /**
+     * Enum identifying the type of AST node being refactored.
+     * Used to determine the appropriate chunk wrapping and dereference strategy.
+     */
+    public enum NodeType {
+        /** Array literal: [...] - chunks wrapped with @{sub{[...]}->()}  */
+        ARRAY,
+        /** Hash literal: {...} - chunks wrapped with %{sub{{...}}->()}, chunk size forced even */
+        HASH,
+        /** List: (...) - chunks wrapped with sub{(...)}->() */
+        LIST
+    }
+
+    /**
+     * Check if refactoring is enabled via environment variable.
+     * When JPERL_LARGECODE=refactor, large literals will be automatically split.
+     */
+    private static boolean isRefactoringEnabled() {
+        String largeCodeMode = System.getenv("JPERL_LARGECODE");
+        return "refactor".equals(largeCodeMode);
+    }
+
+    /**
+     * Main entry point: called from AST node constructors to potentially refactor large element lists.
+     * <p>
+     * This method checks if refactoring is needed based on:
+     * <ol>
+     *   <li>Environment variable JPERL_LARGECODE=refactor must be set</li>
+     *   <li>Element count must exceed LARGE_ELEMENT_COUNT (500)</li>
+     *   <li>Estimated bytecode size must exceed LARGE_BYTECODE_SIZE (30000 bytes)</li>
+     * </ol>
+     * <p>
+     * If refactoring is needed, elements are split into chunks and wrapped in anonymous
+     * subroutines with appropriate dereference operators.
+     *
+     * @param elements   the original elements list from the AST node constructor
+     * @param tokenIndex the token index for creating new AST nodes (for error reporting)
+     * @param nodeType   the type of node being constructed (affects wrapping strategy)
+     * @return the original list if no refactoring needed, or a new list with chunked elements
+     */
+    public static List<Node> maybeRefactorElements(List<Node> elements, int tokenIndex, NodeType nodeType) {
+        if (!isRefactoringEnabled() || !shouldRefactor(elements)) {
+            return elements;
+        }
+
+        int chunkSize = calculateChunkSize(elements);
+        if (nodeType == NodeType.HASH && chunkSize % 2 != 0) {
+            chunkSize++; // Ensure even number for key-value pairs
+        }
+
+        List<Node> chunks = splitIntoChunks(elements, chunkSize);
+        List<Node> refactoredElements = new ArrayList<>();
+
+        for (Node chunk : chunks) {
+            if (chunk instanceof ListNode listChunk && listChunk.elements.size() < MIN_CHUNK_SIZE) {
+                // Small chunk - add elements directly
+                refactoredElements.addAll(listChunk.elements);
+            } else {
+                // Wrap chunk in anonymous sub, then dereference appropriately
+                List<Node> chunkElements = chunk instanceof ListNode ? ((ListNode) chunk).elements : List.of(chunk);
+                Node wrappedChunk = createChunkWrapper(chunkElements, tokenIndex, nodeType);
+                refactoredElements.add(wrappedChunk);
+            }
+        }
+
+        return refactoredElements;
+    }
+
+    /**
+     * Creates a wrapper AST node for a chunk of elements.
+     * <p>
+     * The wrapper structure depends on the node type:
+     * <ul>
+     *   <li>ARRAY: {@code @{ sub { [elements] }->() }} - array ref created in sub, then dereferenced</li>
+     *   <li>HASH: {@code %{ sub { {elements} }->() }} - hash ref created in sub, then dereferenced</li>
+     *   <li>LIST: {@code sub { (elements) }->() } - list returned directly from sub call</li>
+     * </ul>
+     *
+     * @param chunkElements the elements to wrap in this chunk
+     * @param tokenIndex    token index for new nodes
+     * @param nodeType      determines wrapping strategy
+     * @return an AST node representing the wrapped chunk
+     */
+    private static Node createChunkWrapper(List<Node> chunkElements, int tokenIndex, NodeType nodeType) {
+        Node innerLiteral;
+        String derefOp;
+
+        switch (nodeType) {
+            case ARRAY:
+                ArrayLiteralNode arr = new ArrayLiteralNode(chunkElements, tokenIndex);
+                arr.setAnnotation("chunkAlreadyRefactored", true);
+                innerLiteral = arr;
+                derefOp = "@";
+                break;
+            case HASH:
+                HashLiteralNode hash = new HashLiteralNode(chunkElements, tokenIndex);
+                hash.setAnnotation("chunkAlreadyRefactored", true);
+                innerLiteral = hash;
+                derefOp = "%";
+                break;
+            case LIST:
+            default:
+                ListNode list = new ListNode(chunkElements, tokenIndex);
+                list.setAnnotation("chunkAlreadyRefactored", true);
+                innerLiteral = list;
+                // For lists, we just call the sub and let it return the list
+                SubroutineNode subList = new SubroutineNode(null, null, null,
+                        new BlockNode(List.of(innerLiteral), tokenIndex), false, tokenIndex);
+                return new BinaryOperatorNode("->", subList, new ListNode(tokenIndex), tokenIndex);
+        }
+
+        // For array/hash: @{ sub { [...] }->() } or %{ sub { {...} }->() }
+        SubroutineNode sub = new SubroutineNode(null, null, null,
+                new BlockNode(List.of(innerLiteral), tokenIndex), false, tokenIndex);
+        BinaryOperatorNode call = new BinaryOperatorNode("->", sub, new ListNode(tokenIndex), tokenIndex);
+        return new OperatorNode(derefOp, call, tokenIndex);
+    }
+
+    /**
+     * Determines if a list of elements should be refactored based on size criteria.
+     * <p>
+     * Uses {@link BytecodeSizeEstimator#estimateSnippetSize(Node)} to estimate
+     * the bytecode that would be generated for each element.
+     *
+     * @param elements the list of AST nodes to evaluate
+     * @return true if the list exceeds size thresholds and should be refactored
+     */
+    private static boolean shouldRefactor(List<Node> elements) {
+        // Quick check: element count threshold
+        if (elements.size() < LARGE_ELEMENT_COUNT) {
+            return false;
+        }
+
+        // Estimate bytecode size
+        int totalSize = 0;
+        for (Node element : elements) {
+            totalSize += BytecodeSizeEstimator.estimateSnippetSize(element);
+            // Early exit if we're clearly over the threshold
+            if (totalSize > LARGE_BYTECODE_SIZE) {
+                return true;
+            }
+        }
+
+        return totalSize > LARGE_BYTECODE_SIZE;
+    }
+
+    /**
+     * Calculates the optimal chunk size based on sampled element sizes.
+     * <p>
+     * Samples the first 10 elements to estimate average bytecode size per element,
+     * then calculates how many elements would fit in ~20KB of bytecode.
+     * Result is clamped between MIN_CHUNK_SIZE and MAX_CHUNK_SIZE.
+     *
+     * @param elements the list of elements to chunk
+     * @return optimal number of elements per chunk
+     */
+    private static int calculateChunkSize(List<Node> elements) {
+        if (elements.isEmpty()) {
+            return MAX_CHUNK_SIZE;
+        }
+
+        // Sample a few elements to estimate average size
+        int sampleSize = Math.min(10, elements.size());
+        int totalSampleSize = 0;
+        for (int i = 0; i < sampleSize; i++) {
+            totalSampleSize += BytecodeSizeEstimator.estimateSnippetSize(elements.get(i));
+        }
+        int avgElementSize = totalSampleSize / sampleSize;
+
+        // Calculate chunk size to stay under bytecode limit
+        // Target ~20KB per chunk to leave room for overhead
+        int targetChunkBytes = 20000;
+        int calculatedSize = avgElementSize > 0 ? targetChunkBytes / avgElementSize : MAX_CHUNK_SIZE;
+
+        // Clamp to reasonable bounds
+        return Math.max(MIN_CHUNK_SIZE, Math.min(MAX_CHUNK_SIZE, calculatedSize));
+    }
+
+    /**
+     * Splits a list of elements into chunks of the specified size.
+     * <p>
+     * Each chunk is wrapped in a ListNode for uniform handling.
+     * The last chunk may be smaller than chunkSize.
+     *
+     * @param elements  the list to split
+     * @param chunkSize number of elements per chunk
+     * @return list of ListNode chunks
+     */
+    private static List<Node> splitIntoChunks(List<Node> elements, int chunkSize) {
+        List<Node> chunks = new ArrayList<>();
+
+        for (int i = 0; i < elements.size(); i += chunkSize) {
+            int end = Math.min(i + chunkSize, elements.size());
+            List<Node> chunkElements = new ArrayList<>(elements.subList(i, end));
+            chunks.add(new ListNode(chunkElements, elements.get(i).getIndex()));
+        }
+
+        return chunks;
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a generic mechanism to automatically refactor large AST node lists to avoid JVM's 64KB method size limit.

## Changes

### New: LargeNodeRefactorer class
- Splits large element lists into chunks wrapped in anonymous subroutines
- Supports ArrayLiteralNode, HashLiteralNode, and ListNode
- Uses BytecodeSizeEstimator to determine when refactoring is needed
- Enabled via `JPERL_LARGECODE=refactor` environment variable

### BytecodeSizeEstimator enhancements
- Added `estimateSnippetSize(Node)` static method for code snippets
- Added `getRawEstimatedSize()` instance method without BASE_OVERHEAD
- These methods apply calibration factor (1.035×) but not the 1950-byte base overhead

### AST Node constructor integration
- ArrayLiteralNode, HashLiteralNode, and ListNode constructors now call `LargeNodeRefactorer.maybeRefactorElements()`
- Refactoring happens at AST creation time, keeping the AST always at the right size
- Circular dependency breaks naturally when chunks become small enough

## Chunk wrapping strategy
- Arrays: `[@{sub{[chunk1]}->()}, @{sub{[chunk2]}->()}, ...]`
- Hashes: `{%{sub{{chunk1}}->()}, %{sub{{chunk2}}->()}, ...}`
- Lists: `(sub{(chunk1)}->(), sub{(chunk2)}->(), ...)`

## Configuration
- `LARGE_ELEMENT_COUNT = 500` - minimum elements to consider refactoring
- `LARGE_BYTECODE_SIZE = 30000` - target max bytecode per chunk
- `MIN_CHUNK_SIZE = 50` - minimum elements per chunk
- `MAX_CHUNK_SIZE = 200` - maximum elements per chunk