### PR TITLE
Fix eval error handling and VerifyError in ExifTool

### DIFF
--- a/src/main/java/org/perlonjava/codegen/EmitterMethodCreator.java
+++ b/src/main/java/org/perlonjava/codegen/EmitterMethodCreator.java
@@ -580,7 +580,7 @@ public class EmitterMethodCreator implements Opcodes {
             org.perlonjava.astvisitor.TempLocalCountVisitor tempCountVisitor =
                 new org.perlonjava.astvisitor.TempLocalCountVisitor();
             ast.accept(tempCountVisitor);
-            int preInitTempLocalsCount = tempCountVisitor.getMaxTempCount() + 64;  // Optimized: removed min-128 baseline
+            int preInitTempLocalsCount = Math.max(128, tempCountVisitor.getMaxTempCount() + 64);  // Restore min-128 baseline to fix VerifyError
             for (int i = preInitTempLocalsStart; i < preInitTempLocalsStart + preInitTempLocalsCount; i++) {
                 mv.visitInsn(Opcodes.ACONST_NULL);
                 mv.visitVarInsn(Opcodes.ASTORE, i);


### PR DESCRIPTION
## Summary

This PR includes several fixes to eval error handling and resolves a critical VerifyError that affected Image::ExifTool:

- **Fix 5 eval.t tests**: Corrected error message formatting and warn() output to match Perl 5 behavior
- **Improve eval error handling**: Enhanced support for `$SIG{__DIE__}` handlers in both eval BLOCK and eval STRING contexts
- **Fix nested eval exception handling**: Properly handle `$SIG{__DIE__}` in nested eval contexts with correct propagation behavior
- **Fix VerifyError in ExifTool**: Restored minimum 128-slot baseline for temporary variable pre-initialization, resolving "Bad local variable type" errors

The VerifyError fix addresses a regression from commit 6b6709c8 where removing the min-128 baseline caused TempLocalCountVisitor's underestimation to leave slots uninitialized, triggering JVM verification failures in complex code like ExifTool.

## Test plan

- [x] All unit tests pass (`make`)
- [x] eval.t tests now pass (previously 5 failures)
- [x] Image::ExifTool no longer triggers VerifyError
- [x] Nested eval with `$SIG{__DIE__}` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)