### PR TITLE
docs: fix jperl --int -> jperl --interpreter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,7 @@ running tests, which let regressions sneak into commits.  Always use
 - For interpreter changes, test with both backends:
   ```bash
   ./jperl -e 'code'           # JVM backend
-  ./jperl --int -e 'code'     # Interpreter
+  ./jperl --interpreter -e 'code'     # Interpreter
   ```
 
 ### Perl Test Runner

--- a/dev/design/refcount_alignment_plan.md
+++ b/dev/design/refcount_alignment_plan.md
@@ -315,7 +315,7 @@ test pass rates. None regress from today.
 
 ### Phase 7 — Interpreter backend parity (1–2 weeks, runs in parallel)
 
-The interpreter backend (`./jperl --int`) has different refcount
+The interpreter backend (`./jperl --interpreter`) has different refcount
 code paths (AST walker instead of bytecode) and must be updated in
 lockstep. For each Phase 1–5 change:
 

--- a/dev/modules/pod_html.md
+++ b/dev/modules/pod_html.md
@@ -163,7 +163,7 @@ In `RuntimeRegex.java`:
 
    ```bash
    ./jperl       t/regex_multiline_global.t
-   ./jperl --int t/regex_multiline_global.t
+   ./jperl --interpreter t/regex_multiline_global.t
    ```
 
    The interpreter and JVM backends share `RuntimeRegex` so both
@@ -283,7 +283,7 @@ deviation. Track separately if/when somebody cares.
       `RuntimeRegex.matchRegexDirect`.
 - [ ] Add `matcher.useAnchoringBounds(false)` to every
       `matcher.region(...)` site in `RuntimeRegex.java`.
-- [ ] Verify both backends (`./jperl` and `./jperl --int`) pass.
+- [ ] Verify both backends (`./jperl` and `./jperl --interpreter`) pass.
 - [ ] `make` green.
 
 **Phase 1 — Bundle Pod::Html.**

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "00acf915b";
+    public static final String gitCommitId = "435af2ae7";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 28 2026 13:54:08";
+    public static final String buildTimestamp = "Apr 28 2026 14:34:02";
 
     // Prevent instantiation
     private Configuration() {


### PR DESCRIPTION
## Summary

Fix incorrect CLI flag in documentation. The interpreter backend is invoked with `--interpreter`, not `--int` (see `ArgumentParser.java`, which only registers `--interpreter`).

Replaced the three remaining standalone occurrences:
- `AGENTS.md`
- `dev/design/refcount_alignment_plan.md`
- `dev/modules/pod_html.md`

(Most other files matched `jperl --int` only as a substring of `jperl --interpreter` and needed no change.)

#### Test plan
- [x] `make` passes
- [x] `grep -r 'jperl --int\b'` returns no matches

Generated with [Devin](https://cli.devin.ai/docs)
