### PR TITLE
Fix symbolic subroutine references (&$func)

### DIFF
--- a/src/main/java/org/perlonjava/codegen/EmitSubroutine.java
+++ b/src/main/java/org/perlonjava/codegen/EmitSubroutine.java
@@ -193,6 +193,15 @@ public class EmitSubroutine {
         }
 
         node.left.accept(emitterVisitor.with(RuntimeContextType.SCALAR)); // Target - left parameter: Code ref
+        
+        // Handle symbolic references when no strict refs
+        if (!emitterVisitor.ctx.symbolTable.isStrictOptionEnabled(org.perlonjava.perlmodule.Strict.HINT_STRICT_REFS)) {
+            // no strict refs - resolve symbolic code references
+            emitterVisitor.pushCurrentPackage();
+            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/RuntimeScalar",
+                    "codeDerefNonStrict", "(Ljava/lang/String;)Lorg/perlonjava/runtime/RuntimeScalar;", false);
+        }
+        
         mv.visitLdcInsn(subroutineName);
 
         // Generate native RuntimeBase[] array for parameters instead of RuntimeList

--- a/src/main/java/org/perlonjava/codegen/EmitVariable.java
+++ b/src/main/java/org/perlonjava/codegen/EmitVariable.java
@@ -360,6 +360,14 @@ public class EmitVariable {
                 } else {
                     // Regular case: `&$a`
                     node.operand.accept(emitterVisitor.with(RuntimeContextType.SCALAR));
+                    
+                    // Handle symbolic references when no strict refs
+                    if (!emitterVisitor.ctx.symbolTable.isStrictOptionEnabled(HINT_STRICT_REFS)) {
+                        // no strict refs - resolve symbolic code references
+                        emitterVisitor.pushCurrentPackage();
+                        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/RuntimeScalar",
+                                "codeDerefNonStrict", "(Ljava/lang/String;)Lorg/perlonjava/runtime/RuntimeScalar;", false);
+                    }
                 }
 
                 mv.visitVarInsn(Opcodes.ALOAD, 1);  // push @_ to stack

--- a/src/main/java/org/perlonjava/runtime/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/RuntimeScalar.java
@@ -1205,6 +1205,27 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         };
     }
 
+    /**
+     * Dereference a scalar as a code reference when no strict refs is active.
+     * Handles symbolic references like &$func where $func contains a subroutine name.
+     *
+     * @param packageName The current package name for resolving unqualified names
+     * @return RuntimeScalar containing the code reference
+     */
+    public RuntimeScalar codeDerefNonStrict(String packageName) {
+        // If already a CODE reference, return as-is
+        if (type == RuntimeScalarType.CODE) {
+            return this;
+        }
+        
+        // Treat as symbolic reference to subroutine name
+        String subName = this.toString();
+        // Normalize the name with current package context
+        String fullName = NameNormalizer.normalizeVariableName(subName, packageName);
+        // Get the code reference from global symbol table
+        return GlobalVariable.getGlobalCodeRef(fullName);
+    }
+
     // Return a reference to this
     public RuntimeScalar createReference() {
         RuntimeScalar result = new RuntimeScalar();


### PR DESCRIPTION
Adds support for symbolic subroutine references when 'no strict refs' is active.

## Changes
- Added `codeDerefNonStrict()` method in RuntimeCode to resolve string references to code references
- Modified EmitSubroutine.handleApplyOperator() to call codeDerefNonStrict when no strict refs
- Modified EmitVariable.handleVariableOperator() to call codeDerefNonStrict for & operator

## Behavior
This allows code like:
```perl
my $func = 'main::foo';
&$func();  # Works when no strict refs
```

With `use strict 'refs'`, it correctly rejects symbolic references.

## Testing
- ✅ All unit tests pass
- ✅ Symbolic subroutine calls work correctly
- ✅ Respects strict refs pragma
- ✅ ExifTool progresses further (was blocked by this issue)

## Related
This fixes the 'Not a CODE reference' error that was preventing ExifTool from running.