### PR TITLE
Fix Unicode identifier parsing and related runtime Unicode handling

### DIFF
--- a/src/main/java/org/perlonjava/operators/Operator.java
+++ b/src/main/java/org/perlonjava/operators/Operator.java
@@ -247,7 +247,7 @@ public class Operator {
      */
     public static RuntimeScalar substr(int ctx, RuntimeBase... args) {
         String str = args[0].toString();
-        int strLength = str.length();
+        int strLength = str.codePointCount(0, str.length());
 
         int size = args.length;
         int offset = ((RuntimeScalar) args[1]).getInt();
@@ -275,8 +275,10 @@ public class Operator {
         // Ensure length is non-negative and within bounds
         length = Math.max(0, Math.min(length, strLength - offset));
 
-        // Extract the substring
-        String result = str.substring(offset, offset + length);
+        // Extract the substring (offset/length are in Unicode code points)
+        int startIndex = str.offsetByCodePoints(0, offset);
+        int endIndex = str.offsetByCodePoints(startIndex, length);
+        String result = str.substring(startIndex, endIndex);
 
         // Return an LValue "RuntimeSubstrLvalue" that can be used to assign to the original string
         // This allows for in-place modification of the original string if needed

--- a/src/main/java/org/perlonjava/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/parser/StatementParser.java
@@ -130,6 +130,16 @@ public class StatementParser {
             parser.parsingForLoopVariable = false;
         }
 
+        // If we didn't parse a loop variable, Perl expects the '(' of the for(..) header next.
+        // When something else appears (e.g. a bare identifier), perl5 reports:
+        //   Missing $ on loop variable ...
+        if (varNode == null) {
+            LexerToken afterVar = TokenUtils.peek(parser);
+            if (!afterVar.text.equals("(")) {
+                parser.throwCleanError("Missing $ on loop variable " + afterVar.text);
+            }
+        }
+
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, "(");
 
         // Parse the initialization part

--- a/src/main/java/org/perlonjava/parser/Variable.java
+++ b/src/main/java/org/perlonjava/parser/Variable.java
@@ -137,7 +137,7 @@ public class Variable {
         // Store the current position before parsing the identifier
         int startIndex = parser.tokenIndex;
 
-        String varName = IdentifierParser.parseComplexIdentifier(parser);
+        String varName = IdentifierParser.parseComplexIdentifier(parser, sigil.equals("*"));
         parser.ctx.logDebug("Parsing variable: " + varName);
 
         if (varName != null) {

--- a/src/main/java/org/perlonjava/runtime/RuntimeSubstrLvalue.java
+++ b/src/main/java/org/perlonjava/runtime/RuntimeSubstrLvalue.java
@@ -54,7 +54,7 @@ public class RuntimeSubstrLvalue extends RuntimeBaseProxy {
 
         String parentValue = lvalue.toString();
         String newValue = this.toString();
-        int strLength = parentValue.length();
+        int strLength = parentValue.codePointCount(0, parentValue.length());
 
         // Calculate the actual offset, handling negative offsets
         int actualOffset = offset < 0 ? strLength + offset : offset;
@@ -83,14 +83,17 @@ public class RuntimeSubstrLvalue extends RuntimeBaseProxy {
 
         StringBuilder updatedValue = new StringBuilder(parentValue);
 
+        // Convert code point offsets to UTF-16 indices for StringBuilder operations
+        int startIndex = parentValue.offsetByCodePoints(0, actualOffset);
+        int endIndex = parentValue.offsetByCodePoints(startIndex, actualLength);
+
         // Handle the case where the offset is beyond the current string length
         if (actualOffset >= strLength) {
             // append the new value
             updatedValue.append(newValue);
         } else {
             // Replace the substring with the new value
-            int endIndex = actualOffset + actualLength;
-            updatedValue.replace(actualOffset, endIndex, newValue);
+            updatedValue.replace(startIndex, endIndex, newValue);
         }
 
         // Update the parent RuntimeScalar with the modified string


### PR DESCRIPTION
## Summary\n- Make lexer code-point aware for Unicode identifiers (surrogate pairs).\n- Validate identifiers using Unicode XID properties and UTF-8 byte length limits.\n- Fix `substr`/lvalue substring operations to operate on Unicode code points.\n- Improve parser diagnostics (e.g. `for` loop variable error).\n- Fix strict-vars handling for special sort vars ``/`` to avoid aborting regex test files under strict.\n\n## Test results\n- `make`: PASS\n- `perl dev/tools/perl_test_runner.pl perl5_t/t/comp/parser.t`: improved (73/193)\n- `perl dev/tools/perl_test_runner.pl perl5_t/t/uni/variables.t`: improved (66764/66880)\n- `perl dev/tools/perl_test_runner.pl perl5_t/t/re/pat_rt_report.t`: unblocked (2379/2514)\n\n## Notes\nNo test files were modified.