### PR TITLE
fix(state): share storage key between state init and named-sub capture

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "2cc770db1";
+    public static final String gitCommitId = "6d48b1ad0";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 21 2026 19:57:31";
+    public static final String buildTimestamp = "Apr 21 2026 21:54:08";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -1157,9 +1157,19 @@ public class SubroutineParser {
                             entry.perlPackage());
                 } else {
                     OperatorNode ast = entry.ast();
-                    int beginId = RuntimeCode.evalBeginIds.computeIfAbsent(
-                            ast,
-                            k -> EmitterMethodCreator.classCounter++);
+                    // For state variables, the persistent-variable id is already
+                    // assigned (see OperatorParser "state" handling). Reuse it so
+                    // that the storage key here matches the key used by the state
+                    // initializer / retrieveStateScalar (which also use ast.id).
+                    int beginId;
+                    if ("state".equals(entry.decl()) && ast != null && ast.id != 0) {
+                        beginId = ast.id;
+                        RuntimeCode.evalBeginIds.putIfAbsent(ast, beginId);
+                    } else {
+                        beginId = RuntimeCode.evalBeginIds.computeIfAbsent(
+                                ast,
+                                k -> EmitterMethodCreator.classCounter++);
+                    }
                     variableName = NameNormalizer.normalizeVariableName(
                             entry.name().substring(1),
                             PersistentVariable.beginPackage(beginId));

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/StateVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/StateVariable.java
@@ -117,10 +117,19 @@ public class StateVariable {
             // Retrieve variable in the specific code context.
             RuntimeCode code = (RuntimeCode) codeRef.value;
             RuntimeScalar variable = code.stateVariable.get(beginVar);
-            if (variable == null) {
-                variable = new RuntimeScalar();
-                code.stateVariable.put(beginVar, variable);
+            if (variable != null) {
+                return variable;
             }
+            // Fallback: the state variable may have been declared in an
+            // enclosing scope outside any sub (then stored globally with the
+            // same beginVar key). Check the global storage before allocating
+            // a fresh per-sub entry so that a state var shared between the
+            // enclosing scope and an inner sub refers to the same storage.
+            if (GlobalVariable.existsGlobalVariable(beginVar)) {
+                return GlobalVariable.getGlobalVariable(beginVar);
+            }
+            variable = new RuntimeScalar();
+            code.stateVariable.put(beginVar, variable);
             return variable;
         }
     }
@@ -142,10 +151,16 @@ public class StateVariable {
             // Retrieve array in the specific code context.
             RuntimeCode code = (RuntimeCode) codeRef.value;
             RuntimeArray variable = code.stateArray.get(beginVar);
-            if (variable == null) {
-                variable = new RuntimeArray();
-                code.stateArray.put(beginVar, variable);
+            if (variable != null) {
+                return variable;
             }
+            // Fallback: the state variable may have been declared in an
+            // enclosing scope outside any sub (stored globally).
+            if (GlobalVariable.existsGlobalArray(beginVar)) {
+                return GlobalVariable.getGlobalArray(beginVar);
+            }
+            variable = new RuntimeArray();
+            code.stateArray.put(beginVar, variable);
             return variable;
         }
     }
@@ -167,10 +182,16 @@ public class StateVariable {
             // Retrieve hash in the specific code context.
             RuntimeCode code = (RuntimeCode) codeRef.value;
             RuntimeHash variable = code.stateHash.get(beginVar);
-            if (variable == null) {
-                variable = new RuntimeHash();
-                code.stateHash.put(beginVar, variable);
+            if (variable != null) {
+                return variable;
             }
+            // Fallback: the state variable may have been declared in an
+            // enclosing scope outside any sub (stored globally).
+            if (GlobalVariable.existsGlobalHash(beginVar)) {
+                return GlobalVariable.getGlobalHash(beginVar);
+            }
+            variable = new RuntimeHash();
+            code.stateHash.put(beginVar, variable);
             return variable;
         }
     }


### PR DESCRIPTION
## Summary

Fix a bug where a `state` variable declared in a block at top level (no enclosing sub) and referenced by a named sub defined in the same block was read as undef inside the sub, even after the outer block had initialized it.

Found while investigating `jcpan -t QRCode::Encoder`, which failed across 3 test files because `QRCode::Encoder::QRSpec` uses this pattern heavily:

```perl
{
    state $table = [ ...big data... ];
    sub qrspec_data_size ($version, $level) {
        my $item = $table->[$version - 1];   # $table was undef!
        return $item->{words} - $item->{ec}{$level};
    }
}
```

## Root cause

The persistent-variable key differed between the two sides:

- `state $x = ...` stores the value in global storage under `PersistentVariable.beginVariable(sigilNode.id, name)`, where `sigilNode.id` is assigned by `OperatorParser` for `state` declarations.
- When a named sub captures the same lexical, `SubroutineParser` allocated a *separate* begin id via `RuntimeCode.evalBeginIds.computeIfAbsent(ast, k -> classCounter++)`, producing a different global key. The sub's captured field was thus a fresh empty scalar.

## Fix

1. In the named-sub capture path (`SubroutineParser`), for `state` declarations reuse the existing `ast.id` as the begin id instead of allocating a new one, and register it in `evalBeginIds`.
2. As a safety net, `StateVariable.retrieveStateScalar/Array/Hash` now fall back to global storage when the per-sub map has no entry, so a sub accessing a state var declared in an outer (non-sub) scope still sees the shared storage.

## Test plan

- [x] Minimal repro: `{ state $t = [10]; sub f { $t->[0] } }; print f()` now prints `10`.
- [x] State-per-closure-instance semantics still correct (verified with `make make()` + `state $c = 0; ++$c` — instances still have independent counters).
- [x] `jcpan -t QRCode::Encoder` — all tests pass (t/00-load, t/01-hello, t/02-best, t/03-version-7; also Math::ReedSolomon::Encoder dependency).
- [x] `make` (unit tests) passes.

Generated with [Devin](https://cli.devin.ai/docs)
