### PR TITLE
fix(regex): \cX inside character class consumes next char even if special

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "6c981ee03";
+    public static final String gitCommitId = "016a235c7";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 25 2026 09:42:01";
+    public static final String buildTimestamp = "Apr 25 2026 10:11:42";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessor.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessor.java
@@ -1379,6 +1379,11 @@ public class RegexPreprocessor {
             char ch = s.charAt(bracketEnd);
             if (inEscape) {
                 inEscape = false;
+                // \cX consumes the next character (control-character escape),
+                // even if that character is ']' or '\' (e.g., \c], \c\).
+                if (ch == 'c' && bracketEnd + 1 < length) {
+                    bracketEnd++; // skip the control-char target
+                }
             } else if (ch == '\\') {
                 inEscape = true;
             } else if (ch == '[') {

--- a/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessorHelper.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessorHelper.java
@@ -848,6 +848,26 @@ public class RegexPreprocessorHelper {
                         lastChar = 0x08;  // Backspace character for range validation
                         first = false;
                         afterCaret = false;
+                    } else if (s.codePointAt(offset) == 'c' && offset + 1 < length) {
+                        // \cX control-character escape: consume the next character
+                        // and convert to a hex escape so Java doesn't mis-parse
+                        // sequences like \c\, \c[, \c] (where the next char is
+                        // special inside a character class).
+                        // Perl semantics: ord(uc(X)) XOR 0x40, low 8 bits.
+                        int ctrl = s.codePointAt(offset + 1);
+                        if (ctrl >= 'a' && ctrl <= 'z') {
+                            ctrl = ctrl - 'a' + 'A'; // upper-case ASCII letter
+                        }
+                        int value = (ctrl ^ 0x40) & 0xFF;
+                        // Remove the backslash that was already appended
+                        sb.setLength(sb.length() - 1);
+                        sb.append(String.format("\\x{%X}", value));
+                        offset++; // skip past the control-char target (outer loop bumps past it)
+                        lastChar = value;
+                        first = false;
+                        afterCaret = false;
+                        wasEscape = true;
+                        break;
                     } else {
                         int c2 = s.codePointAt(offset);
                         if (c2 >= '0' && c2 <= '7') {


### PR DESCRIPTION
## Summary

Fixes the regex preprocessor's handling of `\cX` inside character classes when `X` is a regex-significant character (`]`, `\`, `[`, `^`, etc.).

In Perl, `\cX` is a control-character escape that **always** consumes the next source character, regardless of what it is — so `\c]` is U+001D (control-`]`), `\c\` is U+001C (control-`\`), and so on. Our preprocessor treated `\c` as a plain one-char escape, which caused two problems:

- **Bracket-end finder**: scanning for the closing `]` of a character class, `\c]` was misread as the class terminator.
- **Class-content emitter**: `\cX` was emitted to Java as-is, so Java's `Pattern` re-parsed sequences like `\c\[` as control-backslash followed by an opening bracket — yielding a misleading `Unclosed character class` error.

### Fix

- `RegexPreprocessor.handleCharacterClass`: skip the character following a `\c` escape when locating the closing `]`.
- `RegexPreprocessorHelper.handleRegexCharacterClassEscape`: detect `\cX` and convert it to `\x{HH}` using Perl semantics (`uc(X) XOR 0x40`, low byte). Java then sees a plain hex escape with no special semantics to misinterpret.

### Motivation

`XML/Dumper.pm:685` strips control chars with:

```
s/[\0\ca\cb\cc...\cz\c[\c\\c]\c^\c_]//g;
```

This regex previously failed with `Regex compilation failed: Unclosed character class near index 89`, taking down 8 of the 32 test files in `jcpan -t Data::Serializer` mid-run with non-zero exit status (the parent test scripts each `die` on regex compilation failure, so subtests after the failure were never reported).

### Impact on `jcpan -t Data::Serializer`

|                          | Before | After    |
| ------------------------ | -----: | -------: |
| Failed test programs     |  10/32 |     9/32 |
| Subtests run             |   1250 | **1842** |
| Subtests reported failed |     13 |       13 |
| Test files aborted       |  8     |        0 |

The remaining 9 failing programs are unrelated logic issues (`Config::General` uses `(?(...)...)` conditional patterns we don't implement; several files share a `PHP::Serialization` issue).

#### Test plan

- [x] `make` (all unit tests pass)
- [x] Added manual coverage: `\ca`..`\cZ`, `\c[`, `\c\`, `\c]`, `\c^`, `\c_`, `\c?` all match the documented Perl values.
- [x] `jcpan -t Data::Serializer` — `XML::Dumper` now passes; cascading regex crashes eliminated.
- [x] `jcpan -t Math::Base::Convert` — still 5350/5350 passing (no regression).

Generated with [Devin](https://cli.devin.ai/docs)
