### PR TITLE
feat(DBI): driver-architecture + pure-Perl DBD support

### DIFF
--- a/dev/modules/dbi_test_parity.md
+++ b/dev/modules/dbi_test_parity.md
@@ -5,7 +5,16 @@ DBI test suite, 200 test files) pass on PerlOnJava.
 
 ## Current Baseline
 
-After Phase 1 (runtime interpreter fallback on VerifyError, PR TBD):
+After Phase 2 (driver-architecture pieces: `install_driver`,
+`_new_drh` / `_new_dbh` / `_new_sth`, `DBD::_::common / dr / db / st`
+base classes):
+
+| | Files | Subtests | Passing | Failing |
+|---|---|---|---|---|
+| `jcpan -t DBI` | 200 | 1600 | 1240 | 360 |
+
+Previous baseline (after Phase 1 — runtime interpreter fallback,
+[PR #542](https://github.com/fglock/PerlOnJava/pull/542)):
 
 | | Files | Subtests | Passing | Failing |
 |---|---|---|---|---|
@@ -146,6 +155,8 @@ and re-invoke, rather than aborting the process.
 ---
 
 ## Phase 2 (priority 2): missing DBI core internals
+
+**Status: done (2026-04-22). Pure-Perl DBDs now load and connect.**
 
 Several tests die with:
 
@@ -306,7 +317,7 @@ Triage these once Phase 1 & 2 are done and we have clean output.
 
 ## Progress Tracking
 
-### Current Status: Phase 1 complete. Phase 2 is next.
+### Current Status: Phase 2 complete. Phase 3 is next.
 
 ### Completed
 
@@ -321,7 +332,7 @@ Triage these once Phase 1 & 2 are done and we have clean output.
     `src/main/perl/lib/DBI/_Utils.pm`.
   - Baseline went from 308/562 passing to 368/638 passing.
 
-- [x] **2026-04-22 — Phase 1: runtime interpreter fallback.** PR TBD.
+- [x] **2026-04-22 — Phase 1: runtime interpreter fallback.** PR #542.
   - Added a second try/catch at the `runtimeCode.apply(...)` call
     site in `PerlLanguageProvider.executeCode`. The existing
     compile-time fallback path only runs while
@@ -341,15 +352,37 @@ Triage these once Phase 1 & 2 are done and we have clean output.
     still fail — those are Phase 2/3 DBI-level issues that were
     previously hidden behind the verifier crash.
 
+- [x] **2026-04-22 — Phase 2: driver-architecture pieces.** PR TBD.
+  - Added `DBI->install_driver`, `DBI->data_sources`,
+    `DBI->available_drivers`, `DBI->installed_drivers`,
+    `DBI->setup_driver`, `DBI::_new_drh`, `DBI::_new_dbh`,
+    `DBI::_new_sth`, `DBI::_get_imp_data` in the new
+    `src/main/perl/lib/DBI/_Handles.pm`.
+  - Added `DBD::_::common` / `dr` / `db` / `st` base classes with
+    FETCH, STORE, err, errstr, state, set_err, trace, trace_msg,
+    parse_trace_flag(s), func, dump_handle, default connect,
+    connect_cached, quote, data_sources, disconnect, finish,
+    fetchrow_array/hashref, rows, etc. — enough for the bundled
+    pure-Perl DBDs to work (`DBD::NullP`, `DBD::ExampleP`,
+    `DBD::Sponge`, `DBD::Mem`, `DBD::File`, `DBD::DBM`).
+  - Stubbed `DBI::dr` / `DBI::db` / `DBI::st` packages so
+    `isa('DBI::dr')` etc. pass; `DBD::_::<suffix>` inherits from
+    them.
+  - Modified `DBI->connect` in `DBI.pm`: when the DSN's driver
+    (`DBD::$name`) has a `driver()` method but no `_dsn_to_jdbc`
+    (i.e. it's a pure-Perl DBD), route through
+    `install_driver($name)->connect(...)` instead of the JDBC path.
+  - Baseline went from 676/946 passing to 1240/1600 passing
+    (+564 additional subtests now pass; +654 more execute). 10
+    fewer test files fail overall.
+
 ### Next Steps
 
-1. Start **Phase 2**: implement `DBI->install_driver`,
-   `DBI::_new_drh`, `DBI::_new_dbh`, `DBI::_new_sth`, and the
-   `DBD::_::common` / `db` / `st` base classes. This should unblock
-   `t/02dbidrv.t`, `t/07kids.t`, `t/10examp.t`,
-   `t/17handle_error.t`, etc.
-2. After Phase 2, re-run `jcpan -t DBI` and refresh the baseline
-   table in this document.
+1. Start **Phase 3**: skip `DBI::PurePerl` cleanly under PerlOnJava
+   (or decide to port it), and triage `DBD::File` / `DBD::DBM`
+   behaviour against `t/49dbd_file.t` and friends. `DBD::Gofer`
+   can be deferred until the others stabilise.
+2. After Phase 3, re-run `jcpan -t DBI` and refresh the baseline.
 
 ### Open Questions
 

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "f552b7301";
+    public static final String gitCommitId = "efbf5541d";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 22 2026 16:07:18";
+    public static final String buildTimestamp = "Apr 22 2026 16:41:49";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/perl/lib/DBI.pm
+++ b/src/main/perl/lib/DBI.pm
@@ -198,6 +198,14 @@ use constant {
 # combined DBI.pm would otherwise exceed a per-method bytecode limit.
 require DBI::_Utils;
 
+# Driver-architecture pieces: DBI->install_driver, DBI::_new_drh /
+# _new_dbh / _new_sth, and the DBD::_::common / dr / db / st base
+# classes. Also lives in its own file for the per-method bytecode
+# size limit reason. Required by the pure-Perl DBDs bundled with
+# upstream DBI (DBD::NullP, DBD::ExampleP, DBD::Sponge, DBD::File,
+# DBD::DBM, DBD::Mem, etc.).
+require DBI::_Handles;
+
 # DSN translation: convert Perl DBI DSN format to JDBC URL
 # This wraps the Java-side connect() to support dbi:Driver:... format
 # Handles attribute syntax: dbi:Driver(RaiseError=1):rest
@@ -230,6 +238,24 @@ require DBI::_Utils;
             eval "require $dbd_class";
             if ($dbd_class->can('_dsn_to_jdbc')) {
                 $dsn = $dbd_class->_dsn_to_jdbc($rest);
+            }
+            elsif ($dbd_class->can('driver')) {
+                # Pure-Perl DBD (no JDBC backing). Route through the
+                # DBI driver-architecture path: install the driver and
+                # let its connect() build the dbh via DBI::_new_dbh.
+                my $drh = eval { DBI->install_driver($driver) };
+                if ($drh) {
+                    my $dbh = $drh->connect($rest, $user, $pass, $attr);
+                    if ($dbh) {
+                        # real DBI does this in _new_dbh but we want
+                        # to be permissive for drivers that don't.
+                        $dbh->{Driver} = $drh;
+                        $dbh->{Name} = $rest if !defined $dbh->{Name};
+                        $dbh->STORE(Active => 1) unless $dbh->FETCH('Active');
+                    }
+                    return $dbh;
+                }
+                # fall through to JDBC path if install_driver croaked
             }
         }
         my $dbh = $orig_connect->($class, $dsn, $user, $pass, $attr);

--- a/src/main/perl/lib/DBI/_Handles.pm
+++ b/src/main/perl/lib/DBI/_Handles.pm
@@ -1,0 +1,477 @@
+# Internal helper module for DBI. Provides the driver-architecture
+# pieces that pure-Perl DBDs (DBD::NullP, DBD::ExampleP, DBD::Sponge,
+# DBD::File, DBD::Mem, DBD::DBM, DBD::Proxy, ...) expect to see:
+#
+#   * DBI->install_driver / installed_drivers / setup_driver
+#   * DBI::_new_drh, DBI::_new_dbh, DBI::_new_sth  (handle factories)
+#   * DBD::_::common / DBD::_::dr / DBD::_::db / DBD::_::st base
+#     classes with FETCH / STORE / set_err / err / errstr / state /
+#     trace / trace_msg / func / DESTROY / finish / default connect.
+#
+# Lives in its own file so PerlOnJava compiles it to a separate JVM
+# class (see note in DBI.pm).
+#
+# NOTE: this is a *minimal* reimplementation aimed at making the
+# bundled DBI test suite load and exercise pure-Perl drivers. It is
+# intentionally simpler than real DBI.pm. Notable differences:
+#
+#   - Handles are plain blessed hashrefs, not tied hashes. `FETCH`
+#     / `STORE` / `can` / `isa` all work, and DBD drivers that use
+#     `$h->STORE(key => val)` / `$h->{key}` interchangeably work,
+#     but `each %$h` and tie-aware introspection do not.
+#   - `_new_drh` / `_new_dbh` / `_new_sth` return the same object
+#     for the outer and inner handle. Real DBI distinguishes them
+#     via a tie; we don't.
+#   - Trace flag parsing is a stub (enough to satisfy tests that
+#     probe it, not a full implementation).
+
+package DBI;
+
+use strict;
+use warnings;
+
+our %installed_drh;    # driver_name => $drh
+
+# ---- handle factories -----------------------------------------------
+
+sub _new_drh {
+    # called by DBD::<name>::driver() with the fully-qualified ::dr
+    # package name as $class, plus initial attrs and private data.
+    my ($class, $initial_attr, $imp_data) = @_;
+    my $drh = {
+        # defaults real DBI copies down to children
+        State       => \my $h_state,
+        Err         => \my $h_err,
+        Errstr      => \(my $h_errstr = ''),
+        TraceLevel  => 0,
+        FetchHashKeyName => 'NAME',
+        %{ $initial_attr || {} },
+        ImplementorClass => $class,
+        Kids        => 0,
+        ActiveKids  => 0,
+        Active      => 1,
+    };
+    $drh->{_private_data} = $imp_data if defined $imp_data;
+    bless $drh, $class;
+    return wantarray ? ($drh, $drh) : $drh;
+}
+
+sub _new_dbh {
+    my ($drh, $attr, $imp_data) = @_;
+    my $imp_class = $drh->{ImplementorClass}
+        or Carp::croak("DBI _new_dbh: $drh has no ImplementorClass");
+    # driver::dr -> driver::db
+    (my $db_class = $imp_class) =~ s/::dr$/::db/;
+    my $dbh = {
+        Err       => \my $h_err,
+        Errstr    => \(my $h_errstr = ''),
+        State     => \my $h_state,
+        TraceLevel => 0,
+        %{ $attr || {} },
+        ImplementorClass => $db_class,
+        Driver    => $drh,
+        Kids      => 0,
+        ActiveKids => 0,
+        Active    => 0,   # driver's connect() is expected to set Active=1
+        Statement => '',
+    };
+    $dbh->{_private_data} = $imp_data if defined $imp_data;
+    bless $dbh, $db_class;
+    $drh->{Kids}++;
+    return wantarray ? ($dbh, $dbh) : $dbh;
+}
+
+sub _new_sth {
+    my ($dbh, $attr, $imp_data) = @_;
+    my $imp_class = $dbh->{ImplementorClass}
+        or Carp::croak("DBI _new_sth: $dbh has no ImplementorClass");
+    (my $st_class = $imp_class) =~ s/::db$/::st/;
+    my $sth = {
+        Err       => \my $h_err,
+        Errstr    => \(my $h_errstr = ''),
+        State     => \my $h_state,
+        TraceLevel => 0,
+        NUM_OF_FIELDS => 0,
+        NUM_OF_PARAMS => 0,
+        %{ $attr || {} },
+        ImplementorClass => $st_class,
+        Database  => $dbh,
+        Active    => 0,
+    };
+    $sth->{_private_data} = $imp_data if defined $imp_data;
+    bless $sth, $st_class;
+    $dbh->{Kids}++;
+    return wantarray ? ($sth, $sth) : $sth;
+}
+
+# ---- driver installation --------------------------------------------
+
+sub install_driver {
+    my ($class, $driver, $attr) = @_;
+    Carp::croak("usage: $class->install_driver(\$driver [, \\%attr])")
+        unless defined $driver && length $driver;
+    return $installed_drh{$driver} if $installed_drh{$driver};
+
+    my $dbd_class = "DBD::$driver";
+    my $ok = eval "require $dbd_class; 1";
+    unless ($ok) {
+        my $err = $@ || 'unknown error';
+        Carp::croak("install_driver($driver) failed: $err");
+    }
+
+    # wire up @ISA for DBD::$driver::{dr,db,st} so SUPER:: works
+    $class->setup_driver($dbd_class);
+
+    my $drh = $dbd_class->driver($attr || {});
+    Carp::croak("$dbd_class->driver() did not return a driver handle")
+        unless ref $drh;
+    $installed_drh{$driver} = $drh;
+    return $drh;
+}
+
+sub setup_driver {
+    my ($class, $driver_class) = @_;
+    no strict 'refs';
+    for my $suffix (qw(dr db st)) {
+        my $h_class = "${driver_class}::${suffix}";
+        my $base    = "DBD::_::${suffix}";
+        push @{"${h_class}::ISA"}, $base
+            unless UNIVERSAL::isa($h_class, $base);
+    }
+}
+
+sub installed_drivers { %installed_drh }
+
+sub data_sources {
+    my ($class, $driver, $attr) = @_;
+    my $drh = ref($class) ? $class : $class->install_driver($driver);
+    return $drh->data_sources($attr);
+}
+
+sub available_drivers {
+    my ($class, $quiet) = @_;
+    # Best-effort: scan @INC for DBD::* modules. Tests usually only
+    # care that this returns a list, not an exact one.
+    my %seen;
+    for my $dir (@INC) {
+        next unless ref($dir) eq '' && -d "$dir/DBD";
+        if (opendir my $dh, "$dir/DBD") {
+            while (my $e = readdir $dh) {
+                next unless $e =~ /^(\w+)\.pm$/;
+                $seen{$1} ||= 1;
+            }
+            closedir $dh;
+        }
+    }
+    return sort keys %seen;
+}
+
+# ---- base classes ----------------------------------------------------
+#
+# Real DBI exposes these as `DBD::_::common` + DBD::_::{dr,db,st},
+# where each DBD::<name>::<suffix> inherits from DBD::_::<suffix>
+# (wired by setup_driver above). Real DBI additionally makes handles
+# pass `isa('DBI::dr')` / `isa('DBI::db')` / `isa('DBI::st')` —
+# DBIx::Class and the DBI self-tests rely on this. We achieve that
+# by having DBD::_::<suffix> inherit from DBI::<suffix>.
+
+{
+    package DBI::dr; our @ISA = ();
+    package DBI::db; our @ISA = ();
+    package DBI::st; our @ISA = ();
+}
+
+sub _get_imp_data {
+    my $h = shift;
+    return ref($h) ? $h->{_private_data} : undef;
+}
+
+{
+    package DBD::_::common;
+    our @ISA = ();
+    use strict;
+
+    sub FETCH {
+        my ($h, $key) = @_;
+        return undef unless ref $h;
+        my $v = $h->{$key};
+        # Err / Errstr / State are stored as scalarref holders so they
+        # can be shared with child handles. Dereference on FETCH.
+        return $$v if ref($v) eq 'SCALAR' && $key =~ /^(?:Err|Errstr|State)$/;
+        return $v;
+    }
+
+    sub STORE {
+        my ($h, $key, $val) = @_;
+        if ($key =~ /^(?:Err|Errstr|State)$/ && ref($h->{$key}) eq 'SCALAR') {
+            ${ $h->{$key} } = $val;
+        } else {
+            $h->{$key} = $val;
+        }
+        return 1;
+    }
+
+    sub EXISTS   { defined($_[0]->FETCH($_[1])) }
+    sub FIRSTKEY { }
+    sub NEXTKEY  { }
+    sub CLEAR    { Carp::carp "Can't CLEAR $_[0] (DBI)" }
+
+    sub err {
+        my $h = shift;
+        my $v = $h->{Err};
+        return ref($v) eq 'SCALAR' ? $$v : $v;
+    }
+    sub errstr {
+        my $h = shift;
+        my $v = $h->{Errstr};
+        return ref($v) eq 'SCALAR' ? $$v : $v;
+    }
+    sub state {
+        my $h = shift;
+        my $v = $h->{State};
+        my $s = ref($v) eq 'SCALAR' ? $$v : $v;
+        return defined $s ? $s : '';
+    }
+
+    sub set_err {
+        my ($h, $err, $errstr, $state, $method, $rv) = @_;
+        $errstr = $err unless defined $errstr;
+        $h->STORE(Err    => $err);
+        $h->STORE(Errstr => $errstr);
+        $h->STORE(State  => $state) if defined $state;
+        # also update $DBI::err / $DBI::errstr / $DBI::state
+        $DBI::err    = $err;
+        $DBI::errstr = $errstr;
+        $DBI::state  = defined $state ? $state : '';
+        if ($h->{PrintError}) {
+            warn "DBI: $errstr\n";
+        }
+        if ($h->{RaiseError}) {
+            die "$errstr\n";
+        }
+        return $rv;   # usually undef
+    }
+
+    sub trace {
+        my ($h, $level, $file) = @_;
+        my $old = ref($h) ? ($h->{TraceLevel} || 0) : 0;
+        if (defined $level) {
+            if (ref $h) {
+                $h->{TraceLevel} = $level;
+            } else {
+                $DBI::dbi_debug = $level;
+            }
+        }
+        return $old;
+    }
+
+    sub trace_msg {
+        my ($h, $msg, $min_level) = @_;
+        $min_level ||= 1;
+        my $level = ref($h) ? ($h->{TraceLevel} || 0) : ($DBI::dbi_debug || 0);
+        print STDERR $msg if $level >= $min_level;
+        return 1;
+    }
+
+    sub parse_trace_flag {
+        my ($h, $name) = @_;
+        return 0x00000100 if $name eq 'SQL';
+        return 0x00000200 if $name eq 'CON';
+        return 0x00000400 if $name eq 'ENC';
+        return 0x00000800 if $name eq 'DBD';
+        return 0x00001000 if $name eq 'TXN';
+        return;
+    }
+
+    sub parse_trace_flags {
+        my ($h, $spec) = @_;
+        my ($level, $flags) = (0, 0);
+        for my $word (split /\s*[|&,]\s*/, $spec // '') {
+            if ($word =~ /^\d+$/ && $word >= 0 && $word <= 0xF) {
+                $level = $word;
+            } elsif ($word eq 'ALL') {
+                $flags = 0x7FFFFFFF;
+                last;
+            } elsif (my $flag = $h->parse_trace_flag($word)) {
+                $flags |= $flag;
+            }
+        }
+        return $flags | $level;
+    }
+
+    sub func {
+        my ($h, @args) = @_;
+        my $method = pop @args;
+        my $target = ref($h) ? $h : $h;
+        my $impl   = ref($h) ? $h->{ImplementorClass} : undef;
+        if ($impl && (my $sub = $impl->can($method))) {
+            return $sub->($h, @args);
+        }
+        Carp::croak("Can't locate DBI object method \"$method\"");
+    }
+
+    sub private_attribute_info { undef }
+
+    sub dump_handle {
+        my ($h, $msg, $level) = @_;
+        $msg = '' unless defined $msg;
+        my $class = ref($h) || $h;
+        print STDERR "$msg $class=HASH\n";
+        if (ref $h) {
+            for my $k (sort keys %$h) {
+                my $v = $h->{$k};
+                next if ref $v;
+                print STDERR "  $k = ", (defined $v ? $v : 'undef'), "\n";
+            }
+        }
+        return 1;
+    }
+
+    sub swap_inner_handle { return 1 }
+    sub visit_child_handles {
+        my ($h, $code, $info) = @_;
+        $info = {} unless defined $info;
+        for my $ch (@{ $h->{ChildHandles} || [] }) {
+            next unless $ch;
+            my $child_info = $code->($ch, $info) or next;
+            $ch->visit_child_handles($code, $child_info);
+        }
+        return $info;
+    }
+
+    sub DESTROY {
+        my $h = shift;
+        # decrement parent's Kids on destruction.
+        if (ref $h eq 'HASH' || ref $h) {
+            my $parent = $h->{Database} || $h->{Driver};
+            if ($parent && ref $parent && exists $parent->{Kids}) {
+                $parent->{Kids}-- if $parent->{Kids} > 0;
+            }
+        }
+    }
+}
+
+{
+    package DBD::_::dr;
+    our @ISA = ('DBI::dr', 'DBD::_::common');
+    use strict;
+
+    sub default_user {
+        my ($drh, $user, $pass) = @_;
+        $user = $ENV{DBI_USER} unless defined $user;
+        $pass = $ENV{DBI_PASS} unless defined $pass;
+        return ($user, $pass);
+    }
+
+    sub connect {
+        # default connect: create a db handle. DBDs typically override.
+        my ($drh, $dsn, $user, $auth, $attr) = @_;
+        my $dbh = DBI::_new_dbh($drh, { Name => $dsn });
+        return $dbh;
+    }
+
+    sub connect_cached {
+        my ($drh, $dsn, $user, $auth, $attr) = @_;
+        my $cache = $drh->{CachedKids} ||= {};
+        my $key = join "!\001",
+            defined $dsn  ? $dsn  : '',
+            defined $user ? $user : '',
+            defined $auth ? $auth : '';
+        my $dbh = $cache->{$key};
+        if ($dbh && $dbh->FETCH('Active')) {
+            return $dbh;
+        }
+        $dbh = $drh->connect($dsn, $user, $auth, $attr);
+        $cache->{$key} = $dbh;
+        return $dbh;
+    }
+
+    sub data_sources { return () }
+    sub disconnect_all { return; }
+}
+
+{
+    package DBD::_::db;
+    our @ISA = ('DBI::db', 'DBD::_::common');
+    use strict;
+
+    sub ping { return 0 }    # DBDs should override
+    sub data_sources {
+        my ($dbh, $attr) = @_;
+        my $drh = $dbh->{Driver} or return ();
+        return $drh->data_sources($attr);
+    }
+    sub disconnect {
+        my $dbh = shift;
+        $dbh->STORE(Active => 0);
+        return 1;
+    }
+    sub commit   { return 1 }
+    sub rollback { return 1 }
+    sub quote {
+        my ($dbh, $str, $type) = @_;
+        return 'NULL' unless defined $str;
+        $str =~ s/'/''/g;
+        return "'$str'";
+    }
+    sub quote_identifier {
+        my ($dbh, @ids) = @_;
+        my $q = '"';
+        return join('.', map { defined $_ ? qq{$q$_$q} : '' } @ids);
+    }
+    sub table_info    { return undef }
+    sub column_info   { return undef }
+    sub primary_key_info { return undef }
+    sub foreign_key_info { return undef }
+    sub type_info_all { return [] }
+    sub get_info      { return undef }
+    sub last_insert_id { return undef }
+    sub take_imp_data { return undef }
+}
+
+{
+    package DBD::_::st;
+    our @ISA = ('DBI::st', 'DBD::_::common');
+    use strict;
+
+    sub rows      { return -1 }
+    sub finish {
+        my $sth = shift;
+        $sth->STORE(Active => 0);
+        return 1;
+    }
+    sub bind_col      { return 1 }
+    sub bind_columns  { return 1 }
+    sub bind_param    { return 1 }
+    sub bind_param_array  { return 1 }
+    sub execute_array { return 0 }
+    sub fetchrow_array {
+        my $sth = shift;
+        my $ref = $sth->fetchrow_arrayref;
+        return $ref ? @$ref : ();
+    }
+    sub fetchrow_hashref {
+        my ($sth, $name_attr) = @_;
+        my $row = $sth->fetchrow_arrayref or return undef;
+        my $names = $sth->{ $name_attr || $sth->{FetchHashKeyName} || 'NAME' };
+        my %h;
+        @h{ @$names } = @$row;
+        return \%h;
+    }
+
+    # Helper used by pure-Perl DBDs (see DBD::NullP::st::fetchrow_arrayref).
+    # Real DBI binds fetched column values into the variables that were
+    # passed to bind_col / bind_columns. Our simplified impl just returns
+    # the array reference unchanged.
+    sub _set_fbav {
+        my ($sth, $data) = @_;
+        if (my $bound = $sth->{_bound_cols}) {
+            for my $i (0 .. $#$bound) {
+                ${ $bound->[$i] } = $data->[$i] if ref $bound->[$i];
+            }
+        }
+        return $data;
+    }
+}
+
+1;


### PR DESCRIPTION
## Summary

Previously `use DBI; DBI->install_driver("NullP")` died with `Undefined subroutine &DBI::install_driver`. The bundled `DBI.pm` talked to the Java DBI backend only, bypassing the DBI driver architecture (`DBD::<name>::driver` factories, `DBI::_new_drh` / `_new_dbh` / `_new_sth`, `DBD::_::common` / `dr` / `db` / `st` base classes). That path covers JDBC drivers (SQLite, H2, ...) but not the pure-Perl DBDs bundled with upstream DBI — `DBD::NullP`, `DBD::ExampleP`, `DBD::Sponge`, `DBD::Mem`, `DBD::File`, `DBD::DBM` — which the DBI self-tests rely on extensively.

This PR adds the minimum driver-architecture pieces needed by those DBDs, in a new file `src/main/perl/lib/DBI/_Handles.pm`:

- `DBI->install_driver` / `installed_drivers` / `data_sources` / `available_drivers` / `setup_driver`;
- `DBI::_new_drh` / `_new_dbh` / `_new_sth` (handle factories, returning plain blessed hashrefs — no tie magic);
- `DBI::_get_imp_data` (stub);
- `DBD::_::common` / `dr` / `db` / `st` base classes with `FETCH`, `STORE`, `err`, `errstr`, `state`, `set_err`, `trace`, `trace_msg`, `parse_trace_flag(s)`, `func`, `dump_handle`, `visit_child_handles`, default `connect` / `connect_cached`, `quote`, `quote_identifier`, `data_sources`, `disconnect`, `commit`, `rollback`, `ping`, `finish`, `fetchrow_array`, `fetchrow_hashref`, `rows`, `bind_col(s)`, `bind_param(_array)`, `execute_array`, `_set_fbav`;
- Stub `DBI::dr` / `DBI::db` / `DBI::st` packages so `isa('DBI::dr')` succeeds; `DBD::_::<suffix>` inherits from `DBI::<suffix>`.

`DBI.pm`'s `connect` wrapper now detects a pure-Perl DBD (has `driver()` but no `_dsn_to_jdbc`) and routes through `install_driver($name)->connect(...)` instead of the JDBC backend.

Lives in a separate `.pm` for the same per-method bytecode-size reason as `DBI/_Utils.pm` from #540.

### Effect on `jcpan -t DBI` (stacked on #542)

| | Files | Subtests | Passing | Failing |
|---|---|---|---|---|
| before | 200 | 946 | 676 | 270 |
| after  | 200 | 1600 | 1240 | 360 |

+564 subtests now pass, +654 more are reached. 10 fewer test files fail overall. The remaining failures are real DBI-level issues (`DBI::PurePerl`, `DBD::File` / `DBM` / `Gofer`, a handful of handle-tracking edge cases) tracked as Phase 3 in `dev/modules/dbi_test_parity.md`.

### Depends on

- #542 (interpreter fallback on runtime VerifyError) — needed so many of the test files get past their BEGIN blocks at all. This PR is based off that branch.

### Test plan

- [x] `make` (full unit tests) passes.
- [x] `./jperl -e 'use DBI; my $drh = DBI->install_driver("NullP"); my $dbh = DBI->connect("dbi:NullP:", "", ""); my $sth = $dbh->prepare("SELECT 1"); $sth->execute'` now works.
- [x] `./jperl ~/.cpan/build/DBI-1.647-5/t/02dbidrv.t` runs 37+ subtests (previously: died on line 155 with `Can't locate object method install_driver`).
- [x] `jcpan -t DBI` baseline matches the table above.

Generated with [Devin](https://cli.devin.ai/docs)
