### PR TITLE
fix(parser): don't greedily consume `new` as indirect-object class

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "1c27ead97";
+    public static final String gitCommitId = "a671eccbf";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 27 2026 20:14:07";
+    public static final String buildTimestamp = "Apr 27 2026 20:46:44";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -258,7 +258,14 @@ public class SubroutineParser {
             if ((isPackage != null && !isPackage)
                     || (isPackage == null && !isKnownSub && token.text.equals("(") && !packageName.contains("::") && subExists)
                     || (subExists && packageName.contains("::") && token.text.equals("(")
-                        && !(isPackage != null && isPackage))) {
+                        && !(isPackage != null && isPackage))
+                    // If packageName is not a known class and the next token is itself a
+                    // bareword identifier, then `packageName` is more likely a method name
+                    // (e.g. `new`) rather than a class — and the inner `packageName IDENT`
+                    // pair is the real indirect-object call. So reject the outer form.
+                    // Example: `myfunc new Foo (4,5)` should parse as `myfunc(Foo->new(4,5))`,
+                    // NOT as `new->myfunc(Foo(4,5))`.
+                    || (isPackage == null && !isKnownSub && token.type == LexerTokenType.IDENTIFIER)) {
                 parser.tokenIndex = currentIndex2;
             } else {
                 // Not a known subroutine, check if it's valid indirect object syntax


### PR DESCRIPTION
## Summary

Fixes a parser bug where PerlOnJava greedily consumed a bareword after a function name as an indirect-object class, breaking common idioms like:

```perl
croak new XML::DOM::DOMException (WRONG_DOCUMENT_ERR, "...")
```

Found while running `jcpan -t XML::Generator` — t/DOM.t failed with:
```
Can't locate object method "getName" via package "Undefined subroutine &XML::DOM::DOMException called at .../XML/DOM.pm line 663"
```

### Root cause

In `SubroutineParser.java`, when seeing `myfunc new Foo (4,5)`:
- subName = `myfunc`, peek = `new` (IDENTIFIER) → enter indirect-method block
- packageName = `new`, peek = `Foo` (IDENTIFIER)
- Existing logic accepted `new` as the indirect-object class for `myfunc`, producing `new->myfunc(Foo(4,5))` — which then called `Foo` as a function and failed.

Real Perl parses this as `myfunc(Foo->new(4,5))`.

### Fix

When the candidate "class" identifier is **not a known package** and **not a known sub**, AND the next token is **itself a bareword identifier**, reject the outer indirect form. The candidate is most likely a method name (e.g. `new`), and the inner `packageName IDENT` pair is the real indirect-object call.

### Minimal repro

```perl
sub myfunc { print ref($_[0]), "\n" }
package Foo;
sub new { my $c = shift; bless {}, $c }
package main;
myfunc new Foo (4,5);
```

Before: `Undefined subroutine &main::Foo called`
After: `Foo`

#### Test plan

- [x] `make` (full unit test suite passes)
- [x] `jcpan -t XML::Generator`: was 154/158 with 4 failures in t/DOM.t → **158/158 PASS**
- [x] Standalone `new Pkg (args)` still works (was already working)
- [x] `myfunc(new Pkg (args))` with explicit parens still works
- [x] Indirect form with known package classes (`myfunc Foo bar` where `Foo` is declared) still works

Generated with [Devin](https://app.devin.ai)
