### PR TITLE
fix(<ARGV>): treat as diamond operator iterating @ARGV

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "b7b7d29d3";
+    public static final String gitCommitId = "8acc9ffd5";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 29 2026 17:16:43";
+    public static final String buildTimestamp = "Apr 29 2026 17:29:18";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -124,6 +124,21 @@ public class OperatorParser {
             LexerToken operand = parser.tokens.get(parser.tokenIndex);
             String tokenText = operand.text;
 
+            // <ARGV> is special: it behaves like the diamond operator <>,
+            // iterating over @ARGV (or STDIN if @ARGV is empty), rather than
+            // reading from a single named filehandle. Treat it as <> so it
+            // routes through DiamondIO.
+            if (operand.type == IDENTIFIER && tokenText.equals("ARGV")
+                    && parser.tokens.get(parser.tokenIndex + 1).text.equals(">")) {
+                parser.tokenIndex += 2; // consume ARGV and >
+                OperatorNode diamond = new OperatorNode(
+                        "<>",
+                        new ListNode(currentTokenIndex),
+                        currentTokenIndex);
+                diamond.setAnnotation("handleName", "ARGV");
+                return diamond;
+            }
+
             // Check if the token looks like a Bareword file handle
             if (operand.type == IDENTIFIER) {
                 Node fileHandle = FileHandle.parseFileHandle(parser);


### PR DESCRIPTION
## Summary

Fixes `./jcpan -t Slurp` which was failing 2/6 subtests due to `<ARGV>` not behaving like the diamond operator.

In Perl, `<ARGV>` is identical to the null filehandle `<>`: it iterates over files named in `@ARGV`. Previously the parser treated `<ARGV>` like `<STDIN>` or `<FILE>`, emitting a plain readline against the (closed) ARGV filehandle. That broke code like Slurp's:

```perl
sub slurp {
    local( $/, @ARGV ) = ( wantarray ? $/ : undef, @_ );
    return <ARGV>;
}
```

which would emit `readline() on unopened filehandle` and return nothing.

Special-case `<ARGV>` in `parseDiamondOperator` so it produces the same `OperatorNode("<>", ...)` that `<>` does, routing through `DiamondIO` which already handles `@ARGV` iteration, STDIN fallback, and aliased `*ARGV` globs.

#### Test plan
- [x] `./jcpan -t Slurp` now PASSes 6/6 (was 4/6)
- [x] `make` (full unit test suite) passes
- [x] Repro one-liner: `local @ARGV = ('/tmp/file1.txt'); my @lines = <ARGV>;` now reads the file

Generated with [Devin](https://cli.devin.ai/docs)
