### PR TITLE
Fix tie() to handle blessed objects correctly

### DIFF
--- a/src/main/java/org/perlonjava/operators/TieOperators.java
+++ b/src/main/java/org/perlonjava/operators/TieOperators.java
@@ -29,9 +29,26 @@ public class TieOperators {
     public static RuntimeScalar tie(int ctx, RuntimeBase... scalars) {
         RuntimeScalar variable = scalars[0].getFirst();
         RuntimeScalar classArg = scalars[1].getFirst();
-        String className = classArg.getBoolean() ? scalars[1].toString() : "main";
 
-        RuntimeArray args = new RuntimeArray(Arrays.copyOfRange(scalars, 2, scalars.length));
+        // Determine the class name and arguments
+        String className;
+        RuntimeArray args;
+
+        // Check if classArg is a blessed reference (object)
+        int blessId = blessedId(classArg);
+        if (blessId != 0) {
+            // classArg is a blessed object, get the package name
+            className = NameNormalizer.getBlessStr(blessId);
+            // Prepend the object to the arguments
+            RuntimeBase[] argsWithObj = new RuntimeBase[scalars.length - 1];
+            argsWithObj[0] = classArg;
+            System.arraycopy(scalars, 2, argsWithObj, 1, scalars.length - 2);
+            args = new RuntimeArray(argsWithObj);
+        } else {
+            // classArg is a string class name
+            className = classArg.getBoolean() ? scalars[1].toString() : "main";
+            args = new RuntimeArray(Arrays.copyOfRange(scalars, 2, scalars.length));
+        }
 
         String method = switch (variable.type) {
             case REFERENCE -> "TIESCALAR";


### PR DESCRIPTION
## Summary
- Fixed tie() builtin to properly handle blessed objects as the class argument
- When tie() receives a blessed object instead of a class name string, extract the package name from the blessed reference
- Pass the blessed object as the first argument to the TIE* constructor method (per Perl semantics)

## Issue Fixed
Previously, calling `tie $x, bless []` would fail with:
```
Can't locate object method "TIESCALAR" via package "Eval1=ARRAY(0x...)"
```

The code was converting the blessed object to its string representation instead of extracting the package name.

## Changes
- Modified `TieOperators.java` to check if the second argument is a blessed reference
- Extract package name using `blessedId()` and `NameNormalizer.getBlessStr()`
- Prepend the blessed object to the TIE* constructor arguments

## Test Results
`perl5_t/t/op/eval.t`:
- Before: 101/173 tests passing (58.4%)
- After: 143/173 tests passing (82.7%)
- Improvement: **42 additional tests passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)