### PR TITLE
fix: @INC duplication and PERL_USE_UNSAFE_INC support

### DIFF
--- a/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
+++ b/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
@@ -129,8 +129,8 @@ public class PerlLanguageProvider {
         );
 
         if (!globalInitialized) {
-            GlobalContext.initializeGlobals(compilerOptions);
             globalInitialized = true;
+            GlobalContext.initializeGlobals(compilerOptions);
         }
 
         if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("parse code: " + compilerOptions.code);
@@ -306,8 +306,8 @@ public class PerlLanguageProvider {
         );
 
         if (!globalInitialized) {
-            GlobalContext.initializeGlobals(compilerOptions);
             globalInitialized = true;
+            GlobalContext.initializeGlobals(compilerOptions);
         }
 
         if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("Using provided AST");
@@ -600,8 +600,8 @@ public class PerlLanguageProvider {
         );
 
         if (!globalInitialized) {
-            GlobalContext.initializeGlobals(compilerOptions);
             globalInitialized = true;
+            GlobalContext.initializeGlobals(compilerOptions);
         }
 
         // Tokenize

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "c92620f4d";
+    public static final String gitCommitId = "4b2bcf8dd";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 20 2026 15:59:13";
+    public static final String buildTimestamp = "Apr 20 2026 16:15:32";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
@@ -219,6 +219,14 @@ public class GlobalContext {
         }
         inc.add(new RuntimeScalar(JAR_PERLLIB));    // internal src/main/perl/lib (lowest priority)
 
+        // Honor PERL_USE_UNSAFE_INC=1 (required by CPAN.pm / Module::Install-based
+        // Makefile.PL scripts that expect `.` in @INC). Perl 5.26 removed `.` from
+        // @INC by default, but CPAN tooling sets PERL_USE_UNSAFE_INC=1 to restore it.
+        String unsafeInc = env.getOrDefault("PERL_USE_UNSAFE_INC", new RuntimeScalar("")).toString();
+        if (!unsafeInc.isEmpty() && !unsafeInc.equals("0")) {
+            inc.add(new RuntimeScalar("."));
+        }
+
         // Initialize %INC
         GlobalVariable.getGlobalHash("main::INC");
 


### PR DESCRIPTION
## Summary

Fixes two bugs that prevented Module::Install-based `Makefile.PL` scripts (e.g. `Iterator::Simple`) from running under `jcpan`.

### Bug 1: `@INC` was duplicated at startup

```
$ ./jperl -e 'print join("|", @INC), "\n"'
/Users/fglock/.perlonjava/lib|jar:PERL5LIB|/Users/fglock/.perlonjava/lib|jar:PERL5LIB
```

`GlobalContext.initializeGlobals()` was being called re-entrantly. During `Builtin.initialize()` (invoked from inside `initializeGlobals`), an `inheritFrom` → `require` → `doFile` chain re-enters `PerlLanguageProvider.executePerlCode`, which checks `globalInitialized`. Because the flag was only set to `true` *after* `initializeGlobals` returned, the nested call ran the whole `@INC` population a second time.

Fix: set `globalInitialized = true` **before** calling `initializeGlobals`, at all three call sites.

### Bug 2: `PERL_USE_UNSAFE_INC` was ignored

Module::Install's `use inc::Module::Install;` requires `.` in `@INC`. Modern Perl (5.26+) removed `.` from `@INC` by default, so CPAN.pm sets `PERL_USE_UNSAFE_INC=1` when invoking `Makefile.PL`. `jperl` was ignoring this env var, making Module::Install-based distributions uninstallable.

Fix: `GlobalContext.initializeGlobals()` now appends `.` to `@INC` when `PERL_USE_UNSAFE_INC` is set to a truthy value.

### Test plan

- [x] `./jperl -e 'print join("|", @INC), "\n"'` shows no duplicates.
- [x] `PERL_USE_UNSAFE_INC=1 ./jperl -e 'print join("|", @INC), "\n"'` ends with `.`.
- [x] `./jcpan -t Iterator::Simple` — all 67 tests across 11 files pass.
- [x] `make` — all unit tests pass.

Generated with [Devin](https://devin.ai)
