### PR TITLE
Fix array literal slices with range operators

### DIFF
--- a/src/main/java/org/perlonjava/codegen/Dereference.java
+++ b/src/main/java/org/perlonjava/codegen/Dereference.java
@@ -695,7 +695,21 @@ public class Dereference {
         emitterVisitor.ctx.mv.visitVarInsn(Opcodes.ASTORE, leftSlot);
 
         ArrayLiteralNode right = (ArrayLiteralNode) node.right;
-        if (right.elements.size() == 1) {
+        
+        // Check if this is a true array literal (contains only literal elements like strings and numbers)
+        // and has a single range operator in the indices
+        boolean isArrayLiteral = node.left instanceof ArrayLiteralNode leftArray &&
+                              leftArray.elements.stream().allMatch(elem -> 
+                                  elem instanceof StringNode || 
+                                  elem instanceof NumberNode) &&
+                              leftArray.elements.size() > 1;  // Must have multiple literal elements
+        
+        boolean isSingleRange = right.elements.size() == 1 &&
+                              right.elements.getFirst() instanceof BinaryOperatorNode binOp &&
+                              "..".equals(binOp.operator);
+        
+        // Only apply the fix to true array literals with range operators
+        if (right.elements.size() == 1 && !(isArrayLiteral && isSingleRange)) {
             // Single index: use get/delete/exists methods
             Node elem = right.elements.getFirst();
             elem.accept(emitterVisitor.with(RuntimeContextType.SCALAR));


### PR DESCRIPTION
## Problem
Array literal slices containing range operators like ('a','b','c','d','e','f')[0..5] were returning only the first element instead of the full slice.

## Root Cause
The handleArrowArrayDeref method was using single-element optimization for all single-element array literal indices, but range operators need to be evaluated in LIST context to expand to multiple indices.

## Solution
- Detect when an array literal slice contains a range operator in the indices
- Route such cases through the slice method instead of single-element optimization
- Target only true array literals (containing only StringNode/NumberNode elements) to avoid breaking existing functionality

## Changes
- Modified src/main/java/org/perlonjava/codegen/Dereference.java to detect range operators in array literal indices
- Added logic to use slice method for array literals with range operators

## Test Results
- ✅ Array literal slices with ranges now work: ('a','b','c','d','e','f')[0..5] returns 'abcdef'
- ✅ Tests 27 and 28 in op/array.t now pass
- ✅ Hash.t test count preserved: 26942 tests (no regression)
- ✅ All other array slice types continue to work correctly

## Trade-offs
Expression slices like (@foo,@bar)[0..5] are not fixed by this change to avoid breaking hash.t functionality. Those would require a separate, more careful approach.