### PR TITLE
Fix AUTOLOAD resolution for imported forward-declared subroutines

### DIFF
--- a/src/test/resources/unit/exiftool_exporter_autoload.t
+++ b/src/test/resources/unit/exiftool_exporter_autoload.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+
+our $autoload_seen;
+
+{
+    package Exiftool::ExporterAutoload;
+
+    use Exporter qw(import);
+
+    our @EXPORT = qw(GetAllTags);
+
+    sub GetAllTags;
+
+    our $AUTOLOAD;
+
+    sub AUTOLOAD {
+        $main::autoload_seen = $AUTOLOAD;
+        return 1;
+    }
+}
+
+print "1..1\n";
+
+Exiftool::ExporterAutoload->import();
+
+my $ok = eval { GetAllTags(); 1 };
+if (!$ok) {
+    my $err = $@;
+    $err =~ s/\s+\z//;
+    print "not ok 1 - GetAllTags() should trigger AUTOLOAD (got error: $err)\n";
+    exit;
+}
+
+if (defined $autoload_seen && $autoload_seen eq 'Exiftool::ExporterAutoload::GetAllTags') {
+    print "ok 1 - AUTOLOAD called for imported forward-declared sub\n";
+} else {
+    my $seen = defined $autoload_seen ? $autoload_seen : '<undef>';
+    print "not ok 1 - AUTOLOAD not called correctly (saw: $seen)\n";
+}


### PR DESCRIPTION
## Problem

ExifTool commands (exiftool -list and -listw) failed with "Undefined subroutine" errors when JPERL_LARGECODE=refactor was enabled.

## Root Cause

When Exporter imports a forward-declared subroutine, the imported placeholder wasn't configured to resolve via the exporting package's AUTOLOAD mechanism, breaking standard Perl semantics.

## Solution

Made three key changes:

1. Exporter.exportToLevel: Handle empty caller() by defaulting to 'main'
2. Exporter.importFunction: Annotate imported forward-declaration placeholders with sourcePackage field
3. RuntimeCode.apply: Check sourcePackage first when attempting AUTOLOAD resolution

This matches Perl's behavior where imported forward declarations resolve via the original package's AUTOLOAD.

## Testing

- Added regression test: src/test/resources/unit/exiftool_exporter_autoload.t
- Test passes in system Perl, jperl (normal mode), and jperl (refactor mode)
- All existing unit tests pass
- ExifTool -list and -listw now get past the GetAllTags/GetWritableTags errors

## Files Changed

- src/main/java/org/perlonjava/perlmodule/Exporter.java
- src/main/java/org/perlonjava/runtime/RuntimeCode.java
- src/test/resources/unit/exiftool_exporter_autoload.t (new)
