### PR TITLE
fix(cpan-tester): initialize $KILL_AFTER before main execution

### DIFF
--- a/dev/tools/cpan_random_tester.pl
+++ b/dev/tools/cpan_random_tester.pl
@@ -57,6 +57,7 @@ my $pass_dat     = File::Spec->catfile($report_dir, 'cpan-compatibility-pass.dat
 my $fail_dat     = File::Spec->catfile($report_dir, 'cpan-compatibility-fail.dat');
 my $skip_dat     = File::Spec->catfile($report_dir, 'cpan-compatibility-skip.dat');
 my $log_dir      = '/tmp/cpan_random_logs';
+my $KILL_AFTER   = 10;  # seconds between SIGTERM and SIGKILL (used by run_with_timeout)
 
 # CPAN package index
 my $packages_gz  = glob('~/.cpan/sources/modules/02packages.details.txt.gz');
@@ -499,7 +500,6 @@ sub parse_all_module_results {
 #      `timeout.exe` there is a sleep-with-countdown, NOT GNU coreutils.
 #   2. Fallback: fork + setpgrp + kill(-$pid) for platforms without
 #      coreutils (and for Windows, where it degrades to a plain alarm).
-my $KILL_AFTER = 10;  # seconds between SIGTERM and SIGKILL
 sub run_with_timeout {
     my ($cmd, $secs) = @_;
 

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "cbde1aacd";
+    public static final String gitCommitId = "44f0a7e9f";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 27 2026 16:05:36";
+    public static final String buildTimestamp = "Apr 27 2026 16:10:12";
 
     // Prevent instantiation
     private Configuration() {


### PR DESCRIPTION
## Summary

`perl dev/tools/cpan_random_tester.pl --count N` has been broken since #573 (commit 1ef073e25). Every test reported `[No parseable output]` because `$KILL_AFTER` was undef.

### Root cause

#573 added:

```perl
my $KILL_AFTER = 10;  # seconds between SIGTERM and SIGKILL
sub run_with_timeout { ... "$timeout_cmd -k ${KILL_AFTER}s ${secs}s $cmd 2>&1" ... }
```

at line ~502, but `run_with_timeout` is invoked from main-line code at line 195 — well before execution reaches line 502 — so the assignment hadn't run yet and `$KILL_AFTER` was undef on every call.

The script printed:

```
Use of uninitialized value $KILL_AFTER in concatenation (.) or string at dev/tools/cpan_random_tester.pl line 509.
```

and the resulting `timeout -k s 300s ...` was rejected by `timeout`, so jcpan was never actually invoked and every module was scored `FAIL [No parseable output]`.

### Fix

Move the `my $KILL_AFTER = 10;` declaration up to the other file-scope `my` declarations so it's initialized before any call site.

#### Test plan
- [x] `perl dev/tools/cpan_random_tester.pl --count 1` — no more uninitialized warning, jcpan actually runs
- [x] `make` passes

Generated with [Devin](https://cli.devin.ai/docs)
