### PR TITLE
fix(Scalar-List-Utils): bump bundled modules to v1.70; fix pair*, uniq, get-magic

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "ef6eaab61";
+    public static final String gitCommitId = "250de1e53";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 21 2026 11:56:14";
+    public static final String buildTimestamp = "Apr 21 2026 12:45:08";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/ListUtil.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/ListUtil.java
@@ -2,6 +2,7 @@ package org.perlonjava.runtime.perlmodule;
 
 import org.perlonjava.runtime.operators.ListOperators;
 import org.perlonjava.runtime.runtimetypes.*;
+import org.perlonjava.runtime.runtimetypes.PerlCompilerException;
 
 import java.util.*;
 
@@ -36,7 +37,7 @@ public class ListUtil extends PerlModuleBase {
     public static void initialize() {
         ListUtil listUtil = new ListUtil();
         // Set $VERSION so CPAN.pm can detect our bundled version
-        GlobalVariable.getGlobalVariable("List::Util::VERSION").set(new RuntimeScalar("1.63"));
+        GlobalVariable.getGlobalVariable("List::Util::VERSION").set(new RuntimeScalar("1.70"));
         try {
             // List reduction functions
             listUtil.registerMethod("reduce", "reduce", "&@");
@@ -101,6 +102,62 @@ public class ListUtil extends PerlModuleBase {
     }
 
     /**
+     * Validates that a scalar is a CODE reference pointing to a defined
+     * subroutine. Used by reduce/first/any/all/none/notall and pair* functions
+     * to produce error messages matching Perl 5's List::Util XS behaviour:
+     *   "Not a subroutine reference"
+     *   "Undefined subroutine in &lt;funcName&gt;"
+     */
+    /**
+     * Check whether a thrown exception represents an "Undefined subroutine ..."
+     * error, possibly wrapped by ListOperators in a plain RuntimeException.
+     */
+    private static boolean isUndefinedSubError(Throwable e) {
+        while (e != null) {
+            String msg = e.getMessage();
+            if (msg != null && msg.startsWith("Undefined subroutine ")) {
+                return true;
+            }
+            if (e.getCause() == e) break;
+            e = e.getCause();
+        }
+        return false;
+    }
+
+    private static void validateCodeRef(RuntimeScalar codeRef, String funcName) {
+        RuntimeScalar deref = codeRef;
+        if (deref != null && deref.type == RuntimeScalarType.READONLY_SCALAR) {
+            deref = (RuntimeScalar) deref.value;
+        }
+        if (deref == null || deref.type != RuntimeScalarType.CODE
+                || !(deref.value instanceof RuntimeCode)) {
+            throw new PerlCompilerException("Not a subroutine reference");
+        }
+        RuntimeCode code = (RuntimeCode) deref.value;
+        if (!code.getDefinedBoolean()) {
+            throw new PerlCompilerException("Undefined subroutine in " + funcName);
+        }
+    }
+
+    /**
+     * Invokes the code block, translating "Undefined subroutine ... called"
+     * errors thrown from stub subs into the List::Util-specific
+     * "Undefined subroutine in &lt;funcName&gt;" message.
+     */
+    private static RuntimeList applyBlock(RuntimeScalar codeRef, RuntimeArray filterArgs,
+                                          int callContext, String funcName) {
+        try {
+            return RuntimeCode.apply(codeRef, filterArgs, callContext);
+        } catch (PerlCompilerException e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.startsWith("Undefined subroutine ")) {
+                throw new PerlCompilerException("Undefined subroutine in " + funcName);
+            }
+            throw e;
+        }
+    }
+
+    /**
      * Gets the package name from a code ref for $a/$b variable resolution.
      * In Perl 5, reduce/pairmap/etc. use $a and $b in the caller's package,
      * not main::. The code ref carries the package it was compiled in.
@@ -127,11 +184,11 @@ public class ListUtil extends PerlModuleBase {
      * Reduces a list by calling a block multiple times.
      */
     public static RuntimeList reduce(RuntimeArray args, int ctx) {
-        if (args.size() < 2) {
+        if (args.size() < 1) {
             return scalarUndef.getList();
         }
-
         RuntimeScalar codeRef = args.get(0);
+        validateCodeRef(codeRef, "reduce");
         RuntimeList values = createSubList(args, 1);
 
         if (values.size() == 0) {
@@ -158,7 +215,7 @@ public class ListUtil extends PerlModuleBase {
                 varA.set(accumulator);
                 varB.set(values.elements.get(i).scalar());
 
-                RuntimeList result = RuntimeCode.apply(codeRef, filterArgs, RuntimeContextType.SCALAR);
+                RuntimeList result = applyBlock(codeRef, filterArgs, RuntimeContextType.SCALAR, "reduce");
                 accumulator = result.getFirst();
             }
 
@@ -178,11 +235,11 @@ public class ListUtil extends PerlModuleBase {
      * Similar to reduce but returns intermediate values.
      */
     public static RuntimeList reductions(RuntimeArray args, int ctx) {
-        if (args.size() < 2) {
+        if (args.size() < 1) {
             return new RuntimeList();
         }
-
         RuntimeScalar codeRef = args.get(0);
+        validateCodeRef(codeRef, "reductions");
         RuntimeList values = createSubList(args, 1);
         RuntimeArray results = new RuntimeArray();
 
@@ -208,7 +265,7 @@ public class ListUtil extends PerlModuleBase {
                 varA.set(accumulator);
                 varB.set(values.elements.get(i).scalar());
 
-                RuntimeList result = RuntimeCode.apply(codeRef, filterArgs, RuntimeContextType.SCALAR);
+                RuntimeList result = applyBlock(codeRef, filterArgs, RuntimeContextType.SCALAR, "reductions");
                 accumulator = result.getFirst();
                 results.push(accumulator.clone());
             }
@@ -224,37 +281,61 @@ public class ListUtil extends PerlModuleBase {
      * Returns true if any element makes the block return true.
      */
     public static RuntimeList any(RuntimeArray args, int ctx) {
-        if (args.size() < 2) {
+        if (args.size() < 1) {
             return scalarFalse.getList();
         }
-
         RuntimeScalar codeRef = args.get(0);
+        validateCodeRef(codeRef, "any");
         RuntimeList values = createSubList(args, 1);
-
-        // Pass the caller's @_ so $-[0], $_[1] etc. are accessible in the block
-        return ListOperators.any(values, codeRef, getCallerArgs(), ctx);
+        try {
+            return ListOperators.any(values, codeRef, getCallerArgs(), ctx);
+        } catch (RuntimeException e) {
+            if (isUndefinedSubError(e)) {
+                throw new PerlCompilerException("Undefined subroutine in any");
+            }
+            throw e;
+        }
     }
 
     /**
      * Returns true if all elements make the block return true.
      */
     public static RuntimeList all(RuntimeArray args, int ctx) {
-        if (args.size() < 2) {
+        if (args.size() < 1) {
             return scalarTrue.getList();
         }
-
         RuntimeScalar codeRef = args.get(0);
+        validateCodeRef(codeRef, "all");
         RuntimeList values = createSubList(args, 1);
-
-        // Pass the caller's @_ so $_[0], $_[1] etc. are accessible in the block
-        return ListOperators.all(values, codeRef, getCallerArgs(), ctx);
+        try {
+            return ListOperators.all(values, codeRef, getCallerArgs(), ctx);
+        } catch (RuntimeException e) {
+            if (isUndefinedSubError(e)) {
+                throw new PerlCompilerException("Undefined subroutine in all");
+            }
+            throw e;
+        }
     }
 
     /**
      * Returns true if no elements make the block return true.
      */
     public static RuntimeList none(RuntimeArray args, int ctx) {
-        RuntimeList result = any(args, ctx);
+        if (args.size() < 1) {
+            return scalarTrue.getList();
+        }
+        RuntimeScalar codeRef = args.get(0);
+        validateCodeRef(codeRef, "none");
+        RuntimeList values = createSubList(args, 1);
+        RuntimeList result;
+        try {
+            result = ListOperators.any(values, codeRef, getCallerArgs(), ctx);
+        } catch (RuntimeException e) {
+            if (isUndefinedSubError(e)) {
+                throw new PerlCompilerException("Undefined subroutine in none");
+            }
+            throw e;
+        }
         return result.getFirst().getBoolean() ? scalarFalse.getList() : scalarTrue.getList();
     }
 
@@ -262,7 +343,21 @@ public class ListUtil extends PerlModuleBase {
      * Returns true if not all elements make the block return true.
      */
     public static RuntimeList notall(RuntimeArray args, int ctx) {
-        RuntimeList result = all(args, ctx);
+        if (args.size() < 1) {
+            return scalarFalse.getList();
+        }
+        RuntimeScalar codeRef = args.get(0);
+        validateCodeRef(codeRef, "notall");
+        RuntimeList values = createSubList(args, 1);
+        RuntimeList result;
+        try {
+            result = ListOperators.all(values, codeRef, getCallerArgs(), ctx);
+        } catch (RuntimeException e) {
+            if (isUndefinedSubError(e)) {
+                throw new PerlCompilerException("Undefined subroutine in notall");
+            }
+            throw e;
+        }
         return result.getFirst().getBoolean() ? scalarFalse.getList() : scalarTrue.getList();
     }
 
@@ -270,11 +365,11 @@ public class ListUtil extends PerlModuleBase {
      * Returns the first element where the block returns true.
      */
     public static RuntimeList first(RuntimeArray args, int ctx) {
-        if (args.size() < 2) {
+        if (args.size() < 1) {
             return scalarUndef.getList();
         }
-
         RuntimeScalar codeRef = args.get(0);
+        validateCodeRef(codeRef, "first");
         RuntimeList values = createSubList(args, 1);
         RuntimeScalar saveValue = getGlobalVariable("main::_");
 
@@ -287,7 +382,7 @@ public class ListUtil extends PerlModuleBase {
                 RuntimeScalar scalar = element.scalar();
                 GlobalVariable.aliasGlobalVariable("main::_", scalar);
 
-                RuntimeList result = RuntimeCode.apply(codeRef, filterArgs, RuntimeContextType.SCALAR);
+                RuntimeList result = applyBlock(codeRef, filterArgs, RuntimeContextType.SCALAR, "first");
                 if (result.getFirst().getBoolean()) {
                     return scalar.getList();
                 }
@@ -453,21 +548,48 @@ public class ListUtil extends PerlModuleBase {
     }
 
     /**
-     * Remove duplicate values using string comparison.
+     * Remove duplicate values. The undef value is distinct from the empty
+     * string; multiple undefs are treated as duplicates of each other.
      */
     public static RuntimeList uniq(RuntimeArray args, int ctx) {
-        return uniqstr(args, ctx);
+        Set<String> seen = new LinkedHashSet<>();
+        boolean seenUndef = false;
+        RuntimeArray result = new RuntimeArray();
+        for (RuntimeScalar arg : args.elements) {
+            if (arg == null || arg.type == RuntimeScalarType.UNDEF) {
+                if (!seenUndef) {
+                    seenUndef = true;
+                    result.push(new RuntimeScalar());
+                }
+            } else {
+                String value = arg.toString();
+                if (seen.add(value)) {
+                    result.push(arg);
+                }
+            }
+        }
+        return ctx == RuntimeContextType.SCALAR ?
+                new RuntimeScalar(result.size()).getList() : result.getList();
     }
 
     /**
-     * Remove duplicate values using integer comparison.
+     * Remove duplicate values using integer comparison. Coerces undef to 0
+     * (with uninitialized-value warning) and returns integers.
      */
     public static RuntimeList uniqint(RuntimeArray args, int ctx) {
         Set<Long> seen = new LinkedHashSet<>();
         RuntimeArray result = new RuntimeArray();
 
         for (RuntimeScalar arg : args.elements) {
-            Long value = arg.getLong();
+            long value;
+            if (arg == null || arg.type == RuntimeScalarType.UNDEF) {
+                org.perlonjava.runtime.operators.WarnDie.warnWithCategory(
+                    new RuntimeScalar("Use of uninitialized value in subroutine entry"),
+                    RuntimeScalarCache.scalarEmptyString, "uninitialized");
+                value = 0L;
+            } else {
+                value = arg.getLong();
+            }
             if (seen.add(value)) {
                 result.push(new RuntimeScalar(value));
             }
@@ -478,14 +600,22 @@ public class ListUtil extends PerlModuleBase {
     }
 
     /**
-     * Remove duplicate values using numerical comparison.
+     * Remove duplicate values using numerical comparison. Warns on undef.
      */
     public static RuntimeList uniqnum(RuntimeArray args, int ctx) {
         Set<Double> seen = new LinkedHashSet<>();
         RuntimeArray result = new RuntimeArray();
 
         for (RuntimeScalar arg : args.elements) {
-            Double value = arg.getDouble();
+            double value;
+            if (arg == null || arg.type == RuntimeScalarType.UNDEF) {
+                org.perlonjava.runtime.operators.WarnDie.warnWithCategory(
+                    new RuntimeScalar("Use of uninitialized value in subroutine entry"),
+                    RuntimeScalarCache.scalarEmptyString, "uninitialized");
+                value = 0.0;
+            } else {
+                value = arg.getDouble();
+            }
             if (seen.add(value)) {
                 result.push(new RuntimeScalar(value));
             }
@@ -496,14 +626,23 @@ public class ListUtil extends PerlModuleBase {
     }
 
     /**
-     * Remove duplicate values using string comparison.
+     * Remove duplicate values using string comparison. Warns on undef
+     * (coerces undef to empty string for comparison).
      */
     public static RuntimeList uniqstr(RuntimeArray args, int ctx) {
         Set<String> seen = new LinkedHashSet<>();
         RuntimeArray result = new RuntimeArray();
 
         for (RuntimeScalar arg : args.elements) {
-            String value = arg.toString();
+            String value;
+            if (arg == null || arg.type == RuntimeScalarType.UNDEF) {
+                org.perlonjava.runtime.operators.WarnDie.warnWithCategory(
+                    new RuntimeScalar("Use of uninitialized value in subroutine entry"),
+                    RuntimeScalarCache.scalarEmptyString, "uninitialized");
+                value = "";
+            } else {
+                value = arg.toString();
+            }
             if (seen.add(value)) {
                 result.push(new RuntimeScalar(value));
             }
@@ -517,8 +656,8 @@ public class ListUtil extends PerlModuleBase {
      * Returns the first elements from a list.
      */
     public static RuntimeList head(RuntimeArray args, int ctx) {
-        if (args.size() < 2) {
-            return new RuntimeList();
+        if (args.isEmpty()) {
+            throw new PerlCompilerException("Not enough arguments for List::Util::head");
         }
 
         int size = args.get(0).getInt();
@@ -540,8 +679,8 @@ public class ListUtil extends PerlModuleBase {
      * Returns the last elements from a list.
      */
     public static RuntimeList tail(RuntimeArray args, int ctx) {
-        if (args.size() < 2) {
-            return new RuntimeList();
+        if (args.isEmpty()) {
+            throw new PerlCompilerException("Not enough arguments for List::Util::tail");
         }
 
         int size = args.get(0).getInt();
@@ -565,9 +704,12 @@ public class ListUtil extends PerlModuleBase {
 
     /**
      * Returns a list of array references from pairs.
+     * Since List::Util 1.39, pairs are blessed into List::Util::_Pair so
+     * they provide ->key / ->value / ->TO_JSON methods.
      */
     public static RuntimeList pairs(RuntimeArray args, int ctx) {
         RuntimeArray result = new RuntimeArray();
+        RuntimeScalar pairClass = new RuntimeScalar("List::Util::_Pair");
 
         for (int i = 0; i < args.size(); i += 2) {
             RuntimeArray pair = new RuntimeArray();
@@ -577,7 +719,9 @@ public class ListUtil extends PerlModuleBase {
             } else {
                 pair.push(scalarUndef);
             }
-            result.push(pair.createReference());
+            RuntimeScalar pairRef = pair.createReference();
+            org.perlonjava.runtime.operators.ReferenceOperators.bless(pairRef, pairClass);
+            result.push(pairRef);
         }
 
         return result.getList();
@@ -592,8 +736,10 @@ public class ListUtil extends PerlModuleBase {
         for (RuntimeScalar pairRef : args.elements) {
             if (pairRef.type == RuntimeScalarType.ARRAYREFERENCE) {
                 RuntimeArray pair = (RuntimeArray) pairRef.value;
-                if (pair.size() >= 1) result.push(pair.get(0));
-                if (pair.size() >= 2) result.push(pair.get(1));
+                // Always emit exactly two values (key, value), padding with undef
+                // when the input arrayref has fewer than two elements.
+                result.push(pair.size() >= 1 ? pair.get(0) : scalarUndef);
+                result.push(pair.size() >= 2 ? pair.get(1) : scalarUndef);
             }
         }
 
@@ -627,39 +773,49 @@ public class ListUtil extends PerlModuleBase {
     }
 
     /**
-     * Maps over pairs with a block.
+     * Maps over pairs with a block. Aliases $a and $b in the caller's
+     * package to the source elements (matching Perl 5 XS semantics).
      */
     public static RuntimeList pairmap(RuntimeArray args, int ctx) {
-        if (args.size() < 2) {
+        if (args.size() < 1) {
             return new RuntimeList();
         }
-
         RuntimeScalar codeRef = args.get(0);
+        validateCodeRef(codeRef, "pairmap");
         RuntimeList kvlist = createSubList(args, 1);
 
         String callerPkg = getCodeRefPackage(codeRef);
-        RuntimeScalar varA = getGlobalVariable(callerPkg + "::a");
-        RuntimeScalar varB = getGlobalVariable(callerPkg + "::b");
-        RuntimeScalar saveA = varA.clone();
-        RuntimeScalar saveB = varB.clone();
+        String aName = callerPkg + "::a";
+        String bName = callerPkg + "::b";
+        RuntimeScalar saveA = getGlobalVariable(aName);
+        RuntimeScalar saveB = getGlobalVariable(bName);
+
+        // Warn on odd-sized list (matches Perl 5 behaviour)
+        if ((kvlist.size() & 1) == 1) {
+            org.perlonjava.runtime.operators.WarnDie.warn(
+                new RuntimeScalar("Odd number of elements in pairmap at "),
+                scalarUndef);
+        }
 
         RuntimeArray result = new RuntimeArray();
 
         try {
-            // Get caller's @_ so $_[0], $_[1] etc. are accessible in the block
             RuntimeArray outerArgs = getCallerArgs();
             RuntimeArray filterArgs = outerArgs != null ? outerArgs : new RuntimeArray();
-            
-            for (int i = 0; i < kvlist.size(); i += 2) {
-                varA.set(kvlist.elements.get(i).scalar());
-                varB.set(i + 1 < kvlist.size() ? kvlist.elements.get(i + 1).scalar() : scalarUndef);
 
-                RuntimeList blockResult = RuntimeCode.apply(codeRef, filterArgs, RuntimeContextType.LIST);
+            for (int i = 0; i < kvlist.size(); i += 2) {
+                GlobalVariable.aliasGlobalVariable(aName, kvlist.elements.get(i).scalar());
+                RuntimeScalar bVal = i + 1 < kvlist.size()
+                        ? kvlist.elements.get(i + 1).scalar()
+                        : new RuntimeScalar();
+                GlobalVariable.aliasGlobalVariable(bName, bVal);
+
+                RuntimeList blockResult = applyBlock(codeRef, filterArgs, RuntimeContextType.LIST, "pairmap");
                 blockResult.addToArray(result);
             }
         } finally {
-            varA.set(saveA);
-            varB.set(saveB);
+            GlobalVariable.aliasGlobalVariable(aName, saveA);
+            GlobalVariable.aliasGlobalVariable(bName, saveB);
         }
 
         return ctx == RuntimeContextType.SCALAR ?
@@ -667,48 +823,53 @@ public class ListUtil extends PerlModuleBase {
     }
 
     /**
-     * Filters pairs with a block.
+     * Filters pairs with a block. Aliases $a and $b to the source elements.
      */
     public static RuntimeList pairgrep(RuntimeArray args, int ctx) {
-        if (args.size() < 2) {
+        if (args.size() < 1) {
             return new RuntimeList();
         }
-
         RuntimeScalar codeRef = args.get(0);
+        validateCodeRef(codeRef, "pairgrep");
         RuntimeList kvlist = createSubList(args, 1);
 
         String callerPkg = getCodeRefPackage(codeRef);
-        RuntimeScalar varA = getGlobalVariable(callerPkg + "::a");
-        RuntimeScalar varB = getGlobalVariable(callerPkg + "::b");
-        RuntimeScalar saveA = varA.clone();
-        RuntimeScalar saveB = varB.clone();
+        String aName = callerPkg + "::a";
+        String bName = callerPkg + "::b";
+        RuntimeScalar saveA = getGlobalVariable(aName);
+        RuntimeScalar saveB = getGlobalVariable(bName);
+
+        if ((kvlist.size() & 1) == 1) {
+            org.perlonjava.runtime.operators.WarnDie.warn(
+                new RuntimeScalar("Odd number of elements in pairgrep at "),
+                scalarUndef);
+        }
 
         RuntimeArray result = new RuntimeArray();
         int pairs = 0;
 
         try {
-            // Get caller's @_ so $_[0], $_[1] etc. are accessible in the block
             RuntimeArray outerArgs = getCallerArgs();
             RuntimeArray filterArgs = outerArgs != null ? outerArgs : new RuntimeArray();
-            
-            for (int i = 0; i < kvlist.size(); i += 2) {
-                varA.set(kvlist.elements.get(i).scalar());
-                varB.set(i + 1 < kvlist.size() ? kvlist.elements.get(i + 1).scalar() : scalarUndef);
 
-                RuntimeList blockResult = RuntimeCode.apply(codeRef, filterArgs, RuntimeContextType.SCALAR);
+            for (int i = 0; i < kvlist.size(); i += 2) {
+                RuntimeScalar aVal = kvlist.elements.get(i).scalar();
+                RuntimeScalar bVal = i + 1 < kvlist.size()
+                        ? kvlist.elements.get(i + 1).scalar()
+                        : new RuntimeScalar();
+                GlobalVariable.aliasGlobalVariable(aName, aVal);
+                GlobalVariable.aliasGlobalVariable(bName, bVal);
+
+                RuntimeList blockResult = applyBlock(codeRef, filterArgs, RuntimeContextType.SCALAR, "pairgrep");
                 if (blockResult.getFirst().getBoolean()) {
-                    result.push(kvlist.elements.get(i).scalar());
-                    if (i + 1 < kvlist.size()) {
-                        result.push(kvlist.elements.get(i + 1).scalar());
-                    } else {
-                        result.push(scalarUndef);
-                    }
+                    result.push(aVal);
+                    result.push(bVal);
                     pairs++;
                 }
             }
         } finally {
-            varA.set(saveA);
-            varB.set(saveB);
+            GlobalVariable.aliasGlobalVariable(aName, saveA);
+            GlobalVariable.aliasGlobalVariable(bName, saveB);
         }
 
         return ctx == RuntimeContextType.SCALAR ?
@@ -716,50 +877,49 @@ public class ListUtil extends PerlModuleBase {
     }
 
     /**
-     * Returns the first pair where the block returns true.
+     * Returns the first pair where the block returns true. Aliases $a/$b.
      */
     public static RuntimeList pairfirst(RuntimeArray args, int ctx) {
-        if (args.size() < 2) {
+        if (args.size() < 1) {
             return ctx == RuntimeContextType.SCALAR ? scalarFalse.getList() : new RuntimeList();
         }
-
         RuntimeScalar codeRef = args.get(0);
+        validateCodeRef(codeRef, "pairfirst");
         RuntimeList kvlist = createSubList(args, 1);
 
         String callerPkg = getCodeRefPackage(codeRef);
-        RuntimeScalar varA = getGlobalVariable(callerPkg + "::a");
-        RuntimeScalar varB = getGlobalVariable(callerPkg + "::b");
-        RuntimeScalar saveA = varA.clone();
-        RuntimeScalar saveB = varB.clone();
+        String aName = callerPkg + "::a";
+        String bName = callerPkg + "::b";
+        RuntimeScalar saveA = getGlobalVariable(aName);
+        RuntimeScalar saveB = getGlobalVariable(bName);
 
         try {
-            // Get caller's @_ so $_[0], $_[1] etc. are accessible in the block
             RuntimeArray outerArgs = getCallerArgs();
             RuntimeArray filterArgs = outerArgs != null ? outerArgs : new RuntimeArray();
-            
-            for (int i = 0; i < kvlist.size(); i += 2) {
-                varA.set(kvlist.elements.get(i).scalar());
-                varB.set(i + 1 < kvlist.size() ? kvlist.elements.get(i + 1).scalar() : scalarUndef);
 
-                RuntimeList blockResult = RuntimeCode.apply(codeRef, filterArgs, RuntimeContextType.SCALAR);
+            for (int i = 0; i < kvlist.size(); i += 2) {
+                RuntimeScalar aVal = kvlist.elements.get(i).scalar();
+                RuntimeScalar bVal = i + 1 < kvlist.size()
+                        ? kvlist.elements.get(i + 1).scalar()
+                        : new RuntimeScalar();
+                GlobalVariable.aliasGlobalVariable(aName, aVal);
+                GlobalVariable.aliasGlobalVariable(bName, bVal);
+
+                RuntimeList blockResult = applyBlock(codeRef, filterArgs, RuntimeContextType.SCALAR, "pairfirst");
                 if (blockResult.getFirst().getBoolean()) {
                     if (ctx == RuntimeContextType.SCALAR) {
                         return scalarTrue.getList();
                     } else {
                         RuntimeArray result = new RuntimeArray();
-                        result.push(kvlist.elements.get(i).scalar());
-                        if (i + 1 < kvlist.size()) {
-                            result.push(kvlist.elements.get(i + 1).scalar());
-                        } else {
-                            result.push(scalarUndef);
-                        }
+                        result.push(aVal);
+                        result.push(bVal);
                         return result.getList();
                     }
                 }
             }
         } finally {
-            varA.set(saveA);
-            varB.set(saveB);
+            GlobalVariable.aliasGlobalVariable(aName, saveA);
+            GlobalVariable.aliasGlobalVariable(bName, saveB);
         }
 
         return ctx == RuntimeContextType.SCALAR ? scalarFalse.getList() : new RuntimeList();

--- a/src/main/java/org/perlonjava/runtime/perlmodule/ScalarUtil.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/ScalarUtil.java
@@ -27,7 +27,7 @@ public class ScalarUtil extends PerlModuleBase {
         ScalarUtil scalarUtil = new ScalarUtil();
         scalarUtil.initializeExporter(); // Use the base class method to initialize the exporter
         // Set $VERSION so CPAN.pm can detect our bundled version
-        GlobalVariable.getGlobalVariable("Scalar::Util::VERSION").set(new RuntimeScalar("1.63"));
+        GlobalVariable.getGlobalVariable("Scalar::Util::VERSION").set(new RuntimeScalar("1.70"));
         scalarUtil.defineExport("EXPORT_OK", "blessed", "refaddr", "reftype", "weaken", "unweaken", "isweak",
                 "dualvar", "isdual", "isvstring", "looks_like_number", "openhandle", "readonly",
                 "set_prototype", "tainted");
@@ -53,6 +53,21 @@ public class ScalarUtil extends PerlModuleBase {
     }
 
     /**
+     * Triggers FETCH on a tied scalar so that get-magic is fired exactly
+     * once for blessed/reftype/refaddr. Also unwraps READONLY_SCALAR.
+     */
+    private static RuntimeScalar magicallyDeref(RuntimeScalar scalar) {
+        if (scalar == null) return scalar;
+        if (scalar.type == TIED_SCALAR) {
+            scalar = scalar.tiedFetch();
+        }
+        if (scalar != null && scalar.type == READONLY_SCALAR) {
+            scalar = (RuntimeScalar) scalar.value;
+        }
+        return scalar;
+    }
+
+    /**
      * Checks if a scalar is blessed and returns the blessing information.
      *
      * @param args The arguments passed to the method.
@@ -64,8 +79,7 @@ public class ScalarUtil extends PerlModuleBase {
             throw new IllegalStateException("Bad number of arguments for blessed() method");
         }
 
-        RuntimeScalar scalar = args.get(0);
-        if (scalar.type == READONLY_SCALAR) scalar = (RuntimeScalar) scalar.value;
+        RuntimeScalar scalar = magicallyDeref(args.get(0));
         int blessId = blessedId(scalar);
         // Return undef for unblessed references (blessId == 0)
         if (blessId == 0) {
@@ -89,8 +103,7 @@ public class ScalarUtil extends PerlModuleBase {
         if (args.size() != 1) {
             throw new IllegalStateException("Bad number of arguments for refaddr() method");
         }
-        RuntimeScalar scalar = args.get(0);
-        if (scalar.type == READONLY_SCALAR) scalar = (RuntimeScalar) scalar.value;
+        RuntimeScalar scalar = magicallyDeref(args.get(0));
         // refaddr returns undef for non-references
         // For references, return the identity hash code of the underlying referenced object
         switch (scalar.type) {
@@ -121,8 +134,7 @@ public class ScalarUtil extends PerlModuleBase {
         if (args.size() != 1) {
             throw new IllegalStateException("Bad number of arguments for reftype() method");
         }
-        RuntimeScalar scalar = args.get(0);
-        if (scalar.type == READONLY_SCALAR) scalar = (RuntimeScalar) scalar.value;
+        RuntimeScalar scalar = magicallyDeref(args.get(0));
         String type = switch (scalar.type) {
             case REFERENCE -> {
                 // Inspect the referent to distinguish SCALAR refs from REF (ref-to-ref)

--- a/src/main/java/org/perlonjava/runtime/perlmodule/SubUtil.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/SubUtil.java
@@ -24,7 +24,7 @@ public class SubUtil extends PerlModuleBase {
         SubUtil subUtil = new SubUtil();
         subUtil.initializeExporter();
         // Set $VERSION so CPAN.pm can detect our bundled version
-        GlobalVariable.getGlobalVariable("Sub::Util::VERSION").set(new RuntimeScalar("1.63"));
+        GlobalVariable.getGlobalVariable("Sub::Util::VERSION").set(new RuntimeScalar("1.70"));
         subUtil.defineExport("EXPORT_OK", "prototype", "set_prototype", "subname", "set_subname");
         try {
             subUtil.registerMethod("prototype", "$");

--- a/src/main/perl/lib/List/Util.pm
+++ b/src/main/perl/lib/List/Util.pm
@@ -1,7 +1,10 @@
 package List::Util;
 use strict;
 use warnings;
-our $VERSION = '1.63';
+
+our $VERSION    = '1.70';
+our $XS_VERSION = $VERSION;
+$VERSION =~ tr/_//d;
 
 require Exporter;
 our @ISA = qw(Exporter);
@@ -15,6 +18,27 @@ our @EXPORT_OK = qw(
 );
 
 use XSLoader;
-XSLoader::load('List::Util', $VERSION);
+XSLoader::load('List::Util', $XS_VERSION);
+
+# Used by shuffle()
+our $RAND;
+
+sub import
+{
+    my $pkg = caller;
+
+    # (RT88848) Touch the caller's $a and $b, to avoid the "Name used only
+    # once: possible typo" warning.
+    no strict 'refs';
+    ${"${pkg}::a"} = ${"${pkg}::a"};
+    ${"${pkg}::b"} = ${"${pkg}::b"};
+
+    goto &Exporter::import;
+}
+
+# For objects returned by pairs()
+sub List::Util::_Pair::key     { shift->[0] }
+sub List::Util::_Pair::value   { shift->[1] }
+sub List::Util::_Pair::TO_JSON { [ @{+shift} ] }
 
 1;

--- a/src/main/perl/lib/Scalar/Util.pm
+++ b/src/main/perl/lib/Scalar/Util.pm
@@ -1,7 +1,7 @@
 package Scalar::Util;
 use strict;
 use warnings;
-our $VERSION = '1.63';
+our $VERSION = '1.70';
 
 use XSLoader;
 XSLoader::load('Scalar::Util', $VERSION);

--- a/src/main/perl/lib/Sub/Util.pm
+++ b/src/main/perl/lib/Sub/Util.pm
@@ -1,7 +1,7 @@
 package Sub::Util;
 use strict;
 use warnings;
-our $VERSION = '1.63';
+our $VERSION = '1.70';
 
 use XSLoader;
 XSLoader::load('Sub::Util', $VERSION);


### PR DESCRIPTION
## Summary

Running `./jcpan -t Scalar::Util` (which tests the CPAN `Scalar-List-Utils-1.70` distribution against the bundled PerlOnJava implementation) went from:

- **25/38** test programs failing, **209/832** subtests failing

to:

- **21/38** test programs failing, **163/842** subtests failing

**−46 subtest failures, 4 whole test programs now pass:** `t/00version.t`, `t/getmagic-once.t`, `t/pair.t`, `t/undefined-block.t`.

## What changed

### Version sync to 1.70
- Bumped `List::Util`, `Scalar::Util`, `Sub::Util` from the 1.63 stubs to **v1.70** (both the `.pm` files and the `$VERSION` strings exposed by the Java implementations).
- `List::Util.pm` now defines:
  - an `import` that touches caller's `$a`/`$b` (RT #88848, silences spurious "Name used only once" warnings);
  - the `List::Util::_Pair` class with `key` / `value` / `TO_JSON` methods.

### ListUtil.java
- Validate code-ref arguments for `reduce` / `reductions` / `first` / `any` / `all` / `none` / `notall` and the `pair*` family:
  - non-CODE args now croak `Not a subroutine reference`;
  - calls into undefined stubs croak `Undefined subroutine in <func>`.
- `pairmap` / `pairgrep` / `pairfirst` now **alias** `$a` and `$b` in the caller's package to the source list elements (matches Perl 5 XS semantics), so modifications inside the block propagate to the caller.
- `pairgrep` / `pairmap` warn on odd-sized input lists (`Odd number of elements in pairmap/pairgrep`).
- `pairs()` blesses returned arrayrefs into `List::Util::_Pair` so `->key`, `->value`, `->TO_JSON` work.
- `unpairs()` pads short input arrayrefs with `undef`.
- `uniq` distinguishes `undef` from the empty string; `uniq` / `uniqstr` / `uniqint` / `uniqnum` now warn on `undef` with the proper uninitialized-value warning.
- `head` / `tail` croak `Not enough arguments for List::Util::head|tail` on empty argument lists.

### ScalarUtil.java
- `blessed` / `reftype` / `refaddr` now trigger `FETCH` on tied scalars exactly once before inspecting the underlying value (fixes `t/getmagic-once.t`).

## Remaining work (not in this PR)

Most of the remaining 163 subtest failures are concentrated in:

- **`t/exotic_names.t` (120 failures):** stash / sub names containing NUL, control characters, or apostrophes. Needs deeper work in `set_subname` + `caller()` to preserve embedded NULs in package/sub names.
- **`t/subname.t` (7):** related to the above.
- **BigInt integration** in `sum` / `product` / `min` (3+3+1): large integers drop to floats because the operators use `double` arithmetic.
- **Misc edge cases:** overload support in `blessed` / `uniqint` / `uniqnum`, tied filehandle recognition in `openhandle`, `DESTROY` tracking in `sample` / `shuffle` / `uniqstr`, taint propagation, weakref edge cases.

#### Test plan
- [x] `make` passes locally (unit tests all green).
- [x] `./jcpan -t Scalar::Util` now reports **Failed 21/38 test programs. 163/842 subtests failed**, down from **25/38 / 209/832**.
- [ ] CI green.

Generated with [Devin](https://cli.devin.ai/docs)
