### PR TITLE
fix(parser): allow `new Foo IDENT => ...` indirect-object form

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "3e7654d5a";
+    public static final String gitCommitId = "69964ee2f";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 27 2026 21:36:05";
+    public static final String buildTimestamp = "Apr 27 2026 22:11:34";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -265,7 +265,12 @@ public class SubroutineParser {
                     // pair is the real indirect-object call. So reject the outer form.
                     // Example: `myfunc new Foo (4,5)` should parse as `myfunc(Foo->new(4,5))`,
                     // NOT as `new->myfunc(Foo(4,5))`.
-                    || (isPackage == null && !isKnownSub && token.type == LexerTokenType.IDENTIFIER)) {
+                    // Only reject when the outer `subName` is itself a known sub — otherwise we'd
+                    // wrongly reject the legitimate top-level case
+                    // `new HTTP::Request GET => $url` where `subName=new` is not declared and
+                    // `packageName=HTTP::Request` followed by IDENTIFIER `GET` is just the
+                    // method's first list-arg.
+                    || (subExists && isPackage == null && !isKnownSub && token.type == LexerTokenType.IDENTIFIER)) {
                 parser.tokenIndex = currentIndex2;
             } else {
                 // Not a known subroutine, check if it's valid indirect object syntax


### PR DESCRIPTION
## Summary

Commit 668a34844 ("don't greedily consume `new` as indirect-object class") introduced a regression that broke the legitimate indirect-object form:

```perl
my $req = new HTTP::Request GET => $config;
```

This is exactly the syntax used in `Log::Log4perl::Config` line 647, so any program that loaded `Log::Log4perl` failed to compile — including CPAN itself, which surfaced as a confusing tail-end failure of `jcpan -t <anything>`:

```
... All tests successful ...
Undefined subroutine &Log::Log4perl::Logger::cleanup called at .../Log/Log4perl.pm line 5
exit 1
```

The actual symptom was a `syntax error ... near "::Request GET "` while requiring `Log::Log4perl::Config`, which then prevented `Log::Log4perl::Logger::cleanup` from being defined when its END block fired.

## Root cause

The added rejection clause in `SubroutineParser.java` fired whenever the candidate "class" was unknown and the next token was an IDENTIFIER. That correctly handled `myfunc new Foo (4,5)` (outer `myfunc` is a known sub) but also wrongly rejected the bare top-level case `new HTTP::Request GET => $url` where `GET` is just the first list-arg.

## Fix

Restrict the rejection clause to `subExists` — i.e. only when the *outer* call is itself a known subroutine (the original target case). The bare top-level `new Class IDENT => ...` then parses as `Class->new(IDENT => ...)` again.

#### Test plan

- [x] `make` passes (all unit tests green)
- [x] `jperl -MLog::Log4perl -e 1` no longer errors
- [x] `jcpan -t URI::Simple` exits 0
- [x] Original disambiguation still works: `f new Foo (1)` parses as `f(Foo->new(1))` (verified with a defined `f` and `Foo::new` printing trace output)

Generated with [Devin](https://app.devin.ai)
