### PR TITLE
fix(parser+autoclean): ${'Pkg::'} string literal; guard Class::MOP get_method_list

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "cb3dcd790";
+    public static final String gitCommitId = "36ce11560";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 29 2026 11:15:25";
+    public static final String buildTimestamp = "Apr 29 2026 11:48:26";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
@@ -213,7 +213,11 @@ public class IdentifierParser {
                 return null; // Force fallback to expression parsing for unary plus + hash constructor
             }
             // Check if this is a leading single quote followed by an identifier ($'foo means $main::foo)
-            if (firstChar == '\'' && (nextToken.type == LexerTokenType.IDENTIFIER || nextToken.type == LexerTokenType.NUMBER)) {
+            // BUT: inside ${...}, a leading ' starts a string literal expression (e.g. ${'Foo::'})
+            // and must not be treated as the legacy package separator. Returning null here forces
+            // parseBracedVariable to fall back to parseBlock, which evaluates the string literal.
+            if (firstChar == '\'' && !insideBraces
+                    && (nextToken.type == LexerTokenType.IDENTIFIER || nextToken.type == LexerTokenType.NUMBER)) {
                 // This is $'foo which means $main::foo
                 // We convert it to ::foo internally (leading :: means main::)
                 variableName.append("::");
@@ -221,6 +225,10 @@ public class IdentifierParser {
                 token = parser.tokens.get(parser.tokenIndex);
                 nextToken = parser.tokens.get(parser.tokenIndex + 1);
                 // Continue to parse the rest of the identifier - fall through to main loop
+            } else if (firstChar == '\'' && insideBraces) {
+                // Inside ${...}: the ' starts a string literal — fail identifier parsing so the
+                // caller falls through to parseBlock and evaluates 'Foo::' as a normal expression.
+                return null;
             } else {
                 // Either it's a special variable like $' (postmatch), $| (autoflush), etc.
                 // Consume the character from the token (which might be "|=" or just "|")

--- a/src/main/perl/lib/namespace/autoclean.pm
+++ b/src/main/perl/lib/namespace/autoclean.pm
@@ -118,7 +118,12 @@ sub _method_check {
     # For Moose/Moo classes, use the metaclass if available
     if (defined &Class::MOP::class_of) {
         my $meta = Class::MOP::class_of($package);
-        if ($meta) {
+        # Only metaclasses that mix in HasMethods (Class::MOP::Class and friends)
+        # implement get_method_list. A bare Class::MOP::Package instance does not,
+        # so guard with can() to avoid "Can't locate object method" errors during
+        # on_scope_end callbacks (seen with MooseX::Types loading namespace::autoclean
+        # in non-class packages).
+        if ($meta && $meta->can('get_method_list')) {
             my %methods = map +($_ => 1), $meta->get_method_list;
             $methods{meta} = 1
                 if $meta->isa('Moose::Meta::Role')


### PR DESCRIPTION
## Summary

Two fixes uncovered by `jcpan -t MooseX::Types`:

### 1. Parser: `${'Pkg::'}` must be a string literal, not legacy `$'foo`

Inside `${...}` braces, a leading `'` starts a string literal expression. Previously the parser still applied the legacy single-quote-as-package-separator rule (used for unbraced `$'foo` => `$main::foo`), so `\%{'Foo::'}` parsed as the bogus identifier `::Foo::'` and resolved to a *different, empty* stash from `\%{"Foo::"}`.

Concrete symptoms:
- `keys %Foo::` listed an entry, but `exists ${'Foo::'}{name}` returned false.
- `delete ${'Pkg::'}{name}` did **not** invalidate `Pkg->can("name")` — the deleted-but-still-callable sub broke MooseX::Types' `t/16_introspection.t`.

Fix in `IdentifierParser.parseComplexIdentifierInner`: when `insideBraces` is true and the first token is `'`, return `null` so `parseBracedVariable` falls through to `parseBlock`, which evaluates the string literal correctly. The unbraced legacy `$'foo` path is unchanged.

### 2. `namespace::autoclean`: guard `get_method_list`

`_method_check` unconditionally called `$meta->get_method_list` whenever `Class::MOP::class_of($package)` returned a metaobject. For non-class packages the metaobject is a bare `Class::MOP::Package` (no `HasMethods` mixin), producing

```
Can't locate object method "get_method_list" via package "Class::MOP::Package"
  at jar:PERL5LIB/namespace/autoclean.pm line 122
```

on every `on_scope_end` callback. Now guarded with `$meta->can('get_method_list')`, falling through to the plain-class subname-based detection otherwise.

### Result

`MooseX-Types-0.51`: was `Files=20, Tests=250, Result: FAIL` (1 failure + warning spam after every test). Now `Result: PASS` with no warnings.

#### Test plan

- [x] `make` (full unit suite) passes
- [x] `./jcpan -t MooseX::Types` -> all 20 test files PASS, 250/250 tests
- [x] Minimal regression check: `\%{'Foo::'}` and `\%{"Foo::"}` now refer to the same stash; `delete ${'Pkg::'}{name}` properly invalidates `Pkg->can("name")`.

Generated with [Devin](https://cli.devin.ai/docs)
