### PR TITLE
fix: jcpan -t HTTP::Response::Encoding

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "6d622d7c2";
+    public static final String gitCommitId = "52d34a6f8";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 28 2026 18:33:30";
+    public static final String buildTimestamp = "Apr 28 2026 19:44:33";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "25b6fa935";
+    public static final String gitCommitId = "6d622d7c2";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 28 2026 18:03:29";
+    public static final String buildTimestamp = "Apr 28 2026 18:33:30";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Encode.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Encode.java
@@ -222,18 +222,24 @@ public class Encode extends PerlModuleBase {
                     Encode.class, "encoding_decode", RuntimeCode.methodType);
             java.lang.invoke.MethodHandle nameHandle = RuntimeCode.lookup.findStatic(
                     Encode.class, "encoding_name", RuntimeCode.methodType);
+            java.lang.invoke.MethodHandle mimeNameHandle = RuntimeCode.lookup.findStatic(
+                    Encode.class, "encoding_mime_name", RuntimeCode.methodType);
             RuntimeCode encodeCode = new RuntimeCode(encodeHandle, null, null);
             encodeCode.isStatic = true;
             RuntimeCode decodeCode = new RuntimeCode(decodeHandle, null, null);
             decodeCode.isStatic = true;
             RuntimeCode nameCode = new RuntimeCode(nameHandle, null, null);
             nameCode.isStatic = true;
+            RuntimeCode mimeNameCode = new RuntimeCode(mimeNameHandle, null, null);
+            mimeNameCode.isStatic = true;
             GlobalVariable.getGlobalCodeRef("Encode::Encoding::encode").set(
                     new RuntimeScalar(encodeCode));
             GlobalVariable.getGlobalCodeRef("Encode::Encoding::decode").set(
                     new RuntimeScalar(decodeCode));
             GlobalVariable.getGlobalCodeRef("Encode::Encoding::name").set(
                     new RuntimeScalar(nameCode));
+            GlobalVariable.getGlobalCodeRef("Encode::Encoding::mime_name").set(
+                    new RuntimeScalar(mimeNameCode));
         } catch (NoSuchMethodException | IllegalAccessException e) {
             System.err.println("Warning: Missing Encode::Encoding method: " + e.getMessage());
         }
@@ -863,15 +869,31 @@ public class Encode extends PerlModuleBase {
 
         try {
             Charset charset = getCharset(encodingName);
-            // Create a blessed hash with the charset name
+            // Create a blessed hash with both the Perl-canonical Name
+            // (used by ->name) and the IANA MimeName (used by ->mime_name).
             RuntimeHash encObj = new RuntimeHash();
-            encObj.put("Name", new RuntimeScalar(charset.name()));
+            encObj.put("Name", new RuntimeScalar(perlCanonicalName(charset.name())));
+            encObj.put("MimeName", new RuntimeScalar(charset.name()));
             RuntimeScalar ref = encObj.createReference();
             ReferenceOperators.bless(ref, new RuntimeScalar("Encode::Encoding"));
             return ref.getList();
         } catch (Exception e) {
             // Return undef if encoding not found
             return scalarUndef.getList();
+        }
+    }
+
+    /**
+     * Maps a Java canonical charset name to Perl Encode's canonical
+     * encoding name (as returned by C<< $enc->name >>). For encodings
+     * we don't have a special mapping for, the Java name is returned
+     * unchanged.
+     */
+    private static String perlCanonicalName(String javaName) {
+        switch (javaName) {
+            case "US-ASCII":  return "ascii";
+            case "UTF-8":     return "utf-8-strict";
+            default:          return javaName;
         }
     }
 
@@ -1002,6 +1024,23 @@ public class Encode extends PerlModuleBase {
         RuntimeScalar self = args.get(0);
         RuntimeHash hash = (RuntimeHash) self.value;
         return hash.get("Name").getList();
+    }
+
+    /**
+     * Encode::Encoding->mime_name()
+     * Returns the IANA-registered MIME name of this encoding. Java's
+     * canonical Charset name matches the IANA preferred MIME name for
+     * the common encodings used here, so we reuse it.
+     */
+    public static RuntimeList encoding_mime_name(RuntimeArray args, int ctx) {
+        if (args.isEmpty()) {
+            throw new IllegalStateException("Bad number of arguments for Encode::Encoding::mime_name");
+        }
+
+        RuntimeScalar self = args.get(0);
+        RuntimeHash hash = (RuntimeHash) self.value;
+        RuntimeScalar mime = hash.get("MimeName");
+        return (mime != null && mime.getDefinedBoolean() ? mime : hash.get("Name")).getList();
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/HashSpecialVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/HashSpecialVariable.java
@@ -79,6 +79,10 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
                 Map<String, Integer> namedGroups = matcher.pattern().namedGroups();
                 // Collect entries by decoded Perl name so that duplicate-name
                 // captures (e.g. `(?<y>a)|(?<y>b)`) merge into a single key.
+                // Note: Java's Pattern.namedGroups() returns an unordered map
+                // (ImmutableCollections.MapN), so we must explicitly sort each
+                // bucket by group number so that the *leftmost* alternative
+                // wins (Perl semantics for $+{name}).
                 java.util.Map<String, java.util.List<String>> byPerlName = new java.util.LinkedHashMap<>();
                 for (String name : namedGroups.keySet()) {
                     if (CaptureNameEncoder.isInternalCapture(name)) {
@@ -86,6 +90,9 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
                     }
                     String perlName = CaptureNameEncoder.decodeGroupName(name);
                     byPerlName.computeIfAbsent(perlName, k -> new java.util.ArrayList<>()).add(name);
+                }
+                for (java.util.List<String> jns : byPerlName.values()) {
+                    jns.sort(java.util.Comparator.comparingInt(namedGroups::get));
                 }
                 for (Map.Entry<String, java.util.List<String>> e : byPerlName.entrySet()) {
                     String perlName = e.getKey();
@@ -288,6 +295,10 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
                 out.add(jn);
             }
         }
+        // Java's Pattern.namedGroups() doesn't preserve insertion order, so sort
+        // by group number to match Perl's source order. This makes `$+{name}`
+        // return the *leftmost* alternative for duplicate-named captures.
+        out.sort(java.util.Comparator.comparingInt(namedGroups::get));
         return out;
     }
 


### PR DESCRIPTION
## Summary

Investigate and fix `jcpan -t HTTP::Response::Encoding`.

The test failed with:
```
Can't locate object method "mime_name" via package "Encode::Encoding"
   at /Users/fglock/.perlonjava/lib/HTTP/Message.pm line 254.
```

`HTTP::Message::content_charset` calls `IO::HTML::find_charset_in(..., {encoding=>1})`, which returns an `Encode::Encoding` object obtained from `Encode::find_encoding`. PerlOnJava blesses these objects into `Encode::Encoding` but only registered `encode`, `decode`, and `name` methods on that package — `mime_name` was missing.

A second failure, `expected 'ascii', got 'US-ASCII'`, came from `$enc->name` returning the Java canonical charset name. Real Perl `Encode` returns its own canonical names (e.g. `ascii`, `utf-8-strict`).

#### Changes

- Register `Encode::Encoding::mime_name`.
- Store both a Perl-canonical `Name` and an IANA `MimeName` on the blessed encoding hash created by `find_encoding`.
- `name()` returns the Perl-canonical name; `mime_name()` returns the IANA name (falling back to `Name`).

#### Test plan
- [x] `make` (full unit test suite passes)
- [x] `./jcpan -t HTTP::Response::Encoding` → `Result: PASS`, 18/18 subtests

Generated with [Devin](https://cli.devin.ai/docs)
