### PR TITLE
fix(eval STRING): preserve 'our' decls so caller-side local() is visible

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -141,6 +141,26 @@ public class BytecodeCompiler implements Visitor {
      */
     public BytecodeCompiler(String sourceName, int sourceLine, ErrorMessageUtil errorUtil,
                             Map<String, Integer> parentRegistry) {
+        this(sourceName, sourceLine, errorUtil, parentRegistry, null);
+    }
+
+    /**
+     * Constructor for eval STRING with parent scope variable registry and declaration kinds.
+     * Initializes symbolTable with variables from parent scope, preserving 'our' vs 'my' decls
+     * so that captured 'our' (package) variables are still resolved via GlobalVariable at
+     * runtime instead of being bound to the scalar captured at eval-entry time (which would
+     * make `local $OurVar` in the caller invisible to the eval body).
+     *
+     * @param sourceName     Source name for error messages
+     * @param sourceLine     Source line for error messages
+     * @param errorUtil      Error message utility
+     * @param parentRegistry Variable registry from parent scope (for eval STRING)
+     * @param parentDecls    Optional map of varName -> decl kind ("my"/"our"/"state"). Any name
+     *                       not present defaults to "my".
+     */
+    public BytecodeCompiler(String sourceName, int sourceLine, ErrorMessageUtil errorUtil,
+                            Map<String, Integer> parentRegistry,
+                            Map<String, String> parentDecls) {
         this.sourceName = sourceName;
         this.sourceLine = sourceLine;
         this.errorUtil = errorUtil;
@@ -153,12 +173,17 @@ public class BytecodeCompiler implements Visitor {
         this.isEvalString = true;
 
         if (parentRegistry != null) {
-            // Add parent scope variables to symbolTable (for eval STRING variable capture)
+            // Add parent scope variables to symbolTable (for eval STRING variable capture).
+            // Preserve the outer declaration kind: 'our' stays 'our' so the variable is
+            // resolved through GlobalVariable (visible to caller-side local), while 'my'/'state'
+            // use the captured register slot.
             for (Map.Entry<String, Integer> entry : parentRegistry.entrySet()) {
                 String varName = entry.getKey();
                 int regIndex = entry.getValue();
                 if (regIndex >= 3) {
-                    symbolTable.addVariableWithIndex(varName, regIndex, "my");
+                    String decl = parentDecls != null ? parentDecls.get(varName) : null;
+                    if (decl == null || decl.isEmpty()) decl = "my";
+                    symbolTable.addVariableWithIndex(varName, regIndex, decl);
                 }
             }
 
@@ -1385,9 +1410,11 @@ public class BytecodeCompiler implements Visitor {
             emitReg(arrayReg);
             emit(nameIdx);
             emit(currentSubroutineBeginId);
-        } else if (hasVariable(arrayVarName)) {
+        } else if (hasVariable(arrayVarName) && !isOurVariable(arrayVarName)) {
             arrayReg = getVariableRegister(arrayVarName);
         } else {
+            // 'our' arrays (or undeclared globals) must be fetched from the global
+            // registry on every access so callers' `local @OurArr` is visible.
             arrayReg = allocateRegister();
             String globalArrayName = NameNormalizer.normalizeVariableName(
                     varName,
@@ -1615,9 +1642,11 @@ public class BytecodeCompiler implements Visitor {
             emitReg(hashReg);
             emit(nameIdx);
             emit(currentSubroutineBeginId);
-        } else if (hasVariable(hashVarName)) {
+        } else if (hasVariable(hashVarName) && !isOurVariable(hashVarName)) {
             hashReg = getVariableRegister(hashVarName);
         } else {
+            // 'our' hashes (or undeclared globals) must be fetched from the global
+            // registry on every access so callers' `local %OurHash` is visible.
             hashReg = allocateRegister();
             String globalHashName = NameNormalizer.normalizeVariableName(
                     varName,

--- a/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
@@ -283,6 +283,11 @@ public class EvalStringHandler {
 
             // Step 4: Compile AST to interpreter bytecode with adjusted variable registry.
             // The compile-time package is already propagated via ctx.symbolTable.
+            // NOTE: We do NOT propagate 'our' decls from the seeded symbol table here,
+            // because nested evals (this code path) inject captured outer `my` variables
+            // as `our` in a synthetic seed package purely for parser purposes. Those
+            // captured-lexical variables must still live in registers at runtime, so
+            // we keep the default "my" decl in the BytecodeCompiler.
             BytecodeCompiler compiler = new BytecodeCompiler(
                     evalFileName,
                     sourceLine,

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "6d48b1ad0";
+    public static final String gitCommitId = "c1e3e0acb";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 21 2026 21:54:08";
+    public static final String buildTimestamp = "Apr 21 2026 22:36:17";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -1366,6 +1366,23 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     }
                 }
 
+                // Build a parallel map of declaration kinds so the BytecodeCompiler can distinguish
+                // 'our' (package) variables from true lexicals. 'our' variables must resolve via
+                // GlobalVariable.getGlobalVariable() on each access so that `local $OurVar` in the
+                // caller is visible inside the eval. Without this hint, captured 'our' vars are
+                // treated as lexical 'my' vars bound to the scalar captured at eval-entry time.
+                Map<String, String> adjustedDecls = new HashMap<>();
+                if (ctx.capturedEnv != null) {
+                    for (int i = 3; i < ctx.capturedEnv.length; i++) {
+                        String varName = ctx.capturedEnv[i];
+                        if (varName == null) continue;
+                        SymbolTable.SymbolEntry entry = capturedSymbolTable.getSymbolEntry(varName);
+                        if (entry != null && !entry.decl().isEmpty()) {
+                            adjustedDecls.put(varName, entry.decl());
+                        }
+                    }
+                }
+
                 // Compile to InterpretedCode with variable registry.
                 //
                 // setCompilePackage() is safe here (unlike EvalStringHandler) because:
@@ -1381,7 +1398,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                         evalCompilerOptions.fileName,
                         1,
                         evalCtx.errorUtil,
-                        adjustedRegistry);
+                        adjustedRegistry,
+                        adjustedDecls);
                 compiler.setCompilePackage(capturedSymbolTable.getCurrentPackage());
                 interpretedCode = compiler.compile(ast, evalCtx);
                 evalTrace("evalStringWithInterpreter compiled tag=" + evalTag +


### PR DESCRIPTION
## Summary

Fixes `eval STRING` so that `local` applied to outer `our`-declared
package variables is visible inside the eval body.

Minimal reproducer that broke before this patch:

```perl
our $x = 1;
sub test { local $x = 42; eval q{print "eval x=$x\n"}; }
test();   # was printing 1, should (and now does) print 42
```

The same issue affected `local @our_array` / `local %our_hash` seen
from inside `eval STRING`, including element access like `$our_hash{k}`.

## Root cause

The bytecode-interpreter eval path (default on PerlOnJava) builds an
`adjustedRegistry` of captured variables in `RuntimeCode` /
`EvalStringHandler` and hands it to `BytecodeCompiler`, which seeded
every captured variable in its symbol table with `decl="my"`.
`compileVariableReference` then took the register path for `our` vars
instead of emitting `LOAD_GLOBAL_SCALAR`, so the eval body read the
scalar that was in the global slot at eval-entry time — not the
currently-localized one.

## Changes

- `RuntimeCode.evalStringWithInterpreter` now builds a parallel
  `adjustedDecls` map from the captured symbol table and passes it to
  `BytecodeCompiler` so `our` stays `our`.
- `BytecodeCompiler` gets a new constructor overload that accepts
  `parentDecls` and preserves the outer decl when seeding its symbol
  table.
- `handleArrayElementAccess` and `handleHashElementAccess` now check
  `isOurVariable` and route `our` aggregates through
  `LOAD_GLOBAL_ARRAY` / `LOAD_GLOBAL_HASH` so element reads see the
  current (possibly localized) slot.
- `EvalStringHandler` deliberately does **not** propagate
  `adjustedDecls`: nested evals seed outer `my` vars as `our` in a
  synthetic package purely for the parser, and at runtime those must
  stay register-bound. A comment explains this.

## Observable impact

`jcpan -t TimeDate` goes from **340/1215 failing subtests across 10
files** to **8/1215 in 1 file** (`t/lang-encoding.t`, a pre-existing
`utf8::is_utf8` issue unrelated to `eval`/`local`). The original
`Date::Parse::str2time` failures (`"Fri Dec 17 00:00:00 1901 GMT"`,
`"Wed, 16 Jun 94 07:29:35 CST"`, …) were all caused by this bug:
`Date::Parse` builds its regex closures via `eval "$strptime"` inside
`local($day_ref,$mon_ref,$suf_ref)`, and the eval was seeing the
pre-local (undef) scalars instead of the freshly-localized ones.

#### Test plan

- [x] `make` (all unit tests pass, including
      `unit/eval_nested_lexicals.t` which exercises the
      `EvalStringHandler` path we intentionally left alone)
- [x] `make test-bundled-modules`
- [x] `jcpan -t TimeDate` — 1/28 test files fail, 8/1215 subtests
      fail (down from 10/28 and 340/1215)

Generated with [Devin](https://cli.devin.ai/docs)
