### PR TITLE
fix(parser): process escape sequences inside \Q...\E quotemeta regions

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,14 +33,14 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "3611e23bd";
+    public static final String gitCommitId = "4623fa856";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitDate = "2026-04-23";
+    public static final String gitCommitDate = "2026-04-24";
 
     /**
      * Build timestamp in Perl 5 "Compiled at" format (e.g., "Apr  7 2026 11:20:00").
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 24 2026 12:28:51";
+    public static final String buildTimestamp = "Apr 24 2026 13:01:40";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/frontend/parser/StringDoubleQuoted.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringDoubleQuoted.java
@@ -57,14 +57,6 @@ public class StringDoubleQuoted extends StringSegmentParser {
     private final Stack<CaseModifier> caseModifiers = new Stack<>();
 
     /**
-     * Flag indicating whether we're inside a \Q...\E quotemeta region.
-     *
-     * <p>When true, all special characters (including $ and @) are treated as literals,
-     * and escape sequences are not processed (except \E to end the region).
-     */
-    private boolean inQuotemeta = false;
-
-    /**
      * Private constructor for StringDoubleQuoted parser.
      *
      * <p>Use {@link #parseDoubleQuotedString} factory method to create instances.
@@ -357,37 +349,20 @@ public class StringDoubleQuoted extends StringSegmentParser {
     /**
      * Parses escape sequences based on context.
      *
-     * <p>This method delegates to different escape handling based on the
-     * parseEscapes flag and quotemeta mode:
+     * <p>Delegates to different escape handling based on the parseEscapes flag:
      * <ul>
-     *   <li>inQuotemeta=true: Only \E is special, everything else is literal</li>
      *   <li>parseEscapes=true: Process escapes like \n to actual newline</li>
      *   <li>parseEscapes=false: Preserve escapes for regex engine</li>
      * </ul>
+     *
+     * <p>Note: \Q...\E quotemeta regions are handled via the case-modifier stack
+     * (pushing a "Q" modifier in the \Q handler and applying it in \E), so no
+     * special in-string state is needed. Inside \Q, escape sequences and variable
+     * interpolation continue to work normally; the accumulated content is wrapped
+     * in quotemeta() at the point where \E is encountered.
      */
     @Override
     protected void parseEscapeSequence() {
-        if (inQuotemeta) {
-            // In quotemeta mode, everything is literal except \E
-            var token = tokens.get(parser.tokenIndex);
-            if (token.text.startsWith("E")) {
-                // End quotemeta mode
-                TokenUtils.consumeChar(parser);
-                flushCurrentSegment();
-                if (!caseModifiers.isEmpty() && caseModifiers.peek().type.equals("Q")) {
-                    applyCaseModifier(caseModifiers.pop());
-                }
-                inQuotemeta = false;
-            } else if (token.text.startsWith("Q")) {
-                // In quotemeta mode, \Q is idempotent and should be ignored.
-                TokenUtils.consumeChar(parser);
-            } else {
-                // Everything else is literal, including the backslash
-                currentSegment.append("\\");
-            }
-            return;
-        }
-
         if (parseEscapes) {
             parseDoubleQuotedEscapes();
         } else {
@@ -423,7 +398,6 @@ public class StringDoubleQuoted extends StringSegmentParser {
             // Quotemeta modifier
             case "Q" -> {
                 flushCurrentSegment();
-                inQuotemeta = true;
                 caseModifiers.push(new CaseModifier("Q", false));
             }
 
@@ -525,7 +499,6 @@ public class StringDoubleQuoted extends StringSegmentParser {
             // Quotemeta modifier
             case "Q" -> {
                 flushCurrentSegment();
-                inQuotemeta = true;
                 caseModifiers.push(new CaseModifier("Q", false));
             }
 


### PR DESCRIPTION
## Summary

Fixes escape-sequence handling inside `\Q...\E` quotemeta regions in double-quoted strings.

Previously, `StringDoubleQuoted` used an `inQuotemeta` flag that disabled normal escape-sequence processing once `\Q` was encountered. Sequences like `\t`, `\n`, `\\`, `\x41`, `\041`, `\cA`, `\$`, `\@` were passed through as a literal backslash + following char before `quotemeta()` ran, producing extra backslashes. Real Perl first decodes string escapes, then applies quotemeta.

Verified against real Perl byte-for-byte:

| input | real Perl | jperl (before) | jperl (after) |
|---|---|---|---|
| `"\Q\t\E"` | `\<tab>` (2) | `\\t` (3) | `\<tab>` (2) |
| `"\Q\\\E"` | `\\` (2) | `\\\\` (4) | `\\` (2) |
| `"\Q\x41\E"` | `A` (1) | `\\x41` (5) | `A` (1) |
| `"\Q\041\E"` | `\!` (2) | `\\041` (5) | `\!` (2) |
| `"\Q\$x\E"` | `\$x` (3) | `\\` (2) | `\$x` (3) |
| `"\Q\@a\E"` | `\@a` (3) | `\\` (2) | `\@a` (3) |
| `"\Q\cA\E"` | `\<0x01>` (2) | `\\cA` (4) | `\<0x01>` (2) |
| `"\Q\Qa.b\E\E"` | `a\\\.b` (double-escaped) | `a\.b` (idempotent — wrong) | `a\\\.b` |

## Fix

Remove the `inQuotemeta` flag entirely. `\Q` simply pushes a `"Q"` case modifier onto the existing case-modifier stack (like `\U`/`\L`); escape processing and variable interpolation continue normally inside the region; `\E` pops and wraps the accumulated content in `quotemeta()`. This also fixes the related bug where nested `\Q\Q...\E\E` was incorrectly treated as idempotent — real Perl applies `quotemeta` twice.

Net change: -37 / +10 lines; the flag-based special case is gone.

## Impact

Investigated via `jcpan -t WWW::Wikipedia`:

- **`Text::Reform 1.20`**: `t/reform.t` test 37 (`form("<<<<<\Q<[^|>]\\\E",123)`) now passes. Module now installs cleanly via `jcpan`, unblocking `Text::Autoformat` and `WWW::Wikipedia`. **Result: PASS** (was FAIL).
- **`WWW::Wikipedia 2.05`**: With `Text::Reform` installed, the 11 test files that were dying on `Can't locate Text/Reform.pm` now load the module. Remaining failures are live network calls using `http://` URLs (Wikipedia now only serves HTTPS; port 80 connect fails through our LWP stack) — unrelated to this change.

#### Test plan

- [x] Verified all 11 escape edge cases match real Perl byte-for-byte
- [x] `make` — all unit tests pass
- [x] `./jcpan -t Text::Reform` → Result: PASS
- [x] `./jcpan -t WWW::Wikipedia` → went from 11/13 test files failing to 6/13, all remaining failures are network-related (not parser)

Generated with [Devin](https://cli.devin.ai/docs)
