### PR TITLE
fix(parser): join multi-element subscripts with $; in chained hash deref

### DIFF
--- a/src/main/java/org/perlonjava/backend/jvm/Dereference.java
+++ b/src/main/java/org/perlonjava/backend/jvm/Dereference.java
@@ -1284,7 +1284,17 @@ public class Dereference {
         }
 
         if (CompilerOptions.DEBUG_ENABLED) emitterVisitor.ctx.logDebug("visit -> (HashLiteralNode) autoquote " + node.right);
-        nodeRight.accept(emitterVisitor.with(RuntimeContextType.SCALAR));
+        if (nodeRight.elements.size() > 1) {
+            // Multiple elements: join them with $; (SUBSEP), like $h{a,b,c}
+            emitterVisitor.ctx.mv.visitLdcInsn("main::;");
+            emitterVisitor.ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC, "org/perlonjava/runtime/runtimetypes/GlobalVariable",
+                    "getGlobalVariable", "(Ljava/lang/String;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;", false);
+            nodeRight.accept(emitterVisitor.with(RuntimeContextType.LIST));
+            emitterVisitor.ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC, "org/perlonjava/runtime/operators/StringOperators",
+                    "join", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;", false);
+        } else {
+            nodeRight.accept(emitterVisitor.with(RuntimeContextType.SCALAR));
+        }
 
         int keySlot = emitterVisitor.ctx.javaClassInfo.acquireSpillSlot();
         boolean pooledKey = keySlot >= 0;

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "6f96f1c74";
+    public static final String gitCommitId = "21a48f590";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 24 2026 13:47:17";
+    public static final String buildTimestamp = "Apr 24 2026 15:10:59";
 
     // Prevent instantiation
     private Configuration() {


### PR DESCRIPTION
## Summary

Fixes a bug where chained hash dereference with multi-element subscripts kept only the last element instead of joining with `$;` (SUBSEP).

```perl
$h{-word => 'ou'}       # FETCH("-word\x1cou")  — already correct
$h{a}{-word => 'ou'}    # FETCH("ou")           — BUG, now fixed
```

Under the hood, `$h{a}{b}` goes through `handleArrowHashDeref` (implicit arrow deref). That path evaluated the subscript list in scalar context, which drops all but the last element. The non-deref top-level path already joined multi-element subscripts with `$;`, so the two disagreed.

Fix: in `handleArrowHashDeref`, when the `HashLiteralNode` has more than one element, emit it as a list and `join($;, ...)`, matching the top-level case.

## Discovery

Found while investigating `jcpan -t Regexp::Common`. Its tied hash chains FETCH calls, and patterns like `$RE{list}{conj}{-word => 'ou'}` rely on `-word` reaching FETCH.

## Test plan

- [x] `make` (full unit test suite) passes
- [x] Repro script shows FETCH now receives the full joined key at every level
- [x] `Regexp::Common` test suite improves from 22/73 failed test files to 11/73; completed subtests jump from 116,146 to 140,752 as previously-aborted files (`t/test_list.t`, `t/URI/http.t`, `t/number/decimal.t`, `t/zip/us.t`, etc.) now run to completion
- [x] `t/test_list.t` in Regexp::Common: 50/50 pass (was aborting at test 33)

### Repro

```perl
package T;
sub TIEHASH { my ($c, @d) = @_; bless \@d, $c }
sub FETCH { my ($s,$k)=@_; print "FETCH len=",length($k),"\n"; bless ref($s)->new(@$s,$k), ref($s) }
sub new { my ($c, @d)=@_; my %h; tie %h, $c, @d; \%h }
package main;
my %RE; tie %RE, 'T';
my $x = $RE{list}{conj}{-word => 'ou'};
```

Before: last FETCH reported `len=2`. After: `len=8`, matching real Perl.

Generated with [Devin](https://cli.devin.ai/docs)
