### PR TITLE
fix(makemaker): mirror upstream prereq check (no false "have 0")

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "44f0a7e9f";
+    public static final String gitCommitId = "90d0bb9f9";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 27 2026 16:10:12";
+    public static final String buildTimestamp = "Apr 27 2026 16:38:19";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/perl/lib/ExtUtils/MakeMaker.pm
+++ b/src/main/perl/lib/ExtUtils/MakeMaker.pm
@@ -63,15 +63,27 @@ sub WriteMakefile {
     print "PerlOnJava MakeMaker: $name v$version\n";
     print "=" x 60, "\n";
     
-    # Check prerequisites first
-    if ($args{PREREQ_PM}) {
-        my @missing = _check_prereqs($args{PREREQ_PM});
-        if (@missing) {
-            print "\nMissing dependencies:\n";
-            print "  - $_\n" for @missing;
-            print "\nPlease install these modules first.\n";
-            print "(PerlOnJava uses bundled modules or pure Perl CPAN modules)\n\n";
-            # Continue anyway - let the module fail at runtime if needed
+    # Check prerequisites. Mirrors upstream ExtUtils::MakeMaker (5.42 / 7.76):
+    # use a static filesystem search + parse_version (no `require`), warn per
+    # missing prereq via STDERR, and only die when PREREQ_FATAL is set.
+    # See ExtUtils::MakeMaker::_installed_file_for_module + the prereq loop in
+    # WriteMakefile (lines ~579-647 of system MakeMaker).
+    if ($args{PREREQ_PM} || $args{BUILD_REQUIRES} || $args{CONFIGURE_REQUIRES} || $args{TEST_REQUIRES}) {
+        my %prereqs;
+        for my $key (qw(PREREQ_PM BUILD_REQUIRES CONFIGURE_REQUIRES TEST_REQUIRES)) {
+            next unless my $h = $args{$key};
+            $prereqs{$_} = $h->{$_} for keys %$h;
+        }
+        my %unsatisfied = _check_prereqs(\%prereqs);
+        if (%unsatisfied && $args{PREREQ_FATAL}) {
+            my $failed = join "\n", map {"    $_ $unsatisfied{$_}"}
+                                    sort { lc $a cmp lc $b } keys %unsatisfied;
+            die <<"END";
+MakeMaker FATAL: prerequisites not found.
+$failed
+
+Please install these modules first and rerun 'perl Makefile.PL'.
+END
         }
     }
     
@@ -86,27 +98,45 @@ sub WriteMakefile {
     return _install_pure_perl($name, $version, \%args);
 }
 
+sub _installed_file_for_module {
+    my ($module) = @_;
+    my $file = $module;
+    $file =~ s{::}{/}g;
+    $file .= '.pm';
+    for my $dir (@INC) {
+        next if ref $dir;  # skip code/array refs and blessed @INC hooks
+        my $candidate = File::Spec->catfile($dir, $file);
+        return $candidate if -r $candidate;
+    }
+    return;
+}
+
 sub _check_prereqs {
     my ($prereqs) = @_;
-    my @missing;
-    
+    my %unsatisfied;
+
     for my $module (sort keys %$prereqs) {
-        my $version = $prereqs->{$module};
+        my $required = $prereqs->{$module};
         # 'perl' is a special key meaning minimum perl version, not a module
         next if $module eq 'perl';
-        my $found = eval "require $module; 1";
-        if (!$found) {
-            push @missing, "$module (>= $version)";
-        } elsif ($version) {
-            # Check version
-            my $installed = eval "\$${module}::VERSION" || 0;
-            if (_version_compare($installed, $version) < 0) {
-                push @missing, "$module (>= $version, have $installed)";
-            }
+
+        my $installed_file = _installed_file_for_module($module);
+        if (!$installed_file) {
+            warn "Warning: prerequisite $module $required not found.\n";
+            $unsatisfied{$module} = 'not installed';
+            next;
+        }
+        next unless $required;
+
+        my $have = eval { MM->parse_version($installed_file) };
+        $have = 0 if !defined $have || $have eq 'undef' || $@;
+        if (_version_compare($have, $required) < 0) {
+            warn "Warning: prerequisite $module $required not found. We have $have.\n";
+            $unsatisfied{$module} = $required || 'unknown version';
         }
     }
-    
-    return @missing;
+
+    return %unsatisfied;
 }
 
 sub _version_compare {


### PR DESCRIPTION
## Summary

Fixes a misleading dependency-check report in PerlOnJava's `ExtUtils::MakeMaker` shim and aligns the prereq logic with upstream MakeMaker (Perl 5.42 / MakeMaker 7.76).

### Problem

`jcpan -t ACME::Error::Coy` was printing a self-contradictory configure block:

```
PerlOnJava MakeMaker: ACME::Error::Coy v0.01
============================================================

Missing dependencies:
  - Coy (>= 0.01, have 0)

Please install these modules first.
(PerlOnJava uses bundled modules or pure Perl CPAN modules)


Will install to: /Users/fglock/.perlonjava/lib
  Coy.pm -> /Users/fglock/.perlonjava/lib/ACME/Error/Coy.pm

============================================================
Configured! 1 files will be installed when 'make install' runs.
```

Root cause: `_check_prereqs` did `eval "require Coy; 1"` and then read `$Coy::VERSION`. CPAN.pm sets `PERL_USE_UNSAFE_INC=1` so `.` is on `@INC`. The cwd at configure time is the `ACME-Error-Coy` build directory, which contains a file literally named `Coy.pm` — but it declares `package ACME::Error::Coy`. `require Coy` happily loads the wrong file, `%INC` records `Coy.pm`, but `$Coy::VERSION` stays undef, so the check reports `have 0`. Coy is in fact not installed at all.

### What real Perl does

System Perl's `ExtUtils::MakeMaker` (5.42, MakeMaker 7.76, lines ~579-647) does not `require` prereqs. It uses:

- `MM->_installed_file_for_module($prereq)` — file-path search of `@INC` for `Foo/Bar.pm`.
- `MM->parse_version($installed_file)` — static parse of `$VERSION = ...` from the file.

Reporting:
- File missing → `warn "Warning: prerequisite Foo 1.0 not found.\n"` and continue.
- Version too low → `warn "Warning: prerequisite Foo 1.0 not found. We have 0.5.\n"` and continue.
- `MakeMaker FATAL: prerequisites not found.\n... Please install these modules first and rerun 'perl Makefile.PL'.` — only on `PREREQ_FATAL`.

I confirmed system Perl on the same build dir is silent (parse_version returns `0.01` from the misnamed file, so the check looks satisfied; CPAN.pm independently catches the real missing dep via its own metadata).

### Fix

`src/main/perl/lib/ExtUtils/MakeMaker.pm`:

- Add `_installed_file_for_module` mirroring upstream (skipping `@INC` code/array/blessed hooks).
- Rewrite `_check_prereqs` to use file-path search + `MM->parse_version`, never `require`.
- Emit per-module `Warning: prerequisite Foo X not found.` / `... We have Y.` to STDERR with the upstream wording.
- Drop the unconditional `Missing dependencies / Please install these modules first` banner that contradicted the subsequent `Configured!` line.
- Honor `PREREQ_FATAL` and die with the upstream message.
- Aggregate `BUILD_REQUIRES`, `CONFIGURE_REQUIRES`, `TEST_REQUIRES` the same way upstream does.

### After

```
$ jcpan -t ACME::Error::Coy
...
PerlOnJava MakeMaker: ACME::Error::Coy v0.01
Configured! 1 files will be installed when 'make install' runs.
PerlOnJava MakeMaker: Coy v0.06
Configured! 2 files will be installed when 'make install' runs.
...
Result: PASS
```

CPAN.pm's own dependency resolution (the `---- Unsatisfied dependencies detected ----` mechanism) still drives the actual Coy build.

#### Test plan

- [x] `make` (build + unit tests): green
- [x] `jcpan -t ACME::Error::Coy` end-to-end on a freshly cleaned `~/.cpan/build`: configure clean, no false `have 0`, both modules tested, exit 0
- [x] Manual `Makefile.PL` with a non-existent prereq: prints `Warning: prerequisite NoSuchModuleZZZ 1.0 not found.` and continues
- [x] Same with `PREREQ_FATAL => 1`: prints the warning and dies with the upstream `MakeMaker FATAL: ... Please install these modules first and rerun 'perl Makefile.PL'.` message
- [x] Spot-checked behaviour against system `perl Makefile.PL` on the same tree — output now matches
- [ ] `make test-bundled-modules` shows 2 pre-existing failures (`Net-SSLeay/t/local/33_x509_create_cert.t`, `Text-CSV/t/55_combi.t`) due to missing test helpers (`./t/util.pl`, `Test::Net::SSLeay`); unrelated to this change.

Generated with [Devin](https://cli.devin.ai/docs)
