### PR TITLE
feat(moose): Moose-as-Moo shim + cross-platform ./jcpan -t Moose harness

### DIFF
--- a/dev/modules/moose_support.md
+++ b/dev/modules/moose_support.md
@@ -253,18 +253,71 @@ through helper subs `Moose::Exporter::_set_flag`/`_get_flag`.
 ./jcpan -t ANSI::Unicode                                            # → PASS
 ./jperl -MMoose -e 'package P { use Moose; has x => (is=>"rw") } P->new(x=>1)'
 
+# Run upstream Moose's full test suite against the shim (no install)
+./jcpan -t Moose                                                    # → see baseline below
+
 # After Phase A (HasCompiler stub)
 ./jperl -MExtUtils::HasCompiler=can_compile_loadable_object \
         -e 'print can_compile_loadable_object(quiet=>1) ? "yes" : "no"'  # → no
 
 # After Phase B (XS-strip in WriteMakefile)
-./jcpan -t Moose                                                    # → install OK, Moose tests run
+./jcpan -t Moose                                                    # → install OK, more tests pass
 
 # After Phase C+D (real Class::MOP / Moose)
 ./jperl -MClass::MOP -e 'print Class::MOP::get_code_info(\&Class::MOP::class_of)'
 ./jcpan -t Moose
 ./jcpan -t MooseX::Types
 ```
+
+### Running upstream Moose's test suite against the shim
+
+`./jcpan -t Moose` is wired up via a CPAN distroprefs entry shipped from
+`src/main/perl/lib/CPAN/Config.pm` (auto-bootstrapped to
+`~/.perlonjava/cpan/prefs/Moose.yml` on first run). It:
+
+- skips `Makefile.PL` (`touch Makefile` placates CPAN's "no Makefile
+  created" fallback path),
+- skips `make` (nothing to build),
+- runs `prove --exec "$JPERL_BIN" -r t/` against the unpacked tarball,
+  with `JPERL_BIN` set by the `jcpan` / `jcpan.bat` wrapper,
+- skips `install` (the shim is already on `@INC` via the jar).
+
+Because `prove --exec` invokes `jperl` per test file without adding
+`lib/` or `blib/lib/` to `@INC`, the **bundled shim from the jar** wins
+over the unpacked upstream `lib/Moose.pm`. So you can run the entire
+upstream suite end-to-end and see honestly which tests pass, without
+patching Moose's `Makefile.PL` or shipping a fragile diff.
+
+The same recipe is the model for any future "test against shim, don't
+install" scenario — define a distroprefs entry that overrides `pl` /
+`make` / `install` with no-ops and `test` with a `prove --exec` line.
+
+### Quick-path baseline (Moose 2.4000)
+
+Snapshot from `./jcpan -t Moose` against the current shim:
+
+| Metric | Value |
+|---|---|
+| Test files executed | 478 |
+| Individual assertions executed | 616 |
+| Fully passing files | ~29 |
+| Partially passing files | ~44 |
+| Compile/load fail (missing `Class::MOP::*`, `Moose::Meta::*`) | ~405 |
+| Assertions ok | 370 |
+| Assertions fail | 246 |
+
+The 29 fully-passing files cover BUILDARGS / BUILD chains, immutable
+round-trips, anonymous role creation, several Moo↔Moose bug regressions,
+the cookbook recipes for basic attribute / inheritance / subtype use,
+and the Type::Tiny integration test. The 44 partials include
+high-value chunks such as `basics/import_unimport.t` (31/48),
+`basics/wrapped_method_cxt_propagation.t` (6/7), and
+`recipes/basics_point_attributesandsubclassing.t` (28/31).
+
+Phases C/D (real `Class::MOP` and `Moose` ports) should move these
+numbers; record the new totals here whenever they shift.
+
+---
 
 ### Lock in progress as bundled-module tests
 

--- a/dev/modules/moose_support.md
+++ b/dev/modules/moose_support.md
@@ -276,21 +276,32 @@ through helper subs `Moose::Exporter::_set_flag`/`_get_flag`.
 `~/.perlonjava/cpan/prefs/Moose.yml` on first run). It:
 
 - ensures `Moo` is installed before testing — the shim delegates to Moo,
-  so the `pl:` step runs `"$JPERL_BIN" -e "require Moo; 1" || "$JCPAN_BIN" Moo`
-  to bootstrap it the first time on a fresh checkout,
-- skips `Makefile.PL` (`touch Makefile` placates CPAN's "no Makefile
-  created" fallback path),
-- skips `make` (nothing to build),
-- runs `prove --exec "$JPERL_BIN" -r t/` against the unpacked tarball,
-  with `JPERL_BIN` and `JCPAN_BIN` both exported by the
-  `jcpan` / `jcpan.bat` wrapper,
-- skips `install` (the shim is already on `@INC` via the jar).
+  so the `pl:` step calls a tiny Perl helper
+  (`PerlOnJava::Distroprefs::Moose::bootstrap_pl_phase`) that does
+  `require Moo` and falls back to `system $ENV{JCPAN_BIN}, "Moo"` if
+  Moo isn't loadable;
+- creates a stub `Makefile` so CPAN.pm's "no Makefile created" fallback
+  path doesn't kick in (also done by the same helper);
+- skips `make` and `install` (`PerlOnJava::Distroprefs::Moose::noop`,
+  cross-platform replacement for POSIX `true`);
+- runs `prove --exec jperl -r t/` against the unpacked tarball.
 
-We deliberately avoid a CPAN `depends:` block — that would force CPAN to
+`jcpan` / `jcpan.bat` prepend the project directory to `PATH` so
+shell-spawned subprocesses (CPAN's distroprefs commandlines, prove's
+child processes) find `jperl` on both Unix and Windows. They also
+export `JCPAN_BIN` for the helper to recursively call jcpan when Moo
+needs installing.
+
+This design avoids POSIX-only shell constructs — `||`, `;`, `touch`,
+`/dev/null`, `$VAR` — that don't work in Windows `cmd.exe`. Each phase
+is a single `jperl -MPerlOnJava::Distroprefs::Moose -e '...'` (or
+`prove --exec jperl ...`) invocation, parsed identically by `bash`,
+`sh`, `cmd.exe`, and PowerShell.
+
+We deliberately avoid a CPAN `depends:` block — it would force CPAN to
 resolve Moose's full upstream prereq tree (`Package::Stash::XS`,
 `MooseX::NonMoose`, …), most of which is XS and unsatisfiable. The
-`pl:` shell-conditional is narrower: it installs only `Moo`, which is
-the real runtime dependency of the shim.
+helper installs only `Moo`, the real runtime dependency of the shim.
 
 Because `prove --exec` invokes `jperl` per test file without adding
 `lib/` or `blib/lib/` to `@INC`, the **bundled shim from the jar** wins

--- a/dev/modules/moose_support.md
+++ b/dev/modules/moose_support.md
@@ -275,12 +275,22 @@ through helper subs `Moose::Exporter::_set_flag`/`_get_flag`.
 `src/main/perl/lib/CPAN/Config.pm` (auto-bootstrapped to
 `~/.perlonjava/cpan/prefs/Moose.yml` on first run). It:
 
+- ensures `Moo` is installed before testing — the shim delegates to Moo,
+  so the `pl:` step runs `"$JPERL_BIN" -e "require Moo; 1" || "$JCPAN_BIN" Moo`
+  to bootstrap it the first time on a fresh checkout,
 - skips `Makefile.PL` (`touch Makefile` placates CPAN's "no Makefile
   created" fallback path),
 - skips `make` (nothing to build),
 - runs `prove --exec "$JPERL_BIN" -r t/` against the unpacked tarball,
-  with `JPERL_BIN` set by the `jcpan` / `jcpan.bat` wrapper,
+  with `JPERL_BIN` and `JCPAN_BIN` both exported by the
+  `jcpan` / `jcpan.bat` wrapper,
 - skips `install` (the shim is already on `@INC` via the jar).
+
+We deliberately avoid a CPAN `depends:` block — that would force CPAN to
+resolve Moose's full upstream prereq tree (`Package::Stash::XS`,
+`MooseX::NonMoose`, …), most of which is XS and unsatisfiable. The
+`pl:` shell-conditional is narrower: it installs only `Moo`, which is
+the real runtime dependency of the shim.
 
 Because `prove --exec` invokes `jperl` per test file without adding
 `lib/` or `blib/lib/` to `@INC`, the **bundled shim from the jar** wins

--- a/dev/modules/moose_support.md
+++ b/dev/modules/moose_support.md
@@ -2,401 +2,399 @@
 
 ## Overview
 
-This document outlines the path to supporting Moose (and Class::MOP) on PerlOnJava. Moose is Perl's most popular object system, providing a rich meta-object protocol (MOP) for defining classes, attributes, roles, and more.
+This document outlines the path to supporting Moose on PerlOnJava. Moose is
+Perl's most popular object system, providing a rich meta-object protocol (MOP)
+for defining classes, attributes, roles, and method modifiers.
 
-## Current Status: Not Feasible (Requires Phase 1)
+## Current Status
 
-### Blockers
+Phase 1 (B-module subroutine introspection) is **complete**. The remaining
+work is split between:
+
+1. **Quick path** — ship a pure-Perl `Moose.pm` shim that delegates to Moo so
+   simple consumers like `ANSI::Unicode` work today.
+2. **Real path** — bundle a pure-Perl `Class::MOP` + `Moose` so existing
+   Moose distributions install through `jcpan` without patching.
+
+The single biggest blocker for the real path is **not** the missing C compiler.
+Modern Moose (2.4000) has 13 `.xs` files plus `mop.c`; even with the compiler
+check bypassed, `ExtUtils::MakeMaker` would still try to build them. We must
+either replace `Moose.pm` outright or intercept `WriteMakefile` to drop the XS
+declarations.
+
+### Out of scope
+
+- **`DESTROY` / `DEMOLISH` timing** and **`weaken` / `isweak`** semantics
+  are being addressed on a separate branch (see
+  `dev/architecture/weaken-destroy.md`). This plan assumes those primitives
+  are available and does **not** track their implementation. Moose's
+  `DEMOLISH` chain falls out of having `DESTROY` work correctly; nothing
+  Moose-specific is needed here.
+- Real JVM-level class generation (Byte Buddy / Javassist / additional ASM
+  use beyond what PerlOnJava already does). `Class::MOP` operates on Perl
+  stashes, not `java.lang.Class`, so no third-party bytecode library is
+  required for correctness. The optional "make_immutable inlining"
+  optimization can reuse the existing ASM infrastructure if/when pursued.
+
+### Verified status (run on master, Apr 2026)
+
+| Component | Status | Verification |
+|-----------|--------|--------------|
+| `B::CV->GV->NAME` | **Works** | `./jperl -e 'sub f{} use B; print B::svref_2object(\&f)->GV->NAME'` → `f` |
+| `Sub::Identify::get_code_info` | **Works** | Returns `("main","f")` for `\&f` |
+| Moo | **Works** | `use Moo; has ...; ->new(...)` (~96% of upstream test suite) |
+| `Try::Tiny` | Works | `use Try::Tiny` succeeds |
+| `Module::Runtime` | Works | `use Module::Runtime` succeeds |
+| `Devel::GlobalDestruction` | Works | `use Devel::GlobalDestruction` succeeds |
+| `Devel::StackTrace` | Works | `use Devel::StackTrace` succeeds |
+| `Devel::OverloadInfo` | Works | `use Devel::OverloadInfo` succeeds |
+| `Sub::Exporter` | Works | `use Sub::Exporter` succeeds |
+| `Sub::Install` | Works | `use Sub::Install` succeeds |
+| `Sub::Identify` | Works | `use Sub::Identify` succeeds |
+| `Data::OptList` | Works | `use Data::OptList` succeeds |
+| `Class::Load` | Works | `use Class::Load` succeeds |
+| `Package::Stash` | Works | `use Package::Stash` succeeds |
+| `Eval::Closure` | Works | `use Eval::Closure` succeeds |
+| `Params::Util` | Works (no env var needed) | `_CLASS("Foo")` returns truthy |
+| `B::Hooks::EndOfScope` | Works | `use B::Hooks::EndOfScope` succeeds |
+| `Package::DeprecationManager` | Loads, requires `-deprecations => {...}` import args (normal upstream behavior) | — |
+| `Class::MOP` | **Missing** | Not bundled |
+| `Moose` | **Missing** | Not bundled; CPAN install fails (XS) |
+| `ExtUtils::HasCompiler` | Returns false in practice | Returns undef early because `$Config{usedl}` is empty |
+
+### Real blockers
 
 | Blocker | Severity | Description |
 |---------|----------|-------------|
-| Subroutine name introspection | **Critical** | `B::CV->GV->NAME` returns `__ANON__` for named subs |
-| Makefile.PL compiler check | Medium | `ExtUtils::HasCompiler` dies without compiler |
-| Class::MOP XS functions | Medium | No pure Perl fallbacks provided |
-| MAGIC-based export tracking | Low | XS uses sv_magic for export flags |
-
-### What Already Works
-
-| Component | Status | Notes |
-|-----------|--------|-------|
-| Moo | **96% tests pass** | Recommended alternative |
-| Params::Util | Works | Requires `PERL_PARAMS_UTIL_PP=1` |
-| Package::Stash | Works | Uses PP fallback automatically |
-| Class::Load | Works | Uses PP fallback automatically |
-| Data::OptList | Works | With Params::Util PP mode |
-| Sub::Install | Mostly works | Some test failures |
+| `Class::MOP` not bundled | **Critical** | Moose can't load; even simple `use Moose` fails |
+| Moose's `Makefile.PL` builds 13 `.xs` files | **Critical** | Compiler-check bypass alone is insufficient; MM still tries to compile |
+| `Moose.pm` not bundled | **Critical** | No alternative entry point on disk |
+| MAGIC-based export tracking in `Moose::Exporter` | Low | Affects re-export warnings only |
 
 ---
 
-## Root Cause Analysis
+## Why Phase 1 was the prerequisite
 
-### The Subroutine Name Problem
+Moose uses `Class::MOP::get_code_info($coderef)` (and `Sub::Identify`'s
+identical helper) to:
 
-When Perl compiles `sub foo { ... }`, it stores metadata about the subroutine:
-- Package name (stash)
-- Subroutine name
-- File and line number
+1. Decide whether a method belongs to a class or was imported.
+2. Track method origins during role composition.
+3. Tell defined subs from re-exported ones.
+4. Build method maps and override tables.
 
-This metadata is accessible via the B (Perl internals) module:
-
-```perl
-sub foo { 1 }
-use B;
-my $cv = B::svref_2object(\&foo);
-print $cv->GV->NAME;    # Should print "foo"
-print $cv->GV->STASH->NAME;  # Should print "main"
-```
-
-**Current PerlOnJava behavior:**
-```
-Name: __ANON__
-Stash: main
-```
-
-**Expected behavior:**
-```
-Name: foo
-Stash: main
-```
-
-### Why This Matters for Moose
-
-Moose uses `Class::MOP::get_code_info($coderef)` extensively:
-
-1. **Method tracking**: Determining if a method belongs to a class or was imported
-2. **Role application**: Checking method origins during role composition
-3. **Export management**: Tracking which subs were exported vs. defined locally
-4. **Metaclass operations**: Building method maps, checking overrides
-
-Without accurate subroutine name introspection, Moose cannot function correctly.
+PerlOnJava now stores `subName`/`packageName` on `RuntimeCode`
+(`src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java`), and
+`B.pm`'s `B::CV`/`B::GV` accessors read them. This is the foundation on which
+either path below can build.
 
 ---
 
-## Implementation Plan
+## Quick path: pure-Perl Moose shim via Moo
 
-### Phase 1: Fix B Module Subroutine Name Introspection (Critical)
+**Goal**: get `use Moose;` working for the common subset (attributes,
+inheritance, roles, method modifiers) by delegating to Moo.
 
-**Goal**: Make `B::CV->GV->NAME` return the actual subroutine name.
+### Deliverables
 
-**Analysis Required**:
+- `src/main/perl/lib/Moose.pm` — shim that translates `Moose` API into Moo
+  calls.
+- `src/main/perl/lib/Moose/Role.pm` — delegates to `Moo::Role`.
+- `src/main/perl/lib/Moose/Util/TypeConstraints.pm` — minimal stub providing
+  `subtype`, `enum`, `as`, `where`, `coerce`, `class_type`, `role_type`.
+- `src/main/perl/lib/Moose/Object.pm` — base class with `new`, `BUILD`,
+  `BUILDARGS`, `meta` (returning a stub metaclass).
 
-1. **Where subroutine names are stored**:
-   - Check `RuntimeCode.java` - does it store the subroutine name?
-   - Check `EmitterMethodCreator.java` - is the name passed during creation?
-   - Check symbol table operations in `GlobalVariable.java`
+Reference implementations to mine: `Mo::Moose`, `Any::Moose`, and
+`MouseX::Types::Moose` (already present in `~/.perlonjava/lib/`).
 
-2. **Where B module queries names**:
-   - `src/main/java/org/perlonjava/perlmodule/B.java`
-   - Methods: `BCV`, `BGV`, `BSTASH`
+### Acceptance criteria
 
-**Likely Fix**:
-
-The `RuntimeCode` class needs to store the subroutine name when created:
-
-```java
-// RuntimeCode.java
-public class RuntimeCode {
-    private String subName;      // Add this field
-    private String packageName;  // Add this field
-    
-    public String getSubName() {
-        return subName != null ? subName : "__ANON__";
-    }
-    
-    public String getPackageName() {
-        return packageName != null ? packageName : "main";
-    }
-}
+```bash
+./jcpan -t ANSI::Unicode      # currently FAIL → must PASS
+./jcpan -t Test::Class::Moose # smoke test
 ```
 
-Then update the B module to query these:
+### Limitations of this path
 
-```java
-// B.java - in the GV NAME accessor
-public static RuntimeScalar getName(RuntimeScalar self) {
-    RuntimeCode code = (RuntimeCode) self.value;
-    return new RuntimeScalar(code.getSubName());
-}
-```
+- No real metaclass introspection (`$class->meta->get_all_attributes` etc.).
+- Type constraints are name-only; no `MooseX::Types`.
+- `Moose::Exporter`-based modules that call deep MOP APIs won't work.
 
-**Files to investigate**:
-- `src/main/java/org/perlonjava/runtime/RuntimeCode.java`
-- `src/main/java/org/perlonjava/perlmodule/B.java`
-- `src/main/java/org/perlonjava/codegen/EmitterMethodCreator.java`
-- `src/main/java/org/perlonjava/runtime/GlobalVariable.java`
-
-**Test**:
-```perl
-sub named_sub { 42 }
-use B;
-my $cv = B::svref_2object(\&named_sub);
-print $cv->GV->NAME eq 'named_sub' ? "ok" : "not ok";
-print $cv->GV->STASH->NAME eq 'main' ? "ok" : "not ok";
-```
+This is enough for the long tail of CPAN modules that just declare attributes
+and method modifiers.
 
 ---
 
-### Phase 2: Bypass Makefile.PL Compiler Check
+## Real path: bundle pure-Perl `Class::MOP` + `Moose`
 
-**Goal**: Allow Moose to install despite lacking a C compiler.
+### Phase A — `ExtUtils::HasCompiler` deterministic stub
 
-**Options**:
-
-#### Option A: Patch ExtUtils::HasCompiler (Recommended)
-
-Create a PerlOnJava-specific version that returns false gracefully:
+The upstream module currently lives at `~/.perlonjava/lib/ExtUtils/HasCompiler.pm`
+and returns false only because `$Config{usedl}` happens to be empty. Make this
+explicit and authoritative:
 
 ```perl
 # src/main/perl/lib/ExtUtils/HasCompiler.pm
 package ExtUtils::HasCompiler;
-use strict;
-use warnings;
+our $VERSION = '0.025';
+use strict; use warnings;
+use base 'Exporter';
+our @EXPORT_OK = qw/can_compile_loadable_object can_compile_static_library can_compile_extension/;
+our %EXPORT_TAGS = (all => \@EXPORT_OK);
 
-sub can_compile_loadable_object {
-    # PerlOnJava cannot compile XS, but modules may have PP fallbacks
-    return 0;
-}
-
-# ... rest of API for compatibility
-```
-
-#### Option B: Environment Variable
-
-Set `PERLONJAVA_SKIP_XS_CHECK=1` and patch Moose's Makefile.PL detection.
-
-#### Option C: jcpan Patching
-
-Have jcpan automatically patch known modules during installation.
-
-**Files to create/modify**:
-- `src/main/perl/lib/ExtUtils/HasCompiler.pm`
-
----
-
-### Phase 3: Implement Class::MOP Java XS Functions
-
-**Goal**: Provide Java implementations for critical MOP functions.
-
-**Functions to implement**:
-
-| Function | Purpose | Complexity |
-|----------|---------|------------|
-| `get_code_info` | Get package/name from coderef | Easy (after Phase 1) |
-| `INSTALL_SIMPLE_READER` | Create hash accessor methods | Medium |
-| `is_stub` | Check if method is a stub | Easy |
-| `_flag_as_reexport` | Mark glob as re-export | Hard (needs MAGIC) |
-| `_export_is_flagged` | Check re-export flag | Hard (needs MAGIC) |
-
-**Implementation approach**:
-
-Create `src/main/java/org/perlonjava/perlmodule/ClassMOP.java`:
-
-```java
-package org.perlonjava.perlmodule;
-
-public class ClassMOP extends PerlModuleBase {
-    
-    public ClassMOP() {
-        super("Class::MOP", false);
-    }
-    
-    public static void initialize() {
-        ClassMOP module = new ClassMOP();
-        try {
-            module.registerMethod("get_code_info", null);
-        } catch (NoSuchMethodException e) {
-            // handle
-        }
-    }
-    
-    /**
-     * get_code_info($coderef)
-     * Returns (package_name, sub_name) for a code reference.
-     */
-    public static RuntimeList get_code_info(RuntimeArray args, int ctx) {
-        RuntimeScalar coderef = args.get(0);
-        if (coderef.type != RuntimeScalarType.CODE) {
-            return new RuntimeList();
-        }
-        
-        RuntimeCode code = (RuntimeCode) coderef.value;
-        RuntimeList result = new RuntimeList();
-        result.add(new RuntimeScalar(code.getPackageName()));
-        result.add(new RuntimeScalar(code.getSubName()));
-        return result;
-    }
-}
-```
-
-**Files to create**:
-- `src/main/java/org/perlonjava/perlmodule/ClassMOP.java`
-
----
-
-### Phase 4: Handle Export Flag Magic (Optional)
-
-**Goal**: Implement MAGIC-based export tracking for Moose::Exporter.
-
-This is lower priority because:
-1. It only affects re-export detection
-2. Moose may work without it (with some export warnings)
-
-**If needed**, implement a simplified version using a WeakHashMap in Java to track flagged globs.
-
----
-
-### Phase 5: Testing and Validation
-
-**Test progression**:
-
-1. **Unit tests for B module fixes**:
-   ```bash
-   ./jperl -e 'sub foo{} use B; print B::svref_2object(\&foo)->GV->NAME'
-   ```
-
-2. **Sub::Identify tests**:
-   ```bash
-   PERL_PARAMS_UTIL_PP=1 ./jcpan -t Sub::Identify
-   ```
-
-3. **Class::Load with Moose dependencies**:
-   ```bash
-   PERL_PARAMS_UTIL_PP=1 ./jperl -e 'use Class::Load qw(load_class); load_class("Moose"); print "ok\n"'
-   ```
-
-4. **Basic Moose functionality**:
-   ```perl
-   use Moose;
-   
-   has 'name' => (is => 'ro', isa => 'Str');
-   
-   my $obj = __PACKAGE__->new(name => 'test');
-   print $obj->name;
-   ```
-
-5. **Full Moose test suite**:
-   ```bash
-   ./jcpan -t Moose
-   ```
-
----
-
-## Alternative: Use Moo
-
-If Moose support proves too complex, **Moo is already working** and provides most functionality:
-
-```perl
-package MyClass;
-use Moo;
-
-has name => (is => 'ro', isa => sub { die unless defined $_[0] });
-has age  => (is => 'rw', default => sub { 0 });
-
-sub greet {
-    my $self = shift;
-    return "Hello, " . $self->name;
-}
-
+sub can_compile_loadable_object { 0 }
+sub can_compile_static_library  { 0 }
+sub can_compile_extension       { 0 }
 1;
 ```
 
-**Moo features that work**:
-- Attributes with `is`, `isa`, `default`, `trigger`, `coerce`
-- Inheritance with `extends`
-- Roles with `Role::Tiny` / `Moo::Role`
-- Method modifiers (`before`, `after`, `around`)
-- BUILD and BUILDARGS
+Verify with:
 
-**Moo limitations on PerlOnJava** (expected):
-- Weak references don't behave like native Perl
-- DEMOLISH timing differs (JVM GC)
-- Some namespace cleanup edge cases
+```bash
+./jperl -MExtUtils::HasCompiler=can_compile_loadable_object \
+        -e 'print can_compile_loadable_object(quiet=>1) ? "yes" : "no"'
+# → no
+```
+
+**Important**: this alone does **not** unblock Moose 2.4000. Its generated
+`Makefile.PL` contains:
+
+```perl
+OBJECT => "xs/Attribute\$(OBJ_EXT) ... mop\$(OBJ_EXT)",
+XS => { "xs/Attribute.xs" => "xs/Attribute.c", ... },  # 13 .xs files
+C  => [ ... ],
+```
+
+After the compiler-check bypass, `WriteMakefile` will still attempt to compile
+those. We need Phase B too.
+
+### Phase B — strip XS in `WriteMakefile` on PerlOnJava
+
+Two sub-options:
+
+**B1.** Patch `src/main/perl/lib/ExtUtils/MakeMaker.pm` (already PerlOnJava's
+own copy) so it scrubs `OBJECT`, `XS`, `C`, `H`, `XSPROTOARG`, `XSOPT` from
+the args before generating the Makefile. Gate behind a config flag so other
+modules with optional XS keep working.
+
+**B2.** Bundle our own `Moose.pm` (Phase D) so the upstream
+`Moose-2.4000/Makefile.PL` never runs.
+
+Preferred: **B1** — it's a one-time investment that helps every XS module
+that ships pure-Perl fallbacks.
+
+### Phase C — Java `Class::MOP` helpers
+
+Create `src/main/java/org/perlonjava/runtime/perlmodule/ClassMOP.java`. Most
+of `Class::MOP` is already pure Perl upstream and runs unmodified once the
+helpers exist. We only need Java for the irreducible pieces:
+
+| Function | Trivial after Phase 1? | Notes |
+|----------|------------------------|-------|
+| `get_code_info($cv)` | Yes | Read `RuntimeCode.packageName`/`subName` |
+| `is_stub($cv)` | Yes | Check that the code body is empty |
+| `_definition_context()` | Yes | Capture `caller(1)` |
+| `_flag_as_reexport($glob)` | No | Needs MAGIC; defer to Phase E |
+| `_export_is_flagged($glob)` | No | Needs MAGIC; defer to Phase E |
+| `INSTALL_SIMPLE_READER` etc. | Optional | Pure-Perl version is fine; Java only for speed |
+
+Skeleton:
+
+```java
+package org.perlonjava.runtime.perlmodule;
+
+public class ClassMOP extends PerlModuleBase {
+    public ClassMOP() { super("Class::MOP", false); }
+
+    public static void initialize() {
+        ClassMOP m = new ClassMOP();
+        try { m.registerMethod("get_code_info", null); }
+        catch (NoSuchMethodException e) { throw new RuntimeException(e); }
+    }
+
+    public static RuntimeList get_code_info(RuntimeArray args, int ctx) {
+        RuntimeScalar cv = args.get(0);
+        if (cv.type != RuntimeScalarType.CODE) return new RuntimeList();
+        RuntimeCode code = (RuntimeCode) cv.value;
+        RuntimeList r = new RuntimeList();
+        r.add(new RuntimeScalar(code.packageName != null ? code.packageName : "main"));
+        r.add(new RuntimeScalar(code.subName     != null ? code.subName     : "__ANON__"));
+        return r;
+    }
+}
+```
+
+Wire it up in `org.perlonjava.runtime.perlmodule` initialization next to
+`Mro`, `Internals`, etc.
+
+### Phase D — bundle pure-Perl `Class::MOP` and `Moose`
+
+Drop the upstream `.pm` tree (without the `xs/` and `mop.c`) into
+`src/main/perl/lib/Class/MOP*` and `src/main/perl/lib/Moose*`. Add a small
+`PERL_CLASSMOP_PP=1`-style wrapper that forces every `Class::MOP::*` module
+to skip `Class::Load::XS`/XS-only branches.
+
+### Phase E — export-flag magic (optional)
+
+Lower priority; only affects `Moose::Exporter` re-export tracking. Implement
+as a `WeakHashMap<GlobReference, ExportFlags>` on the Java side, exposed
+through helper subs `Moose::Exporter::_set_flag`/`_get_flag`.
 
 ---
 
-## Dependencies Graph
+## Verification matrix
 
+```bash
+# Phase 1 sanity (already passes)
+./jperl -e 'sub f{} use B; print B::svref_2object(\&f)->GV->NAME'   # → f
+
+# After Quick path (shim)
+./jcpan -t ANSI::Unicode                                            # → PASS
+./jperl -MMoose -e 'package P { use Moose; has x => (is=>"rw") } P->new(x=>1)'
+
+# After Phase A (HasCompiler stub)
+./jperl -MExtUtils::HasCompiler=can_compile_loadable_object \
+        -e 'print can_compile_loadable_object(quiet=>1) ? "yes" : "no"'  # → no
+
+# After Phase B (XS-strip in WriteMakefile)
+./jcpan -t Moose                                                    # → install OK, Moose tests run
+
+# After Phase C+D (real Class::MOP / Moose)
+./jperl -MClass::MOP -e 'print Class::MOP::get_code_info(\&Class::MOP::class_of)'
+./jcpan -t Moose
+./jcpan -t MooseX::Types
 ```
-Moose
-├── Class::MOP (XS - needs Java impl)
-│   └── MRO::Compat (works)
-├── Class::Load (works with PP)
-│   ├── Data::OptList (works)
-│   │   ├── Params::Util (needs PERL_PARAMS_UTIL_PP=1)
-│   │   └── Sub::Install (mostly works)
-│   └── Package::Stash (works with PP)
-├── Devel::GlobalDestruction (works)
-├── Devel::OverloadInfo (needs investigation)
-├── Devel::StackTrace (works)
-├── Dist::CheckConflicts (works)
-├── Eval::Closure (needs investigation)
-├── List::Util (built-in)
-├── Module::Runtime (works)
-├── Package::DeprecationManager (needs investigation)
-├── Params::Util (needs PP flag)
-├── Scalar::Util (built-in)
-├── Sub::Exporter (needs investigation)
-└── Try::Tiny (works)
+
+### Lock in progress as bundled-module tests
+
+`src/test/resources/module/{Distribution}/` is reserved for **unmodified
+upstream test files** of CPAN distributions we actually bundle. Use it
+**only** when both apply:
+
+1. The distribution itself is bundled (its `.pm` files live in
+   `src/main/perl/lib/`, or the test directory ships its own `lib/`).
+2. The tests being copied are the upstream tests for **that** distribution.
+
+So:
+
+- When we eventually bundle a pure-Perl `Moose` (Phase D), copy
+  `Moose-2.4000/t/...` into `src/test/resources/module/Moose/t/`.
+- Same for `Class::MOP`, `MooseX::Types`, etc., as each gets bundled.
+- Do **not** snapshot tests for downstream consumers we don't bundle
+  (e.g. ANSI::Unicode). Those stay as `./jcpan -t` smoke checks.
+- Do **not** put shim-specific or PerlOnJava-specific tests under
+  `module/`. Shim coverage belongs in `src/test/resources/unit/` if it's
+  needed beyond the `jcpan -t` smoke.
+
+Conventions for bundled-distribution snapshots (see existing layouts under
+`src/test/resources/module/`, e.g. `Clone-PP/`, `Math-BigInt/`,
+`XML-Parser/`):
+
+- One directory per CPAN distribution (`Moose/`, `Class-MOP/`, …); use the
+  dist name with `::` replaced by `-`.
+- Mirror the upstream `t/` layout exactly. Don't edit the test files; if a
+  test is genuinely incompatible, prefer fixing the runtime over editing the
+  test (per AGENTS.md).
+- Tests are picked up automatically by the Gradle `testModule` task —
+  no JUnit wiring is needed.
+
+Verify with:
+
+```bash
+make test-bundled-modules
 ```
+
+This gives us a regression net: every newly-passing upstream Moose-ecosystem
+test we vendor in becomes guarded against regressions, and `git log
+src/test/resources/module/Moose*` becomes the historical record of progress.
+
+For the **current PR (Quick path / shim only)** there are no bundled
+upstream distributions yet, so nothing is snapshotted under `module/`.
+The regression net for the shim is `make` plus the `./jcpan -t
+ANSI::Unicode` smoke check.
 
 ---
 
-## Environment Variables for PP Mode
+## Dependency graph (verified)
 
-Until Java XS is implemented, use these environment variables:
-
-```bash
-export PERL_PARAMS_UTIL_PP=1
-# Future: export PERL_CLASS_MOP_PP=1
+```
+Moose                              ← MISSING
+└── Class::MOP                     ← MISSING (Phase C+D)
+    ├── MRO::Compat                ← upstream copy works
+    ├── Class::Load                ← works
+    │   ├── Module::Runtime        ← works
+    │   ├── Data::OptList          ← works
+    │   │   ├── Params::Util       ← works (no env var)
+    │   │   └── Sub::Install       ← works
+    │   └── Try::Tiny              ← works
+    ├── Devel::GlobalDestruction   ← works
+    ├── Devel::OverloadInfo        ← works
+    ├── Devel::StackTrace          ← works
+    ├── Dist::CheckConflicts       ← works
+    ├── Eval::Closure              ← works
+    ├── Package::DeprecationManager← works (normal import-arg requirement)
+    ├── Package::Stash             ← works
+    ├── Sub::Exporter              ← works
+    ├── Sub::Identify              ← works (Phase 1)
+    ├── List::Util                 ← built-in
+    ├── Scalar::Util               ← built-in
+    └── B::Hooks::EndOfScope       ← works
 ```
 
-Or create a wrapper script:
-
-```bash
-#!/bin/bash
-# jperl-moose - Run jperl with Moose-compatible settings
-export PERL_PARAMS_UTIL_PP=1
-exec jperl "$@"
-```
+The whole "needs investigation" / "needs PP flag" column from the previous
+revision of this doc is gone — every `Class::MOP` runtime dependency that
+isn't `Class::MOP` itself loads cleanly today.
 
 ---
 
 ## Progress Tracking
 
-### Current Status: Phase 0 - Investigation Complete
+### Current Status
+
+- **Phase 1 — DONE.** B-module subroutine name/stash introspection works.
+- **Quick path — not started.** Highest leverage: ships `Moose.pm` shim, immediately unblocks ANSI::Unicode-class modules.
+- **Phase A — not started.** Trivial; replace upstream `ExtUtils::HasCompiler` with deterministic stub.
+- **Phase B — not started.** Strip XS keys in `WriteMakefile`.
+- **Phase C — not started.** Java `Class::MOP::get_code_info` + helpers.
+- **Phase D — not started.** Bundle pure-Perl `Class::MOP` and `Moose`.
+- **Phase E — deferred.** Export-flag MAGIC.
 
 ### Completed
-- [x] Investigation of Moose requirements (2025-03-27)
-- [x] Identified root cause: B module subroutine names
-- [x] Verified Moo works as alternative (96% tests pass)
-- [x] Documented dependency tree and status
 
-### Next Steps
-1. [ ] Phase 1: Fix B module subroutine name introspection
-2. [ ] Phase 2: Create ExtUtils::HasCompiler stub
-3. [ ] Phase 3: Implement Class::MOP Java XS
-4. [ ] Phase 4: Handle export flag magic (if needed)
-5. [ ] Phase 5: Full Moose test suite
+- [x] Phase 1: B-module subroutine name introspection
+- [x] Verified working dependency tree (Apr 2026)
 
-### Open Questions
-- Should we prioritize Moose or focus on Moo compatibility?
-- Is there demand for full Moose metaclass introspection?
-- Can we implement a "Moose-lite" that covers common use cases?
+### Decision needed
+
+Pick one to pursue first:
+
+1. **Quick path (Moose-as-Moo shim).** ~1–2 days. Unblocks ANSI::Unicode and similar. Won't unblock anything that depends on real MOP introspection.
+2. **Phases A → B → D.** ~1–2 weeks. Lets `jcpan -t Moose` actually run upstream Moose. Bigger payoff, bigger risk.
+3. **Phase C standalone (Java helpers only).** Unblocks nothing on its own but is a prerequisite for path 2 and a strict superset of what the shim needs.
+
+Recommendation: **(1) first to ship value quickly, then (3) → (2)** as the real fix.
+
+### Open work items
+
+- [ ] Decide path (above).
+- [ ] If path 1: write `src/main/perl/lib/Moose.pm`, `Moose/Role.pm`, `Moose/Object.pm`, `Moose/Util/TypeConstraints.pm`.
+- [ ] If path 2: write Phase A stub, Phase B MakeMaker patch, Phase C Java module, Phase D bundle.
+- [ ] In either case: add `./jcpan -t ANSI::Unicode` to a smoke test list.
+- [ ] Each time we **bundle** a Moose-ecosystem distribution (Moose itself, Class::MOP, MooseX::Types, …), snapshot its upstream `t/` under `src/test/resources/module/{Distribution}/t/` so `make test-bundled-modules` guards against regressions. Do not snapshot tests for non-bundled downstream consumers; those remain `./jcpan -t` smoke checks.
 
 ---
 
 ## Related Documents
 
-- [xs_fallback.md](xs_fallback.md) - XS fallback mechanism
-- [makemaker_perlonjava.md](makemaker_perlonjava.md) - MakeMaker implementation
-- [cpan_client.md](cpan_client.md) - CPAN client support
-- `.agents/skills/port-cpan-module/` - Module porting skill
-
----
+- [xs_fallback.md](xs_fallback.md) — XS fallback mechanism
+- [makemaker_perlonjava.md](makemaker_perlonjava.md) — MakeMaker implementation
+- [cpan_client.md](cpan_client.md) — CPAN client support
+- `.agents/skills/port-cpan-module/` — Module porting skill
 
 ## References
 
 - [Moose Manual](https://metacpan.org/pod/Moose::Manual)
 - [Class::MOP](https://metacpan.org/pod/Class::MOP)
-- [Moo](https://metacpan.org/pod/Moo) - Minimalist Object Orientation
-- [B module](https://perldoc.perl.org/B) - Perl compiler backend
+- [Moo](https://metacpan.org/pod/Moo)
+- [B module](https://perldoc.perl.org/B)

--- a/jcpan
+++ b/jcpan
@@ -56,4 +56,8 @@ fi
 # Override: JPERL_TEST_TIMEOUT=0 (disable) or JPERL_TEST_TIMEOUT=600 (10 min)
 export JPERL_TEST_TIMEOUT="${JPERL_TEST_TIMEOUT:-300}"
 
+# Expose the jperl launcher so distroprefs (e.g. Moose.yml) can run
+# upstream tests against the bundled shims with `prove --exec "$JPERL_BIN"`.
+export JPERL_BIN="$SCRIPT_DIR/jperl"
+
 exec "$SCRIPT_DIR/jperl" "$CPAN_SCRIPT" "${ARGS[@]}"

--- a/jcpan
+++ b/jcpan
@@ -58,13 +58,17 @@ export JPERL_TEST_TIMEOUT="${JPERL_TEST_TIMEOUT:-300}"
 
 # Expose the jperl launcher AND the jcpan launcher itself so distroprefs
 # (e.g. Moose.yml) can run upstream tests against the bundled shims with
-# `prove --exec "$JPERL_BIN"`, and bootstrap missing helper modules with
-# `"$JCPAN_BIN" SomeModule`.
+# `prove --exec jperl`, and bootstrap missing helper modules with
+# `jcpan SomeModule`. We also prepend SCRIPT_DIR to PATH so shell-spawned
+# subprocesses (CPAN's distroprefs commandlines, prove --exec, ...) find
+# `jperl` and `jcpan` cross-platform without needing $JPERL_BIN tokens
+# that don't expand in Windows cmd.exe.
 export JPERL_BIN="$SCRIPT_DIR/jperl"
 export JCPAN_BIN="${BASH_SOURCE[0]}"
 case "$JCPAN_BIN" in
     /*) ;;                       # already absolute
     *)  JCPAN_BIN="$SCRIPT_DIR/jcpan" ;;
 esac
+export PATH="$SCRIPT_DIR:$PATH"
 
 exec "$SCRIPT_DIR/jperl" "$CPAN_SCRIPT" "${ARGS[@]}"

--- a/jcpan
+++ b/jcpan
@@ -56,8 +56,15 @@ fi
 # Override: JPERL_TEST_TIMEOUT=0 (disable) or JPERL_TEST_TIMEOUT=600 (10 min)
 export JPERL_TEST_TIMEOUT="${JPERL_TEST_TIMEOUT:-300}"
 
-# Expose the jperl launcher so distroprefs (e.g. Moose.yml) can run
-# upstream tests against the bundled shims with `prove --exec "$JPERL_BIN"`.
+# Expose the jperl launcher AND the jcpan launcher itself so distroprefs
+# (e.g. Moose.yml) can run upstream tests against the bundled shims with
+# `prove --exec "$JPERL_BIN"`, and bootstrap missing helper modules with
+# `"$JCPAN_BIN" SomeModule`.
 export JPERL_BIN="$SCRIPT_DIR/jperl"
+export JCPAN_BIN="${BASH_SOURCE[0]}"
+case "$JCPAN_BIN" in
+    /*) ;;                       # already absolute
+    *)  JCPAN_BIN="$SCRIPT_DIR/jcpan" ;;
+esac
 
 exec "$SCRIPT_DIR/jperl" "$CPAN_SCRIPT" "${ARGS[@]}"

--- a/jcpan.bat
+++ b/jcpan.bat
@@ -22,7 +22,9 @@ goto parse_args
 :run
 rem Set default per-test timeout (300s) to kill hanging tests
 if not defined JPERL_TEST_TIMEOUT set "JPERL_TEST_TIMEOUT=300"
-rem Expose jperl launcher for distroprefs (e.g. Moose.yml) to use as
-rem prove --exec "%JPERL_BIN%".
+rem Expose jperl launcher AND jcpan launcher itself for distroprefs
+rem (e.g. Moose.yml) to use as `prove --exec "%JPERL_BIN%"` and
+rem `"%JCPAN_BIN%" SomeModule`.
 set "JPERL_BIN=%SCRIPT_DIR%jperl.bat"
+set "JCPAN_BIN=%SCRIPT_DIR%jcpan.bat"
 "%SCRIPT_DIR%jperl.bat" "%SCRIPT_DIR%src\main\perl\bin\cpan" %JCPAN_ARGS%

--- a/jcpan.bat
+++ b/jcpan.bat
@@ -22,9 +22,11 @@ goto parse_args
 :run
 rem Set default per-test timeout (300s) to kill hanging tests
 if not defined JPERL_TEST_TIMEOUT set "JPERL_TEST_TIMEOUT=300"
-rem Expose jperl launcher AND jcpan launcher itself for distroprefs
-rem (e.g. Moose.yml) to use as `prove --exec "%JPERL_BIN%"` and
-rem `"%JCPAN_BIN%" SomeModule`.
+rem Expose jperl and jcpan launchers, and prepend SCRIPT_DIR to PATH so
+rem shell-spawned subprocesses (distroprefs commandlines, prove --exec,
+rem etc.) can find jperl/jcpan without tokens that don't expand in
+rem POSIX sh. See src/main/perl/lib/CPAN/Config.pm (Moose.yml).
 set "JPERL_BIN=%SCRIPT_DIR%jperl.bat"
 set "JCPAN_BIN=%SCRIPT_DIR%jcpan.bat"
+set "PATH=%SCRIPT_DIR%;%PATH%"
 "%SCRIPT_DIR%jperl.bat" "%SCRIPT_DIR%src\main\perl\bin\cpan" %JCPAN_ARGS%

--- a/jcpan.bat
+++ b/jcpan.bat
@@ -22,4 +22,7 @@ goto parse_args
 :run
 rem Set default per-test timeout (300s) to kill hanging tests
 if not defined JPERL_TEST_TIMEOUT set "JPERL_TEST_TIMEOUT=300"
+rem Expose jperl launcher for distroprefs (e.g. Moose.yml) to use as
+rem prove --exec "%JPERL_BIN%".
+set "JPERL_BIN=%SCRIPT_DIR%jperl.bat"
 "%SCRIPT_DIR%jperl.bat" "%SCRIPT_DIR%src\main\perl\bin\cpan" %JCPAN_ARGS%

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "76f47af13";
+    public static final String gitCommitId = "55bb5d0f8";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 26 2026 18:25:55";
+    public static final String buildTimestamp = "Apr 26 2026 19:13:32";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "55bb5d0f8";
+    public static final String gitCommitId = "9065a9db9";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 26 2026 19:13:32";
+    public static final String buildTimestamp = "Apr 26 2026 19:38:42";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "472d4e2da";
+    public static final String gitCommitId = "76f47af13";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 26 2026 17:43:24";
+    public static final String buildTimestamp = "Apr 26 2026 18:25:55";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "9065a9db9";
+    public static final String gitCommitId = "df9a9f3f9";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 26 2026 19:38:42";
+    public static final String buildTimestamp = "Apr 26 2026 20:39:38";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/perl/lib/CPAN/Config.pm
+++ b/src/main/perl/lib/CPAN/Config.pm
@@ -90,20 +90,25 @@ comment: |
 match:
   distribution: "^ETHER/Moose-"
 disabled: 0
+# Cross-platform commandlines: each phase invokes `jperl` (which is on
+# PATH thanks to jcpan/jcpan.bat prepending SCRIPT_DIR) with -M to load
+# a small Perl helper. We avoid POSIX-only shell constructs (||, ;,
+# `touch`, /dev/null, $VAR) because CPAN.pm's commandline runs through
+# Perl's system(), which on Windows hands off to cmd.exe.
+#
+# We also avoid CPAN's `depends:` block: it would force CPAN to resolve
+# Moose's full upstream prereq tree (Package::Stash::XS,
+# MooseX::NonMoose, ...), most of which is XS and unsatisfiable on
+# PerlOnJava. The pl-phase helper installs only the one thing the
+# Moose-as-Moo shim genuinely needs: Moo itself.
 pl:
-  # The Moose shim delegates to Moo at runtime. Auto-install Moo if it
-  # isn't already loadable, then create a stub Makefile so CPAN's "no
-  # Makefile created" fallback path doesn't kick in. We avoid the
-  # `depends:` block here because CPAN would then try to resolve
-  # Moose's full upstream prereq tree (Package::Stash::XS,
-  # MooseX::NonMoose, ...), most of which is XS and unsatisfiable.
-  commandline: '"$JPERL_BIN" -e "require Moo; 1" >/dev/null 2>&1 || "$JCPAN_BIN" Moo; touch Makefile'
+  commandline: 'jperl -MPerlOnJava::Distroprefs::Moose -e "PerlOnJava::Distroprefs::Moose::bootstrap_pl_phase()"'
 make:
-  commandline: "true"
+  commandline: 'jperl -MPerlOnJava::Distroprefs::Moose -e "PerlOnJava::Distroprefs::Moose::noop()"'
 test:
-  commandline: 'prove --exec "$JPERL_BIN" -r t/'
+  commandline: 'prove --exec jperl -r t/'
 install:
-  commandline: "true"
+  commandline: 'jperl -MPerlOnJava::Distroprefs::Moose -e "PerlOnJava::Distroprefs::Moose::noop()"'
 YAML
     );
 

--- a/src/main/perl/lib/CPAN/Config.pm
+++ b/src/main/perl/lib/CPAN/Config.pm
@@ -57,6 +57,48 @@ pl:
   env:
     PARAMS_VALIDATE_IMPLEMENTATION: PP
 YAML
+        'Moose.yml' => <<'YAML',
+---
+comment: |
+  PerlOnJava distroprefs for Moose.
+
+  Modern Moose ships 13 .xs files plus mop.c. PerlOnJava cannot compile
+  XS, so a normal install/test cycle fails at Makefile.PL with
+  "This distribution requires a working compiler".
+
+  PerlOnJava bundles a pure-Perl Moose-as-Moo shim at
+  src/main/perl/lib/Moose.pm (loaded from the jar via PERL5LIB), so we
+  don't need to build or install the upstream distribution at all. We
+  just need to run its tests against the shim. This distropref:
+
+    - Skips Makefile.PL (would die on the compiler check).
+    - Skips make (nothing to build).
+    - Runs the upstream t/ tree with jperl directly via prove --exec,
+      so the bundled shim from the jar wins over the unpacked
+      lib/Moose.pm.
+    - Skips install (the shim is already on @INC via the jar).
+
+  Required: jcpan / jcpan.bat exports JPERL_BIN pointing at the right
+  jperl launcher. See bin/jcpan.
+
+  Expected result on `jcpan -t Moose`: most upstream tests fail to load
+  because they require Class::MOP, Moose::Meta::Class, etc. that the
+  shim doesn't provide. The shim-supported subset (basic attributes,
+  roles, BUILD/BUILDARGS, immutable round-trips, method modifiers,
+  cookbook recipes) does pass. See dev/modules/moose_support.md for
+  the baseline numbers and the plan for improving them.
+match:
+  distribution: "^ETHER/Moose-"
+disabled: 0
+pl:
+  commandline: "touch Makefile"
+make:
+  commandline: "true"
+test:
+  commandline: 'prove --exec "$JPERL_BIN" -r t/'
+install:
+  commandline: "true"
+YAML
     );
 
     # Check if any files need to be written

--- a/src/main/perl/lib/CPAN/Config.pm
+++ b/src/main/perl/lib/CPAN/Config.pm
@@ -91,7 +91,13 @@ match:
   distribution: "^ETHER/Moose-"
 disabled: 0
 pl:
-  commandline: "touch Makefile"
+  # The Moose shim delegates to Moo at runtime. Auto-install Moo if it
+  # isn't already loadable, then create a stub Makefile so CPAN's "no
+  # Makefile created" fallback path doesn't kick in. We avoid the
+  # `depends:` block here because CPAN would then try to resolve
+  # Moose's full upstream prereq tree (Package::Stash::XS,
+  # MooseX::NonMoose, ...), most of which is XS and unsatisfiable.
+  commandline: '"$JPERL_BIN" -e "require Moo; 1" >/dev/null 2>&1 || "$JCPAN_BIN" Moo; touch Makefile'
 make:
   commandline: "true"
 test:

--- a/src/main/perl/lib/Moose.pm
+++ b/src/main/perl/lib/Moose.pm
@@ -1,0 +1,311 @@
+package Moose;
+
+# PerlOnJava Moose shim.
+#
+# This is NOT the real Moose. It is a thin compatibility layer that delegates
+# to Moo, intended to make modules that use the simple Moose attribute /
+# inheritance / role API work on PerlOnJava (which cannot run Moose's XS
+# implementation).
+#
+# Supported (covers the long tail of CPAN modules that use Moose for plain
+# attribute declarations):
+#   - use Moose;
+#   - has $name => (is => 'ro|rw', isa => 'Type', default => ..., builder => ...,
+#                   required => ..., lazy => ..., trigger => ..., predicate => ...,
+#                   clearer => ..., handles => ..., weak_ref => ..., init_arg => ...,
+#                   coerce => ...)
+#   - extends 'Parent::Class', ...
+#   - with 'Role::Name', ...
+#   - before / after / around method modifiers
+#   - String type-constraint names: Any, Item, Defined, Undef, Bool, Value,
+#     Ref, Str, Num, Int, ScalarRef, ArrayRef, HashRef, CodeRef, RegexpRef,
+#     GlobRef, FileHandle, Object, ClassName. Unknown strings are treated as
+#     class names (`isa`-checked).
+#   - __PACKAGE__->meta->make_immutable (no-op)
+#
+# NOT supported:
+#   - Full meta-object protocol introspection ($class->meta->get_all_attributes etc.)
+#   - Moose::Util::TypeConstraints subtype/coerce/enum machinery beyond the
+#     simple stubs in Moose::Util::TypeConstraints
+#   - Moose::Exporter-based modules that drive deep MOP APIs
+#   - Native traits (Array, Hash, Counter, ...)
+#
+# See dev/modules/moose_support.md for the broader plan.
+
+use strict;
+use warnings;
+
+our $VERSION = '2.4000';  # Match the version most CPAN code expects.
+
+# Prevent Moo::sification from triggering its Moose-bridge (which would
+# require the real Class::MOP) when Moo loads. The bridge fires from
+# Moo::sification->import() if $INC{"Moose.pm"} is already true — and in
+# our case it always is, because *we* are Moose.pm. We must short-circuit
+# this BEFORE Moo gets a chance to load, hence the BEGIN block.
+BEGIN {
+    local $@;
+    eval {
+        require Moo::sification;
+        no warnings 'once';
+        $Moo::sification::setup_done = 1;
+        $Moo::sification::disabled   = 1;
+        1;
+    };
+}
+
+use Moo ();
+use Carp ();
+use Scalar::Util ();
+
+# ---------------------------------------------------------------------------
+# Type constraint name -> validator coderef. Returns a Moo-compatible
+# isa-checker that croaks on validation failure.
+# ---------------------------------------------------------------------------
+
+my %TYPE_CHECKS = (
+    Any        => sub { 1 },
+    Item       => sub { 1 },
+    Defined    => sub { defined $_[0] },
+    Undef      => sub { !defined $_[0] },
+    Bool       => sub { !defined $_[0] || $_[0] eq '' || $_[0] eq '0' || $_[0] eq '1' },
+    Value      => sub { defined $_[0] && !ref $_[0] },
+    Ref        => sub { ref $_[0] ? 1 : 0 },
+    Str        => sub { defined $_[0] && !ref $_[0] },
+    Num        => sub {
+        defined $_[0] && !ref $_[0]
+            && $_[0] =~ /\A-?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?\z/;
+    },
+    Int        => sub { defined $_[0] && !ref $_[0] && $_[0] =~ /\A-?\d+\z/ },
+    ScalarRef  => sub { ref $_[0] eq 'SCALAR' || ref $_[0] eq 'REF' },
+    ArrayRef   => sub { ref $_[0] eq 'ARRAY' },
+    HashRef    => sub { ref $_[0] eq 'HASH' },
+    CodeRef    => sub { ref $_[0] eq 'CODE' },
+    RegexpRef  => sub { ref $_[0] eq 'Regexp' },
+    GlobRef    => sub { ref $_[0] eq 'GLOB' },
+    FileHandle => sub {
+        ref $_[0] eq 'GLOB'
+            || (Scalar::Util::blessed($_[0]) && $_[0]->isa('IO::Handle'));
+    },
+    Object     => sub { Scalar::Util::blessed($_[0]) ? 1 : 0 },
+    ClassName  => sub {
+        defined $_[0] && !ref $_[0] && $_[0] =~ /\A[A-Za-z_][\w:]*\z/;
+    },
+);
+
+sub _make_isa_check {
+    my ($type) = @_;
+
+    # Already a coderef or Type::Tiny-like object: pass through.
+    return $type if ref $type eq 'CODE';
+    return $type if Scalar::Util::blessed($type) && $type->can('check');
+
+    # Strip "Maybe[Foo]" -> Foo with maybe-undef wrapper.
+    if ($type =~ /\AMaybe\[(.+)\]\z/) {
+        my $inner = _make_isa_check($1);
+        return sub {
+            return if !defined $_[0];
+            $inner->(@_);
+        };
+    }
+
+    # Strip "ArrayRef[Foo]" / "HashRef[Foo]" - drop parameterization for now.
+    if ($type =~ /\A(ArrayRef|HashRef)\[/) {
+        my $base = $1;
+        my $check = $TYPE_CHECKS{$base};
+        my $name  = $type;
+        return sub {
+            $check->($_[0])
+                or Carp::croak("Validation for '$name' failed for value "
+                    . (defined $_[0] ? "'$_[0]'" : 'undef'));
+        };
+    }
+
+    if (my $check = $TYPE_CHECKS{$type}) {
+        my $name = $type;
+        return sub {
+            $check->($_[0])
+                or Carp::croak("Validation for '$name' failed for value "
+                    . (defined $_[0] ? "'$_[0]'" : 'undef'));
+        };
+    }
+
+    # Treat unknown name as a class name; verify via UNIVERSAL::isa.
+    my $class = $type;
+    return sub {
+        my $val = $_[0];
+        Scalar::Util::blessed($val) && $val->isa($class)
+            or Carp::croak("Validation for class '$class' failed for value "
+                . (defined $val ? "'$val'" : 'undef'));
+    };
+}
+
+# ---------------------------------------------------------------------------
+# Translate a Moose-style has() call into a Moo-compatible one. Drops
+# Moose-only options Moo doesn't recognize (with a soft warning the first
+# time per option).
+# ---------------------------------------------------------------------------
+
+my %MOO_KNOWN_OPTS = map { $_ => 1 } qw(
+    is isa coerce default builder lazy required init_arg
+    predicate clearer handles trigger weak_ref reader writer
+    moosify
+);
+
+sub _translate_has_args {
+    my ($name_or_names, %opts) = @_;
+
+    if (exists $opts{isa} && !ref $opts{isa}) {
+        $opts{isa} = _make_isa_check($opts{isa});
+    }
+    elsif (exists $opts{isa}
+        && Scalar::Util::blessed($opts{isa})
+        && $opts{isa}->can('check'))
+    {
+        # Type::Tiny-style. Convert to coderef Moo accepts.
+        my $tt = $opts{isa};
+        $opts{isa} = sub { $tt->assert_valid($_[0]) };
+    }
+
+    # lazy_build => 1 expands to lazy + builder + clearer + predicate (Moose
+    # convention). Translate into the underlying primitives.
+    if (delete $opts{lazy_build}) {
+        $opts{lazy} = 1;
+        my $base = ref $name_or_names ? $name_or_names->[0] : $name_or_names;
+        $opts{builder}   //= "_build_$base";
+        $opts{clearer}   //= "clear_$base";
+        $opts{predicate} //= "has_$base";
+    }
+
+    # 'auto_deref' is a Moose-ism for ArrayRef/HashRef accessors.
+    delete $opts{auto_deref};
+
+    # Documentation/traits/metaclass/order are MOP-only metadata.
+    delete @opts{qw(documentation traits metaclass order definition_context)};
+
+    return ($name_or_names, %opts);
+}
+
+# ---------------------------------------------------------------------------
+# import / unimport
+# ---------------------------------------------------------------------------
+
+sub import {
+    my ($class, @args) = @_;
+    my $target = caller;
+
+    return if $target eq 'main';  # `perl -MMoose -e ...` shouldn't blow up.
+
+    strict->import;
+    warnings->import;
+
+    # Run `use Moo` inside $target so Moo's caller() detection sees it.
+    my $err;
+    {
+        local $@;
+        eval "package $target; use Moo; 1" or $err = $@ || 'unknown error';
+    }
+    Carp::croak("Moose shim: failed to load Moo for $target: $err") if $err;
+
+    # Wrap the target's `has` to translate Moose-style options before Moo
+    # sees them.
+    my $orig_has = do { no strict 'refs'; \&{"${target}::has"} };
+    if ($orig_has) {
+        no strict 'refs';
+        no warnings 'redefine';
+        *{"${target}::has"} = sub {
+            $orig_has->( _translate_has_args(@_) );
+        };
+    }
+
+    # Provide Moose::Object as an inheritance marker so $obj->isa('Moose::Object')
+    # is true, matching common idioms.
+    {
+        no strict 'refs';
+        my @isa = @{"${target}::ISA"};
+        unless (grep { $_ eq 'Moose::Object' } @isa) {
+            push @{"${target}::ISA"}, 'Moose::Object';
+        }
+    }
+
+    # Install a meta() stub for $class->meta->make_immutable() etc.
+    no strict 'refs';
+    unless (defined &{"${target}::meta"}) {
+        *{"${target}::meta"} = sub { Moose::_FakeMeta->_for($target) };
+    }
+}
+
+sub unimport {
+    my $target = caller;
+    no strict 'refs';
+    for my $sym (qw(has extends with before after around requires meta)) {
+        delete ${"${target}::"}{$sym};
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Stub metaclass so `__PACKAGE__->meta->make_immutable` and a few common
+# idioms don't blow up.
+# ---------------------------------------------------------------------------
+
+package Moose::_FakeMeta;
+
+sub _for {
+    my ($class, $for) = @_;
+    bless { name => $for }, $class;
+}
+
+sub name           { $_[0]->{name} }
+sub make_immutable { $_[0] }
+sub make_mutable   { $_[0] }
+sub is_immutable   { 0 }
+sub get_attribute_list { () }
+sub get_all_attributes { () }
+sub superclasses {
+    my $self = shift;
+    no strict 'refs';
+    if (@_) { @{"$self->{name}::ISA"} = @_ }
+    return @{"$self->{name}::ISA"};
+}
+sub linearized_isa {
+    my $self = shift;
+    require mro;
+    @{ mro::get_linear_isa($self->{name}) };
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Moose - PerlOnJava compatibility shim that delegates to Moo
+
+=head1 SYNOPSIS
+
+    package MyClass;
+    use Moose;
+
+    has name => (is => 'rw', isa => 'Str', default => 'world');
+    has age  => (is => 'ro', isa => 'Int', required => 1);
+
+    sub greet { "Hello, " . $_[0]->name }
+
+    no Moose;
+    __PACKAGE__->meta->make_immutable;
+
+=head1 DESCRIPTION
+
+This is not the real CPAN Moose distribution. PerlOnJava cannot install
+Moose because Moose ships substantial XS code (13 .xs files plus mop.c).
+This shim provides a useful subset of the Moose API by translating
+declarations into the equivalent Moo idioms.
+
+If you need the full Moose meta-object protocol, run on system Perl with the
+real Moose installed. See C<dev/modules/moose_support.md> for the longer-term
+plan to bundle a pure-Perl Class::MOP and Moose port.
+
+=head1 SEE ALSO
+
+L<Moo>, L<Moose>, C<dev/modules/moose_support.md>
+
+=cut

--- a/src/main/perl/lib/Moose/Object.pm
+++ b/src/main/perl/lib/Moose/Object.pm
@@ -1,0 +1,64 @@
+package Moose::Object;
+
+# PerlOnJava Moose::Object stub.
+#
+# Real Moose objects inherit from Moose::Object, which provides BUILDARGS,
+# BUILD/DEMOLISH chaining, ->new, ->meta, ->does, ->DOES, etc. The Moose shim
+# in Moose.pm sets up Moo as the actual constructor backend, so this module
+# only needs to:
+#   - exist (so $obj->isa('Moose::Object') is true)
+#   - provide a polite `new` if someone calls Moose::Object->new directly
+#   - provide ->meta/->does/->DOES that work in the absence of a real MOP
+#
+# See dev/modules/moose_support.md.
+
+use strict;
+use warnings;
+
+our $VERSION = '2.4000';
+
+sub new {
+    my $class = shift;
+    my %args  = @_ == 1 && ref $_[0] eq 'HASH' ? %{ $_[0] } : @_;
+    bless { %args }, $class;
+}
+
+sub meta {
+    my $self = shift;
+    my $name = ref($self) || $self;
+    require Moose;
+    Moose::_FakeMeta->_for($name);
+}
+
+sub does {
+    my ($self, $role) = @_;
+    return $self->isa($role);
+}
+
+sub DOES {
+    my ($self, $role) = @_;
+    return $self->isa($role);
+}
+
+sub BUILDARGS {
+    my $class = shift;
+    return @_ == 1 && ref $_[0] eq 'HASH' ? { %{ $_[0] } } : { @_ };
+}
+
+sub BUILDALL    { }
+sub DEMOLISHALL { }
+
+1;
+
+__END__
+
+=head1 NAME
+
+Moose::Object - PerlOnJava Moose::Object compatibility stub
+
+=head1 DESCRIPTION
+
+Marker base class used by the Moose shim. See L<Moose> and
+C<dev/modules/moose_support.md>.
+
+=cut

--- a/src/main/perl/lib/Moose/Role.pm
+++ b/src/main/perl/lib/Moose/Role.pm
@@ -1,0 +1,73 @@
+package Moose::Role;
+
+# PerlOnJava Moose::Role shim. Delegates to Moo::Role; translates string
+# isa => 'Type' on `has` declarations into coderef checks (same translation
+# Moose.pm performs for classes).
+#
+# See dev/modules/moose_support.md.
+
+use strict;
+use warnings;
+
+our $VERSION = '2.4000';
+
+use Moo::Role ();
+use Carp ();
+use Scalar::Util ();
+use Moose ();   # for _make_isa_check / _translate_has_args
+
+sub import {
+    my ($class, @args) = @_;
+    my $target = caller;
+
+    return if $target eq 'main';
+
+    strict->import;
+    warnings->import;
+
+    my $err;
+    {
+        local $@;
+        eval "package $target; use Moo::Role; 1" or $err = $@ || 'unknown error';
+    }
+    Carp::croak("Moose::Role shim: failed to load Moo::Role for $target: $err")
+        if $err;
+
+    # Wrap target's `has` to translate Moose-style options.
+    my $orig_has = do { no strict 'refs'; \&{"${target}::has"} };
+    if ($orig_has) {
+        no strict 'refs';
+        no warnings 'redefine';
+        *{"${target}::has"} = sub {
+            $orig_has->( Moose::_translate_has_args(@_) );
+        };
+    }
+
+    # meta() stub.
+    no strict 'refs';
+    unless (defined &{"${target}::meta"}) {
+        *{"${target}::meta"} = sub { Moose::_FakeMeta->_for($target) };
+    }
+}
+
+sub unimport {
+    my $target = caller;
+    no strict 'refs';
+    for my $sym (qw(has with before after around requires meta excludes)) {
+        delete ${"${target}::"}{$sym};
+    }
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Moose::Role - PerlOnJava Moose::Role compatibility shim (delegates to Moo::Role)
+
+=head1 SEE ALSO
+
+L<Moose>, L<Moo::Role>, C<dev/modules/moose_support.md>
+
+=cut

--- a/src/main/perl/lib/Moose/Util/TypeConstraints.pm
+++ b/src/main/perl/lib/Moose/Util/TypeConstraints.pm
@@ -1,0 +1,181 @@
+package Moose::Util::TypeConstraints;
+
+# PerlOnJava Moose::Util::TypeConstraints stub.
+#
+# Provides the most common subroutines exported by the upstream module so
+# code that imports them at compile time doesn't fail. Type registration is
+# tracked in a flat hash; declared types are accepted but not deeply enforced
+# (the Moose shim's `has isa => 'TypeName'` uses Moose.pm's own translator,
+# which falls back to a class-name isa check for unknown names).
+#
+# This is enough for many CPAN modules that just do:
+#
+#   use Moose::Util::TypeConstraints;
+#   subtype 'PositiveInt', as 'Int', where { $_ > 0 };
+#   enum 'Direction', [qw(north south east west)];
+#
+# See dev/modules/moose_support.md.
+
+use strict;
+use warnings;
+
+our $VERSION = '2.4000';
+
+use Carp ();
+use Scalar::Util ();
+use Exporter 'import';
+
+our @EXPORT = qw(
+    type subtype as where message optimize_as
+    coerce from via
+    enum union
+    class_type role_type duck_type
+    find_type_constraint register_type_constraint
+    create_type_constraint_union
+);
+our @EXPORT_OK = @EXPORT;
+
+# Registry of declared types. Values are hashrefs:
+#   { name => $name, parent => $parent, constraint => $coderef, message => $coderef }
+my %TYPES;
+
+sub _store {
+    my $def = shift;
+    $TYPES{ $def->{name} } = $def;
+    return $def;
+}
+
+# subtype 'Name', as 'Parent', where { ... }, message { ... };
+sub subtype {
+    my $name = shift;
+
+    # Anonymous subtype: subtype as 'Parent', where { ... }
+    if (ref $name eq 'HASH' || @_ == 0) {
+        return { %{ $name || {} }, name => undef, anonymous => 1 };
+    }
+
+    my %opts;
+    while (@_) {
+        my $key = shift;
+        if (ref $key eq 'HASH') {
+            %opts = (%opts, %$key);
+        }
+        else {
+            $opts{$key} = shift;
+        }
+    }
+    return _store({ name => $name, %opts });
+}
+
+sub type {
+    my $name = shift;
+    my %opts = @_ == 1 && ref $_[0] eq 'HASH' ? %{ $_[0] } : @_;
+    return _store({ name => $name, %opts });
+}
+
+# These are the "DSL" keywords. They return key/value pairs that subtype()
+# stitches together.
+sub as          { (parent     => $_[0]) }
+sub where (&)   { (constraint => $_[0]) }
+sub message (&) { (message    => $_[0]) }
+sub optimize_as (&) { (optimized => $_[0]) }
+sub from        { (coerce_from => $_[0]) }
+sub via (&)     { (coerce_via  => $_[0]) }
+
+sub coerce {
+    my $name = shift;
+    my %opts = @_;
+    my $type = $TYPES{$name} or do {
+        Carp::carp("Cannot apply coerce to unknown type '$name'");
+        return;
+    };
+    push @{ $type->{coercions} ||= [] }, \%opts;
+    return $type;
+}
+
+sub enum {
+    my $name = shift;
+    my $values = ref $_[0] eq 'ARRAY' ? $_[0] : [@_];
+    my %ok = map { $_ => 1 } @$values;
+    return _store({
+        name       => $name,
+        parent     => 'Str',
+        constraint => sub { defined $_[0] && exists $ok{$_[0]} },
+        values     => $values,
+    });
+}
+
+sub union {
+    my ($name, $members) = @_;
+    return _store({
+        name    => $name,
+        parent  => 'Any',
+        members => $members,
+    });
+}
+
+sub class_type {
+    my ($name, $opts) = @_;
+    my $class = $opts && $opts->{class} ? $opts->{class} : $name;
+    return _store({
+        name       => $name,
+        parent     => 'Object',
+        class      => $class,
+        constraint => sub {
+            Scalar::Util::blessed($_[0]) && $_[0]->isa($class);
+        },
+    });
+}
+
+sub role_type {
+    my ($name, $opts) = @_;
+    my $role = $opts && $opts->{role} ? $opts->{role} : $name;
+    return _store({
+        name       => $name,
+        parent     => 'Object',
+        role       => $role,
+        constraint => sub {
+            Scalar::Util::blessed($_[0]) && $_[0]->can('does') && $_[0]->does($role);
+        },
+    });
+}
+
+sub duck_type {
+    my $name = shift;
+    my $methods = ref $_[0] eq 'ARRAY' ? $_[0] : [@_];
+    return _store({
+        name       => $name,
+        parent     => 'Object',
+        methods    => $methods,
+        constraint => sub {
+            my $val = $_[0];
+            return 0 unless Scalar::Util::blessed($val);
+            for my $m (@$methods) {
+                return 0 unless $val->can($m);
+            }
+            1;
+        },
+    });
+}
+
+sub find_type_constraint           { $TYPES{ $_[0] } }
+sub register_type_constraint       { _store({ %{ $_[0] } }) }
+sub create_type_constraint_union   { union(@_) }
+
+1;
+
+__END__
+
+=head1 NAME
+
+Moose::Util::TypeConstraints - PerlOnJava compatibility stub
+
+=head1 DESCRIPTION
+
+A best-effort stub of L<Moose::Util::TypeConstraints>. Type declarations are
+accepted and remembered but not deeply enforced. Sufficient for code that
+declares types at compile time without later relying on the full Moose MOP.
+
+See C<dev/modules/moose_support.md>.
+
+=cut

--- a/src/main/perl/lib/PerlOnJava/Distroprefs/Moose.pm
+++ b/src/main/perl/lib/PerlOnJava/Distroprefs/Moose.pm
@@ -1,0 +1,81 @@
+package PerlOnJava::Distroprefs::Moose;
+
+# Helpers invoked from the bundled CPAN distropref for the Moose CPAN
+# distribution (see src/main/perl/lib/CPAN/Config.pm). The distropref's
+# pl: phase calls bootstrap_pl_phase() to:
+#
+#   1. Make sure Moo is installed (it is the runtime dependency of the
+#      PerlOnJava Moose-as-Moo shim at src/main/perl/lib/Moose.pm).
+#      If Moo is missing, recursively invoke jcpan via $ENV{JCPAN_BIN}.
+#   2. Create a stub Makefile so CPAN.pm's "no Makefile created"
+#      fallback path doesn't try to regenerate Makefile.PL.
+#
+# This module exists so the distropref's commandline can be a single
+# cross-platform Perl invocation:
+#
+#   jperl -MPerlOnJava::Distroprefs::Moose \
+#         -e 'PerlOnJava::Distroprefs::Moose::bootstrap_pl_phase()'
+#
+# instead of POSIX-shell-only constructs (||, ;, $VAR, touch, /dev/null)
+# that don't work in Windows cmd.exe.
+
+use strict;
+use warnings;
+
+our $VERSION = '0.01';
+
+sub bootstrap_pl_phase {
+    _ensure_moo();
+    _touch_makefile();
+    return 0;
+}
+
+sub _ensure_moo {
+    return if eval { require Moo; 1 };
+
+    my $jcpan = $ENV{JCPAN_BIN}
+        or die "PerlOnJava::Distroprefs::Moose: JCPAN_BIN not set; "
+             . "cannot install Moo. Run `jcpan Moo` manually.\n";
+
+    print "PerlOnJava: Moose shim requires Moo; installing via $jcpan...\n";
+    my $rc = system $jcpan, 'Moo';
+    if ($rc != 0) {
+        die "PerlOnJava::Distroprefs::Moose: '$jcpan Moo' failed "
+          . "(exit $rc). Install Moo manually before running "
+          . "`jcpan -t Moose`.\n";
+    }
+
+    # Verify it now loads. CPAN may report "OK" while still leaving the
+    # module unimportable — fail loudly here so we don't pretend the
+    # bootstrap succeeded.
+    delete $INC{'Moo.pm'};
+    eval { require Moo; 1 }
+        or die "PerlOnJava::Distroprefs::Moose: Moo still not "
+             . "loadable after install: $@\n";
+}
+
+sub _touch_makefile {
+    open my $fh, '>>', 'Makefile' or die "Cannot create Makefile: $!\n";
+    close $fh;
+}
+
+# A no-op equivalent of POSIX `true` / Windows `cmd /c exit 0`. Used by
+# the make/install phases of the Moose distropref so they're a portable
+# `jperl -MPerlOnJava::Distroprefs::Moose -e
+# 'PerlOnJava::Distroprefs::Moose::noop()'`.
+sub noop { 0 }
+
+1;
+
+__END__
+
+=head1 NAME
+
+PerlOnJava::Distroprefs::Moose - cross-platform helpers for the bundled
+Moose distropref
+
+=head1 SEE ALSO
+
+L<dev/modules/moose_support.md>, L<CPAN/Config.pm>.
+
+=cut


### PR DESCRIPTION
## Summary

Implements the **Quick path** from `dev/modules/moose_support.md`: a thin pure-Perl Moose compatibility layer that delegates to Moo, so simple CPAN modules using `use Moose; has ...; extends; with;` can install and run on PerlOnJava without the real `Class::MOP` / `mop.c`.

This unblocks the long tail of CPAN modules that use Moose only for attribute declarations, inheritance, roles, and method modifiers — including the originally-reported `ANSI::Unicode`. It also wires up `./jcpan -t Moose` to run upstream Moose's full test suite against the shim, in a cross-platform way (Unix + Windows).

## Commits in this PR

1. **`feat(moose): add Moose-as-Moo compatibility shim (Phase 1, Quick path)`** — the `Moose.pm` / `Moose/Role.pm` / `Moose/Object.pm` / `Moose/Util/TypeConstraints.pm` shim files.
2. **`feat(moose): wire up ./jcpan -t Moose via CPAN distroprefs`** — bundled `Moose.yml` distropref so `./jcpan -t Moose` actually runs the upstream test suite against the shim.
3. **`feat(moose): auto-install Moo when running ./jcpan -t Moose`** — first iteration of Moo bootstrapping (POSIX-only).
4. **`feat(moose): make ./jcpan -t Moose distropref cross-platform`** — replaces the POSIX-only shell with a small Perl helper so Windows works too.

## Motivation

`./jcpan -t ANSI::Unicode` previously **FAILED**:

```
ETHER/Moose-2.4000.tar.gz
This distribution requires a working compiler at Makefile.PL line 12.
  /Users/fglock/projects/PerlOnJava2/jperl Makefile.PL -- NOT OK
...
Can't locate Moose.pm in @INC ...
t/basic.t ... Dubious, test returned 2
```

Moose 2.4000 ships 13 `.xs` files plus `mop.c` and dies in `Makefile.PL` if no C compiler is available. PerlOnJava can't satisfy that, and Moose isn't bundled.

## What's bundled

| File | Purpose |
|---|---|
| `src/main/perl/lib/Moose.pm` | Sets up the target as a Moo class; wraps `has` to translate string `isa => 'Int' \| 'Str' \| ...` into Moo-compatible coderef checks; drops Moose-only attribute options Moo doesn't know; expands `lazy_build`; installs a stub `meta()` and a `Moose::Object` ancestor marker. |
| `src/main/perl/lib/Moose/Role.pm` | Analogous shim over `Moo::Role`. |
| `src/main/perl/lib/Moose/Object.pm` | Minimal base class with `new` / `BUILDARGS` / `does` / `DOES` / `meta`. |
| `src/main/perl/lib/Moose/Util/TypeConstraints.pm` | Best-effort stub for `type` / `subtype` / `enum` / `class_type` / `role_type` / `duck_type` / `coerce` DSL. |
| `src/main/perl/lib/PerlOnJava/Distroprefs/Moose.pm` | Cross-platform helpers (`bootstrap_pl_phase`, `noop`) used by the bundled distropref's commandlines. |
| Bundled `Moose.yml` in `src/main/perl/lib/CPAN/Config.pm` | Auto-bootstrapped to `~/.perlonjava/cpan/prefs/Moose.yml` so `./jcpan -t Moose` runs the upstream suite against the shim. |

## Type translation

The shim recognises Moose's standard scalar type names: `Any`, `Item`, `Defined`, `Undef`, `Bool`, `Value`, `Ref`, `Str`, `Num`, `Int`, `ScalarRef`, `ArrayRef`, `HashRef`, `CodeRef`, `RegexpRef`, `GlobRef`, `FileHandle`, `Object`, `ClassName`, plus `Maybe[X]` and `ArrayRef[X]` / `HashRef[X]` (parameterization is dropped, base is checked). Unknown names are treated as class names and verified via `UNIVERSAL::isa`.

## Key implementation note: avoiding Moo's MOP bridge

`Moo` ships `Moo::sification`, which auto-bridges to real Moose's MOP whenever it sees `$INC{"Moose.pm"}` on Moo load. Since **we** are `Moose.pm`, this would unconditionally fire and require `Class::MOP`. `Moose.pm` pre-sets `$Moo::sification::setup_done` / `$disabled` in a `BEGIN` block before `use Moo ()` so the sification bridge is a no-op.

## `./jcpan -t Moose` against the shim

The bundled `Moose.yml` distropref makes `./jcpan -t Moose` work end-to-end:

```yaml
match:
  distribution: "^ETHER/Moose-"
pl:      jperl -MPerlOnJava::Distroprefs::Moose -e 'PerlOnJava::Distroprefs::Moose::bootstrap_pl_phase()'
make:    jperl -MPerlOnJava::Distroprefs::Moose -e 'PerlOnJava::Distroprefs::Moose::noop()'
test:    prove --exec jperl -r t/
install: jperl -MPerlOnJava::Distroprefs::Moose -e 'PerlOnJava::Distroprefs::Moose::noop()'
```

What each phase does:

- **`pl`** — runs `bootstrap_pl_phase()`: `require Moo` and recursively invoke `system $ENV{JCPAN_BIN}, 'Moo'` if missing; then create a stub `Makefile` (so CPAN.pm's "no Makefile created" fallback path doesn't kick in).
- **`make`** / **`install`** — `noop()` returns 0; cross-platform replacement for POSIX `true` / `cmd /c exit 0`.
- **`test`** — runs `prove --exec jperl -r t/` against the unpacked tarball. Because `prove --exec` invokes `jperl` per file without adding `lib/` or `blib/lib/` to `@INC`, the bundled shim from the jar wins over the unpacked upstream `lib/Moose.pm`.

To make this portable, `jcpan` / `jcpan.bat` now prepend the project directory to `PATH` (so `jperl` is findable as a plain command in any shell) and export `JCPAN_BIN` (so the helper can recursively call jcpan with an absolute path).

### Why not a CPAN `depends:` block?

I tried it. Adding `depends: requires: Moo: 0` to `Moose.yml` makes CPAN merge it with Moose's full upstream `META.yml` prereq tree (`Package::Stash::XS`, `MooseX::NonMoose`, …), and CPAN starts trying to install all of it — most is XS and unsatisfiable. Lots of noise, several unwanted side-effects. The pl-helper approach is narrower: it installs only the one thing the shim genuinely needs.

### Cross-platform

The `Moose.yml` commandlines avoid POSIX-only constructs (`||`, `;`, `touch`, `/dev/null`, `$VAR`) so they parse identically in `bash`, `sh`, `cmd.exe`, and PowerShell. All the actual logic is in the `PerlOnJava::Distroprefs::Moose` Perl module.

## Out of scope (deferred to follow-up phases)

- Real `Class::MOP` introspection (`$meta->get_all_attributes` etc.) — see Phase C/D in `moose_support.md`.
- `MooseX::Types`, native traits (`traits => ['Array']`), `Moose::Exporter` deep MOP APIs.
- Bundling Moo itself into the jar (still loaded from `~/.perlonjava/lib`; auto-installed by the distropref on first jcpan run).
- `DESTROY` / `weaken` semantics — handled on a separate branch (`dev/architecture/weaken-destroy.md`).

## Plan updates

`dev/modules/moose_support.md`:

- Marked Phase 1 (B-module sub names) as **complete** with the verification one-liner.
- Corrected status of every dependency in the `Class::MOP` tree; removed stale "needs PP flag" / "needs investigation" notes after empirical re-checking on master.
- Noted that Moose 2.4000 has 13 `.xs` files: bypassing the compiler check alone is **necessary but not sufficient**.
- Added an **Out of scope** callout for `DESTROY`/`weaken` and JVM bytecode libraries (Byte Buddy / Javassist).
- Added a **Lock in progress as bundled-module tests** section: when (and only when) we bundle a CPAN distribution from the Moose ecosystem, vendor its upstream `t/` under `src/test/resources/module/{Distribution}/`. Tests for non-bundled downstream consumers (e.g. ANSI::Unicode) stay as `./jcpan -t` smoke checks, not as `module/` snapshots.
- Added a **Running upstream Moose's test suite against the shim** section explaining the cross-platform distropref design and why we don't use `depends:`.
- Added a **Quick-path baseline** table recording the 478 / 616 / ~29 / 370 / 246 numbers as the metric Phases C/D will improve.

## Regression net

`src/test/resources/module/` is reserved for unmodified upstream test files of CPAN distributions we **actually bundle**. Since this PR only ships a shim — no real Moose distribution is bundled yet — nothing is snapshotted under `module/`. The regression net is `make` plus the `./jcpan -t ANSI::Unicode` end-to-end check. Upstream `Moose-2.4000/t/` will be vendored once Phase D bundles a pure-Perl `Moose`.

## Test plan

- [x] `make` — all unit tests pass.
- [x] `make test-bundled-modules` — all module tests pass (no new snapshots in this PR).
- [x] `./jcpan -t ANSI::Unicode` — Result: **PASS** (`t/basic.t ... ok`, `All tests successful`).
- [x] `./jcpan -t Moose` — full upstream suite runs end-to-end via the new distroprefs entry: **478 files / 616 assertions executed, ~29 files fully pass, 370 assertions ok, 246 fail** (expected — most files require `Class::MOP`/`Moose::Meta::*` not provided by the shim). Recorded as Quick-path baseline in the plan.
- [x] Smoke-test of attribute creation, type validation (`isa => 'Int'`), `required => 1`, accessor read/write, `isa('Moose::Object')` — all expected behaviour.
- [x] JVM and interpreter backends both load the shim cleanly.
- [x] Missing-Moo path: hiding `~/.perlonjava/lib/Moo.pm` and invoking `PerlOnJava::Distroprefs::Moose::bootstrap_pl_phase` directly triggers the `system $ENV{JCPAN_BIN}, 'Moo'` fallback.
- [ ] Windows: distroprefs commandlines designed to be cmd.exe / PowerShell-portable but not yet exercised on a Windows runner; can be confirmed via the existing Windows CI workflow on demand.

Generated with [Devin](https://cli.devin.ai/docs)
