### PR TITLE
Git CPAN module support: fix local-tie + System::Command IPC::Open3 fallback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -288,7 +288,15 @@ tasks.register('testModule', Test) {
     useJUnitPlatform {
         includeTags 'module'
     }
-    
+
+    // Tests that spawn a child perl (via $^X, e.g. System::Command)
+    // need PERLONJAVA_EXECUTABLE set to a real launcher, since under
+    // Gradle "jperl" isn't on $PATH. GlobalContext reads this env var
+    // when initializing $^X.
+    def jperlLauncher = org.gradle.internal.os.OperatingSystem.current().isWindows()
+            ? "jperl.bat" : "jperl"
+    environment 'PERLONJAVA_EXECUTABLE', file(jperlLauncher).absolutePath
+
     shouldRunAfter testUnit
 }
 

--- a/dev/modules/git_modules_support.md
+++ b/dev/modules/git_modules_support.md
@@ -196,6 +196,27 @@ the Crypt::OpenSSL Bouncy Castle port. Defer until asked.
     a `$ENV{SHLVL}` mismatch — IPC::Open3 appears to wrap the child in a
     shell, bumping SHLVL. Unrelated to fork, low priority.
 
+- [x] **Phase 2b — open3 exec-failure + waitpid SIG{CHLD}=IGNORE (2026-04-22)**
+  - Real-Perl parity for `IPC::Open3` shell-wrapping: bare single-arg
+    commands now exec directly instead of via `/bin/sh -c`, so exec
+    failures surface as `open3: exec of X failed: Y`. The bundled
+    `System/Command.pm` translates that into the fork-path's
+    `Can't exec( @cmd ): Y` so `eval`-based error tests keep working.
+  - `WaitpidOperator` now honours `$SIG{CHLD} eq 'IGNORE'`: when set,
+    waitpid on a tracked Java child returns -1 (ECHILD simulation)
+    and leaves `$?` untouched, so `System::Command::Reaper` reports
+    the `(-1, -1, -1)` BOGUS triple the POSIX semantics call for.
+  - Also fixed a real `ConcurrentModificationException` in
+    `GlobalDestruction.runGlobalDestruction` uncovered while
+    repro'ing t/30-exit.t: DESTROY callbacks could mutate the global
+    HashMaps mid-iteration. Snapshot before walking.
+  - **`./jcpan -t System::Command`: 230/241 pass (95.4%)**, up from 94%.
+    - t/11-spawn-fail.t  2/2 (was 0/2)
+    - t/20-zombie.t     31/32 (was 27/30)
+    - Remaining 11 are 9 DESTROY-scope tests (tracked on the
+      `weaken/DESTROY` branch) + 1 `-Ilib` test-harness artifact
+      + 1 related zombie-DESTROY assertion.
+
 ### Caveat: install-time precedence
 
 `@INC` lists `~/.perlonjava/lib` before the JAR-bundled lib. If a user

--- a/dev/modules/git_modules_support.md
+++ b/dev/modules/git_modules_support.md
@@ -170,26 +170,68 @@ the Crypt::OpenSSL Bouncy Castle port. Defer until asked.
 
 ## Progress Tracking
 
-### Current Status: Phase 1 in progress
+### Current Status: Phase 2 complete (with caveat); Phase 3 pending
 
 ### Completed Phases
-_(none yet)_
+
+- [x] **Phase 1 — `local $tied_scalar = value` (2026-04-22)**
+  - Unit test added in `src/test/resources/unit/tie_scalar.t` asserting
+    STORE dispatch on entry, inside, and exit of a localized scope.
+  - `GlobalRuntimeScalar.dynamicSaveState/dynamicRestoreState` now detects
+    `TIED_SCALAR` and keeps the tie in place, dispatching `STORE(undef)`
+    on entry and `STORE(savedValue)` on exit (matches real Perl).
+  - **`./jcpan -t Git::Wrapper`: 75/75 pass** (was 52/57).
+  - `make` stays green.
+
+- [x] **Phase 2 — `System::Command` IPC::Open3 fallback (2026-04-22)**
+  - Patched `_spawn` in `System/Command.pm`: on PerlOnJava (detected via
+    `$Config{perlonjava}`), route through `IPC::Open3::open3` instead of
+    the manual pipe+fork+exec. `cwd` and `env` are already handled by
+    the caller via `chdir` and `local %ENV`.
+  - Bundled patched `System/Command.pm` + unchanged `System/Command/Reaper.pm`
+    in `src/main/perl/lib/` so fresh installs get the working version.
+  - **`./jcpan -t Git::Repository`: 304/328 pass (93%)**, previously almost
+    fully skipped with `fork() not supported`.
+  - **`./jcpan -t System::Command`: 132/140 pass (94%)**. Remaining 8 are
+    a `$ENV{SHLVL}` mismatch — IPC::Open3 appears to wrap the child in a
+    shell, bumping SHLVL. Unrelated to fork, low priority.
+
+### Caveat: install-time precedence
+
+`@INC` lists `~/.perlonjava/lib` before the JAR-bundled lib. If a user
+has previously run `./jcpan -i System::Command`, their installed copy
+shadows the bundled patched version. Workarounds:
+
+1. Manually remove `~/.perlonjava/lib/System/Command.pm` — the bundled
+   version will then load.
+2. **Future**: teach `jcpan`/MakeMaker to apply the `_spawn` patch during
+   install for modules listed in a patch registry. See
+   `dev/modules/cpan_patch_plan.md` for a broader strategy.
+
+For this PR we accept that existing users need workaround (1). New
+installations Just Work out of the box.
 
 ### Next Steps
-1. Write unit test for `local $tied_scalar = value`.
-2. Fix `GlobalRuntimeScalar.dynamicSaveState/dynamicRestoreState` for
-   `TieScalar`.
-3. Verify `./jcpan -t Git::Wrapper` reaches 57/57.
+
+- Phase 3 housekeeping: update `docs/FEATURE_MATRIX.md` if it mentions
+  Git modules.
+- Optional: investigate the `SHLVL` mismatch in `System::Command` tests.
+- Optional: investigate the 24 remaining Git::Repository subtest failures
+  (they look like minor edge cases — `hello redefined` warnings, version
+  parse variants, etc.).
+- Optional: implement an install-time patching mechanism so that
+  `~/.perlonjava/lib/System/Command.pm` is auto-patched after
+  `jcpan -i`.
 
 ### Open Questions
-- Does `IPC::Open3::open3` on PerlOnJava honour the parent's cwd at the
-  moment `open3` is called? Quick test showed **yes**, it uses the Java
-  process's current cwd. Good — that means `chdir + open3 + chdir back` is
-  a viable path for `System::Command`'s `cwd` option.
-- Do we need a `ProcessBuilder.directory()`/`environment()` helper exposed
-  to Perl? Probably not if we can do `local %ENV` and manual chdir.
+
+- Should the bundled copy override the user install instead? Would require
+  reordering `@INC` (JAR first) for specific paths — risky as it would
+  break legitimate user upgrades of other modules.
 
 ## Related Docs
 
 - `dev/modules/ipc_open3_fix.md` — prior work on IPC::Open3 / IO::Select.
 - `dev/modules/xs_fallback.md` — XS/C handling in MakeMaker.
+- `dev/modules/cpan_patch_plan.md` — broader strategy for patching CPAN
+  modules on PerlOnJava.

--- a/dev/modules/git_modules_support.md
+++ b/dev/modules/git_modules_support.md
@@ -1,0 +1,195 @@
+# Git CPAN Module Support on PerlOnJava
+
+## Goal
+
+Make Git-related CPAN modules (`Git::Wrapper`, `Git::Repository`, and
+transitively `System::Command`) pass their test suites on PerlOnJava.
+
+`Git::Raw` is out of scope — it's an XS wrapper around libgit2 and requires
+a from-scratch JGit-backed port. See the summary at the end.
+
+## Motivation
+
+Users asked about Git CPAN module support. `./jcpan -t Git::Raw` fails because
+Git::Raw is XS-only. `./jcpan -t Git::Wrapper` and `./jcpan -t Git::Repository`
+install cleanly (both are pure Perl) but fail at runtime:
+
+- **Git::Wrapper**: 5/57 subtests fail across 2 test files.
+- **Git::Repository**: most tests silently skip with
+  `fork() not supported on this platform (Java/JVM)` because its core dependency
+  `System::Command` uses `fork + exec`.
+
+## Investigation Results
+
+### Root cause #1 — `local $tied_scalar = value` does not dispatch through STORE
+
+This is the **primary bug** blocking `Git::Wrapper`. `File::chdir` exports a
+tied scalar `$CWD` whose STORE calls `chdir`. `Git::Wrapper::RUN` uses
+`local $CWD = $self->dir` to scope the cwd change around each `git` invocation.
+
+Minimal reproduction:
+
+```perl
+package T;
+sub TIESCALAR { bless [], shift }
+sub FETCH { print "FETCH\n"; $_[0][0] }
+sub STORE { print "STORE: $_[1]\n"; $_[0][0] = $_[1] }
+package main;
+our $x; tie $x, "T";
+$x = "direct";             # STORE called — OK
+{ local $x = "scoped"; }   # PerlOnJava: NO STORE, NO FETCH.
+```
+
+| | Real Perl | PerlOnJava |
+|---|---|---|
+| `local $x = value` (entering scope) | FETCH → STORE "" → STORE value | (silent; tie is bypassed) |
+| Inside scope, reading `$x` | FETCH returns "scoped" | returns "scoped" from plain slot |
+| Leaving scope | STORE original | (silent) |
+
+**Consequence for Git::Wrapper**: every `local $CWD = $self->dir` is a no-op,
+so every `git` subcommand runs in the process's original cwd (the build
+directory, which contains 32 files). `ls_files` returns those 32 files, `add
+.` stages them, and so on. This explains all 5 basic.t failures and the
+2 path_class.t failures in one go.
+
+**Location**: `src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeScalar.java`
+— `dynamicSaveState()` replaces the slot in `GlobalVariable.globalVariables`
+with a fresh untied `GlobalRuntimeScalar`, dropping the `TieScalar` magic.
+`dynamicRestoreState()` restores the original slot verbatim.
+
+**Fix direction**:
+1. In `dynamicSaveState()`, when the original slot's `value` is a `TieScalar`,
+   call `tiedFetch()` to save the current FETCH result, then call `tiedStore()`
+   with the empty string (matching real Perl's "clear first" behaviour).
+2. Do **not** replace the slot — keep the same tied scalar throughout the
+   localized scope so that assignments go through `tiedStore`.
+3. In `dynamicRestoreState()`, call `tiedStore()` with the saved FETCH value
+   to restore.
+4. If instead we keep the "replace slot" approach, the new slot must be a
+   freshly-constructed `TieScalar` bound to the same handler object so STORE
+   still dispatches. This is trickier because `local` restore then has to
+   re-install the original tied scalar.
+
+Strategy (1)+(2)+(3) is closest to real Perl semantics and avoids copying
+the tie magic. It's also consistent with how non-global tied scalars would
+need to behave.
+
+### Root cause #2 — `System::Command` can't spawn without `fork`
+
+`System::Command::_spawn` is a hand-rolled `pipe + fork + exec` using
+`Symbol::gensym`, `pipe`, `fork`, `setpgrp`, `fcntl(F_GETFD)`, and
+`exec { $cmd[0] } @cmd`. PerlOnJava has no `fork`, so this path dies.
+`Git::Repository` depends on it; its test suite detects the failure and
+skips almost every test.
+
+**Fix direction — two options, not mutually exclusive**:
+
+**Option A (preferred): ship a patched `System/Command.pm`** in
+`src/main/perl/lib/` that replaces `$_spawn` with a code path using
+`IPC::Open3::open3` (already implemented on PerlOnJava via `ProcessBuilder`;
+see `dev/modules/ipc_open3_fix.md`). We need:
+
+- `pid`, `stdin`, `stdout`, `stderr` handles that behave like the fork
+  versions. `open3` already gives us all four.
+- `cwd`, `env` options — implement via `ProcessBuilder` directly? Current
+  `IPC::Open3` does not expose cwd/env. We may need a thin Java helper, or
+  wrap `open3` with a `chdir ... open3 ... chdir back` shim (env via
+  `local %ENV = (%ENV, %override)` is fine).
+- `setpgrp` is a no-op on JVM — OK.
+- `interactive` mode uses `system`, which already works.
+- `System::Command::Reaper` wraps the handles and `waitpid`s on close. Should
+  still work since `open3` returns a real PID that `waitpid` understands
+  (verified by Git::Wrapper's working test cases — it waitpids on an open3
+  PID).
+
+**Option B: upstream-compatible shim** — only monkey-patch `_spawn` without
+changing the rest. Less invasive, easier to keep in sync with CPAN.
+
+We'll prototype Option B first (smallest patch), fall back to Option A if
+there are integration issues.
+
+### Root cause #3 — `Git::Repository` calls uninitialized values
+
+After System::Command failure, `Git::Repository->new` continues without a
+`git_dir` and prints warnings like:
+
+```
+Use of uninitialized value in join or string at Git/Repository.pm line 99.
+Use of uninitialized value in join or string at Git/Repository.pm line 102.
+```
+
+These disappear once System::Command works. Not a PerlOnJava bug — just
+downstream fallout.
+
+## Plan
+
+### Phase 1 — Fix `local $tied_scalar = value` (unblocks Git::Wrapper)
+
+1. Reproduce with a minimal unit test under `src/test/resources/unit/` that
+   counts STORE/FETCH calls on a tied scalar inside a `local` scope. Ensure
+   the test matches the sequence observed in system `perl`:
+   `FETCH, STORE "", STORE value, FETCH (inside), STORE original_value`.
+2. Modify `GlobalRuntimeScalar.dynamicSaveState/dynamicRestoreState` to
+   detect `TieScalar` and route through `tiedFetch`/`tiedStore` instead of
+   swapping the slot.
+3. Verify the tied magic is preserved inside the scope (assignments still
+   dispatch STORE) and restored on exit.
+4. Re-run `./jcpan -t Git::Wrapper`. Expect basic.t and path_class.t to
+   recover. Confirm with `make` (must stay green).
+
+### Phase 2 — Patch `System::Command` (unblocks Git::Repository)
+
+1. Copy `System/Command.pm` into `src/main/perl/lib/System/Command.pm` as a
+   baseline.
+2. Rewrite `$_spawn` (and the `MSWin32` special case) to route through
+   `IPC::Open3::open3`, handling `cwd`, `env`, and `input` options.
+3. Audit `System::Command::Reaper` for fork-specific assumptions. If `waitpid`
+   on an open3 PID + `close` on the handles is sufficient, leave it alone.
+4. Remove the `fork() not supported` skip guard in `System/Command.pm` (or
+   leave untouched if the new path doesn't trigger it).
+5. Re-run `./jcpan -t System::Command` first (simpler surface), then
+   `./jcpan -t Git::Repository`.
+6. Iterate on any remaining issues — e.g., `setpgrp`, `trace`, signal
+   handling — but treat these as optional if the happy path passes.
+
+### Phase 3 — Follow-up housekeeping
+
+- Update `docs/FEATURE_MATRIX.md` (or equivalent) noting Git::Wrapper and
+  Git::Repository as supported, Git::Raw as unsupported.
+- Add a short note to `AGENTS.md` about the `local $tied = ...` fix so
+  others know it now works.
+- Consider opening issues for any residual `System::Command` options we
+  don't bother supporting (e.g., `setpgrp`) so users know what's missing.
+
+## Out of scope — `Git::Raw`
+
+Git::Raw bundles libgit2 + zlib + pcre + http-parser source and requires a
+C compiler. PerlOnJava would need a JGit-backed Perl module that
+re-implements ~40 classes' worth of Git::Raw's API. Comparable in size to
+the Crypt::OpenSSL Bouncy Castle port. Defer until asked.
+
+## Progress Tracking
+
+### Current Status: Phase 1 in progress
+
+### Completed Phases
+_(none yet)_
+
+### Next Steps
+1. Write unit test for `local $tied_scalar = value`.
+2. Fix `GlobalRuntimeScalar.dynamicSaveState/dynamicRestoreState` for
+   `TieScalar`.
+3. Verify `./jcpan -t Git::Wrapper` reaches 57/57.
+
+### Open Questions
+- Does `IPC::Open3::open3` on PerlOnJava honour the parent's cwd at the
+  moment `open3` is called? Quick test showed **yes**, it uses the Java
+  process's current cwd. Good — that means `chdir + open3 + chdir back` is
+  a viable path for `System::Command`'s `cwd` option.
+- Do we need a `ProcessBuilder.directory()`/`environment()` helper exposed
+  to Perl? Probably not if we can do `local %ENV` and manual chdir.
+
+## Related Docs
+
+- `dev/modules/ipc_open3_fix.md` — prior work on IPC::Open3 / IO::Select.
+- `dev/modules/xs_fallback.md` — XS/C handling in MakeMaker.

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "b53fcc952";
+    public static final String gitCommitId = "1d86c9d60";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 22 2026 13:40:27";
+    public static final String buildTimestamp = "Apr 22 2026 13:53:05";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "fd595db7d";
+    public static final String gitCommitId = "925289257";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 22 2026 13:07:46";
+    public static final String buildTimestamp = "Apr 22 2026 13:17:02";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "1d86c9d60";
+    public static final String gitCommitId = "687b74120";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 22 2026 13:53:05";
+    public static final String buildTimestamp = "Apr 22 2026 14:52:02";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "bd326524c";
+    public static final String gitCommitId = "fd595db7d";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 22 2026 13:43:46";
+    public static final String buildTimestamp = "Apr 22 2026 13:07:46";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "6f5048138";
+    public static final String gitCommitId = "b53fcc952";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 22 2026 13:31:33";
+    public static final String buildTimestamp = "Apr 22 2026 13:40:27";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "925289257";
+    public static final String gitCommitId = "6f5048138";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 22 2026 13:17:02";
+    public static final String buildTimestamp = "Apr 22 2026 13:31:33";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/operators/WaitpidOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/WaitpidOperator.java
@@ -10,6 +10,7 @@ import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalHash;
 import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalVariable;
 import static org.perlonjava.runtime.runtimetypes.RuntimeContextType.SCALAR;
 
@@ -37,6 +38,23 @@ public class WaitpidOperator {
             return waitpidWindows(pid, flags);
         } else {
             return waitpidPosix(pid, flags);
+        }
+    }
+
+    /**
+     * Returns true if $SIG{CHLD} is currently set to 'IGNORE'. Under
+     * that disposition POSIX mandates the kernel auto-reap children, so
+     * subsequent waitpid() returns -1 with errno=ECHILD (see waitpid(2)
+     * on Linux, and Perl's perlipc documentation). We simulate that so
+     * test suites like System::Command's t/20-zombie.t can observe the
+     * expected "BOGUS exit status" pattern instead of a clean reap.
+     */
+    private static boolean isChldIgnored() {
+        try {
+            RuntimeScalar h = getGlobalHash("main::SIG").get("CHLD");
+            return h != null && "IGNORE".equals(h.toString());
+        } catch (Exception e) {
+            return false;
         }
     }
 
@@ -71,16 +89,25 @@ public class WaitpidOperator {
 
     private static RuntimeScalar waitpidJavaProcess(int pid, Process process, int flags) {
         boolean nonBlocking = (flags & WNOHANG) != 0;
+        boolean chldIgnore = isChldIgnored();
         if (nonBlocking) {
             if (process.isAlive()) return new RuntimeScalar(0);
             int exitCode = process.exitValue();
             RuntimeIO.removeChildProcess(pid);
+            if (chldIgnore) {
+                // Kernel auto-reap simulation: discard status, signal
+                // ECHILD by returning -1. Do NOT update $?.
+                return new RuntimeScalar(-1);
+            }
             setExitStatus(exitCode << 8);
             return new RuntimeScalar(pid);
         }
         try {
             int exitCode = process.waitFor();
             RuntimeIO.removeChildProcess(pid);
+            if (chldIgnore) {
+                return new RuntimeScalar(-1);
+            }
             setExitStatus(exitCode << 8);
             return new RuntimeScalar(pid);
         } catch (InterruptedException e) {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/IPCOpen3.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/IPCOpen3.java
@@ -62,6 +62,51 @@ public class IPCOpen3 extends PerlModuleBase {
     }
 
     /**
+     * Shell-metacharacter sniffer used to decide whether a single-arg
+     * command should be handed to `/bin/sh -c` or exec'd directly.
+     * Mirrors the heuristic real Perl uses in IPC::Open3 / system():
+     * any of these characters cause shell invocation; otherwise we
+     * exec directly so that exec-failure can be caught by the caller.
+     */
+    private static boolean hasShellMetacharacters(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (Character.isWhitespace(c)) return true;
+            switch (c) {
+                case '|': case '&': case ';': case '<': case '>':
+                case '(': case ')': case '$': case '`': case '\\':
+                case '"': case '\'': case '*': case '?': case '[':
+                case ']': case '{': case '}': case '!': case '#':
+                case '~': case '=':
+                    return true;
+                default:
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Translate a java.io.IOException from ProcessBuilder.start() into
+     * a short, Perl-style $! string. We pattern-match rather than chain
+     * through strerror because the JDK's wording varies per-platform.
+     */
+    private static String translateIOError(java.io.IOException ioe) {
+        String msg = ioe.getMessage();
+        if (msg == null) return "Exec failed";
+        if (msg.contains("error=2")
+                || msg.contains("No such file or directory")) {
+            return "No such file or directory";
+        }
+        if (msg.contains("error=13") || msg.contains("Permission denied")) {
+            return "Permission denied";
+        }
+        // Strip the "(in directory ...)" decoration the JDK tacks on.
+        int cut = msg.indexOf(" (in directory ");
+        if (cut > 0) return msg.substring(0, cut);
+        return msg;
+    }
+
+    /**
      * Register child process for waitpid() - handles both Windows and POSIX.
      */
     private static void registerChildProcess(Process process) {
@@ -108,12 +153,21 @@ public class IPCOpen3 extends PerlModuleBase {
             // Build the command
             String[] command;
             if (commandList.size() == 1) {
-                // Single string - use shell
+                // Single-element @cmd: follow real Perl's IPC::Open3
+                // rule — wrap in a shell only if the string contains
+                // shell metacharacters. Bare executable names go
+                // direct, which matches `exec { $cmd[0] } @cmd` in the
+                // fork path and lets us surface exec-failure errors
+                // (System::Command's t/11-spawn-fail.t depends on this).
                 String cmd = commandList.get(0);
-                if (IS_WINDOWS) {
-                    command = new String[]{"cmd.exe", "/c", cmd};
+                if (hasShellMetacharacters(cmd)) {
+                    if (IS_WINDOWS) {
+                        command = new String[]{"cmd.exe", "/c", cmd};
+                    } else {
+                        command = new String[]{"/bin/sh", "-c", cmd};
+                    }
                 } else {
-                    command = new String[]{"/bin/sh", "-c", cmd};
+                    command = new String[]{cmd};
                 }
             } else {
                 // Multiple arguments - direct execution
@@ -140,7 +194,21 @@ public class IPCOpen3 extends PerlModuleBase {
             }
 
             // Start the process
-            Process process = processBuilder.start();
+            Process process;
+            try {
+                process = processBuilder.start();
+            } catch (java.io.IOException ioe) {
+                // Match real Perl's IPC::Open3 error phrasing so callers
+                // (notably System::Command, which croaks $@ and matches
+                // `qr/^Can't exec\( ... \): /` in its test suite) can
+                // recognise the failure. We also preserve the Java
+                // errno-ish detail after the colon.
+                String cmd0 = commandList.get(0);
+                String detail = translateIOError(ioe);
+                getGlobalVariable("main::!").set(detail);
+                throw new RuntimeException(
+                        "open3: exec of " + cmd0 + " failed: " + detail);
+            }
             long pid = process.pid();
 
             // Register the process for waitpid() - works on both Windows and POSIX
@@ -176,6 +244,10 @@ public class IPCOpen3 extends PerlModuleBase {
 
             return new RuntimeScalar(pid).getList();
 
+        } catch (RuntimeException re) {
+            // Our inner throw already carries the correct "open3: ..."
+            // prefix; don't double-wrap.
+            throw re;
         } catch (Exception e) {
             getGlobalVariable("main::!").set(e.getMessage());
             throw new RuntimeException("open3: " + e.getMessage());
@@ -336,12 +408,17 @@ public class IPCOpen3 extends PerlModuleBase {
             // Build the command
             String[] command;
             if (commandList.size() == 1) {
-                // Single string - use shell
+                // Single-element @cmd: only wrap in a shell if the
+                // string has shell metacharacters (same rule as open3).
                 String cmd = commandList.get(0);
-                if (IS_WINDOWS) {
-                    command = new String[]{"cmd.exe", "/c", cmd};
+                if (hasShellMetacharacters(cmd)) {
+                    if (IS_WINDOWS) {
+                        command = new String[]{"cmd.exe", "/c", cmd};
+                    } else {
+                        command = new String[]{"/bin/sh", "-c", cmd};
+                    }
                 } else {
-                    command = new String[]{"/bin/sh", "-c", cmd};
+                    command = new String[]{cmd};
                 }
             } else {
                 // Multiple arguments - direct execution
@@ -359,7 +436,16 @@ public class IPCOpen3 extends PerlModuleBase {
             processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
 
             // Start the process
-            Process process = processBuilder.start();
+            Process process;
+            try {
+                process = processBuilder.start();
+            } catch (java.io.IOException ioe) {
+                String cmd0 = commandList.get(0);
+                String detail = translateIOError(ioe);
+                getGlobalVariable("main::!").set(detail);
+                throw new RuntimeException(
+                        "open2: exec of " + cmd0 + " failed: " + detail);
+            }
             long pid = process.pid();
 
             // Register the process for waitpid() - works on both Windows and POSIX
@@ -373,6 +459,8 @@ public class IPCOpen3 extends PerlModuleBase {
 
             return new RuntimeScalar(pid).getList();
 
+        } catch (RuntimeException re) {
+            throw re;
         } catch (Exception e) {
             getGlobalVariable("main::!").set(e.getMessage());
             throw new RuntimeException("open2: " + e.getMessage());

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalDestruction.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalDestruction.java
@@ -1,5 +1,7 @@
 package org.perlonjava.runtime.runtimetypes;
 
+import java.util.ArrayList;
+
 /**
  * Handles global destruction at program exit.
  * <p>
@@ -19,28 +21,36 @@ public class GlobalDestruction {
         // Set ${^GLOBAL_PHASE} to "DESTRUCT"
         GlobalVariable.getGlobalVariable(GlobalContext.GLOBAL_PHASE).set("DESTRUCT");
 
+        // Snapshot the collections before iterating: a DESTROY callback may
+        // mutate GlobalVariable.{globalVariables,globalArrays,globalHashes}
+        // (e.g. by creating a new tied variable, opening/closing handles,
+        // or installing END-like cleanup), which would otherwise raise
+        // ConcurrentModificationException. Real-world trigger: exit(N)
+        // while holding a System::Command object whose Reaper's DESTROY
+        // spawns further cleanup. See dev/modules/git_modules_support.md.
+
         // Walk all global scalars
-        for (RuntimeScalar val : GlobalVariable.globalVariables.values()) {
+        for (RuntimeScalar val : new ArrayList<>(GlobalVariable.globalVariables.values())) {
             destroyIfTracked(val);
         }
 
         // Walk global arrays for blessed ref elements
-        for (RuntimeArray arr : GlobalVariable.globalArrays.values()) {
+        for (RuntimeArray arr : new ArrayList<>(GlobalVariable.globalArrays.values())) {
             // Skip tied arrays — iterating them calls FETCHSIZE/FETCH on the
             // tie object, which may already be destroyed or invalid at global
             // destruction time (e.g., broken ties from eval+last).
             if (arr.type == RuntimeArray.TIED_ARRAY) continue;
-            for (RuntimeScalar elem : arr) {
+            for (RuntimeScalar elem : new ArrayList<>(arr.elements)) {
                 destroyIfTracked(elem);
             }
         }
 
         // Walk global hashes for blessed ref values
-        for (RuntimeHash hash : GlobalVariable.globalHashes.values()) {
+        for (RuntimeHash hash : new ArrayList<>(GlobalVariable.globalHashes.values())) {
             // Skip tied hashes — iterating them dispatches through FIRSTKEY/
             // NEXTKEY/FETCH which may fail if the tie object is already gone.
             if (hash.type == RuntimeHash.TIED_HASH) continue;
-            for (RuntimeScalar elem : hash.values()) {
+            for (RuntimeScalar elem : new ArrayList<>(hash.elements.values())) {
                 destroyIfTracked(elem);
             }
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeScalar.java
@@ -46,7 +46,29 @@ public class GlobalRuntimeScalar extends RuntimeScalar {
         // Save the current global reference
         var originalVariable = GlobalVariable.globalVariables.get(fullName);
 
-        localizedStack.push(new SavedGlobalState(fullName, originalVariable));
+        // Tied scalars need special handling: the tie magic must stay in
+        // place for the duration of the localized scope, so that an
+        // assignment `local $tied = value` dispatches through STORE (and
+        // restoration on scope exit dispatches STORE with the saved
+        // value). This matches real Perl semantics and is required by
+        // modules like File::chdir whose tied $CWD actually chdir's in
+        // STORE. See dev/modules/git_modules_support.md.
+        if (originalVariable != null
+                && originalVariable.type == RuntimeScalarType.TIED_SCALAR) {
+            RuntimeScalar savedValue = originalVariable.tiedFetch();
+            // Real Perl dispatches STORE(undef) on entry to localize so
+            // the tie handler sees the transition. Modules like
+            // File::chdir explicitly short-circuit on undef
+            // (`return unless defined $_[1];`).
+            originalVariable.tiedStore(RuntimeScalarCache.scalarUndef);
+            localizedStack.push(
+                    new SavedGlobalState(fullName, originalVariable, savedValue));
+            // Do NOT replace the slot — the tied scalar stays in place so
+            // that the subsequent `= value` assignment dispatches STORE.
+            return;
+        }
+
+        localizedStack.push(new SavedGlobalState(fullName, originalVariable, null));
 
         // Create a new variable for the localized scope.
         // For output separator variables, create the matching special type so that
@@ -84,6 +106,16 @@ public class GlobalRuntimeScalar extends RuntimeScalar {
             if (saved.fullName.equals(this.fullName)) {
                 localizedStack.pop();
 
+                // Tied path: the slot was never replaced. Restore the
+                // original value by dispatching STORE on the tied scalar.
+                if (saved.originalVariable != null
+                        && saved.originalVariable.type == RuntimeScalarType.TIED_SCALAR) {
+                    if (saved.savedTiedValue != null) {
+                        saved.originalVariable.tiedStore(saved.savedTiedValue);
+                    }
+                    return;
+                }
+
                 // Decrement refCount of the CURRENT (local) value being displaced.
                 // Do NOT increment the restored value — it already has the correct
                 // refCount from its original counting.
@@ -117,7 +149,10 @@ public class GlobalRuntimeScalar extends RuntimeScalar {
         }
     }
 
-    private record SavedGlobalState(String fullName, RuntimeScalar originalVariable) {
+    private record SavedGlobalState(
+            String fullName,
+            RuntimeScalar originalVariable,
+            RuntimeScalar savedTiedValue) {
     }
 }
 

--- a/src/main/perl/lib/System/Command.pm
+++ b/src/main/perl/lib/System/Command.pm
@@ -1,0 +1,830 @@
+package System::Command;
+$System::Command::VERSION = '1.122';
+use warnings;
+use strict;
+use 5.006;
+
+use Carp;
+use Cwd qw( cwd );
+use IO::Handle;
+use Symbol ();
+use Scalar::Util qw( blessed reftype );
+use List::Util qw( reduce );
+use System::Command::Reaper;
+
+use Config;
+use Fcntl qw( F_GETFD F_SETFD FD_CLOEXEC );
+
+# MSWin32 support
+use constant MSWin32 => $^O eq 'MSWin32';
+require IPC::Run if MSWin32;
+
+our $QUIET = 0;
+
+# trace setup at startup
+my $_trace_opts = sub {
+    my ( $trace, $file, $th ) = split /=/, shift, 2;
+    open $th, '>>', $file or carp "Can't open $file: $!" if $file;
+    $th ||= *STDERR;
+    return ( $trace, $th );
+};
+my @trace;
+@trace = $_trace_opts->( $ENV{SYSTEM_COMMAND_TRACE} )
+    if $ENV{SYSTEM_COMMAND_TRACE};
+
+sub import {
+    my ( $class, @args ) = @_;
+    my %arg = ( quiet => sub { $QUIET = 1 } );
+    for my $arg (@args) {
+        $arg =~ s/^-//;    # allow dashed options
+        croak "Unknown option '$arg' in 'use System::Command'"
+            if !exists $arg{$arg};
+        $arg{$arg}->();
+    }
+}
+
+# a few simple accessors
+{
+    no strict 'refs';
+    for my $attr (qw( pid stdin stdout stderr options )) {
+        *$attr = sub { return $_[0]{$attr} };
+    }
+    for my $attr (qw( exit signal core )) {
+        no strict 'refs';
+        *$attr = sub { $_[0]->is_terminated(); return $_[0]{$attr} };
+    }
+    for my $attr (qw( cmdline )) {
+        *$attr = sub { return @{ $_[0]{$attr} } };
+    }
+}
+
+# REALLY PRIVATE FUNCTIONS
+# PerlOnJava detection: PerlOnJava has no fork() — use IPC::Open3 instead.
+# See dev/modules/git_modules_support.md in the PerlOnJava repository.
+use constant PERLONJAVA => defined $Config{perlonjava};
+require IPC::Open3 if PERLONJAVA;
+
+# a sub-process spawning function
+my $_spawn = sub {
+    my ($o, @cmd) = @_;
+    my $pid;
+
+    # setup filehandles
+    my $in  = Symbol::gensym;
+    my $out = Symbol::gensym;
+    my $err = Symbol::gensym;
+
+    # no buffering on pipes used for writing
+    select( ( select($in), $| = 1 )[0] );
+
+    # start the command
+    if (PERLONJAVA) {
+
+        # PerlOnJava has no fork(). Delegate to IPC::Open3, which is
+        # implemented on top of java.lang.ProcessBuilder. cwd and env
+        # are already handled by the caller (System::Command::new)
+        # via chdir + `local %ENV`.
+        $pid = IPC::Open3::open3($in, $out, $err, @cmd);
+    }
+    elsif (MSWin32) {
+        $pid = IPC::Run::start(
+            [@cmd],
+            '<pipe'  => $in,
+            '>pipe'  => $out,
+            '2>pipe' => $err,
+        );
+    }
+    else {
+
+        # the code below takes inspiration from IPC::Open3 and Sys::Cmd
+
+        # create handles for the child process (using CAPITALS)
+        my $IN  = Symbol::gensym;
+        my $OUT = Symbol::gensym;
+        my $ERR = Symbol::gensym;
+
+        # no buffering on pipes used for writing
+        select( ( select($OUT), $| = 1 )[0] );
+        select( ( select($ERR), $| = 1 )[0] );
+
+        # connect parent and child with pipes
+        pipe $IN,  $in  or croak "input pipe(): $!";
+        pipe $out, $OUT or croak "output pipe(): $!";
+        pipe $err, $ERR or croak "errput pipe(): $!";
+
+        # an extra pipe to communicate exec() failure
+        pipe my ( $stat_r, $stat_w );
+
+        # create the child process
+        $pid = fork;
+        croak "Can't fork: $!" if !defined $pid;
+
+        if ($pid) {
+
+            # parent won't use those handles
+            close $stat_w;
+            close $IN;
+            close $OUT;
+            close $ERR;
+
+            # failed to fork+exec?
+            my $mesg = do { local $/; <$stat_r> };
+            die $mesg if $mesg;
+        }
+        else {    # kid
+
+            # use $stat_r to communicate errors back to the parent
+            eval {
+
+                # child won't use those handles
+                close $stat_r;
+                close $in;
+                close $out;
+                close $err;
+
+                # setup process group if possible
+                setpgrp 0, 0 if $o->{setpgrp} && $Config{d_setpgrp};
+
+                # close $stat_w on exec
+                my $flags = fcntl( $stat_w, F_GETFD, 0 )
+                    or croak "fcntl GETFD failed: $!";
+                fcntl( $stat_w, F_SETFD, $flags | FD_CLOEXEC )
+                    or croak "fcntl SETFD failed: $!";
+
+                # associate STDIN, STDOUT and STDERR to the pipes
+                my ( $fd_IN, $fd_OUT, $fd_ERR )
+                    = ( fileno $IN, fileno $OUT, fileno $ERR );
+                open \*STDIN, "<&=$fd_IN"
+                    or croak "Can't open( \\*STDIN, '<&=$fd_IN' ): $!";
+                open \*STDOUT, ">&=$fd_OUT"
+                    or croak "Can't open( \\*STDOUT, '<&=$fd_OUT' ): $!";
+                open \*STDERR, ">&=$fd_ERR"
+                    or croak "Can't open( \\*STDERR, '<&=$fd_ERR' ): $!";
+
+                # and finally, exec into @cmd
+                exec( { $cmd[0] } @cmd )
+                    or do { croak "Can't exec( @cmd ): $!"; }
+            };
+
+            # something went wrong
+            print $stat_w $@;
+            close $stat_w;
+
+            # DIE DIE DIE
+            eval { require POSIX; POSIX::_exit(255); };
+            exit 255;
+        }
+    }
+
+    return ( $pid, $in, $out, $err );
+};
+
+my $_dump_ref = sub {
+    require Data::Dumper;    # only load if needed
+    local $Data::Dumper::Indent    = 0;
+    local $Data::Dumper::Purity    = 0;
+    local $Data::Dumper::Maxdepth  = 0;
+    local $Data::Dumper::Quotekeys = 0;
+    local $Data::Dumper::Sortkeys  = 1;
+    local $Data::Dumper::Useqq     = 1;
+    local $Data::Dumper::Terse     = 1;
+    return Data::Dumper->Dump( [shift] );
+};
+
+my $_do_trace = sub {
+    my ( $trace, $th, $pid, $cmd, $o ) = @_;
+    print $th "System::Command cmd[$pid]: ",
+        join( ' ', map /\s/ ? $_dump_ref->($_) : $_, @$cmd ), "\n";
+    print $th map "System::Command opt[$pid]: $_->[0] => $_->[1]\n",
+        map [ $_ => $_dump_ref->( $o->{$_} ) ],
+        grep { $_ ne 'env' } sort keys %$o
+        if $trace > 1;
+    print $th map "System::Command env[$pid]: $_->[0] => $_->[1]\n",
+        map [ $_ => $_dump_ref->( $o->{env}{$_} ) ],
+        keys %{ $o->{env} || {} }
+        if $trace > 2;
+};
+
+# module methods
+sub new {
+    my ( $class, @cmd ) = @_;
+
+    # split the args
+    my @o = { setpgrp => 1 };
+    @cmd = grep { !( ref eq 'HASH' ? push @o, $_ : 0 ) } @cmd;
+
+    # merge the option hashes
+    my $o = reduce {
+        +{  %$a, %$b,
+            exists $a->{env} && exists $b->{env}
+            ? ( env => { %{ $a->{env} }, %{ $b->{env} } } )
+            : ()
+        };
+    }
+    @o;
+
+    # open the trace file before changing directory
+    my ( $trace, $th );
+    ( $trace, $th ) = $_trace_opts->( $o->{trace} ) if $o->{trace};
+    ( $trace, $th ) = @trace if @trace;    # environment override
+
+    # chdir to the expected directory
+    my $orig = cwd;
+    my $dest = defined $o->{cwd} ? $o->{cwd} : undef;
+    if ( defined $dest ) {
+        chdir $dest or croak "Can't chdir to $dest: $!";
+    }
+
+    # keep changes to the environment local
+    local %ENV = %ENV;
+
+    # update the environment
+    if ( exists $o->{env} ) {
+        croak "ENV variables cannot be empty strings on Win32"
+            if MSWin32 and grep { defined and !length } values %{ $o->{env} };
+        @ENV{ keys %{ $o->{env} } } = values %{ $o->{env} };
+        delete $ENV{$_}
+            for grep { !defined $o->{env}{$_} } keys %{ $o->{env} };
+    }
+
+    # interactive mode requested
+    if ( $o->{interactive} ) {
+        croak "Can't run command in interactive mode: not a terminal"
+          unless -t STDIN;
+
+        system { $cmd[0] } @cmd;
+
+        my $self = bless {
+            cmdline => [@cmd],
+            options => $o,
+            stdin   => IO::Handle->new,
+            stdout  => IO::Handle->new,
+            stderr  => IO::Handle->new,
+            exit    => $? >> 8,
+            signal  => $? & 127,
+            core    => $? & 128,
+        }, $class;
+
+        defined reftype( $o->{$_} )
+          and reftype( $o->{$_} ) eq 'SCALAR'
+          and ${ $o->{$_} } = $self->{$_}
+          for qw( exit signal core );
+
+        return $self;
+    }
+
+    # start the command
+    my ( $pid, $in, $out, $err ) = eval { $_spawn->( $o, @cmd ); };
+
+    # FIXME - better check error conditions
+    if ( !defined $pid ) {
+        $_do_trace->( $trace, $th, '!', \@cmd, $o ) if $trace;
+        croak $@;
+    }
+
+    # trace is mostly a debugging tool
+    $_do_trace->( $trace, $th, $pid, \@cmd, $o ) if $trace;
+
+    # some input was provided
+    if ( defined $o->{input} ) {
+        local $SIG{PIPE}
+            = sub { croak "Broken pipe when writing to: @cmd" }
+            if $Config{sig_name} =~ /\bPIPE\b/;
+        print {$in} $o->{input} if length $o->{input};
+        $in->close;
+    }
+
+    # chdir back to origin
+    if ( defined $dest ) {
+        chdir $orig or croak "Can't chdir back to $orig: $!";
+    }
+
+    # create the object
+    my $self = bless {
+        cmdline  => [@cmd],
+        options  => $o,
+        pid      => MSWin32 ? $pid->{KIDS}[0]{PID} : $pid,
+        stdin    => $in,
+        stdout   => $out,
+        stderr   => $err,
+      ( _ipc_run => $pid )x!! MSWin32,
+    }, $class;
+
+    # create the subprocess reaper and link the handles and command to it
+    ${*$in} = ${*$out} = ${*$err} = $self->{reaper}    # typeglobs FTW
+      = System::Command::Reaper->new( $self, { trace => $trace, th => $th } );
+
+    return $self;
+}
+
+sub spawn {
+    my ( $class, @cmd ) = @_;
+    return @{ $class->new(@cmd) }{qw( pid stdin stdout stderr )};
+}
+
+sub loop_on {
+    my $self = shift;
+
+    # handle options and defaults
+    my %args = (
+        stderr => sub { print STDERR shift },
+        @_
+    );
+    for my $which ( grep exists $args{$_}, qw( stdout stderr ) ) {
+        if ( $args{$which} ) {
+            croak "'$which' option must be a CODE reference"
+              if reftype $args{$which} ne 'CODE';
+        }
+        else {
+            delete $args{$which};
+        }
+    }
+
+    # create an object for the class method
+    if ( !ref $self ) {
+        die "'command' attribute required by loop_on when used as a class method"
+          if !exists $args{command};
+        $self = $self->new( @{ $args{command} } );
+    }
+
+    require IO::Select;
+    my $select = IO::Select->new( $self->stdout, $self->stderr );
+
+    local $/ = $args{input_record_separator}
+      if exists $args{input_record_separator};
+
+    # loop until end of streams
+    while ( my @ready = $select->can_read ) {
+        for my $fh (@ready) {
+            my $which = $fh == $self->stdout ? 'stdout' : 'stderr';
+            if ( defined( my $line = <$fh> ) ) {
+                my $ret = 1;
+                $ret = $args{$which}->($line)
+                  if exists $args{$which};
+                return if !$ret;
+            }
+            else {
+                $select->remove($fh);
+                $fh->close;
+            }
+        }
+    }
+
+    # close all pipes and wait for the child to terminate
+    $self->close;
+
+    # success in the Unix sense
+    return defined $self->exit && $self->exit == 0;
+}
+
+# delegate those to the reaper (when there's one)
+sub is_terminated {
+    return $_[0]{options}{interactive}
+      ? 1
+      : $_[0]{reaper}->is_terminated();
+}
+
+sub close {
+    $_[0]{reaper}->close() unless $_[0]{options}{interactive};
+    return $_[0];
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+System::Command - Object for running system commands
+
+=head1 VERSION
+
+version 1.122
+
+=head1 SYNOPSIS
+
+    use System::Command;
+
+    # invoke an external command, and return an object
+    $cmd = System::Command->new( @cmd );
+
+    # options can be passed as a hashref
+    $cmd = System::Command->new( @cmd, \%option );
+
+    # $cmd is basically a hash, with keys / accessors
+    $cmd->stdin();     # filehandle to the process stdin (write)
+    $cmd->stdout();    # filehandle to the process stdout (read)
+    $cmd->stderr();    # filehandle to the process stdout (read)
+    $cmd->pid();       # pid of the child process
+
+    # find out if the child process died
+    if ( $cmd->is_terminated() ) {
+        # the handles are not closed yet
+        # but $cmd->exit() et al. are available if it's dead
+    }
+
+    # done!
+    $cmd->close();
+
+    # exit information
+    $cmd->exit();      # exit status
+    $cmd->signal();    # signal
+    $cmd->core();      # core dumped? (boolean)
+
+    # cut to the chase
+    my ( $pid, $in, $out, $err ) = System::Command->spawn(@cmd);
+
+=head1 DESCRIPTION
+
+System::Command is a class that launches external system commands
+and return an object representing them, allowing to interact with them
+through their C<STDIN>, C<STDOUT> and C<STDERR> handles.
+
+=head1 METHODS
+
+System::Command supports the following methods:
+
+=head2 new
+
+    my $cmd = System::Command->new( @cmd )
+
+Runs an external command using the list in C<@cmd>.
+
+If C<@cmd> contains a hash reference, it is taken as an I<option> hash.
+
+If several option hashes are passed to C<new()>, they will be merged
+together with individual values being overridden by those (with the same
+key) from hashes that appear later in the list.
+
+To allow subclasses to support their own set of options, unrecognized
+options are silently ignored.
+
+The recognized keys are:
+
+=over 4
+
+=item C<cwd>
+
+The I<current working directory> in which the command will be run.
+
+=item C<env>
+
+A hashref containing key / values to add to the command environment.
+
+If several option hashes define the C<env> key, the hashes they point
+to will be merged into one (instead of the last one taking precedence).
+
+If a value is C<undef>, the variable corresponding to the key will
+be I<removed> from the environment.
+
+=item C<input>
+
+A string that is send to the command's standard input, which is then closed.
+
+Using the empty string as C<input> will close the command's standard input
+without writing to it.
+
+Using C<undef> as C<input> will not do anything. This behaviour provides
+a way to modify previous options populated by some other part of the program.
+
+On some systems, some commands may close standard input on startup,
+which will cause a SIGPIPE when trying to write to it. This will raise
+an exception.
+
+=item C<interactive>
+
+If true, the command will actually be run using the L<perlfunc/system>
+builtin. If C<STDIN> is not a terminal, the constructor will die.
+
+Not reaper object will be created, and the C<stdin>, C<stdout> and
+C<stderr> filehandles will point to dummy closed handles. The C<exit>,
+C<signal> and C<core> attributes will be correctly set.
+
+(Added in version 1.114.)
+
+=item C<setpgrp>
+
+By default, the spawned process is made the leader of its own process
+group using C<setpgrp( 0, 0 )> (if possible). This enables sending a
+signal to the command and all its child processes at once:
+
+    # negative signal is sent to the process group
+    kill -SIGKILL, $cmd->pid;
+
+Setting the C<setpgrp> option to a false value disables this behaviour.
+
+(Added in version 1.110.)
+
+=item C<trace>
+
+The C<trace> option defines the trace settings for System::Command.
+The C<SYSTEM_COMMAND_TRACE> environment variable can be used to specify
+a global trace setting at startup. The environment variable overrides
+individual C<trace> options.
+
+If C<trace> or C<SYSTEM_COMMAND_TRACE> contains an C<=> character then
+what follows it is used as the name of the file to append the trace to.
+When using the C<trace> option, it is recommended to use an absolute
+path for the trace file, in case the main program C<chdir()> before
+calling System::Command.
+
+At trace level 1, only the command line is shown:
+
+    System::Command cmd[12834]: /usr/bin/git commit -m "Test option hash in new()"
+
+Note: Command-line parameters containing whitespace will be properly quoted.
+
+At trace level 2, the options values are shown:
+
+    System::Command opt[12834]: cwd => "/tmp/kHkPUBIVWd"
+    System::Command opt[12834]: fatal => {128 => 1,129 => 1}
+    System::Command opt[12834]: git => "/usr/bin/git"
+
+Note: The C<fatal> and C<git> options in the example above are actually
+used by L<Git::Repository> to determine the command to be run, and
+ignored by System::Command. References are dumped using L<Data::Dumper>.
+
+At trace level 3, the content of the C<env> option is also listed:
+
+    System::Command env[12834]: GIT_AUTHOR_EMAIL => "author\@example.com"
+    System::Command env[12834]: GIT_AUTHOR_NAME => "Example author"
+
+If the command cannot be spawned, the trace will show C<!> instead of
+the pid:
+
+    System::Command cmd[!]: does-not-exist
+
+(Added in version 1.108.)
+
+=item exit
+
+=item core
+
+=item signal
+
+The above three options can be set to point to a reference to a scalar,
+which will be automatically updated when the command is terminated. See
+the L</Accessors> section for details about what the attributes of the
+same name mean.
+
+(Added in version 1.114.)
+
+=back
+
+The System::Command object returned by C<new()> has a number of
+attributes defined (see below).
+
+
+=head2 close
+
+    $cmd->close;
+
+Close all pipes to the child process, collects exit status, etc.
+and defines a number of attributes (see below).
+
+Returns the invocant, so one can do things like:
+
+    my $exit = $cmd->close->exit;
+
+=head2 is_terminated
+
+    if ( $cmd->is_terminated ) {...}
+
+Returns a true value if the underlying process was terminated.
+
+If the process was indeed terminated, collects exit status, etc.
+and defines the same attributes as C<close()>, but does B<not> close
+all pipes to the child process.
+
+
+=head2 spawn
+
+    my ( $pid, $in, $out, $err ) = System::Command->spawn(@cmd);
+
+This shortcut method calls C<new()> (and so accepts options in the same
+manner) and directly returns the C<pid>, C<stdin>, C<stdout> and C<stderr>
+attributes, in that order.
+
+(Added in version 1.01.)
+
+=head2 loop_on
+
+    $cmd->loop_on(
+        stdout => sub { ... },
+        stderr => sub { ... },
+    );
+
+This method calls the corresponding code references with each line
+produced on the standard output and errput of the command.
+
+If the C<stdout> or C<stderr> argument is not given, the default is to
+silently drop the data for C<stdout>, and to pass through (to STDERR)
+the data for C<stderr>. To prevent any processing, pass a false value
+to the parameter.
+
+For example, the following line will silently run the command to
+completion:
+
+    $cmd->loop_on( stderr => '' );
+
+The method blocks until the command is completed (or rather, until
+its output and errput handles have been closed), or until one of the
+callbacks returns a false value.
+
+Data is read using L<readline|perlfunc/readline>, which depends on C<$/>
+for its definition of a "line". To that effect, the method takes a third
+optional argument, C<input_record_separator>, which sets the value for
+C<$/> for the duration of the call.
+
+I<Caveat Emptor>: since C<loop_on> is line-based, it may B<block> if
+either output or errput sends incomplete lines (e.g. if the command is
+some sort of interactive shell with a prompt).
+
+The return value is true if the command exited with status 0, and false
+otherwise (i.e. the Unix traditional definition of success).
+
+(Added in version 1.117.)
+
+=head2 Accessors
+
+The attributes of a System::Command object are also accessible
+through a number of accessors.
+
+The object returned by C<new()> will have the following attributes defined:
+
+=over 4
+
+=item cmdline
+
+Return the command-line actually executed, as a list of strings.
+
+=item options
+
+The merged list of options used to run the command.
+
+=item pid
+
+The PID of the underlying command.
+
+=item stdin
+
+A filehandle opened in write mode to the child process' standard input.
+
+=item stdout
+
+A filehandle opened in read mode to the child process' standard output.
+
+=item stderr
+
+A filehandle opened in read mode to the child process' standard error output.
+
+=back
+
+Regarding the handles to the child process, note that in the following code:
+
+    my $fh = System::Command->new( @cmd )->stdout;
+
+C<$fh> is opened and points to the output handle of the child process,
+while the anonymous System::Command object has been destroyed. Once
+C<$fh> is destroyed, the subprocess will be reaped, thus avoiding zombies.
+(L<System::Command::Reaper> undertakes this process.)
+
+After the call to C<close()> or after C<is_terminated()> returns true,
+the following attributes will be defined (note that the accessors
+always run C<is_terminated()>, to improve their chance of getting
+a value if the process just finished):
+
+=over 4
+
+=item exit
+
+The exit status of the underlying command.
+
+=item signal
+
+The signal, if any, that killed the command.
+
+=item core
+
+A boolean value indicating if the command dumped core.
+
+=back
+
+Even when not having a reference to the System::Command object any more,
+it's still possible to get the C<exit>, C<core> or C<signal> values,
+using the options of the same name:
+
+    my $fh = System::Command->new( @cmd, { exit => \my $exit } )->stdout;
+
+Once the command is terminated, the C<$exit> variable will contain the
+value that would have been returned by the C<exit()> method.
+
+=head1 CAVEAT EMPTOR
+
+Note that System::Command uses C<waitpid()> to catch the status
+information of the child processes it starts. This means that if your
+code (or any module you C<use>) does something like the following:
+
+    local $SIG{CHLD} = 'IGNORE';    # reap child processes
+
+System::Command will not be able to capture the C<exit>, C<signal>
+and C<core> attributes. It will instead set all of them to the
+impossible value C<-1>, and display the warning
+C<Child process already reaped, check for a SIGCHLD handler>.
+
+To silence this warning (and accept the impossible status information),
+load System::Command with:
+
+    use System::Command -quiet;
+
+It is also possible to more finely control the warning by setting
+the C<$System::Command::QUIET> variable (the warning is not emitted
+if the variable is set to a true value).
+
+If the subprocess started by System::Command has a short life
+expectancy, and no other child process is expected to die during that
+time, you could even disable the handler locally (use at your own risks):
+
+    {
+        local $SIG{CHLD};
+        my $cmd = System::Command->new(@cmd);
+        ...
+    }
+
+=head1 AUTHOR
+
+Philippe Bruhat (BooK), C<< <book at cpan.org> >>
+
+=head1 ACKNOWLEDGEMENTS
+
+Thanks to Alexis Sukrieh (SUKRIA) who, when he saw the description of
+L<Git::Repository::Command> during my talk at OSDC.fr 2010, asked
+why it was not an independent module. This module was started by
+taking out of L<Git::Repository::Command> 1.08 the parts that
+weren't related to Git.
+
+Thanks to Christian Walde (MITHALDU) for his help in making this
+module work better under Win32.
+
+The L<System::Command::Reaper> class was added after the addition
+of Git::Repository::Command::Reaper in L<Git::Repository::Command> 1.11.
+It was later removed from L<System::Command> version 1.03, and brought
+back from the dead to deal with the zombie apocalypse in version 1.106.
+The idea of a reaper class comes from Vincent Pit.
+
+Thanks to Tim Bunce for using L<Git::Repository> and making many
+suggestions based on his use and needs. Most of them turned into
+improvement for System::Command instead, once we figured out that the
+more general feature idea really belonged there.
+
+=head1 BUGS
+
+Please report any bugs or feature requests to C<bug-system-command at rt.cpan.org>, or through
+the web interface at L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=System-Command>.  I will be notified, and then you'll
+automatically be notified of progress on your bug as I make changes.
+
+=head1 SUPPORT
+
+You can find documentation for this module with the perldoc command.
+
+    perldoc System::Command
+
+
+You can also look for information at:
+
+=over 4
+
+=item * RT: CPAN's request tracker
+
+L<http://rt.cpan.org/NoAuth/Bugs.html?Dist=System-Command>
+
+=item * AnnoCPAN: Annotated CPAN documentation
+
+L<http://annocpan.org/dist/System-Command>
+
+=item * CPAN Ratings
+
+L<http://cpanratings.perl.org/d/System-Command>
+
+=item * Search CPAN
+
+L<http://search.cpan.org/dist/System-Command/>
+
+=back
+
+
+=head1 COPYRIGHT
+
+Copyright 2010-2016 Philippe Bruhat (BooK).
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of either: the GNU General Public License as published
+by the Free Software Foundation; or the Artistic License.
+
+See L<http://dev.perl.org/licenses/> for more information.
+
+=cut

--- a/src/main/perl/lib/System/Command.pm
+++ b/src/main/perl/lib/System/Command.pm
@@ -84,7 +84,17 @@ my $_spawn = sub {
         # implemented on top of java.lang.ProcessBuilder. cwd and env
         # are already handled by the caller (System::Command::new)
         # via chdir + `local %ENV`.
-        $pid = IPC::Open3::open3($in, $out, $err, @cmd);
+        $pid = eval { IPC::Open3::open3($in, $out, $err, @cmd) };
+        if (my $err_msg = $@) {
+            # Translate IPC::Open3's "open3: exec of X failed: Y" into
+            # System::Command's own fork-path format
+            # "Can't exec( @cmd ): Y", so error-handling tests (e.g.
+            # t/11-spawn-fail.t) see the expected string in $@.
+            if ($err_msg =~ /^open3: exec of \S+ failed: (.*)$/m) {
+                croak "Can't exec( @cmd ): $1";
+            }
+            die $err_msg;
+        }
     }
     elsif (MSWin32) {
         $pid = IPC::Run::start(

--- a/src/main/perl/lib/System/Command/Reaper.pm
+++ b/src/main/perl/lib/System/Command/Reaper.pm
@@ -1,0 +1,271 @@
+package System::Command::Reaper;
+$System::Command::Reaper::VERSION = '1.122';
+use strict;
+use warnings;
+use 5.006;
+
+use Carp;
+use Scalar::Util qw( weaken reftype );
+
+use POSIX ":sys_wait_h";
+
+use constant MSWin32 => $^O eq 'MSWin32';
+use constant HANDLES => qw( stdin stdout stderr );
+use constant STATUS  => qw( exit signal core );
+
+for my $attr ( HANDLES ) {
+    no strict 'refs';
+    *$attr = sub { return $_[0]{$attr} };
+}
+for my $attr ( STATUS ) {
+    no strict 'refs';
+    *$attr = sub { $_[0]->is_terminated(); return $_[0]{$attr} };
+}
+
+sub new {
+    my ($class, $command, $o) = @_;
+    $o ||= {};
+    my $self = bless { %$o, command => $command }, $class;
+
+    # copy/weaken the important keys
+    @{$self}{ pid => HANDLES } = @{$command}{ pid => HANDLES };
+    weaken $self->{$_} for ( command => HANDLES );
+
+    return $self;
+}
+
+# this is necessary, because kill(0,pid) is misimplemented in perl core
+my $_is_alive = MSWin32
+    ? sub { return `tasklist /FO CSV /NH /fi "PID eq $_[0]"` =~ /^"/ }
+    : sub { return kill 0, $_[0]; };
+
+sub is_terminated {
+    my ($self) = @_;
+    my $pid = $self->{pid};
+
+    # Zed's dead, baby. Zed's dead.
+    return $pid if !$_is_alive->($pid) and exists $self->{exit};
+
+    # If that is a re-animated body, we're gonna have to kill it.
+    return $self->_reap(WNOHANG);
+}
+
+sub _reap {
+    my ( $self, $flags ) = @_;
+
+    $flags = 0 if ! defined $flags;
+
+    my $pid = $self->{pid};
+
+    # REPENT/THE END IS/EXTREMELY/FUCKING/NIGH
+    if ( !exists $self->{exit} and my $reaped = waitpid( $pid, $flags ) ) {
+
+        # Well, it's a puzzle because, technically, you're not alive.
+        my $zed = $reaped == $pid;
+        carp "Child process already reaped, check for a SIGCHLD handler"
+            if !$zed && !$System::Command::QUIET && !MSWin32;
+
+        # What do you think? "Zombie Kill of the Week"?
+        @{$self}{ STATUS() }
+            = $zed
+            ? ( $? >> 8, $? & 127, $? & 128 )
+            : ( -1, -1, -1 );
+
+        # Who died and made you fucking king of the zombies?
+        if ( defined( my $cmd = $self->{command} ) ) {
+            @{$cmd}{ STATUS() } = @{$self}{ STATUS() };
+
+            # I know you're here, because I can smell your brains.
+            my $o = $cmd->{options};
+            defined reftype( $o->{$_} )
+              and reftype( $o->{$_} ) eq 'SCALAR'
+              and ${ $o->{$_} } = $self->{$_}
+              for STATUS();
+        }
+
+        # I think it's safe to assume it isn't a zombie.
+        print { $self->{th} } "System::Command xit[$pid]: ",
+          join( ', ', map "$_: $self->{$_}", STATUS() ), "\n"
+          if $self->{trace};
+
+        return $reaped;    # It's dead, Jim!
+    }
+
+    # Look! It's moving. It's alive. It's alive...
+    return;
+}
+
+sub close {
+    my ($self) = @_;
+
+    # close all pipes
+    my ( $in, $out, $err ) = @{$self}{qw( stdin stdout stderr )};
+    $in  and $in->opened  and $in->close  || carp "error closing stdin: $!";
+    $out and $out->opened and $out->close || carp "error closing stdout: $!";
+    $err and $err->opened and $err->close || carp "error closing stderr: $!";
+
+    # and wait for the child (if any)
+    $self->_reap();
+
+    return $self;
+}
+
+sub DESTROY {
+    my ($self) = @_;
+    local $?;
+    local $!;
+    $self->close if !exists $self->{exit};
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+System::Command::Reaper - Reap processes started by System::Command
+
+=head1 VERSION
+
+version 1.122
+
+=head1 SYNOPSIS
+
+This class is used for internal purposes.
+Move along, nothing to see here.
+
+=head1 DESCRIPTION
+
+The L<System::Command> objects delegate the reaping of child
+processes to System::Command::Reaper objects. This allows a user
+to create a L<System::Command> and discard it after having obtained
+one or more references to its handles connected to the child process.
+
+The typical use case looks like this:
+
+    my $fh = System::Command->new( @cmd )->stdout();
+
+The child process is reaped either through a direct call to C<close()>
+or when the command object and all its handles have been destroyed,
+thus avoiding zombies (which would be reaped by the system at the end
+of the main program).
+
+This is possible thanks to the following reference graph:
+
+        System::Command
+         |   |   |  ^|
+         v   v   v  !|
+        in out err  !|
+        ^|  ^|  ^|  !|
+        !v  !v  !v  !v
+    System::Command::Reaper
+
+Legend:
+    | normal ref
+    ! weak ref
+
+The System::Command::Reaper object acts as a sentinel, that takes
+care of reaping the child process when the original L<System::Command>
+and its filehandles have been destroyed (or when L<System::Command>
+C<close()> method is being called).
+
+=head1 METHODS
+
+System::Command::Reaper supports the following methods:
+
+=head2 new
+
+    my $reaper = System::Command::Reaper->new( $cmd, \%extra );
+
+Create a new System::Command::Reaper object attached to the
+L<System::Command> object passed as a parameter.
+
+An optional hash reference can be used to pass extra attributes to the object.
+
+=head2 close
+
+    $reaper->close();
+
+Close all the opened filehandles of the main L<System::Command> object,
+reaps the child process, and updates the main object with the status
+information of the child process.
+
+C<DESTROY> calls C<close()> when the sentinel is being destroyed.
+
+=head2 is_terminated
+
+    if ( $reaper->is_terminated ) {...}
+
+Returns a true value if the underlying process was terminated.
+
+If the process was indeed terminated, collects exit status, etc.
+
+=head2 Accessors
+
+The attributes of a System::Command::Reaper object are also accessible
+through a number of accessors.
+
+The object returned by C<new()> will have the following attributes defined
+(as copied from the L<System::Command> object that created the reaper):
+
+=over 4
+
+=item pid
+
+The PID of the underlying command.
+
+=item stdin
+
+A filehandle opened in write mode to the child process' standard input.
+
+=item stdout
+
+A filehandle opened in read mode to the child process' standard output.
+
+=item stderr
+
+A filehandle opened in read mode to the child process' standard error output.
+
+=back
+
+After the call to C<close()> or after C<is_terminated()> returns true,
+the following attributes will be defined:
+
+=over 4
+
+=item exit
+
+The exit status of the underlying command.
+
+=item core
+
+A boolean value indicating if the command dumped core.
+
+=item signal
+
+The signal, if any, that killed the command.
+
+=back
+
+=head1 AUTHOR
+
+Philippe Bruhat (BooK), C<< <book at cpan.org> >>
+
+=head1 ACKNOWLEDGEMENTS
+
+This scheme owes a lot to Vincent Pit who on #perlfr provided the
+general idea (use a proxy to delay object destruction and child process
+reaping) with code examples, which I then adapted to my needs.
+
+=head1 COPYRIGHT
+
+Copyright 2010-2016 Philippe Bruhat (BooK), all rights reserved.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or modify it
+under the same terms as Perl itself.
+
+=cut

--- a/src/test/resources/module/System-Command/t/00-compile.t
+++ b/src/test/resources/module/System-Command/t/00-compile.t
@@ -1,0 +1,61 @@
+use 5.006;
+use strict;
+use warnings;
+
+# this test was generated with Dist::Zilla::Plugin::Test::Compile 2.058
+
+use Test::More;
+
+plan tests => 2 + ($ENV{AUTHOR_TESTING} ? 1 : 0);
+
+my @module_files = (
+    'System/Command.pm',
+    'System/Command/Reaper.pm'
+);
+
+
+
+# no fake home requested
+
+my @switches = (
+    -d 'blib' ? '-Mblib' : '-Ilib',
+);
+
+use File::Spec;
+use IPC::Open3;
+use IO::Handle;
+
+open my $stdin, '<', File::Spec->devnull or die "can't open devnull: $!";
+
+my @warnings;
+for my $lib (@module_files)
+{
+    # see L<perlfaq8/How can I capture STDERR from an external command?>
+    my $stderr = IO::Handle->new;
+
+    diag('Running: ', join(', ', map { my $str = $_; $str =~ s/'/\\'/g; q{'} . $str . q{'} }
+            $^X, @switches, '-e', "require q[$lib]"))
+        if $ENV{PERL_COMPILE_TEST_DEBUG};
+
+    my $pid = open3($stdin, '>&STDERR', $stderr, $^X, @switches, '-e', "require q[$lib]");
+    binmode $stderr, ':crlf' if $^O eq 'MSWin32';
+    my @_warnings = <$stderr>;
+    waitpid($pid, 0);
+    is($?, 0, "$lib loaded ok");
+
+    shift @_warnings if @_warnings and $_warnings[0] =~ /^Using .*\bblib/
+        and not eval { +require blib; blib->VERSION('1.01') };
+
+    if (@_warnings)
+    {
+        warn @_warnings;
+        push @warnings, @_warnings;
+    }
+}
+
+
+
+is(scalar(@warnings), 0, 'no warnings found')
+    or diag 'got warnings: ', ( Test::More->can('explain') ? Test::More::explain(\@warnings) : join("\n", '', @warnings) ) if $ENV{AUTHOR_TESTING};
+
+

--- a/src/test/resources/module/System-Command/t/01-load.t
+++ b/src/test/resources/module/System-Command/t/01-load.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More;
+
+my @tests = (
+    [ q{use System::Command},         0 ],
+    [ q{use System::Command 'quiet'}, 1 ],
+    [ q{use System::Command -quiet},  1 ],
+    [ q{use System::Command 'verbose'}, undef, qr/^Unknown option 'verbose'/ ],
+    [ q{use System::Command -verbose},  undef, qr/^Unknown option 'verbose'/ ],
+);
+
+plan tests => 2 * @tests;
+
+for my $t (@tests) {
+    my ( $code, $expected, $at ) = @$t;
+
+    # clean up
+    no warnings 'once';
+    delete $INC{'System/Command.pm'};
+    $System::Command::QUIET = 0;
+
+    # test
+    local $SIG{__WARN__} = sub { };
+    is( eval "$code; \$System::Command::QUIET", $expected, $code );
+    like( $@, $at || qr/^$/, 'use ' . ( $at ? 'failed' : 'succeeded' ) );
+}
+

--- a/src/test/resources/module/System-Command/t/21-loop_on.t
+++ b/src/test/resources/module/System-Command/t/21-loop_on.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use Test::More;
+
+use File::Spec;
+use System::Command;
+
+my @cmd = ( $^X, File::Spec->catfile( t => 'lines.pl' ) );
+
+my $O = 1 + int rand 5;
+my $E = 1 + int rand 5;
+plan tests => $O + $E + 2;
+
+# basic usage
+my ( $o, $e ) = ( 1, 1 );
+my $cmd = System::Command->new( @cmd, $O, $E );
+$cmd->loop_on(
+    stdout =>
+      sub { like( shift, qr/^STDOUT line $o$/, "STDOUT line $o" ); $o++ },
+    stderr =>
+      sub { like( shift, qr/^STDERR line $e$/, "STDERR line $e" ); $e++ },
+);
+
+# early abort
+my $c = 0;
+$cmd = System::Command->new( @cmd, 10, 10 );
+$cmd->loop_on(
+    stdout => sub { return !( ++$c == 5 ) },
+    stderr => ''
+);
+is( $c, 5, 'Aborted after 5 lines' );
+
+like( $cmd->stdout->getline, qr/^STDOUT line 6/, 'Command still runs' );

--- a/src/test/resources/module/System-Command/t/25-refopts.t
+++ b/src/test/resources/module/System-Command/t/25-refopts.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+use System::Command;
+
+my @cmd = ( $^X, '-eexit+shift' );
+my @codes = ( 0 .. 2, 127 .. 129 );
+
+plan tests => 3 * @codes;
+
+for my $code ( @codes ) {
+    my $cmd = System::Command->new(@cmd, $code, { exit => \my $exit } );
+    sleep 1 while !$cmd->is_terminated;
+
+    # ensure waitpid isn't called twice, thus clobbering $?
+    $cmd->close;
+    is( $? >> 8, $code, "\$? >> 8 is $code" );
+
+    # check the exit value
+    is( $cmd->exit, $code, "\$cmd->exit is $code" );
+    is( $exit, $code, "\$exit is $code" );
+}

--- a/src/test/resources/module/System-Command/t/90-output.t
+++ b/src/test/resources/module/System-Command/t/90-output.t
@@ -1,0 +1,41 @@
+use warnings;
+use strict;
+use Test::More;
+
+BEGIN {
+    if ( !eval 'use Test::Output; 1;' ) {
+        $ENV{RELEASE_TESTING}
+            ? die "Test::Output is required for RELEASE_TESTING"
+            : plan skip_all => 'Test::Output not available';
+    }
+}
+
+use System::Command;
+
+sub print_implicit { print "STDOUT\n"; }
+sub print_stdout   { print STDOUT "STDOUT\n"; }
+sub print_stderr   { print STDERR "STDERR\n"; }
+
+plan tests => 10;
+
+# before
+stdout_is( \&print_implicit, "STDOUT\n", 'print' );
+stdout_is( \&print_stdout,   "STDOUT\n", 'print STDOUT' );
+stderr_is( \&print_stderr, "STDERR\n", 'print STDERR' );
+
+# during
+{
+    my $cmd = System::Command->new( $^X => qw( -le print+1 ) );
+    stdout_is( \&print_implicit, "STDOUT\n", 'print' );
+    stdout_is( \&print_stdout,   "STDOUT\n", 'print STDOUT' );
+    stderr_is( \&print_stderr, "STDERR\n", 'print STDERR' );
+
+    is( $cmd->stdout->getline, "1\n", 'expected command output' );
+    $cmd->close;
+}
+
+# after
+stdout_is( \&print_implicit, "STDOUT\n", 'print' );
+stdout_is( \&print_stdout,   "STDOUT\n", 'print STDOUT' );
+stderr_is( \&print_stderr, "STDERR\n", 'print STDERR' );
+

--- a/src/test/resources/module/System-Command/t/lines.pl
+++ b/src/test/resources/module/System-Command/t/lines.pl
@@ -1,0 +1,13 @@
+#!perl
+use strict;
+use warnings;
+
+my @fh = map { [ $_ => \do { my $ln = 1 } ] } qw( STDOUT STDERR );
+
+for my $lines (@ARGV) {
+    no strict 'refs';
+    push @fh, [ my ( $nm, $ln ) = @{ shift @fh } ];
+    my $fh = \*$nm;
+    print $fh join '', $nm, ' line ', $$ln++, "\n" while $lines--;
+}
+

--- a/src/test/resources/unit/tie_scalar.t
+++ b/src/test/resources/unit/tie_scalar.t
@@ -225,14 +225,60 @@ subtest 'Local and tied scalars' => sub {
     our $scalar;
     tie $scalar, 'TiedScalar';
     $scalar = "original";
-    
+
     {
         local $scalar = "localized";
         is($scalar, "localized", 'local value set correctly');
     }
-    
+
     # Note: behavior with local and tie can be complex
     # The exact behavior may depend on the Perl implementation
+};
+
+subtest 'local on tied scalar dispatches STORE/FETCH' => sub {
+    # Real Perl dispatches FETCH/STORE through the tie handler during
+    # `local $tied = value`. Critically: STORE must fire on assignments
+    # inside the localized scope, and on scope exit the original value
+    # must be restored through the tie (so downstream modules like
+    # File::chdir actually chdir back).
+    @TrackedTiedScalar::method_calls = ();
+    our $tvar;
+    tie $tvar, 'TrackedTiedScalar';
+
+    $tvar = "original";
+    my $direct_store = grep { $_->[0] eq 'STORE' && $_->[1] eq 'original' }
+        @TrackedTiedScalar::method_calls;
+    is($direct_store, 1, 'direct assignment dispatches STORE');
+
+    @TrackedTiedScalar::method_calls = ();
+    {
+        local $tvar = "scoped";
+        # Inside the scope, the tie must still be active: reading must
+        # call FETCH and return the currently-stored value.
+        my $v = $tvar;
+        is($v, "scoped", 'local value visible inside scope');
+
+        # And a fresh assignment must dispatch STORE, not just write the
+        # slot — this is what File::chdir / Git::Wrapper depend on.
+        $tvar = "scoped-again";
+        my $stored_scoped_again = grep {
+            $_->[0] eq 'STORE' && $_->[1] eq 'scoped-again'
+        } @TrackedTiedScalar::method_calls;
+        is($stored_scoped_again, 1,
+            'assignment inside local scope dispatches STORE');
+    }
+
+    # After the scope, the tied scalar must be visible again with its
+    # original value. The exact restore mechanism is implementation-
+    # defined, but the observable value must be "original".
+    is($tvar, "original", 'original value restored after local scope');
+
+    # Was STORE called at least once with the localized value during
+    # entry to the scope? (Real Perl does STORE(""), STORE($newval).)
+    my $store_scoped = grep {
+        $_->[0] eq 'STORE' && $_->[1] eq 'scoped'
+    } @TrackedTiedScalar::method_calls;
+    ok($store_scoped >= 1, 'local entry dispatches STORE with new value');
 };
 
 subtest 'References to tied scalars' => sub {


### PR DESCRIPTION
## Summary

Make Git-related CPAN modules work on PerlOnJava. Plan & investigation in
[`dev/modules/git_modules_support.md`](dev/modules/git_modules_support.md).

**Results**

| Module | Before | After |
|---|---|---|
| Git::Wrapper | 52/57 (91%) | **75/75 (100%)** |
| System::Command | mostly skipped | **132/140 (94%)** |
| Git::Repository | ~15/~60 running (rest skipped) | **304/328 (93%)** |

`Git::Raw` is XS-only libgit2 and remains unsupported — a JGit-backed
port would be a separate, sizable effort comparable to the recent
Crypt::OpenSSL Bouncy Castle work.

## Changes

### 1. `fix(tie): dispatch STORE/FETCH through tie magic under `local``

`GlobalRuntimeScalar.dynamicSaveState/dynamicRestoreState` previously
swapped the tied slot for a fresh untied `GlobalRuntimeScalar` when
entering a `local $tied = value` scope, silently dropping the tie.
`File::chdir`'s tied `$CWD` never called `chdir` under `local`, which
meant `Git::Wrapper`'s `local $CWD = $self->dir` was a no-op — every
failure in its suite traced back to this one bug.

Now, when the slot holds a `TIED_SCALAR`, the tie stays in place for
the whole localized scope. We dispatch `STORE(undef)` on entry and
`STORE(savedValue)` on exit, matching real Perl's observable behaviour
(verified against system `perl`).

New subtest in `src/test/resources/unit/tie_scalar.t` pins this down.

### 2. `feat(System::Command): IPC::Open3 fallback for PerlOnJava (no fork)`

`System::Command::_spawn` was hand-rolled `pipe + fork + exec`. Since
the JVM has no `fork`, every `Git::Repository` test harness skipped
with `1..0 # SKIP fork() not supported on this platform (Java/JVM)`.

The bundled `src/main/perl/lib/System/Command.pm` now detects
PerlOnJava via `$Config{perlonjava}` and routes the child through
`IPC::Open3::open3` (already implemented on top of
`java.lang.ProcessBuilder`). The caller's existing `cwd`/`env`
handling (`chdir` + `local %ENV`) around `_spawn` is untouched.

### 3. `test(System::Command): bundle test suite under src/test/resources/module`

Add the cleanly-passing subset of System::Command's test suite
(`00-compile.t`, `01-load.t`, `21-loop_on.t`, `25-refopts.t`,
`90-output.t` + `t/lines.pl`) under `src/test/resources/module/System-Command/`
so the patch is regression-covered by `make test-bundled-modules`.

Tests that need deeper fork semantics are left out for now and
documented in the plan doc.

The `testModule` gradle task now exports `PERLONJAVA_EXECUTABLE`
pointing at the project's `jperl` launcher so `$^X` resolves during
tests that spawn a child perl (most of System::Command's suite).

## Test plan

- [x] `make` — full unit tests pass
- [x] `make test-bundled-modules` — all 5 new System::Command tests pass
- [x] `./jcpan -t Git::Wrapper` — 75/75
- [x] `./jcpan -t System::Command` — 132/140 (remaining 8 are SHLVL diffs,
  unrelated to fork)
- [x] `./jcpan -t Git::Repository` — 304/328 (remaining failures are
  minor edge cases)
- [x] New unit subtest `tie_scalar.t: local on tied scalar dispatches STORE/FETCH`
  passes under both system `perl` and `jperl`

## Caveat

`~/.perlonjava/lib` takes precedence over the JAR-bundled lib in `@INC`.
Users who already installed System::Command from CPAN need to
`rm ~/.perlonjava/lib/System/Command.pm` once to pick up the bundled
patch. New installs Just Work. Plan doc discusses an install-time
patching hook as follow-up.

Generated with [Devin](https://cli.devin.ai/docs)
