### PR TITLE
docs: add bundled modules links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ PerlOnJava compiles Perl to JVM bytecode — run existing Perl scripts on any pl
 
 - **Single jar distribution** — no installation, no dependencies beyond Java
 - **Full toolchain** — `jperl`, `jperldoc`, `jcpan`, `jprove`
-- **150+ modules included** — [DBI](docs/guides/database-access.md), HTTP::Tiny, JSON, XML::Parser, YAML, Text::CSV, and more
+- **150+ modules included** — [DBI](docs/guides/database-access.md), HTTP::Tiny, JSON, XML::Parser, YAML, Text::CSV, and [more](docs/reference/bundled-modules.md)
 - **Install more with jcpan** — [pure-Perl CPAN modules](docs/guides/using-cpan-modules.md) work out of the box
 - **JDBC database access** — [PostgreSQL, MySQL, SQLite, Oracle](docs/guides/database-access.md) via standard JDBC drivers
 - **Embed in Java apps** — [JSR-223 ScriptEngine](docs/guides/java-integration.md) integration
@@ -38,6 +38,7 @@ make
 | [Quick Start](QUICKSTART.md) | [Java Integration](docs/guides/java-integration.md) | [CLI Options](docs/reference/cli-options.md) |
 | [Docker](docs/getting-started/docker.md) | [Using CPAN Modules](docs/guides/using-cpan-modules.md) | [Architecture](docs/reference/architecture.md) |
 | [One-liners](docs/getting-started/oneliners.md) | [Module Porting](docs/guides/module-porting.md) | [Testing](docs/reference/testing.md) |
+| | | [Bundled Modules](docs/reference/bundled-modules.md) |
 
 **About:** [Why PerlOnJava?](docs/about/why-perlonjava.md) | [Roadmap](docs/about/roadmap.md) | [Changelog](docs/about/changelog.md) | [Support](docs/about/support.md) | [Security](SECURITY.md) | [AI Policy](AI_POLICY.md)
 

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "849185954";
+    public static final String gitCommitId = "7f674c424";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 12 2026 19:01:31";
+    public static final String buildTimestamp = "Apr 12 2026 19:31:33";
 
     // Prevent instantiation
     private Configuration() {


### PR DESCRIPTION
## Summary

- Link "more" in the "150+ modules included" feature bullet to `docs/reference/bundled-modules.md`
- Add a **Bundled Modules** row in the Documentation table under Reference

These make the bundled modules reference page discoverable from the main README.

#### Test plan
- [x] `make` passes
- [x] Links render correctly in markdown preview
