### PR TITLE
Fix qualified subroutine name resolution when same-named sub exists in current package

### DIFF
--- a/src/main/java/org/perlonjava/parser/ParsePrimary.java
+++ b/src/main/java/org/perlonjava/parser/ParsePrimary.java
@@ -122,7 +122,8 @@ public class ParsePrimary {
         // IMPORTANT: Check for lexical subs AFTER CORE::, but before checking for quote-like operators!
         // This allows "my sub y" to shadow the "y///" transliteration operator
         // But doesn't interfere with CORE:: prefix handling
-        if (!calledWithCore) {
+        // ALSO: Don't treat as lexical sub if :: follows - that's a qualified name like Encode::is_utf8
+        if (!calledWithCore && !nextTokenText.equals("::")) {
             String lexicalKey = "&" + operator;
             SymbolTable.SymbolEntry lexicalEntry = parser.ctx.symbolTable.getSymbolEntry(lexicalKey);
             if (lexicalEntry != null && lexicalEntry.ast() instanceof OperatorNode) {


### PR DESCRIPTION
Fixes #93

## Problem
When a subroutine like `sub Encode` exists in the current package, qualified calls like `Encode::is_utf8()` were incorrectly being resolved to the local subroutine instead of the external package.

This caused ExifTool to fail with:
```
PerlCompilerException: Not enough arguments for Image::ExifTool::Encode
```

## Root Cause
The parser was checking for lexical subs and package sub overrides **before** checking if `::` follows the identifier. So when parsing `Encode::is_utf8`, it would see that `XYZ::Encode` exists and treat `Encode` as a subroutine call.

## Fixes

### 1. ParsePrimary.java
Don't treat an identifier as a lexical sub call if `::` follows. `Encode::is_utf8` is a qualified name to the Encode package, not a call to local `sub Encode`.

### 2. OperatorParser.java  
Parse bareword module names in `require` directly using `parseSubroutineIdentifier()` instead of going through the expression parser. This prevents `require Encode` from treating `Encode` as a subroutine call when a sub with the same name exists in the current package.

## Test Case
```perl
package XYZ;
sub Encode ($$) {}
require Encode;
Encode::is_utf8("");
```

This now works correctly.