### PR TITLE
Fix: Use 4-byte offsets for EVAL_TRY to support large code

### DIFF
--- a/src/main/java/org/perlonjava/interpreter/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/interpreter/BytecodeInterpreter.java
@@ -1167,13 +1167,11 @@ public class BytecodeInterpreter {
 
                     case Opcodes.EVAL_TRY: {
                         // Start of eval block with exception handling
-                        // Format: [EVAL_TRY] [catch_offset_high] [catch_offset_low]
+                        // Format: [EVAL_TRY] [catch_target_high] [catch_target_low]
+                        // catch_target is absolute bytecode address (4 bytes)
 
-                        int catchOffsetHigh = bytecode[pc++];
-                        int catchOffsetLow = bytecode[pc++];
-                        int catchOffset = (catchOffsetHigh << 8) | catchOffsetLow;
-                        int tryStartPc = pc - 3; // PC where EVAL_TRY opcode is
-                        int catchPc = tryStartPc + catchOffset;
+                        int catchPc = readInt(bytecode, pc);  // Read 4-byte absolute address
+                        pc += 2;  // Skip the 2 shorts we just read
 
                         // Push catch PC onto eval stack
                         evalCatchStack.push(catchPc);

--- a/src/main/java/org/perlonjava/interpreter/InterpretedCode.java
+++ b/src/main/java/org/perlonjava/interpreter/InterpretedCode.java
@@ -451,11 +451,10 @@ public class InterpretedCode extends RuntimeCode {
                     sb.append("WARN r").append(rs).append("\n");
                     break;
                 case Opcodes.EVAL_TRY: {
-                    int catchOffsetHigh = bytecode[pc++];
-                    int catchOffsetLow = bytecode[pc++];
-                    int catchOffset = (catchOffsetHigh << 8) | catchOffsetLow;
-                    int tryPc = pc - 3;
-                    int catchPc = tryPc + catchOffset;
+                    // Read 4-byte absolute catch target
+                    int high = bytecode[pc++] & 0xFFFF;
+                    int low = bytecode[pc++] & 0xFFFF;
+                    int catchPc = (high << 16) | low;
                     sb.append("EVAL_TRY catch_at=").append(catchPc).append("\n");
                     break;
                 }


### PR DESCRIPTION
## Summary

Changes EVAL_TRY catch offset from 2 bytes to 4 bytes to support bytecode larger than 32KB. This brings EVAL_TRY in line with all other control flow opcodes (GOTO, GOTO_IF_FALSE, FOREACH_NEXT_OR_EXIT, etc.)

## Problem

The original implementation had **3 bugs**:

1. **Compiler** (BytecodeCompiler.java): Emitted 2 shorts but only patched the first one
2. **Interpreter** (BytecodeInterpreter.java): Combined shorts with 8-bit shift `(high << 8) | low` instead of 16-bit shift
3. **GOTO patching**: Same issue - only patched first short

This limited eval blocks to 32KB of bytecode (16-bit offset).

## Solution

Changed EVAL_TRY to use **4-byte absolute addresses** like all other control flow:

- **BytecodeCompiler.java**: Use `emitInt()` and `patchIntOffset()` for proper 4-byte patching
- **BytecodeInterpreter.java**: Use `readInt()` helper (correct 16-bit shift)  
- **InterpretedCode.java**: Fix disassembler to use 16-bit shift `(high << 16) | low`

## Impact

- ✅ All control flow opcodes now support bytecode up to ~2GB
- ✅ All existing tests pass
- ✅ Large code file (412KB) tested and works
- ✅ Code simplified (-9 lines)

## Test Plan

```bash
make dev           # Clean build
make test-unit     # All tests pass
./jperl --interpreter --disassemble -c src/test/resources/unit/code_too_large.t  # 412KB file works
```

🤖 Generated with Claude Code