### PR TITLE
Remove Spring from integration list - requires thread safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 A Perl compiler and runtime for the JVM that:
 - Compiles Perl scripts to Java bytecode
-- Integrates with Java ecosystems (JDBC, Maven, Spring)
+- Integrates with Java libraries (JDBC databases, Maven dependencies)
 - Supports most Perl 5.42 features
 - Includes 150+ core Perl modules (DBI, HTTP::Tiny, JSON, YAML, Text::CSV)
 


### PR DESCRIPTION
## Issue

The README claimed PerlOnJava integrates with Spring, but:
- PerlOnJava does not support threading (per feature-matrix.md)
- Spring web applications are multi-threaded by default (concurrent HTTP requests)
- Using PerlOnJava in Spring without thread safety would cause race conditions and data corruption

## Changes

Changed from:
> Integrates with Java ecosystems (JDBC, Maven, Spring)

To:
> Integrates with Java libraries (JDBC databases, Maven dependencies)

## Rationale

JDBC and Maven don't require threading:
- JDBC: Database access can be used single-threaded
- Maven: Build-time dependency management, not runtime

Spring requires thread safety for production use, which PerlOnJava currently lacks.

🤖 Generated with Claude Code