### PR TITLE
test: balance unit test shards by isolating heavy test (and fix shard index bug)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ check-java-gradle:
 
 wrapper: check-java-gradle
 
-# Standard build - incremental compilation with parallel tests (4 JVMs)
+# Standard build - incremental compilation with parallel tests (5 JVMs; last shard isolates heavy tests)
 build: check-java-gradle
 ifeq ($(OS),Windows_NT)
 	gradlew.bat classes testUnitParallel --parallel shadowJar
@@ -149,7 +149,7 @@ else
 	./gradlew testAll --rerun-tasks
 endif
 
-# Parallel unit tests via Gradle/JUnit (4 JVMs)
+# Parallel unit tests via Gradle/JUnit (5 JVMs; last shard isolates heavy tests)
 test-gradle-parallel: check-java-gradle
 ifeq ($(OS),Windows_NT)
 	gradlew.bat testUnitParallel --parallel --rerun-tasks
@@ -157,12 +157,12 @@ else
 	./gradlew testUnitParallel --parallel --rerun-tasks
 endif
 
-# Parallel unit tests via Maven (4 JVMs)
+# Parallel unit tests via Maven (5 JVMs; last shard isolates heavy tests)
 test-maven-parallel:
 ifeq ($(OS),Windows_NT)
-	start /B mvn test -Pshard1 & start /B mvn test -Pshard2 & start /B mvn test -Pshard3 & start /B mvn test -Pshard4
+	start /B mvn test -Pshard1 & start /B mvn test -Pshard2 & start /B mvn test -Pshard3 & start /B mvn test -Pshard4 & start /B mvn test -Pshard5
 else
-	mvn test -Pshard1 & mvn test -Pshard2 & mvn test -Pshard3 & mvn test -Pshard4 & wait
+	mvn test -Pshard1 & mvn test -Pshard2 & mvn test -Pshard3 & mvn test -Pshard4 & mvn test -Pshard5 & wait
 endif
 
 clean: check-java-gradle

--- a/build.gradle
+++ b/build.gradle
@@ -402,7 +402,12 @@ tasks.named('processTestResources', Copy) {
 
 // Parallel test execution tasks
 // Run with: ./gradlew testUnitParallel --parallel
-def parallelShards = 4
+//
+// Shard layout: the LAST shard is dedicated to a small set of known-heavy
+// tests (see HEAVY_TESTS in PerlScriptExecutionTest.java). The other shards
+// round-robin the remaining tests. This keeps wall-time roughly balanced
+// even when one test dominates (e.g. unit/code_too_large.t).
+def parallelShards = 5
 
 (0..<parallelShards).each { index ->
     tasks.register("testUnitShard${index}", Test) {
@@ -425,7 +430,8 @@ def parallelShards = 4
 tasks.register('testUnitParallel') {
     group = 'verification'
     description = 'Runs unit tests in parallel across multiple JVMs. Usage: gradle testUnitParallel --parallel'
-    dependsOn 'testUnitShard0', 'testUnitShard1', 'testUnitShard2', 'testUnitShard3'
+    def shardTasks = (0..<parallelShards).collect { "testUnitShard${it}" }
+    dependsOn shardTasks
 }
 
 // Version catalog update configuration

--- a/pom.xml
+++ b/pom.xml
@@ -221,8 +221,11 @@
     </build>
 
     <!-- Profiles for parallel test execution -->
-    <!-- Usage: Run all 4 shards in parallel with separate terminal windows or background processes:
-         mvn test -Pshard1 & mvn test -Pshard2 & mvn test -Pshard3 & mvn test -Pshard4 & wait
+    <!-- Usage: Run all 5 shards in parallel with separate terminal windows or background processes:
+         mvn test -Pshard1 & mvn test -Pshard2 & mvn test -Pshard3 & mvn test -Pshard4 & mvn test -Pshard5 & wait
+
+         The last shard (shard5) is dedicated to known-heavy tests; see
+         HEAVY_TESTS in PerlScriptExecutionTest.java.
     -->
     <profiles>
         <profile>
@@ -233,7 +236,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>--enable-native-access=ALL-UNNAMED -Dtest.shard.index=1 -Dtest.shard.total=4</argLine>
+                            <argLine>--enable-native-access=ALL-UNNAMED -Dtest.shard.index=0 -Dtest.shard.total=5</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -247,7 +250,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>--enable-native-access=ALL-UNNAMED -Dtest.shard.index=2 -Dtest.shard.total=4</argLine>
+                            <argLine>--enable-native-access=ALL-UNNAMED -Dtest.shard.index=1 -Dtest.shard.total=5</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -261,7 +264,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>--enable-native-access=ALL-UNNAMED -Dtest.shard.index=3 -Dtest.shard.total=4</argLine>
+                            <argLine>--enable-native-access=ALL-UNNAMED -Dtest.shard.index=2 -Dtest.shard.total=5</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -275,7 +278,21 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>--enable-native-access=ALL-UNNAMED -Dtest.shard.index=4 -Dtest.shard.total=4</argLine>
+                            <argLine>--enable-native-access=ALL-UNNAMED -Dtest.shard.index=3 -Dtest.shard.total=5</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>shard5</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>--enable-native-access=ALL-UNNAMED -Dtest.shard.index=4 -Dtest.shard.total=5</argLine>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,14 +33,14 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "0663a8089";
+    public static final String gitCommitId = "2c7f37913";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitDate = "2026-04-25";
+    public static final String gitCommitDate = "2026-04-26";
 
     /**
      * Build timestamp in Perl 5 "Compiled at" format (e.g., "Apr  7 2026 11:20:00").
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 26 2026 09:17:16";
+    public static final String buildTimestamp = "Apr 26 2026 17:32:55";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/test/java/org/perlonjava/PerlScriptExecutionTest.java
+++ b/src/test/java/org/perlonjava/PerlScriptExecutionTest.java
@@ -122,27 +122,59 @@ public class PerlScriptExecutionTest {
             return sortedScripts.stream();
         }
 
-        // Sharding logic
+        // Sharding logic.
+        //
+        // We use a simple "heavy-test isolation" scheme for balance:
+        //   - The LAST shard is dedicated to known-heavy tests (HEAVY_TESTS).
+        //   - All other shards round-robin the remaining (light) tests.
+        //
+        // Rationale: a single test (currently unit/code_too_large.t at ~16s)
+        // can dominate one shard's wall time well beyond what round-robin
+        // can balance. Putting it on its own shard lets the others split
+        // the rest evenly. To extend, just add filenames to HEAVY_TESTS.
         String shardIndexProp = System.getProperty("test.shard.index");
         String shardTotalProp = System.getProperty("test.shard.total");
-        
-        if (shardIndexProp != null && !shardIndexProp.isEmpty() && 
+
+        if (shardIndexProp != null && !shardIndexProp.isEmpty() &&
             shardTotalProp != null && !shardTotalProp.isEmpty()) {
             try {
                 int shardIndex = Integer.parseInt(shardIndexProp);
                 int shardTotal = Integer.parseInt(shardTotalProp);
-                
-                // Maven surefire.forkNumber is 1-indexed, convert to 0-indexed
-                if (shardIndex >= 1 && shardIndex <= shardTotal) {
-                    shardIndex = shardIndex - 1;
-                }
-                
+
+                // Both Gradle and Maven now pass 0-indexed shard.index values
+                // (see build.gradle and pom.xml). Earlier code attempted to
+                // detect Maven 1-indexed values heuristically, which silently
+                // collapsed shard 1 onto shard 0 and dropped the last shard
+                // entirely; do not reintroduce that.
+
                 if (shardTotal > 1 && shardIndex >= 0 && shardIndex < shardTotal) {
                     System.out.println("Running shard " + (shardIndex + 1) + " of " + shardTotal);
+
+                    // Tests known to be much slower than the rest. Use forward
+                    // slashes; we match against both '/' and '\' separators.
+                    final List<String> HEAVY_TESTS = List.of(
+                        "unit/code_too_large.t"
+                    );
+                    java.util.function.Predicate<String> isHeavy = s -> {
+                        String norm = s.replace('\\', '/');
+                        return HEAVY_TESTS.contains(norm);
+                    };
+
+                    final int lastShard = shardTotal - 1;
+                    if (shardIndex == lastShard) {
+                        // Dedicated shard: only the heavy tests.
+                        return sortedScripts.stream().filter(isHeavy);
+                    }
+
+                    // Light shards: round-robin over the remaining (shardTotal - 1) shards.
+                    List<String> lightScripts = sortedScripts.stream()
+                            .filter(isHeavy.negate())
+                            .collect(Collectors.toList());
+                    final int lightShards = shardTotal - 1;
                     final int finalShardIndex = shardIndex;
-                    return IntStream.range(0, sortedScripts.size())
-                        .filter(i -> i % shardTotal == finalShardIndex)
-                        .mapToObj(sortedScripts::get);
+                    return IntStream.range(0, lightScripts.size())
+                            .filter(i -> i % lightShards == finalShardIndex)
+                            .mapToObj(lightScripts::get);
                 }
             } catch (NumberFormatException e) {
                 // Silently fall through to run all tests


### PR DESCRIPTION
## Summary

Balances the 4 parallel unit-test shards run by `make` and fixes a related correctness bug that was silently skipping tests.

### Background

Profiling the existing 4-shard layout from `build/test-results/testUnitShard*/TEST-*.xml`:

| Shard | Tests | Time |
|------:|------:|-----:|
| 0 | 49 | 16.6 s |
| 1 | 49 | 16.6 s |
| 2 | 49 | **31.8 s** |
| 3 | 48 | 18.6 s |

Shard 2 was nearly 2x slower than the others. Cause: a single test, `unit/code_too_large.t`, takes ~15.7 s by itself — the next-slowest test is 1.45 s. Pure round-robin sharding cannot balance this; one shard's runtime is dominated by that one file.

### Changes

**1. Heavy-test isolation (5 shards)**

Add a small `HEAVY_TESTS` list in `PerlScriptExecutionTest.java`. The last shard runs only those tests; the other shards round-robin the rest. Bumping to 5 shards lets the heavy shard run in parallel with 4 evenly-balanced light shards. Adding more heavy tests later is just a one-line edit.

**2. Bug fix: off-by-one in shard index handling**

While verifying the new layout I noticed the dedicated heavy shard wasn't actually running `code_too_large.t`. Root cause is pre-existing:

```java
// Maven surefire.forkNumber is 1-indexed, convert to 0-indexed
if (shardIndex >= 1 && shardIndex <= shardTotal) {
    shardIndex = shardIndex - 1;
}
```

This conversion fired for *any* index in `[1, shardTotal]`, including Gradle's already-0-indexed values. With the original 4 shards:

- gradle index 0 → stays 0 → runs `i % 4 == 0`
- gradle index 1 → becomes 0 → **runs the same tests as shard 0**
- gradle index 2 → becomes 1 → runs `i % 4 == 1`
- gradle index 3 → becomes 2 → runs `i % 4 == 2`
- nothing runs `i % 4 == 3` → **about 25% of unit tests were silently skipped**

This is consistent with what the surefire XMLs showed: the first 3 test names on shards 0 and 1 were identical. With the new 5-shard layout, the heavy test fell into the never-run bucket, exposing the bug.

Fix: standardize on 0-indexed in both `build.gradle` and `pom.xml`; remove the conversion.

### Result

Verified by parsing `build/test-results/testUnitShard*/TEST-*.xml` after the new run:

| Shard | Tests | Time | Heaviest |
|------:|------:|-----:|:---------|
| 0 | 49 | 23.5 s | array.t (1.9s) |
| 1 | 48 | 23.9 s | array_autovivification.t (2.3s) |
| 2 | 48 | 21.1 s | bare_block_return.t (2.1s) |
| 3 | 48 | 24.1 s | autoload.t (1.7s) |
| 4 (heavy) | 1 | 14.9 s | **code_too_large.t (14.9s)** |

Total: 194 unique tests across all shards, 0 duplicates.

Wall time on `make`: ~32 s → ~22–26 s (≈25% faster), and now actually runs every test.

### Test plan

- [x] `make` succeeds and reports all shards green
- [x] Verified per-shard timings via XML reports (table above)
- [x] Verified 194 unique tests run with 0 duplicates
- [x] Verified `code_too_large.t` runs on shard 4

Generated with [Devin](https://cli.devin.ai/docs)
