### PR TITLE
Align identifier rules with Perl XID_* and tighten whitespace+sigil parsing

### DIFF
--- a/src/main/java/org/perlonjava/lexer/Lexer.java
+++ b/src/main/java/org/perlonjava/lexer/Lexer.java
@@ -80,6 +80,14 @@ public class Lexer {
         return c1;
     }
 
+    private static boolean isPerlIdentifierStart(int codePoint) {
+        return codePoint == '_' || UCharacter.hasBinaryProperty(codePoint, UProperty.XID_START);
+    }
+
+    private static boolean isPerlIdentifierPart(int codePoint) {
+        return codePoint == '_' || UCharacter.hasBinaryProperty(codePoint, UProperty.XID_CONTINUE);
+    }
+
     private void advanceCodePoint(int codePoint) {
         position += Character.charCount(codePoint);
     }
@@ -150,7 +158,7 @@ public class Lexer {
             }
         } else if (current >= '0' && current <= '9') {
             return consumeNumber();
-        } else if (currentCp == '_' || Character.isUnicodeIdentifierStart(currentCp)) {
+        } else if (isPerlIdentifierStart(currentCp)) {
             return consumeIdentifier();
         } else if (current < 128 && isOperator[current]) {
             return consumeOperator();
@@ -187,7 +195,7 @@ public class Lexer {
 
         while (position < length) {
             int curCp = getCurrentCodePoint();
-            if (curCp == '_' || Character.isUnicodeIdentifierPart(curCp)) {
+            if (isPerlIdentifierPart(curCp)) {
                 advanceCodePoint(curCp);
             } else {
                 break;


### PR DESCRIPTION
This PR makes progress on perl5_t/t/uni/variables.t.

Changes:
- Lexer: use ICU XID_START/XID_CONTINUE for identifier tokenization.
- IdentifierParser: treat evalbytes as bytes (ignore use utf8 hint there for identifier validation), always reject C1 controls as identifier starts, and make $<whitespace><punct> (e.g. "$\t = 4") a syntax error instead of a punctuation special variable.

Status:
- make: passing
- perl5_t/t/uni/variables.t: 72 failures (down from 76)