### PR TITLE
fix(runtime): values() in scalar context returns count, not last element

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "bebebd07e";
+    public static final String gitCommitId = "517239c4e";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 29 2026 12:11:44";
+    public static final String buildTimestamp = "Apr 29 2026 13:50:07";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArray.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArray.java
@@ -1156,7 +1156,14 @@ public class RuntimeArray extends RuntimeBase implements RuntimeScalarReference,
     public RuntimeArray values() {
         // Reset the each iterator when values() is called
         this.eachIteratorIndex = null;
-        return this;
+        // Return a new RuntimeArray that aliases the elements but carries
+        // scalarContextSize so values() in scalar context yields the count
+        // (matching real Perl). We do not set scalarContextSize on `this`
+        // because that would persist and corrupt later scalar(@arr) results.
+        RuntimeArray result = new RuntimeArray();
+        result.elements.addAll(this.elements);
+        result.scalarContextSize = this.elements.size();
+        return result;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
@@ -924,6 +924,8 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
                 isKey = !isKey;
             }
             hashIterator = null; // keys resets the iterator
+            // Set scalarContextSize so that values() in scalar context returns the count
+            list.scalarContextSize = list.elements.size();
             return list;
         }
 
@@ -936,6 +938,8 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
             list.elements.add(value); // push an alias to the value (direct reference, not a copy)
         }
         hashIterator = null; // values resets the iterator
+        // Set scalarContextSize so that values() in scalar context returns the count
+        list.scalarContextSize = list.elements.size();
         return list;
     }
 


### PR DESCRIPTION
## Summary

Fix `values()` losing its scalar-context count when the result passes through a sub return (or any list-collapse path).

In real Perl, `scalar(values %hash)` returns the number of values, just like `scalar(keys %hash)`. PerlOnJava already did this for direct calls, but as soon as the result went through a sub return the scalar context degraded to "last list element" semantics:

```perl
my %h = (a=>10, b=>20, c=>30);
sub f { return values %h }
my $x = f();   # Before: 30   |   After: 3
```

### Root cause

`RuntimeHash.keys()` set `scalarContextSize` on the returned `RuntimeArray` so the later list-to-scalar conversion yielded the count. `RuntimeHash.values()` and `RuntimeArray.values()` did not, so any list-collapse path (sub return, comma operator, etc.) treated the result as a plain list and applied last-element semantics.

### Fix

- `RuntimeHash.values()` sets `scalarContextSize` on the returned array for both the regular and `TIED_HASH` paths.
- `RuntimeArray.values()` now returns a fresh `RuntimeArray` aliasing the elements (so `for (values @a) { $_++ }` still mutates `@a`) with `scalarContextSize` set on the new array, so the original `@a`'s own scalar-context behaviour is not affected.

### How this surfaced

`Class::MOP::Class::get_all_attributes` ends in `return values %attrs`. Every `scalar $meta->get_all_attributes` therefore returned a stringified `Moose::Meta::Attribute=HASH(0x…)` instead of a count, breaking 3 subtests in `MooseX::Role::Parameterized`'s `t/001-parameters.t` (and any downstream code using the same pattern).

#### Test plan
- [x] `make` passes (full unit test suite)
- [x] `prove src/test/resources/unit` shows identical pass/fail set vs master (no regressions; same pre-existing failures only)
- [x] Direct `scalar(values %h)` still returns count
- [x] `return values %h` from a sub returns count in scalar context
- [x] `for (values @a) { $_ *= 10 }` still mutates `@a` (alias semantics preserved)
- [x] `for (values %h) { $_ *= 10 }` still mutates hash values
- [x] Targeted repro:
  ```
  $ ./jperl -e 'sub f{return values %{{a=>10,b=>20,c=>30}}} print scalar(f()),"\n"'
  3
  ```

Generated with [Devin](https://cli.devin.ai/docs)
