### PR TITLE
Fix LargeBlockRefactorer closure capture for PersistentVariable

### DIFF
--- a/src/main/java/org/perlonjava/astrefactor/BlockRefactor.java
+++ b/src/main/java/org/perlonjava/astrefactor/BlockRefactor.java
@@ -21,9 +21,11 @@ public class BlockRefactor {
     public static BinaryOperatorNode createAnonSubCall(int tokenIndex, BlockNode nestedBlock) {
         ArrayList<Node> args = new ArrayList<>(1);
         args.add(variableAst("@", "_", tokenIndex));
+        SubroutineNode subNode = new SubroutineNode(null, null, null, nestedBlock, false, tokenIndex);
+        subNode.setAnnotation("largeBlockRefactorerCreated", true);
         return new BinaryOperatorNode(
                 "->",
-                new SubroutineNode(null, null, null, nestedBlock, false, tokenIndex),
+                subNode,
                 new ListNode(args, tokenIndex),
                 tokenIndex
         );


### PR DESCRIPTION
### Why
LargeBlockRefactorer splits oversized blocks into anonymous subroutines. Some captured lexical variables (especially `my`/`state` with BEGIN-assigned ids) were still loaded via `ALOAD`, which can point at uninitialized locals inside these refactored anon subs. This triggers JVM verifier failures like:

```
java.lang.VerifyError: Bad local variable type
  Location: org/perlonjava/anon830.apply ... @3958: aload
  Reason: locals[68] is top
```

We need a precise fix scoped to these refactored closures to avoid breaking other code paths.

### What
- Mark anon subs created by LargeBlockRefactorer with `largeBlockRefactorerCreated`.
- When emitting those subs, mark captured `my/state` variables with non-zero id as `needsPersistentVariable`.
- When emitting variable access, use `PersistentVariable.retrieveBegin*()` for annotated lexical vars instead of `ALOAD`.

### Tests
- `make`

### Notes
ExifTool now progresses past the JVM verifier error but fails later with:
```
Undefined subroutine &Image::ExifTool::JPEG::ProcessJPEG
```
This appears unrelated and will be investigated next.
