### PR TITLE
fix: scan root-level .pm files alongside lib/ in MakeMaker

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "f006e8c7b";
+    public static final String gitCommitId = "1afee082e";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 13 2026 11:44:38";
+    public static final String buildTimestamp = "Apr 13 2026 13:09:59";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/perl/lib/ExtUtils/MakeMaker.pm
+++ b/src/main/perl/lib/ExtUtils/MakeMaker.pm
@@ -233,14 +233,16 @@ sub _install_pure_perl {
             }, 'blib/lib');
         }
         
-        # Fallback: scan current directory for .pm files (flat layout)
-        # Some CPAN distributions (e.g. Crypt::RC4) have .pm files at the
-        # root level instead of in lib/. Standard MakeMaker handles this via
-        # PMLIBDIRS which defaults to ['lib', $self->{BASEEXT}].
-        # We derive the install subdirectory from the NAME parameter.
-        if (!%pm && $name) {
+        # Scan root-level .pm files and BASEEXT directory.
+        # Standard MakeMaker maps:  ./*.pm => $(INST_LIBDIR)/*.pm
+        # where INST_LIBDIR = INST_LIB/Parent/Path (derived from NAME).
+        # PMLIBDIRS defaults to ['lib', $BASEEXT], so both lib/ (handled
+        # above) and root .pm files / BASEEXT dir are always scanned.
+        # This handles distributions like Math::Base::Convert where the
+        # main .pm lives at the root alongside sub-modules in lib/.
+        if ($name) {
             my @parts = split /::/, $name;
-            my $baseext = pop @parts;  # Remove BASEEXT (e.g. XML::Parser -> Parser)
+            my $baseext = pop @parts;  # BASEEXT (e.g. XML::Parser -> Parser)
             my $parent_dir = @parts ? File::Spec->catdir(@parts) : '';
             
             # Scan flat .pm files in current directory
@@ -251,7 +253,8 @@ sub _install_pure_perl {
                     my $dest_rel = $parent_dir
                         ? File::Spec->catfile($parent_dir, $file)
                         : $file;
-                    $pm{$file} = File::Spec->catfile($INSTALL_BASE, $dest_rel);
+                    $pm{$file} = File::Spec->catfile($INSTALL_BASE, $dest_rel)
+                        unless exists $pm{$file};
                 }
                 closedir($dh);
             }
@@ -266,7 +269,8 @@ sub _install_pure_perl {
                         my $rel = $parent_dir
                             ? File::Spec->catfile($parent_dir, $src)
                             : $src;
-                        $pm{$src} = File::Spec->catfile($INSTALL_BASE, $rel);
+                        $pm{$src} = File::Spec->catfile($INSTALL_BASE, $rel)
+                            unless exists $pm{$src};
                     },
                     no_chdir => 1,
                 }, $baseext);


### PR DESCRIPTION
## Summary

- Fix `ExtUtils::MakeMaker` to scan root-level `.pm` files alongside `lib/`, not just as a fallback when `lib/` is empty
- Matches real MakeMaker's `PMLIBDIRS` behavior where `./*.pm` maps to `$(INST_LIBDIR)/*.pm`
- Fixes CPAN modules with mixed layouts (main `.pm` at root, sub-modules in `lib/`)

### Root Cause

PerlOnJava's `_install_pure_perl` only scanned root-level `.pm` files when `lib/` found nothing (`if (!%pm && $name)`). Distributions like `Math::Base::Convert` have `Convert.pm` at the root and sub-modules under `lib/Math/Base/Convert/`, so the main module was silently dropped during install.

### Test Results

**Math::Base::Convert:**
- Before: 0/20 test programs pass (`Can't locate Math/Base/Convert.pm`)
- After: 15/20 test programs pass (remaining failures are unrelated runtime issues)

#### Test plan

- [x] `make` passes (build + unit tests)
- [x] `jcpan -t Math::Base::Convert` now finds and loads the module

Generated with [Devin](https://cli.devin.ai/docs)
