### PR TITLE
fix: create blib/arch in generated Makefile for -Mblib compatibility

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "c065e5f5f";
+    public static final String gitCommitId = "8459cabfb";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr  9 2026 21:31:23";
+    public static final String buildTimestamp = "Apr  9 2026 22:21:34";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/perl/lib/ExtUtils/MakeMaker.pm
+++ b/src/main/perl/lib/ExtUtils/MakeMaker.pm
@@ -579,7 +579,9 @@ pm_to_blib:
 $install_cmds_str
 
 # Copy to blib/lib for test compatibility (make test uses PERL5LIB=./blib/lib)
+# Also create blib/arch so that "use blib" / "-Mblib" works (blib.pm requires both)
 pure_all:
+\t\@mkdir -p blib/arch
 $blib_cmds_str
 
 # Process PL_FILES


### PR DESCRIPTION
## Summary

- The generated Makefile's `pure_all` target only created `blib/lib/` but not `blib/arch/`
- The `blib.pm` pragma requires all three directories (`blib/`, `blib/lib/`, `blib/arch/`) to exist
- Without `blib/arch/`, `use blib` / `-Mblib` dies with `Cannot find blib even in ...`
- This caused CPAN module test suites (e.g. HTTP::Thin's `t/00-compile.t`) to fail when they use `open3($^X, '-Mblib', ...)` to verify modules load cleanly

### Fix

Add `mkdir -p blib/arch` to the `pure_all` target in the generated Makefile so the directory always exists alongside `blib/lib`.

#### Test plan

- [x] `make` passes (all unit tests green)
- [x] `./jcpan -t HTTP::Thin` now passes (`t/00-compile.t .. ok`)

Generated with [Devin](https://cli.devin.ai/docs)