### PR TITLE
Avoid emit-time AST mutation in codegen

### DIFF
--- a/src/main/java/org/perlonjava/astnode/SubroutineNode.java
+++ b/src/main/java/org/perlonjava/astnode/SubroutineNode.java
@@ -41,6 +41,10 @@ public class SubroutineNode extends AbstractNode {
         this.block = block;
         this.useTryCatch = useTryCatch;
         this.tokenIndex = tokenIndex;
+
+        if (block instanceof AbstractNode abstractNode) {
+            abstractNode.setAnnotation("blockIsSubroutine", true);
+        }
     }
 
     /**

--- a/src/main/java/org/perlonjava/codegen/EmitOperator.java
+++ b/src/main/java/org/perlonjava/codegen/EmitOperator.java
@@ -491,8 +491,11 @@ public class EmitOperator {
             }
         } else {
             // Handle globbing if the argument is not empty or "<>".
-            node.operator = "glob";
-            handleGlobBuiltin(emitterVisitor, node);
+            // Do not mutate the original AST: create a local copy with operator rewritten.
+            OperatorNode globNode = new OperatorNode("glob", node.operand, node.tokenIndex);
+            globNode.id = node.id;
+            globNode.annotations = node.annotations;
+            handleGlobBuiltin(emitterVisitor, globNode);
         }
     }
 

--- a/src/main/java/org/perlonjava/codegen/EmitSubroutine.java
+++ b/src/main/java/org/perlonjava/codegen/EmitSubroutine.java
@@ -84,10 +84,6 @@ public class EmitSubroutine {
         }
         MethodVisitor mv = ctx.mv;
 
-        // Mark the block as subroutine block,
-        // this prevents the "code too large" transform in emitBlock()
-        node.block.setAnnotation("blockIsSubroutine", true);
-
         // Retrieve closure variable list
         // Alternately, scan the AST for variables and capture only the ones that are used
         Map<Integer, SymbolTable.SymbolEntry> visibleVariables = ctx.symbolTable.getAllVisibleVariables();

--- a/src/main/java/org/perlonjava/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/parser/ParseInfix.java
@@ -74,10 +74,10 @@ public class ParseInfix {
             if (operator.equals("..") || operator.equals("...")) {
                 // Handle regex in: /3/../5/
                 if (left instanceof OperatorNode operatorNode && operatorNode.operator.equals("matchRegex")) {
-                    operatorNode.operator = "quoteRegex";
+                    left = new OperatorNode("quoteRegex", operatorNode.operand, operatorNode.tokenIndex);
                 }
                 if (right instanceof OperatorNode operatorNode && operatorNode.operator.equals("matchRegex")) {
-                    operatorNode.operator = "quoteRegex";
+                    right = new OperatorNode("quoteRegex", operatorNode.operand, operatorNode.tokenIndex);
                 }
             }
 


### PR DESCRIPTION
## Summary
- Avoids mutating the AST during emission so emitter retries do not see a modified tree.

## Changes
- EmitRegex: bind-regex no longer appends to the existing operand list; uses a copied operator/list.
- EmitOperator: diamond/glob path no longer rewrites node.operator; uses a copied node.
- EmitBlock: temporary pre-evaluated foreach array index is now restored via try/finally.
- SubroutineNode: subroutine block annotation is set at construction time; EmitSubroutine no longer sets it.
- ParseInfix: avoids in-place rewrite of matchRegex -> quoteRegex for range parsing by creating new nodes.

## Testing
- make
