### PR TITLE
fix(given/when): implicit break and skip smartmatch on boolean exprs

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -474,17 +474,59 @@ public class StatementParser {
         BlockNode whenBlock = ParseBlock.parseBlock(parser);
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, "}");
 
-        // Create smartmatch condition: $_ ~~ whenCondition
-        Node dollarUnderscore = new OperatorNode("$",
-                new IdentifierNode("_", index),
-                index);
-        Node smartmatchCondition = new BinaryOperatorNode("~~",
-                dollarUnderscore,
-                whenCondition,
-                index);
+        // After a successful when match, Perl implicitly breaks out of the
+        // enclosing given block. Append `last;` to the when block so that
+        // execution leaves the surrounding bare-block (which acts as a
+        // single-iteration loop) once the matching block has run.
+        whenBlock.elements.add(new OperatorNode("last", new ListNode(index), index));
+
+        // Determine whether to smart-match against $_ or use the value directly.
+        // Per perlsyn, when(EXPR) skips the implicit `$_ ~~` and uses EXPR
+        // as a boolean for these exceptional forms:
+        //   - comparison operators (==, !=, <, >, <=, >=, <=>, eq, ne, lt, gt, le, ge, cmp)
+        //   - boolean combinators (&&, ||, //, and, or, xor)
+        //   - regex bind/no-bind (=~, !~) or a bare m// at top level
+        //   - negation (!EXPR, not EXPR)
+        //   - defined / exists
+        Node ifCondition;
+        if (whenIsBoolean(whenCondition)) {
+            ifCondition = whenCondition;
+        } else {
+            // Create smartmatch condition: $_ ~~ whenCondition
+            Node dollarUnderscore = new OperatorNode("$",
+                    new IdentifierNode("_", index),
+                    index);
+            ifCondition = new BinaryOperatorNode("~~",
+                    dollarUnderscore,
+                    whenCondition,
+                    index);
+        }
 
         // Return as an if statement
-        return new IfNode("if", smartmatchCondition, whenBlock, null, index);
+        return new IfNode("if", ifCondition, whenBlock, null, index);
+    }
+
+    /**
+     * Returns true when the given when-expression should be treated as a
+     * plain boolean test rather than a smart-match against $_.
+     */
+    private static boolean whenIsBoolean(Node node) {
+        if (node instanceof BinaryOperatorNode b) {
+            return switch (b.operator) {
+                case "==", "!=", "<", ">", "<=", ">=", "<=>",
+                     "eq", "ne", "lt", "gt", "le", "ge", "cmp",
+                     "&&", "||", "//", "and", "or", "xor",
+                     "=~", "!~" -> true;
+                default -> false;
+            };
+        }
+        if (node instanceof OperatorNode o) {
+            return switch (o.operator) {
+                case "!", "not", "defined", "exists" -> true;
+                default -> false;
+            };
+        }
+        return false;
     }
 
     /**
@@ -560,6 +602,10 @@ public class StatementParser {
         statements.addAll(blockContent.elements);
 
         BlockNode givenBlock = new BlockNode(statements, index, parser);
+        // Mark as a loop block so that the implicit `last` emitted by each
+        // when-clause breaks out of this given-block instead of escaping
+        // to an outer loop or the program top level.
+        givenBlock.isLoop = true;
         givenBlock.setAnnotation("postBlockHintHashId", postBlockHintHashId);
         return givenBlock;
     }


### PR DESCRIPTION
## Summary

Fix two bugs in PerlOnJava's `given`/`when` transformation that caused `DateTime::Calendar::Discordian` to fail 21/73 subtests in `t/cardinals.t` under `jcpan -t` (e.g. `1st` came out as `1stth`).

The failing test pattern:

```perl
given ($i) {
    when ($i % 10 == 1 && $i != 11) { $cardinal .= 'st' }
    when ($i % 10 == 2 && $i != 12) { $cardinal .= 'nd' }
    when ($i % 10 == 3 && $i != 13) { $cardinal .= 'rd' }
    default                          { $cardinal .= 'th' }
}
```

### Bug 1 — missing implicit `last`

Per `perlsyn`, after a `when` block runs, control implicitly breaks out of the enclosing `given`. PerlOnJava just expanded `when (COND) { BLOCK }` into `if ($_ ~~ COND) { BLOCK }`, so every `when` (and the `default`) ran in turn, producing things like `1stth`.

Fix: append a synthetic `last;` to every parsed when-block and mark the synthesized `given` `BlockNode` as `isLoop = true` so that `last` exits the `given` instead of escaping to an outer loop / the program.

### Bug 2 — `when` always smart-matched against `$_`

Per `perlsyn`, `when(EXPR)` does **not** smart-match against `$_` when `EXPR` is one of:

- a comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`, `<=>`, `eq`, `ne`, `lt`, `gt`, `le`, `ge`, `cmp`
- a boolean combinator: `&&`, `||`, `//`, `and`, `or`, `xor`
- a regex bind: `=~`, `!~`
- a negation: `!`, `not`
- `defined` / `exists`

PerlOnJava unconditionally wrapped, so e.g. `when ($i % 10 == 2 && $i != 12)` for `$i = 2` became `2 ~~ 1` (false) instead of using the boolean `1` directly.

Fix: add `whenIsBoolean(...)` to detect those exceptional forms and use the expression's value directly as a boolean instead of wrapping with `$_ ~~`.

#### Test plan

- [x] `jcpan -t DateTime::Calendar::Discordian` — `Files=16, Tests=271 ... Result: PASS` (was 21/73 failures in `t/cardinals.t`)
- [x] `make` — full unit-test suite green, no regressions
- [x] Spot checks confirming `when` semantics match `perl` for both smart-match and boolean cases

Generated with [Devin](https://cli.devin.ai/docs)
