### PR TITLE
fix(File::Spec): abs2rel returns "." when path equals base

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "435af2ae7";
+    public static final String gitCommitId = "f7bbbc40b";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 28 2026 14:34:02";
+    public static final String buildTimestamp = "Apr 28 2026 14:48:58";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
@@ -528,6 +528,11 @@ public class FileSpec extends PerlModuleBase {
         }
         
         String relPath = baseObj.relativize(pathObj).toString();
+        // Perl's File::Spec->abs2rel returns "." (curdir) when path equals base,
+        // but Java's Path.relativize returns an empty string in that case.
+        if (relPath.isEmpty()) {
+            relPath = ".";
+        }
         return new RuntimeScalar(relPath).getList();
     }
 


### PR DESCRIPTION
## Summary

Fixes `File::Spec->abs2rel($p, $p)` returning an empty string instead of `"."`, which broke `Path::Iterator::Rule` with `relative => 1`.

### Root cause

Java's `Path.relativize()` returns an empty `Path` when both paths are equal, while Perl's `File::Spec->abs2rel` returns the curdir token `"."`. `Path::Iterator::Rule` (when called with `relative => 1`) uses `abs2rel($origin, $origin)` for the root entry, then feeds the result into `Path::Tiny->path(...)`, which dies on the empty string:

```
Path::Tiny paths require defined, positive-length parts at t/relative.t line 54.
```

### Fix

In `FileSpec.abs2rel`, map an empty `relativize()` result to `"."` to match Perl's behavior.

#### Test plan

- [x] `make` (full unit test suite passes)
- [x] `jperl -MFile::Spec -e 'print File::Spec->abs2rel("/tmp/foo", "/tmp/foo")'` now prints `.` (was empty)
- [x] `jcpan -t Path::Iterator::Rule` — all 23 test files / 91 subtests pass (previously `t/relative.t` failed with exit 255)

Generated with [Devin](https://cli.devin.ai/docs)
