### PR TITLE
fix: preserve string portion of $! for unknown error messages

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "121ffb20f";
+    public static final String gitCommitId = "c6eb7bdc7";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 29 2026 20:58:13";
+    public static final String buildTimestamp = "Apr 29 2026 22:10:32";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ErrnoVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ErrnoVariable.java
@@ -228,13 +228,15 @@ public class ErrnoVariable extends RuntimeScalar {
             int num = Integer.parseInt(value.trim());
             return set(num);
         } catch (NumberFormatException e) {
-            // Not a number and not a known message - store as message with errno 0
-            // Always maintain INTEGER type so numeric operations use the fast path
-            // and never trigger "isn't numeric" warnings via NumberParser.parseNumber()
+            // Not a number and not a known message - store as message with errno 0.
+            // Use DUALVAR so the string portion is preserved when $! is read or
+            // copied (e.g. `my $str = $!`). The numeric side of the dualvar is 0
+            // (a plain INTEGER scalar) so numeric ops don't go through
+            // NumberParser.parseNumber() and won't emit "isn't numeric" warnings.
             this.errno = 0;
             this.message = value;
-            this.type = RuntimeScalarType.INTEGER;
-            this.value = 0;
+            this.type = RuntimeScalarType.DUALVAR;
+            this.value = new DualVar(new RuntimeScalar(0), new RuntimeScalar(value));
             return this;
         }
     }


### PR DESCRIPTION
## Summary

Fixes a `$!` dualvar bug discovered while running `./jcpan -t File::Digest`.

`ErrnoVariable.set(String)` was discarding the string and storing `type=INTEGER, value=0` whenever the input was neither a number nor a known `strerror()` message. This is the path `SystemOperator` takes when it sets `$!` from a Java `IOException` message (e.g. after `system` of a nonexistent program). As a result, `my $str = $!` saw `0` instead of the message, breaking dualvar semantics.

### Reproducer (before fix)

```
$ ./jperl -e 'system "/tmp/nonexistent"; my $str = $!; print "[$str]\n"; print $str ? "TRUE\n" : "FALSE\n"'
[0]
FALSE
```

System Perl correctly returns `[No such file or directory]` / `TRUE`.

### Fix

Store the unknown-string branch as `DUALVAR` (numeric side `RuntimeScalar(0)`, string side the message), matching the other `set(...)` paths in the same file. Numeric ops still take the fast path through `DualVar.numericValue()`, so they don't go through `NumberParser.parseNumber()` and don't emit "isn't numeric" warnings — preserving the intent of 712484220.

### Impact

Unblocks `PERLANCAR/Proc-ChildError` `t/01-basics.t`, which does:

```perl
system "/tmp/nonexistent...";
like(explain_child_error(), qr/^failed to execute: \S.+ \(-1\)/);
```

This in turn unblocks much of the `File::Digest` dependency chain under `./jcpan -t File::Digest`:

- Proc::ChildError — PASS (was FAIL)
- IPC::System::Options — PASS
- Perinci::Object — PASS
- File::Digest — PASS

Remaining failures in the chain (`JavaScript::QuickJS`, parts of `Data::Sah::Coerce`, `Time::Moment`) are unrelated XS/native-binding issues.

#### Test plan

- [x] `make` passes (all unit tests green)
- [x] `./jperl -e 'system "/tmp/nonexistent"; my $str = $!; ...'` now matches system Perl's behaviour
- [x] `./jcpan -t Proc::ChildError` — Result: PASS
- [x] `./jcpan -t File::Digest` — File::Digest itself: Result: PASS

Generated with [Devin](https://cli.devin.ai/docs)
