### PR TITLE
fix: make DynaLoader::bootstrap delegate to XSLoader::load fallback chain

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "7f674c424";
+    public static final String gitCommitId = "63c473e40";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 12 2026 19:31:33";
+    public static final String buildTimestamp = "Apr 12 2026 20:39:23";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/DynaLoader.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/DynaLoader.java
@@ -37,11 +37,16 @@ public class DynaLoader extends PerlModuleBase {
             ).getList();
         }
 
-        String module = args.getFirst().toString();
-        return WarnDie.die(
-                new RuntimeScalar("Can't load module " + module),
-                new RuntimeScalar("\n")
-        ).getList();
+        // Delegate to XSLoader::load() which has a multi-stage fallback:
+        //   1. Java XS class found       → initialize and return true
+        //   2. @ISA has functional parent → return true (inheritance fallback)
+        //   3. ::PP companion loaded      → return true
+        //   4. die with "Can't load loadable object..." (matches /loadable object/
+        //      pattern that CPAN modules use to detect XS failure and fall back)
+        //
+        // This makes DynaLoader-based modules (Image::Magick, Tk, etc.)
+        // behave the same as XSLoader-based modules in PerlOnJava.
+        return XSLoader.load(args, ctx);
     }
 
     public static RuntimeList boot_DynaLoader(RuntimeArray args, int ctx) {

--- a/src/main/perl/lib/DynaLoader.pm
+++ b/src/main/perl/lib/DynaLoader.pm
@@ -21,7 +21,9 @@ BEGIN {
         *bootstrap = sub {
             my ($module) = @_;
             $module = caller() unless defined $module;
-            die "Can't load module $module\n";
+            # Delegate to XSLoader::load for its multi-stage fallback
+            require XSLoader;
+            return XSLoader::load($module);
         };
     }
 


### PR DESCRIPTION
## Summary

`DynaLoader::bootstrap()` previously always died with `"Can't load module"`, making **all DynaLoader-based XS modules** fail immediately at load time. This prevented modules like Image::Magick, Tk, and others that use `DynaLoader` instead of `XSLoader` from loading at all.

Meanwhile, `XSLoader::load()` already had a sophisticated multi-stage fallback:
1. Java XS class found → initialize and return true
2. `@ISA` has functional parent → return true (inheritance fallback)
3. `::PP` companion loaded → return true
4. die with `"Can't load loadable object..."` (matches `/loadable object/` pattern for CPAN fallback detection)

### Changes

- **DynaLoader.java**: delegate `bootstrap()` to `XSLoader.load()` instead of unconditionally dying
- **DynaLoader.pm**: Perl-side fallback also delegates to `XSLoader::load`
- **ImageMagick.java**: stub Java class with no-op `UNLOAD()` and `constant()` so Image::Magick loads cleanly

### Before / After

| | Before | After |
|---|---|---|
| `use Image::Magick` | Dies: `"Can't load module Image::Magick"` | Succeeds |
| `Image::Magick->new` | N/A (can't load) | Creates object |
| `eval { require Image::Magick }` | Sets `$@`, module unusable | Succeeds, `$@` empty |
| Error message pattern | `"Can't load module"` (non-standard) | `"Can't load loadable object..."` (matches CPAN fallback pattern) |

### Impact

This fix improves CPAN compatibility broadly — any module using `DynaLoader` instead of `XSLoader` now gets the same fallback behavior. The Image::Magick stub specifically enables the module to load and create objects; actual image operations require a future Java backend (e.g., via `javax.imageio`).

#### Test plan

- [x] `make` passes (all unit tests)
- [x] `use Image::Magick` loads without error
- [x] `Image::Magick->new` creates objects
- [x] `eval { require Image::Magick }` works for optional dependency checks
- [x] `jcpan Image::Magick` reports "up to date"
- [x] `jcpan -t Image::Magick` tests run (fail on missing backend, not on load)

Generated with [Devin](https://cli.devin.ai/docs)
