### PR TITLE
Revert regression commits that broke Getopt::Long and caused ASM errors

### DIFF
--- a/src/main/java/org/perlonjava/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/parser/SubroutineParser.java
@@ -474,12 +474,6 @@ public class SubroutineParser {
             RuntimeCode codeRef = (RuntimeCode) GlobalVariable.getGlobalCodeRef(fullName).value;
             codeRef.prototype = prototype;
             codeRef.attributes = attributes;
-            
-            // If the prototype is empty, this is a constant subroutine
-            if (prototype != null && prototype.isEmpty()) {
-                codeRef.constantValue = new RuntimeList();
-            }
-            
             // return an empty AST list
             return new ListNode(parser.tokenIndex);
         }

--- a/src/main/java/org/perlonjava/runtime/GlobalVariable.java
+++ b/src/main/java/org/perlonjava/runtime/GlobalVariable.java
@@ -214,12 +214,7 @@ public class GlobalVariable {
     public static RuntimeHash getGlobalHash(String key) {
         RuntimeHash var = globalHashes.get(key);
         if (var == null) {
-            // Check if this is a package stash (ends with ::)
-            if (key.endsWith("::")) {
-                var = new RuntimeStash(key);
-            } else {
-                var = new RuntimeHash();
-            }
+            var = new RuntimeHash();
             globalHashes.put(key, var);
         }
         return var;

--- a/src/main/java/org/perlonjava/runtime/RuntimeStashEntry.java
+++ b/src/main/java/org/perlonjava/runtime/RuntimeStashEntry.java
@@ -279,25 +279,4 @@ public class RuntimeStashEntry extends RuntimeGlob {
         return this;
     }
 
-    /**
-     * Returns a string representation of the stash entry.
-     * For constant subroutines, returns the prototype.
-     * For other cases, returns the glob representation.
-     *
-     * @return A string representation of the stash entry.
-     */
-    @Override
-    public String toString() {
-        // Check if this is a constant subroutine
-        RuntimeScalar codeRef = GlobalVariable.getGlobalCodeRef(this.globName);
-        if (codeRef.type == RuntimeScalarType.CODE && codeRef.value instanceof RuntimeCode code) {
-            if (code.constantValue != null) {
-                // For constant subroutines, return the prototype
-                return code.prototype != null ? code.prototype : "";
-            }
-        }
-        // Default to glob representation
-        return "*" + this.globName;
-    }
-
 }


### PR DESCRIPTION
This reverts:
- d6400c01 (Merge pull request #137 from fglock/fix-constant-subroutine-prototype)
- c08ebfdc (Fix constant subroutine prototype handling in stash entries)
- b48654f7 (Fix constant subroutine prototype handling in stash entries)

These commits introduced:
- ASM frame computation errors in Getopt::Long processing
- Command line parsing failures in life_bitpacked.pl example

Reverting restores functionality to working state where: ✅ ./jperl examples/life_bitpacked.pl --width=10 --height=5 --generations=1 works ✅ All tests pass
✅ No ASM frame errors
✅ Getopt::Long functions correctly