### PR TITLE
fix: dispatch <> overload on blessed objects instead of warning

### DIFF
--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -663,7 +663,8 @@ The `:encoding()` layer supports all encodings provided by Java's `Charset.forNa
   - ✅ Implemented: `<=>`, `cmp`, `<`, `<=`, `>`, `>=`, `==`, `!=`, `lt`, `le`, `gt`, `ge`, `eq`, `ne`.
   - ✅ Implemented: `qr`.
   - ✅ Implemented: `+=`, `-=`, `*=`, `/=`, `%=`.
-  - ❌ Missing: `++`, `--`, `=`, `<>`.
+  - ✅ Implemented: `<>`.
+  - ❌ Missing: `++`, `--`, `=`.
   - ❌ Missing: `&`, `|`, `^`, `~`, `<<`, `>>`, `&.`, `|.`, `^.`, `~.`, `x`, `.`.
   - ❌ Missing: `**=`, `<<=`, `>>=`, `x=`, `.=`, `&=`, `|=`, `^=`, `&.=`, `|.=`, `^.=`.
   - ❌ Missing: `-X`.

--- a/src/main/java/org/perlonjava/backend/bytecode/OpcodeHandlerExtended.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/OpcodeHandlerExtended.java
@@ -837,8 +837,13 @@ public class OpcodeHandlerExtended {
         RuntimeScalar fh = (RuntimeScalar) registers[fhReg];
         // Diamond operator <> passes a plain string scalar (not a glob/IO).
         // Route to DiamondIO.readline which manages @ARGV / STDIN iteration.
+        // But blessed objects may have <> overload, so route those to Readline.
         if (fh.getRuntimeIO() == null) {
-            registers[rd] = DiamondIO.readline(fh, ctx);
+            if (RuntimeScalarType.blessedId(fh) < 0) {
+                registers[rd] = Readline.readline(fh, ctx);
+            } else {
+                registers[rd] = DiamondIO.readline(fh, ctx);
+            }
         } else {
             registers[rd] = Readline.readline(fh, ctx);
         }

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "7bf93f44f";
+    public static final String gitCommitId = "0d83f6c7e";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 13 2026 14:15:09";
+    public static final String buildTimestamp = "Apr 13 2026 14:49:28";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/operators/Readline.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Readline.java
@@ -20,6 +20,18 @@ public class Readline {
         RuntimeIO fh = fileHandle.getRuntimeIO();
 
         if (fh == null) {
+            // Check for <> overload before warning about unopened filehandle
+            int blessId = RuntimeScalarType.blessedId(fileHandle);
+            if (blessId < 0) {
+                OverloadContext overloadCtx = OverloadContext.prepare(blessId);
+                if (overloadCtx != null) {
+                    RuntimeScalar result = overloadCtx.tryOverload("(<>", new RuntimeArray(fileHandle));
+                    if (result != null) {
+                        return result;
+                    }
+                }
+            }
+
             // Perl warns and returns undef for unopened filehandle, doesn't die
             WarnDie.warn(new RuntimeScalar("readline() on unopened filehandle"), new RuntimeScalar("\n"));
             return ctx == RuntimeContextType.LIST ? new RuntimeList() : scalarUndef;


### PR DESCRIPTION
## Summary

- Fix `<>` overload dispatch on blessed objects in both JVM and bytecode interpreter backends
- When `<$obj>` is used on a blessed object with `use overload '<>' => sub { ... }`, PerlOnJava now correctly invokes the overloaded method instead of warning about an "unopened filehandle"
- `Readline.readline()` now checks for `(<>` overload before falling through to the unopened filehandle warning
- Bytecode interpreter backend (`OpcodeHandlerExtended.executeReadline`) now routes blessed objects to `Readline.readline()` instead of `DiamondIO.readline()`

This unblocks Iterator::Simple which now passes **67/67 tests** (previously 65/67 with 2 `<>` overload failures).

#### Test plan

- [x] `make` passes (all unit tests)
- [x] Manual test: `<$obj>` with overloaded `<>` works in both JVM and interpreter backends
- [x] Iterator::Simple: all 11 test files, 67/67 tests pass

Generated with [Devin](https://cli.devin.ai/docs)
