### PR TITLE
Fix parsing of %{EXPR} and @{EXPR} as hash/array dereferences

### DIFF
--- a/src/main/java/org/perlonjava/parser/ListParser.java
+++ b/src/main/java/org/perlonjava/parser/ListParser.java
@@ -329,9 +329,13 @@ public class ListParser {
             } else if (token.text.equals("&")) {
                 // Looks like a subroutine call, not an infix `&`
                 parser.ctx.logDebug("parseZeroOrMoreList looks like subroutine call");
-            } else if (token.text.equals("%") && (nextToken.text.equals("$") || nextToken.type == LexerTokenType.IDENTIFIER)) {
+            } else if (token.text.equals("%") && (nextToken.text.equals("$") || nextToken.text.equals("{") || nextToken.type == LexerTokenType.IDENTIFIER)) {
                 // Looks like a hash deref, not an infix `%`
-                parser.ctx.logDebug("parseZeroOrMoreList looks like Hash");
+                // %$ref, %{expr}, %hash
+                parser.ctx.logDebug("parseZeroOrMoreList looks like Hash: token=" + token.text + " nextToken=" + nextToken.text);
+            } else if (token.text.equals("@") && nextToken.text.equals("{")) {
+                // Looks like an array deref @{expr}, not an infix `@`
+                parser.ctx.logDebug("parseZeroOrMoreList looks like Array deref");
             } else if (token.text.equals(".") && token1.type == LexerTokenType.NUMBER) {
                 // Looks like a fractional number, not an infix `.`
                 parser.ctx.logDebug("parseZeroOrMoreList looks like Number");


### PR DESCRIPTION
## Problem

`%{expr}` was incorrectly parsed as an infix modulo operator when used as an argument to functions like `say`. For example:

```perl
say %{sub {{ a => 3 }}->()}
```

was parsed as `(say $_) % {hash_literal}` instead of `say(%{sub...->()})`, producing:
- "Odd number of elements in anonymous hash" warning
- Empty output

## Fix

Added `{` to the lookahead check in `looksLikeEmptyList()` so that `%{...}` and `@{...}` are recognized as hash/array dereferences rather than infix operators.

## Testing

- `./jperl -E 'say %{sub {{ a => 3 }}->()}'` now correctly outputs `a3` (matching Perl behavior)
- All unit tests pass

## Context

This fix is needed for `JPERL_LARGECODE=refactor` which generates constructs like `%{sub{...}->()}` to wrap large hash literals.