### PR TITLE
fix next if loop scope

### DIFF
--- a/src/main/java/org/perlonjava/astvisitor/ControlFlowFinder.java
+++ b/src/main/java/org/perlonjava/astvisitor/ControlFlowFinder.java
@@ -41,8 +41,12 @@ public class ControlFlowFinder implements Visitor {
 
         if (root instanceof AbstractNode abstractNode) {
             Boolean cached = abstractNode.getCachedHasAnyControlFlow();
-            if (cached != null) {
-                foundControlFlow = cached;
+            // IMPORTANT: Only trust positive cache entries.
+            // A cached FALSE can become stale if the AST is rewritten (e.g. during large-block
+            // refactoring / macros) and would cause us to miss control flow, leading to unsafe
+            // extraction of chunks that contain next/last/redo/goto.
+            if (Boolean.TRUE.equals(cached)) {
+                foundControlFlow = true;
                 return;
             }
         }

--- a/src/main/java/org/perlonjava/codegen/EmitBlock.java
+++ b/src/main/java/org/perlonjava/codegen/EmitBlock.java
@@ -132,13 +132,12 @@ public class EmitBlock {
 
         if (node.isLoop) {
             // A labeled/bare block used as a loop target (e.g. SKIP: { ... }) is a
-            // pseudo-loop: it supports labeled next/last/redo (e.g. next SKIP), but
-            // an unlabeled next/last/redo must target the nearest enclosing true loop.
+            // pseudo-loop: it supports *labeled* next/last/redo (e.g. next SKIP), but
+            // an *unlabeled* next/last/redo must target the nearest enclosing true loop.
             //
-            // However, a *bare* block with loop control (e.g. `{ ...; redo }` or
-            // `{ ... } continue { ... }`) is itself a valid target for *unlabeled*
-            // last/next/redo, matching Perl semantics.
-            boolean isBareBlock = node.labelName == null;
+            // Perl semantics: unlabeled next/last/redo prefer a real loop if one exists,
+            // but outside any real loop a bare block can act as the target.
+            boolean isUnlabeledTarget = node.labelName == null;
             emitterVisitor.ctx.javaClassInfo.pushLoopLabels(
                     node.labelName,
                     nextLabel,
@@ -146,8 +145,9 @@ public class EmitBlock {
                     nextLabel,
                     emitterVisitor.ctx.javaClassInfo.stackLevelManager.getStackLevel(),
                     emitterVisitor.ctx.contextType,
-                    isBareBlock,
-                    isBareBlock);
+                    true,
+                    isUnlabeledTarget,
+                    false);
         }
 
         // Special case: detect pattern of `local $_` followed by `For1Node` with needsArrayOfAlias

--- a/src/main/java/org/perlonjava/codegen/EmitControlFlow.java
+++ b/src/main/java/org/perlonjava/codegen/EmitControlFlow.java
@@ -70,6 +70,22 @@ public class EmitControlFlow {
         }
         
         if (loopLabels == null) {
+            if (ctx.compilerOptions != null && ctx.compilerOptions.debugEnabled) {
+                ctx.logDebug("visit(next): loopLabels == null; dumping loopLabelStack (top-first):");
+                int depth = 0;
+                for (LoopLabels ll : ctx.javaClassInfo.loopLabelStack) {
+                    ctx.logDebug(
+                            "  [" + (depth++) + "] label=" + ll.labelName +
+                                    " isTrueLoop=" + ll.isTrueLoop +
+                                    " isRealLoop=" + ll.isRealLoop +
+                                    " isUnlabeledTarget=" + ll.isUnlabeledControlFlowTarget +
+                                    " asmStackLevel=" + ll.asmStackLevel +
+                                    " context=" + ll.context);
+                }
+                if (depth == 0) {
+                    ctx.logDebug("  <empty>");
+                }
+            }
             // Non-local control flow: return tagged RuntimeControlFlowList
             ctx.logDebug("visit(next): Non-local control flow for " + operator + " " + labelStr);
             

--- a/src/main/java/org/perlonjava/codegen/EmitForeach.java
+++ b/src/main/java/org/perlonjava/codegen/EmitForeach.java
@@ -305,8 +305,10 @@ public class EmitForeach {
                 emitterVisitor.ctx.javaClassInfo.stackLevelManager.getStackLevel(),
                 RuntimeContextType.VOID);
         currentLoopLabels.controlFlowHandler = controlFlowHandler;
-
+        emitterVisitor.ctx.logDebug("FOR1 pushLoopLabels label=" + node.labelName + " asmStackLevel=" + currentLoopLabels.asmStackLevel);
         emitterVisitor.ctx.javaClassInfo.pushLoopLabels(currentLoopLabels);
+
+        emitterVisitor.ctx.logDebug("FOR1 loopLabelStack depth after push=" + emitterVisitor.ctx.javaClassInfo.loopLabelStack.size());
 
         node.body.accept(emitterVisitor.with(RuntimeContextType.VOID));
         
@@ -314,6 +316,9 @@ public class EmitForeach {
         emitRegistryCheck(mv, currentLoopLabels, redoLabel, continueLabel, loopEnd);
 
         LoopLabels poppedLabels = emitterVisitor.ctx.javaClassInfo.popLoopLabels();
+
+        emitterVisitor.ctx.logDebug("FOR1 popLoopLabels label=" + (poppedLabels != null ? poppedLabels.labelName : null) +
+                " remainingDepth=" + emitterVisitor.ctx.javaClassInfo.loopLabelStack.size());
 
         mv.visitLabel(continueLabel);
 

--- a/src/main/java/org/perlonjava/codegen/EmitStatement.java
+++ b/src/main/java/org/perlonjava/codegen/EmitStatement.java
@@ -159,6 +159,7 @@ public class EmitStatement {
                 // Unlabeled next/last/redo must be allowed for *bare* blocks (no label), but
                 // must *not* accidentally target pseudo-loops like `SKIP: { ... }`.
                 boolean isUnlabeledTarget = !node.isSimpleBlock || node.labelName == null;
+
                 emitterVisitor.ctx.javaClassInfo.pushLoopLabels(
                         node.labelName,
                         continueLabel,
@@ -167,7 +168,8 @@ public class EmitStatement {
                         emitterVisitor.ctx.javaClassInfo.stackLevelManager.getStackLevel(),
                         RuntimeContextType.VOID,
                         true,
-                        isUnlabeledTarget);
+                        isUnlabeledTarget,
+                        !node.isSimpleBlock);
 
                 // Visit the loop body
                 node.body.accept(voidVisitor);

--- a/src/main/java/org/perlonjava/codegen/JavaClassInfo.java
+++ b/src/main/java/org/perlonjava/codegen/JavaClassInfo.java
@@ -154,6 +154,10 @@ public class JavaClassInfo {
     public void pushLoopLabels(String labelName, Label nextLabel, Label redoLabel, Label lastLabel, int stackLevel, int context, boolean isTrueLoop, boolean isUnlabeledControlFlowTarget) {
         loopLabelStack.push(new LoopLabels(labelName, nextLabel, redoLabel, lastLabel, stackLevel, context, isTrueLoop, isUnlabeledControlFlowTarget));
     }
+
+    public void pushLoopLabels(String labelName, Label nextLabel, Label redoLabel, Label lastLabel, int stackLevel, int context, boolean isTrueLoop, boolean isUnlabeledControlFlowTarget, boolean isRealLoop) {
+        loopLabelStack.push(new LoopLabels(labelName, nextLabel, redoLabel, lastLabel, stackLevel, context, isTrueLoop, isUnlabeledControlFlowTarget, isRealLoop));
+    }
     
     /**
      * Pushes a LoopLabels object onto the loop label stack.
@@ -228,11 +232,20 @@ public class JavaClassInfo {
      * @return the innermost LoopLabels with isTrueLoop=true, or null if none
      */
     public LoopLabels findInnermostTrueLoopLabels() {
+        // Prefer a real loop (for/foreach/while/until) if one exists.
+        for (LoopLabels loopLabels : loopLabelStack) {
+            if (loopLabels != null && loopLabels.isUnlabeledControlFlowTarget && loopLabels.isRealLoop) {
+                return loopLabels;
+            }
+        }
+
+        // Fallback: allow a block to act as a loop target only when there's no real loop.
         for (LoopLabels loopLabels : loopLabelStack) {
             if (loopLabels != null && loopLabels.isUnlabeledControlFlowTarget) {
                 return loopLabels;
             }
         }
+
         return null;
     }
 

--- a/src/main/java/org/perlonjava/codegen/LoopLabels.java
+++ b/src/main/java/org/perlonjava/codegen/LoopLabels.java
@@ -52,6 +52,15 @@ public class LoopLabels {
     public boolean isTrueLoop;
 
     /**
+     * Whether this is a "real" loop construct (for/foreach/while/until).
+     *
+     * Perl semantics for *unlabeled* next/last/redo:
+     * - Prefer the nearest enclosing real loop.
+     * - Only when there is no real loop, a block can act as a loop target.
+     */
+    public boolean isRealLoop;
+
+    /**
      * Whether unlabeled next/last/redo should target this loop/block.
      *
      * Perl semantics:
@@ -101,6 +110,12 @@ public class LoopLabels {
         this.context = context;
         this.isTrueLoop = isTrueLoop;
         this.isUnlabeledControlFlowTarget = isUnlabeledControlFlowTarget;
+        this.isRealLoop = true;
+    }
+
+    public LoopLabels(String labelName, Label nextLabel, Label redoLabel, Label lastLabel, int asmStackLevel, int context, boolean isTrueLoop, boolean isUnlabeledControlFlowTarget, boolean isRealLoop) {
+        this(labelName, nextLabel, redoLabel, lastLabel, asmStackLevel, context, isTrueLoop, isUnlabeledControlFlowTarget);
+        this.isRealLoop = isRealLoop;
     }
 
     /**

--- a/src/test/resources/unit/next_if_should_skip_iteration.t
+++ b/src/test/resources/unit/next_if_should_skip_iteration.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+use Test::More;
+
+# Regression test for perl5_t/t/uni/variables.t drift.
+# In perl, `next if (...)` must skip the *entire* loop iteration.
+# jperl currently mis-handles this in a specific shape, causing +12 extra checks.
+
+my $count = 0;
+
+for my $ord (0x21 .. 0x2f) { # includes '#' (0x23) and '*' (0x2a)
+    my $chr = chr $ord;
+    my $tests = 0;
+
+    if ($chr =~ /[[:punct:][:digit:]]/a) {
+        next if ($chr eq '#' or $chr eq '*');
+
+        $count++;
+        $tests++;
+        $count++;
+        $tests++;
+    }
+
+    $count++;
+    $tests++;
+
+    SKIP: {
+        my $pad = 6 - $tests;
+        $count += $pad if $pad > 0;
+    }
+}
+
+is($count, 78, 'next-if must skip the whole iteration (no +12 drift)');
+
+done_testing();


### PR DESCRIPTION
- **Lexer/IdentifierParser: align identifier rules and tighten whitespace+sigil parsing**
- **Fix uni/variables.t diagnostics under no-utf8/evalbytes**
- **Fix eval string control-flow propagation; add unit test**
- **Fix state vars skipped by goto in bare blocks**
- **Fix next-if in loops when refactoring creates closures**
