### PR TITLE
fix(parser): process pending heredocs before use/no BEGIN-time evaluation

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "4623fa856";
+    public static final String gitCommitId = "6f96f1c74";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 24 2026 13:01:40";
+    public static final String buildTimestamp = "Apr 24 2026 13:47:17";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -743,6 +743,29 @@ public class StatementParser {
                 // call Module->import( LIST )
                 // or Module->unimport( LIST )
 
+                // Before executing the argument list, process any pending heredocs.
+                // This handles cases like: use constant FOO => <<'EOT'; ... \n heredoc content \n EOT
+                // The heredoc content comes after the newline that follows the ';', but the
+                // BEGIN-equivalent evaluation of the import list happens immediately, so we
+                // must fill in heredoc bodies before the list is compiled and executed.
+                if (!parser.getHeredocNodes().isEmpty()) {
+                    int savedIndex = parser.tokenIndex;
+                    int newlineIndex = -1;
+                    for (int i = savedIndex; i < parser.tokens.size(); i++) {
+                        if (parser.tokens.get(i).type == LexerTokenType.NEWLINE) {
+                            newlineIndex = i;
+                            break;
+                        }
+                    }
+                    if (newlineIndex >= 0) {
+                        parser.tokenIndex = newlineIndex;
+                        ParseHeredoc.parseHeredocAfterNewline(parser);
+                        parser.heredocSkipToIndex = parser.tokenIndex;
+                        parser.heredocNewlineIndex = newlineIndex;
+                        parser.tokenIndex = savedIndex;
+                    }
+                }
+
                 // Execute the argument list immediately in LIST context
                 // This is necessary for expressions like: use lib ($path =~ /^(.*)$/);
                 // where the regex match must return captured groups, not just success/failure


### PR DESCRIPTION
## Summary

Fixes a parser bug where heredocs used as arguments to `use`/`no` declarations (e.g. `use constant FOO => <<'EOT';`) were not resolved before the import list was compiled and executed at BEGIN time, causing:

```
HEREDOC marker EOT not found
BEGIN failed--compilation aborted
```

### Root cause

`StatementParser.parseUseDeclaration` evaluates the import list immediately via `runSpecialBlock(parser, "BEGIN", list, ...)`. Heredoc bodies are normally filled in by the whitespace handler when it consumes the NEWLINE after the statement, but that hasn't happened yet at the point `runSpecialBlock` runs — so the HEREDOC placeholder OperatorNode is still unresolved and `EmitOperatorNode.handleMissingHeredoc` throws.

`SpecialBlockParser` already had the same fix for explicit `BEGIN { ... }` blocks; the `use`/`no` path just wasn't mirroring it.

### Fix

Before `runSpecialBlock`, if heredocs are pending, seek forward to the next NEWLINE, call `ParseHeredoc.parseHeredocAfterNewline` to fill the bodies, record `heredocSkipToIndex` / `heredocNewlineIndex` so the outer whitespace handler does not re-process them, then restore `parser.tokenIndex`.

### Discovered via

`jcpan -t Text::Table` → `t/10_Table.t` previously failed all 166 subtests at:

```perl
use constant T_SINGLE => <<'EOT2';
single line title
EOT2
```

#### Test plan

- [x] Minimal repros for `use constant NAME => <<'EOT'`, `use constant { NAME => <<'EOT' }`, and `use constant A => "x", B => <<'EOT'` all compile and run correctly.
- [x] `jcpan -t Text::Table` — `Result: PASS`, 175/175 tests across 7 files (was 0/166 in `t/10_Table.t`).
- [x] `make` (full unit test suite) — `BUILD SUCCESSFUL`, no regressions.

Generated with [Devin](https://cli.devin.ai/docs)
