### PR TITLE
fix(parser): make `dump` an overridable core operator

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "7a3b8de7c";
+    public static final String gitCommitId = "5f0ebe111";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 29 2026 10:20:45";
+    public static final String buildTimestamp = "Apr 29 2026 10:39:59";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/frontend/parser/ParserTables.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParserTables.java
@@ -27,7 +27,7 @@ public class ParserTables {
     public static final Set<String> OVERRIDABLE_OP = Set.of(
             "bless",
             "caller", "chdir", "close", "connect",
-            "die", "do",
+            "die", "do", "dump",
             "exec", "exit",
             "fork",
             "getpwuid", "glob",


### PR DESCRIPTION
## Summary

Make Perl's `dump` builtin overridable so modules that export their own `dump` sub (notably `Data::Dump`) can be loaded.

PerlOnJava's parser was unconditionally throwing `Not implemented: operator: dump` before checking for a user override, which broke any module that imports a `dump` sub. Concretely, `Data::Dump` declares `use subs qw(dump)` and exports `dump` via Exporter; inside `Data/Dump.pm` itself calls like `dump(@_)` (line 82, in `sub dd`) hit the parser's hardcoded reject path:

```
Error:  Not implemented: operator: dump at .../Data/Dump.pm line 82, near "(@_"
```

This blocks any CPAN distribution that uses `Data::Dump`, which is how I found it: `jcpan -t CPU::Z80::Assembler::Token` failed at the `use Data::Dump;` line.

## Fix

Add `"dump"` to `ParserTables.OVERRIDABLE_OP`. The existing override path in `ParsePrimary` (which already handles `use subs`, Exporter typeglob assignment, and `CORE::GLOBAL::*`) is now consulted before `CoreOperatorResolver` raises the unimplemented-op error.

`CORE_PROTOTYPES` still maps `dump` → `""`, so an explicit `CORE::dump()` keeps hitting the unimplemented path — only user/imported `dump` subs resolve to the imported sub.

## Test plan

- [x] `t/Token-new.t` from `CPU-Z80-Assembler-2.10` passes 32/32 (previously aborted at `use CPU::Z80::Assembler::Token` because Data::Dump failed to compile)
- [x] `t/Token-error.t` passes 28/28
- [x] `make` (full unit suite) BUILD SUCCESSFUL

Generated with [Devin](https://cli.devin.ai/docs)
