### PR TITLE
fix: unblock jcpan -t CPAN::Faker (Time::Piece %s, IO::Zlib, glob alias)

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "c6eb7bdc7";
+    public static final String gitCommitId = "d5085fda8";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 29 2026 22:10:32";
+    public static final String buildTimestamp = "Apr 30 2026 08:15:13";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/CompressZlib.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/CompressZlib.java
@@ -594,10 +594,21 @@ public class CompressZlib extends PerlModuleBase {
             self.put("_eof", new RuntimeScalar(0));
 
             if (mode.startsWith("r")) {
-                // Read mode
-                InputStream fis = new FileInputStream(filename);
-                GZIPInputStream gis = new GZIPInputStream(fis);
-                self.put("_stream", new RuntimeScalar(gis));
+                // Read mode. zlib's gzopen transparently reads non-gzip files
+                // in 'rb' mode, so detect the gzip magic and fall back to a
+                // plain InputStream when the file isn't actually gzip-compressed.
+                InputStream fis = new BufferedInputStream(new FileInputStream(filename));
+                fis.mark(2);
+                int b1 = fis.read();
+                int b2 = fis.read();
+                fis.reset();
+                InputStream is;
+                if (b1 == 0x1F && b2 == 0x8B) {
+                    is = new GZIPInputStream(fis);
+                } else {
+                    is = fis;
+                }
+                self.put("_stream", new RuntimeScalar(is));
             } else if (mode.startsWith("w")) {
                 // Write mode - check for compression level
                 OutputStream fos = new FileOutputStream(filename);

--- a/src/main/java/org/perlonjava/runtime/perlmodule/TimePiece.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/TimePiece.java
@@ -73,6 +73,20 @@ public class TimePiece extends PerlModuleBase {
         boolean isLocal = args.get(2).getBoolean();
         RuntimeHash locales = args.size() > 3 ? args.get(3).hashDeref() : null;
 
+        // Special-case %s (epoch seconds) — Java's DateTimeFormatter has no
+        // direct strftime-style %s token, so handle it explicitly.
+        if (format.trim().equals("%s")) {
+            try {
+                long epoch = Long.parseLong(dateString.trim());
+                ZonedDateTime zdt = isLocal
+                        ? Instant.ofEpochSecond(epoch).atZone(ZoneId.systemDefault())
+                        : Instant.ofEpochSecond(epoch).atZone(ZoneOffset.UTC);
+                return buildTimeArray(zdt, isLocal);
+            } catch (NumberFormatException e) {
+                return new RuntimeList();
+            }
+        }
+
         // Convert strftime format to Java DateTimeFormatter pattern
         String javaPattern = convertStrftimeToJava(format, locales);
         

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
@@ -301,7 +301,12 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
                 // Note: \@array and \%hash come in as ARRAYREFERENCE/HASHREFERENCE types,
                 // not REFERENCE, so they are handled above in their respective cases.
                 if (value.value instanceof RuntimeScalar) {
-                    GlobalVariable.aliasGlobalVariable(this.globName, (RuntimeScalar) value.value);
+                    // Update all glob aliases so that earlier `*A = *B`
+                    // (which makes A and B share their SCALAR slot) keeps both
+                    // names pointing at the new aliased scalar after `*A = \$x`.
+                    for (String aliasedName : GlobalVariable.getGlobAliasGroup(this.globName)) {
+                        GlobalVariable.aliasGlobalVariable(aliasedName, (RuntimeScalar) value.value);
+                    }
                     // Mark as explicitly declared for strict vars (e.g., Exporter imports)
                     GlobalVariable.declareGlobalVariable(this.globName);
                 }


### PR DESCRIPTION
## Summary

Running `./jcpan -t CPAN::Faker` failed in three different places in the dependency chain. Each failure traced back to a real PerlOnJava bug, all fixed in this PR:

### 1. `Time::Piece::strptime` did not support `%s`
Java's `DateTimeFormatter` has no strftime-style `%s` (epoch seconds) token, so `Time::Piece->strptime($epoch, "%s")` returned an empty list and `_mktime` then died with `Day '' out of range 1..31`. Special-cased `%s` in `TimePiece::_strptime` to parse the input as a Long epoch directly.

Fixes `Data::Fake` `t/dates.t`.

### 2. `Compress::Zlib::gzopen` failed on non-gzip files in `'rb'` mode
zlib's `gzopen` transparently reads plain (uncompressed) files, but Java's `GZIPInputStream` throws on missing gzip magic, so `IO::Zlib->open` returned `undef` and `Archive::Tar->read($file, 1)` reported `Could not create filehandle for ...`. Peek at the first two bytes and fall back to a plain `InputStream` when the file isn't actually gzip-compressed.

Fixes `Archive::Any::Create` `t/01_tar.t`.

### 3. Glob aliasing wasn't propagated through scalar-ref assignment
`local *SYM = *foo; *SYM = \$val` left `$foo` unchanged because `RuntimeGlob.set(REFERENCE)` only updated `this.globName` and ignored the alias group, while the existing `ARRAYREFERENCE` and `HASHREFERENCE` cases already iterated `getGlobAliasGroup`. Mirrored that loop for the SCALAR case.

Fixes `Text::Template`'s `_install_hash`, and therefore `Module::Faker` `t/makefile-pl.t` and `t/requires.t`.

## Test plan

- [x] `make` (full unit-test build) passes
- [x] `./jcpan -t CPAN::Faker` now runs the whole chain (`CPAN::Checksums`, `Archive::Any::Create`, `Text::Lorem`, `Data::Fake`, `Module::Faker`, `CPAN::Faker`) green:

```
Running test for module 'CPAN::Checksums'             Result: PASS
Running test for module 'Archive::Any::Create'        Result: PASS
Running test for module 'Text::Lorem'                 Result: PASS
Running test for module 'Data::Fake'                  Result: PASS
Running test for module 'Module::Faker::Dist'         Result: PASS
Running test for module 'CPAN::Faker'                 Result: PASS
```

- [x] Targeted regression checks for each bug fix:
  - `Time::Piece->strptime(1234567890, "%s")->strftime("%Y-%m-%dT%H:%M:%SZ")` -> `2009-02-13T23:31:30Z`
  - `IO::Zlib` opens a plain tar file and reads it transparently
  - `local *SYM = *main::x; *SYM = \$obj` updates `$main::x`

Generated with [Devin](https://cli.devin.ai/docs)
