### PR TITLE
fix(Filter::Util::Call): implement method filters and fix block-mode filter_read

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "f8e0a8fc1";
+    public static final String gitCommitId = "ef6eaab61";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 21 2026 11:24:02";
+    public static final String buildTimestamp = "Apr 21 2026 11:56:14";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FilterUtilCall.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FilterUtilCall.java
@@ -179,11 +179,8 @@ public class FilterUtilCall extends PerlModuleBase {
                         block.append(line);
                         bytesRead += line.length();
                         context.currentLine++;
-
-                        // Check if line ends with newline to stop
-                        if (line.endsWith("\n")) {
-                            break;
-                        }
+                        // In block mode, keep reading until we hit blockSize or EOF.
+                        // Do NOT stop on newlines — that's line mode.
                     } else {
                         // Partial line read
                         int remaining = blockSize - bytesRead;
@@ -332,11 +329,43 @@ public class FilterUtilCall extends PerlModuleBase {
                         GlobalVariable.getGlobalVariable("main::_").set("");
                     }
                 } else {
-                    // Method filter: call the filter() method on the object
-                    // String filterMethod = packageName.toString() + "::filter";
-                    // TODO: Implement method filter calling
-                    // For now, just return the original source
-                    return sourceCode;
+                    // Method filter: call the "filter" method on the blessed filter object
+                    // repeatedly until it returns a non-positive status.
+                    String pkg = packageName.toString();
+                    RuntimeScalar method = org.perlonjava.runtime.mro.InheritanceResolver
+                            .findMethodInHierarchy("filter", pkg, null, 0);
+                    if (method == null || method.type != org.perlonjava.runtime.runtimetypes.RuntimeScalarType.CODE) {
+                        if (debug) {
+                            System.err.println("[FILTER] No filter() method found in " + pkg
+                                    + "; returning source unchanged");
+                        }
+                        return sourceCode;
+                    }
+                    RuntimeCode code = (RuntimeCode) method.value;
+                    boolean continueFiltering = true;
+                    while (continueFiltering) {
+                        // Call $obj->filter  (pass $self as first arg)
+                        RuntimeArray callArgs = new RuntimeArray();
+                        callArgs.push(filterObj);
+                        RuntimeBase result = code.apply(callArgs, RuntimeContextType.SCALAR);
+
+                        String chunk = GlobalVariable.getGlobalVariable("main::_").toString();
+                        if (!chunk.isEmpty()) {
+                            filteredCode.append(chunk);
+                            if (debug) {
+                                System.err.println("[FILTER] Method filter chunk: " + chunk);
+                            }
+                        }
+
+                        int status = result.scalar().getInt();
+                        if (debug) {
+                            System.err.println("[FILTER] Method filter status: " + status);
+                        }
+                        if (status <= 0) {
+                            continueFiltering = false;
+                        }
+                        GlobalVariable.getGlobalVariable("main::_").set("");
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

Makes CPAN's `Switch` module (and any other module that uses method-style source filters via `Filter::Util::Call`) work on PerlOnJava.

`./jcpan -t Switch` before: all 3 test files fail with `syntax error ... near ""` (0/3).
`./jcpan -t Switch` after: `Files=3, Tests=590, Result: PASS`.

## Root cause

`Switch.pm` is a source filter. In its `import()` it calls `filter_add({})` (a hashref), which Filter::Util::Call blesses into the caller's package — a **method filter**. Its `filter()` method does `filter_read(1_000_000)` to slurp the whole source, then rewrites `switch`/`case` blocks via `Text::Balanced`.

Two bugs in `FilterUtilCall.java` broke this:

1. **Method filters were unimplemented.** `applyFilters()` had an explicit `// TODO: Implement method filter calling` branch that just returned the source unchanged, so `switch (...) { case ... }` was passed verbatim to the parser.
2. **`filter_read($blocksize)` was broken in block mode.** The read loop broke out on the first `"\n"`, turning block reads into line reads. `Switch::filter` asked for 1,000,000 bytes but got only `"\n"` then `"switch (1) {\n"`, so `Text::Balanced::_match_codeblock` failed with `Bad switch statement (problem in the code block?)`.

## Fix

In `src/main/java/org/perlonjava/runtime/perlmodule/FilterUtilCall.java`:

- **Method-filter support:** resolve `${pkg}::filter` via `InheritanceResolver.findMethodInHierarchy`, call it with the blessed filter object as `$self`, accumulate `$_`, and loop until status ≤ 0 — matching the closure-filter loop that was already there.
- **Block-mode fix:** remove the erroneous `if (line.endsWith("\n")) break;` so `filter_read($n)` reads up to `$n` bytes instead of up to one line.

## Test plan

- [x] `make` — BUILD SUCCESSFUL, all unit tests pass, no regressions
- [x] `./jcpan -t Switch` — `Files=3, Tests=590, Result: PASS`
  - `t/given.t` — 293/293
  - `t/nested.t` — 4/4
  - `t/switch.t` — 293/293

Generated with [Devin](https://cli.devin.ai/docs)
