### PR TITLE
Fix glob operations in uni/gv.t test

### DIFF
--- a/src/main/java/org/perlonjava/runtime/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/RuntimeGlob.java
@@ -501,7 +501,7 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
 
     /**
      * Undefines the elements of the typeglob.
-     * This method clears the CODE reference and invalidates the method resolution cache.
+     * This method clears all slots (CODE, FORMAT, SCALAR, ARRAY, HASH) and invalidates the method resolution cache.
      *
      * @return The current RuntimeGlob instance after undefining its elements.
      */
@@ -519,7 +519,15 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         // Undefine FORMAT
         GlobalVariable.getGlobalFormatRef(this.globName).undefineFormat();
 
-        // XXX TODO undefine scalar, array, hash
+        // Undefine SCALAR
+        GlobalVariable.getGlobalVariable(this.globName).set(new RuntimeScalar());
+
+        // Undefine ARRAY - create empty array
+        GlobalVariable.globalArrays.put(this.globName, new RuntimeArray());
+
+        // Undefine HASH - create empty hash
+        GlobalVariable.globalHashes.put(this.globName, new RuntimeHash());
+
         return this;
     }
 


### PR DESCRIPTION
This PR fixes test failures at tests 110, 111, and 112 in the uni/gv.t test suite.

## Issues Fixed

### 1. undef glob operation not clearing all slots (Tests 110-112)
Problem: The RuntimeGlob.undefine() method was only clearing CODE and FORMAT slots, leaving SCALAR, ARRAY, and HASH slots intact.

Solution: Updated RuntimeGlob.undefine() to properly clear all slots:
- SCALAR slot clearing
- ARRAY slot clearing  
- HASH slot clearing

### 2. Constant subroutine creation for glob references (Test 111)
Problem: When assigning a glob reference to a symbol table slot, the GLOBREFERENCE case was not creating a constant subroutine.

Solution: Updated the GLOBREFERENCE case in RuntimeStashEntry.set() to create a constant subroutine that returns the glob.

## Test Results
- Test 110: scalar now correctly returns undef after undef operation
- Test 111: prototype now correctly returns empty string
- Test 112: hash count now correctly returns 0 after undef operation

The test now progresses to test 159 instead of dying at test 112.