### PR TITLE
Fix ExifTool issues: scalar dereference autovivification and hexadecimal parsing

### DIFF
--- a/src/main/java/org/perlonjava/parser/NumberParser.java
+++ b/src/main/java/org/perlonjava/parser/NumberParser.java
@@ -181,7 +181,13 @@ public class NumberParser {
                     exponentStr = String.valueOf(exponent);
                 }
             } else {
+                // Save token index for backtracking
+                int savedTokenIndex = parser.tokenIndex;
                 exponentStr = parseHexExponentTokens(parser);
+                if (exponentStr.isEmpty()) {
+                    // No exponent found, backtrack
+                    parser.tokenIndex = savedTokenIndex;
+                }
             }
         }
 
@@ -262,8 +268,9 @@ public class NumberParser {
         if (parser.tokenIndex < parser.tokens.size() &&
                 parser.tokens.get(parser.tokenIndex).type == LexerTokenType.NUMBER) {
             exponentStr.append(cleanUnderscores(TokenUtils.consume(parser).text));
-        } else if (exponentStr.length() > 0) {
-            parser.throwError("Malformed hexadecimal floating-point exponent");
+        } else {
+            // Not a valid exponent - return empty string
+            return "";
         }
 
         return exponentStr.toString();

--- a/src/main/java/org/perlonjava/runtime/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/RuntimeScalar.java
@@ -1068,7 +1068,13 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         }
 
         return switch (type) {
-            case UNDEF -> throw new PerlCompilerException("Can't use an undefined value as a SCALAR reference");
+            case UNDEF -> {
+                // Autovivify: create a new scalar reference for undefined values
+                RuntimeScalar newScalar = new RuntimeScalar();
+                this.value = newScalar;
+                this.type = RuntimeScalarType.REFERENCE;
+                yield newScalar;
+            }
             case REFERENCE -> (RuntimeScalar) value;
             case STRING, BYTE_STRING ->
                     throw new PerlCompilerException("Can't use string (\"" + this + "\") as a SCALAR ref while \"strict refs\" in use");


### PR DESCRIPTION
## Summary

This PR fixes two critical issues that were preventing ExifTool from running on PerlOnJava:

### Issue 1: Scalar Dereference Autovivification
- Problem: 'Can't use an undefined value as a SCALAR reference' errors
- Solution: Modified RuntimeScalar.scalarDeref() to autovivify undefined values
- Matches Perl's behavior where ${undef} creates an undefined scalar reference

### Issue 2: Hexadecimal Number Parsing Backtracking  
- Problem: 'Malformed hexadecimal floating-point exponent' errors for -0x40-$offset
- Solution: Added proper backtracking in NumberParser.parseHexExponentTokens()
- Parser now correctly restores token index when exponent parsing fails

## Testing
- All unit tests pass
- ExifTool test suite progresses from failing at test 2 to reaching test 3
- Test scripts created to verify both fixes

## Files Changed
- src/main/java/org/perlonjava/runtime/RuntimeScalar.java
- src/main/java/org/perlonjava/parser/NumberParser.java

These fixes bring PerlOnJava's behavior closer to native Perl, ensuring compatibility with existing Perl libraries like ExifTool.