### PR TITLE
docs(agents): mandatory pre-flight + forbidden-commands warnings for dirty trees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,65 @@
 # PerlOnJava Agent Guidelines
 
+> **Read this file before touching the working tree.**
+> The two warning blocks below are not decorative — they document
+> real incidents in which agents silently destroyed user work.
+> If you skip them you will eventually be the next incident.
+
+## ⚠️⚠️⚠️ MANDATORY PRE-FLIGHT FOR ANY DIRTY TREE ⚠️⚠️⚠️
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║                                                                              ║
+║   IF `git status` SHOWS *ANY* MODIFIED OR UNTRACKED FILES YOU DID NOT        ║
+║   CREATE IN THIS SESSION, RUN THIS BEFORE DOING ANYTHING ELSE:               ║
+║                                                                              ║
+║       ts=$(date +%Y%m%d-%H%M%S)                                              ║
+║       git diff           > /tmp/wip-unstaged-$ts.patch                       ║
+║       git diff --cached  > /tmp/wip-staged-$ts.patch                         ║
+║       git status -s      > /tmp/wip-status-$ts.txt                           ║
+║                                                                              ║
+║   Then put the changes into a real commit on a WIP branch:                   ║
+║                                                                              ║
+║       git checkout -b wip/<topic>-$ts                                        ║
+║       git add -A && git commit -m "wip: snapshot before <action>"            ║
+║                                                                              ║
+║   Only AFTER both backups exist may you run anything that touches the        ║
+║   working tree (rebase, checkout, restore, reset, clean, stash, …).          ║
+║                                                                              ║
+║   The user's unstaged edits are NOT in git's object database. A single       ║
+║   wrong `git checkout <path>` overwrites them with no possible recovery.     ║
+║                                                                              ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+## ⚠️⚠️⚠️ FORBIDDEN COMMANDS ON A DIRTY TREE ⚠️⚠️⚠️
+
+```
+╔══════════════════════════════════════════════════════════════════════════════╗
+║                                                                              ║
+║   The following commands SILENTLY DESTROY unstaged user work.                ║
+║   Do NOT run them on a dirty tree, even "just to clean up":                  ║
+║                                                                              ║
+║     git checkout <path>          ← overwrites working tree from index        ║
+║     git checkout -- <path>       ← same thing, no safer                      ║
+║     git restore <path>           ← overwrites working tree from index        ║
+║     git restore --staged <path>  ← only safe if you've snapshot-ed           ║
+║     git reset --hard             ← nukes everything unstaged                 ║
+║     git clean -fd                ← deletes untracked files permanently       ║
+║     git stash / git stash pop    ← see warning below; can lose data          ║
+║                                                                              ║
+║   If you really need to drop a single file's changes:                        ║
+║     1. Do the pre-flight backup above.                                       ║
+║     2. `mv path/to/file /tmp/discarded-$ts` instead of `git checkout`.       ║
+║     3. Re-create from HEAD with `git show HEAD:path > path` if needed.       ║
+║                                                                              ║
+║   When the user asks "open a PR with these changes", your FIRST action       ║
+║   is `git checkout -b <branch> && git add -A && git commit -m wip`.          ║
+║   Branch first, snapshot second, polish third. Never reorder these.          ║
+║                                                                              ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
 ## ⚠️⚠️⚠️ CRITICAL WARNING: NEVER USE `git stash` ⚠️⚠️⚠️
 
 ```
@@ -17,6 +77,15 @@
 ║                                                                              ║
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
+
+## Incident Log (do not delete — this is why the rules above exist)
+
+| Date       | What was lost                                  | Root cause                                        |
+|------------|------------------------------------------------|---------------------------------------------------|
+| 2026-04-28 | ~600 cpan-tester module results (4736 → 4139)  | Agent ran `git checkout dev/cpan-reports/` on an unstaged refresh; concurrent `cpan_random_tester.pl` instances also race on `.dat` files (separate bug). |
+
+When you cause a new incident, append a row here in the same commit
+that fixes it. Future agents need to see that these warnings are real.
 
 ---
 

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,14 +33,14 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "69964ee2f";
+    public static final String gitCommitId = "7d7723dfb";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitDate = "2026-04-27";
+    public static final String gitCommitDate = "2026-04-28";
 
     /**
      * Build timestamp in Perl 5 "Compiled at" format (e.g., "Apr  7 2026 11:20:00").
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 27 2026 22:11:34";
+    public static final String buildTimestamp = "Apr 28 2026 12:16:39";
 
     // Prevent instantiation
     private Configuration() {


### PR DESCRIPTION
## Summary

AGENTS.md already warned about `git stash`, but said nothing about
`git checkout <path>`, `git restore`, `git reset --hard`, or
`git clean` — which are equally destructive when run on a dirty
working tree. This gap caused a real data-loss incident on
2026-04-28, where ~600 module results from `cpan_random_tester.pl`
were silently destroyed by an agent running
`git checkout dev/cpan-reports/`.

This PR makes the rules harder to ignore:

1. **MANDATORY PRE-FLIGHT** block at the very top: the exact `git diff
   > /tmp/wip-*.patch` + WIP-branch commit commands an agent must run
   the moment `git status` shows unstaged work it didn't create.
2. **FORBIDDEN COMMANDS ON A DIRTY TREE** block enumerating each
   destructive verb (`checkout <path>`, `restore`, `reset --hard`,
   `clean -fd`, `stash`) with the safe alternative (`mv` aside, then
   `git show HEAD:path`).
3. **Incident Log** table: each new incident appends a row in the same
   commit that fixes it, so future agents can see the warnings are
   tied to real failures rather than abstract caution.
4. Top-of-file note telling readers the warning blocks document real
   losses.

The two existing rules already in AGENTS.md (the `git stash` warning
block and the "save with `git diff > backup.patch`" guidance under
"How to Check Regressions") are preserved verbatim.

#### Test plan

- `make` passes locally (BUILD SUCCESSFUL, parallel unit tests green)
- Documentation-only change; no runtime impact

Generated with [Devin](https://cli.devin.ai/docs)
