### PR TITLE
fix(values,GCString): values %h scalar context, split GCString shim into own file

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "ff1da2bbb";
+    public static final String gitCommitId = "775a74956";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 29 2026 13:59:18";
+    public static final String buildTimestamp = "Apr 29 2026 15:16:52";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
@@ -923,7 +923,12 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
                 }
                 isKey = !isKey;
             }
-            hashIterator = null; // keys resets the iterator
+            hashIterator = null; // values resets the iterator
+            // Set scalarContextSize so that values() in scalar context returns the count.
+            // Without this, when `values %h` is the last expression of a sub called in
+            // scalar context, getList() copies the elements into a RuntimeList whose
+            // scalar() yields the LAST element instead of the count.
+            list.scalarContextSize = list.elements.size();
             return list;
         }
 
@@ -936,6 +941,8 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
             list.elements.add(value); // push an alias to the value (direct reference, not a copy)
         }
         hashIterator = null; // values resets the iterator
+        // Mirror keys(): mark this array so scalar context returns the count, not the last value.
+        list.scalarContextSize = list.elements.size();
         return list;
     }
 

--- a/src/main/perl/lib/Unicode/GCString.pm
+++ b/src/main/perl/lib/Unicode/GCString.pm
@@ -1,0 +1,78 @@
+package Unicode::GCString;
+
+# Minimal pure-Perl shim of Unicode::GCString for PerlOnJava.
+#
+# The original module is part of the XS-based Unicode::LineBreak
+# distribution and provides a grapheme-cluster string API.  PerlOnJava
+# ships only the tiny subset of GCString that downstream modules
+# (String::Print, Text::vCard, ...) actually use.
+#
+# If a CPAN install of Unicode::LineBreak would otherwise overwrite
+# this file with the XS-needing version, MakeMaker.pm in PerlOnJava
+# detects the bundled copy in jar:PERL5LIB/Unicode/GCString.pm and
+# skips it, preserving this shim.
+#
+# If you need the full functionality, please open an issue.
+
+use strict;
+use warnings;
+
+our $VERSION = '2019.001';
+
+sub new {
+    my ($class, $str) = @_;
+    $str = '' unless defined $str;
+    my @clusters = ($str =~ /(\X)/gs);
+    return bless { str => $str, clusters => \@clusters }, $class;
+}
+
+sub length { return scalar @{ $_[0]->{clusters} }; }
+
+sub as_string { return $_[0]->{str}; }
+
+sub substr {
+    my ($self, $start, $len) = @_;
+    my @c = @{ $self->{clusters} };
+    my $total = scalar @c;
+    $start = 0 if !defined $start;
+    if ($start < 0) { $start = $total + $start; }
+    $start = 0      if $start < 0;
+    $start = $total if $start > $total;
+    my $end;
+    if (!defined $len) {
+        $end = $total;
+    } elsif ($len < 0) {
+        $end = $total + $len;
+    } else {
+        $end = $start + $len;
+    }
+    $end = $start  if $end < $start;
+    $end = $total  if $end > $total;
+    my $piece = join '', @c[$start .. $end - 1];
+    return Unicode::GCString->new($piece);
+}
+
+# Approximate column width (1 per grapheme cluster).
+sub columns { return scalar @{ $_[0]->{clusters} }; }
+
+use overload
+    '""'     => \&as_string,
+    'bool'   => sub { CORE::length( $_[0]->{str} ) > 0 },
+    '0+'     => \&length,
+    fallback => 1;
+
+1;
+
+__END__
+
+=head1 NAME
+
+Unicode::GCString - Minimal PerlOnJava shim
+
+=head1 DESCRIPTION
+
+Provides just enough of L<Unicode::GCString> for modules like
+L<String::Print> and L<Text::vCard> that only need basic grapheme
+cluster splitting.
+
+=cut

--- a/src/main/perl/lib/Unicode/LineBreak.pm
+++ b/src/main/perl/lib/Unicode/LineBreak.pm
@@ -39,57 +39,15 @@ sub break {
     return defined $str ? $str : '';
 }
 
-package Unicode::GCString;
-
-# Minimal grapheme-cluster string class.  Uses \X to split the string
-# into grapheme clusters.  Only the methods used by Text::vCard et al
-# are implemented: new, length, substr, as_string, columns.
-
-use strict;
-use warnings;
-
-sub new {
-    my ($class, $str) = @_;
-    $str = '' unless defined $str;
-    my @clusters = ($str =~ /(\X)/gs);
-    return bless { str => $str, clusters => \@clusters }, $class;
-}
-
-sub length { return scalar @{ $_[0]->{clusters} }; }
-
-sub as_string { return $_[0]->{str}; }
-
-# String overload would be nice, but keep it explicit.
-sub substr {
-    my ($self, $start, $len) = @_;
-    my @c = @{ $self->{clusters} };
-    my $total = scalar @c;
-    $start = 0 if !defined $start;
-    if ($start < 0) { $start = $total + $start; }
-    $start = 0     if $start < 0;
-    $start = $total if $start > $total;
-    my $end;
-    if (!defined $len) {
-        $end = $total;
-    } elsif ($len < 0) {
-        $end = $total + $len;
-    } else {
-        $end = $start + $len;
-    }
-    $end = $start if $end < $start;
-    $end = $total if $end > $total;
-    my $piece = join '', @c[$start .. $end - 1];
-    return Unicode::GCString->new($piece);
-}
-
-# Approximate column width (1 per grapheme cluster).
-sub columns { return scalar @{ $_[0]->{clusters} }; }
-
-use overload
-    '""'   => \&as_string,
-    'bool' => sub { CORE::length( $_[0]->{str} ) > 0 },
-    '0+'   => \&length,
-    fallback => 1;
+# The Unicode::GCString package now lives in its own file
+# (lib/Unicode/GCString.pm) so that:
+#   * `use Unicode::GCString` works without first loading
+#     Unicode::LineBreak (e.g. String::Print does this);
+#   * the MakeMaker SKIP-bundled-file logic detects
+#     jar:PERL5LIB/Unicode/GCString.pm and refuses to overwrite the
+#     pure-Perl shim with the XS-needing version from CPAN's
+#     Unicode-LineBreak distribution.
+require Unicode::GCString;
 
 1;
 


### PR DESCRIPTION
## Summary

Two fixes uncovered while investigating `jcpan -t User::Identity`. The full dependency chain is `User::Identity` → `Log::Report` → `Log::Report::Util` → `String::Print` → `Unicode::GCString`, and it was failing at every step.

### 1. `values %h` in scalar context as a sub's last expression

```perl
my %h = (a => "X", b => "Y", c => "Z");
sub v { values %h }
my $n = v();   # was: "Z"   now: 3
```

`RuntimeHash.keys()` set `scalarContextSize` on the resulting `RuntimeArray` so `getList()` wrapped (rather than copied) it; `values()` did not, so the resulting list scalarized to its **last element** instead of the count. Affected both JVM and interpreter backends.

Fix: mirror `keys()` and set `list.scalarContextSize = list.elements.size()` in both the plain and `TIED_HASH` paths of `RuntimeHash.values()`.

This was the root cause of `t/30col.t` failures in `User::Identity`, where `User::Identity::Collection::roles` is defined as `sub roles() { values %{ $_[0]->{UIC_roles}} }` and called via `cmp_ok($col->roles, '==', 1, ...)`.

### 2. `Unicode::GCString` shim wasn't a discrete file

The pure-Perl shim of `Unicode::GCString` lived as a second package inside `lib/Unicode/LineBreak.pm`. Two problems followed:

- `use Unicode::GCString` (without first loading `LineBreak`) couldn't find a `.pm` file, so it failed with "Can't locate Unicode/GCString.pm". `String::Print` does exactly this.
- MakeMaker's "skip files already bundled in the PerlOnJava JAR" logic only saw `Unicode/LineBreak.pm`. Installing CPAN's `Unicode-LineBreak` distribution would therefore install/shadow the shim with the XS-needing `Unicode/GCString.pm` from blib, which then died with "Can't locate object method `_new`".

Fix: move the shim into its own file `src/main/perl/lib/Unicode/GCString.pm` and have `LineBreak.pm` `require` it. Now both files are visible under `jar:PERL5LIB` and the SKIP logic preserves both:

```
SKIP: Unicode/GCString.pm (bundled in PerlOnJava JAR)
SKIP: Unicode/LineBreak.pm (bundled in PerlOnJava JAR)
```

### Result

- `jcpan -t User::Identity` now passes all 114 subtests across 3 test files (was 4/4 subtests failing because `use User::Identity` blew up immediately).
- `String::Print` test pass rate jumps from 1/19 test files to 15/19; remaining failures are wide-character column-width formatting in the shim, unrelated to this PR.

#### Test plan
- [x] `make` (full unit test suite) — passes
- [x] `./jperl -e '...'` and `./jperl --interpreter -e '...'` — both yield count 3 for `values %h` in sub-scalar context
- [x] `./jcpan -t User::Identity` — `Result: PASS`, all 114 subtests successful

Generated with [Devin](https://cli.devin.ai/docs)
