### PR TITLE
Fix 'when' keyword parsing to respect 'use feature switch'

### DIFF
--- a/src/main/java/org/perlonjava/parser/ListParser.java
+++ b/src/main/java/org/perlonjava/parser/ListParser.java
@@ -222,11 +222,11 @@ public class ListParser {
             return false;
         }
         
-        // Special case: and/or/xor before => should be treated as barewords, not terminators
-        if (token.text.equals("and") || token.text.equals("or") || token.text.equals("xor")) {
+        // Special case: and/or/xor/when before => should be treated as barewords, not terminators
+        if (token.text.equals("and") || token.text.equals("or") || token.text.equals("xor") || token.text.equals("when")) {
             // Look ahead to see if => follows
             int saveIndex = parser.tokenIndex;
-            TokenUtils.consume(parser); // consume and/or/xor
+            TokenUtils.consume(parser); // consume and/or/xor/when
             LexerToken nextToken = TokenUtils.peek(parser);
             parser.tokenIndex = saveIndex; // restore
             if (nextToken.text.equals("=>")) {
@@ -297,8 +297,8 @@ public class ListParser {
         // Check if this is a list terminator, but we need to restore position for the check
         boolean isTerminator = false;
         if (ParserTables.LIST_TERMINATORS.contains(token.text)) {
-            // Special case: check if and/or/xor followed by =>
-            if (token.text.equals("and") || token.text.equals("or") || token.text.equals("xor")) {
+            // Special case: check if and/or/xor/when followed by =>
+            if (token.text.equals("and") || token.text.equals("or") || token.text.equals("xor") || token.text.equals("when")) {
                 if (nextToken.text.equals("=>")) {
                     isTerminator = false; // Not a terminator, it's a hash key
                 } else {

--- a/src/main/java/org/perlonjava/parser/StatementResolver.java
+++ b/src/main/java/org/perlonjava/parser/StatementResolver.java
@@ -69,11 +69,17 @@ public class StatementResolver {
 
                 case "while", "until" -> StatementParser.parseWhileStatement(parser, label);
 
-                case "given" -> StatementParser.parseGivenStatement(parser);
+                case "given" -> parser.ctx.symbolTable.isFeatureCategoryEnabled("switch")
+                        ? StatementParser.parseGivenStatement(parser)
+                        : null;
 
-                case "when" -> StatementParser.parseWhenStatement(parser);
+                case "when" -> parser.ctx.symbolTable.isFeatureCategoryEnabled("switch")
+                        ? StatementParser.parseWhenStatement(parser)
+                        : null;
 
-                case "default" -> StatementParser.parseDefaultStatement(parser);
+                case "default" -> parser.ctx.symbolTable.isFeatureCategoryEnabled("switch")
+                        ? StatementParser.parseDefaultStatement(parser)
+                        : null;
 
                 case "try" -> parser.ctx.symbolTable.isFeatureCategoryEnabled("try")
                         ? StatementParser.parseTryStatement(parser)


### PR DESCRIPTION
## Problem

The `when` keyword was being treated as a reserved keyword unconditionally, causing parser errors when used as a bareword hash key. This broke ExifTool's XMP.pm which uses `when` as a hash key:

```perl
when => { %dateTimeInfo, Groups => { 2 => 'Time' } }
```

The `when` keyword should only be reserved when `use feature 'switch'` is active, similar to how `try` and `class` are handled.

## Changes

### StatementResolver.java
- Added feature flag checks for `given`, `when`, and `default` keywords
- These keywords now only act as statement keywords when `use feature 'switch'` is enabled
- Without the feature, they fall through to be treated as regular identifiers

### ListParser.java (2 locations)
- Added `when` to the list of keywords that should be treated as barewords when followed by `=>` (fat comma)
- This matches the existing behavior for `and`, `or`, and `xor` keywords

## Testing

Tested with ExifTool 13.44:

**Before fix:**
```
Expected token OPERATOR with text ) but got LexerToken{type=IDENTIFIER, text='when'}
```

**After fix:**
- XMP.pm parses successfully
- Commands like `-h`, `-json`, `-X`, `-listx` now proceed past the parser stage
- The `when => { ... }` hash key is correctly recognized as a bareword

## Impact

This fix allows code that uses `when` as a bareword (hash keys, subroutine names, etc.) to work correctly when the switch feature is not enabled, matching standard Perl behavior.