### PR TITLE
fix uni variables

### DIFF
--- a/src/main/java/org/perlonjava/lexer/Lexer.java
+++ b/src/main/java/org/perlonjava/lexer/Lexer.java
@@ -174,7 +174,7 @@ public class Lexer {
         while (position < length
                 && input.charAt(position) != '\n'
                 && input.charAt(position) != '\r'
-                && (input.charAt(position) == ' ' || Character.isWhitespace(input.charAt(position)))) {
+                && (input.charAt(position) == ' ' || input.charAt(position) == '\t' || input.charAt(position) == '\f')) {
             position++;
         }
         return new LexerToken(LexerTokenType.WHITESPACE, input.substring(start, position));

--- a/src/main/java/org/perlonjava/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/parser/ParseInfix.java
@@ -295,7 +295,7 @@ public class ParseInfix {
                     parser.tokenIndex--;
                     return left;
                 }
-                throw new PerlCompilerException(parser.tokenIndex, "Unexpected infix operator: " + token, parser.ctx.errorUtil);
+                throw new PerlCompilerException(parser.tokenIndex, "syntax error", parser.ctx.errorUtil);
         }
     }
 


### PR DESCRIPTION
- **Lexer/IdentifierParser: align identifier rules and tighten whitespace+sigil parsing**
- **Fix uni/variables.t diagnostics under no-utf8/evalbytes**
