### PR TITLE
fix: unblock jcpan -t Reply (PerlIO::utf8_strict stub)

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "cfdf262ba";
+    public static final String gitCommitId = "f83cf214c";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 30 2026 10:41:56";
+    public static final String buildTimestamp = "Apr 30 2026 12:00:17";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/runtime/io/LayeredIOHandle.java
+++ b/src/main/java/org/perlonjava/runtime/io/LayeredIOHandle.java
@@ -376,8 +376,12 @@ public class LayeredIOHandle implements IOHandle {
                 inputPipeline = inputPipeline.andThen(inputTransform);
                 outputPipeline = outputPipeline.andThen(outputTransform);
             }
-            case "utf8" -> {
-                // UTF-8 encoding layer - convenience alias for :encoding(UTF-8)
+            case "utf8", "utf8_strict" -> {
+                // UTF-8 encoding layer - convenience alias for :encoding(UTF-8).
+                // :utf8_strict (from the PerlIO::utf8_strict CPAN module) is treated
+                // as an alias for :utf8 here: the JVM's UTF-8 CharsetDecoder already
+                // rejects malformed sequences by default, which matches the "strict"
+                // semantics the XS module provides.
                 EncodingLayer layer = new EncodingLayer(StandardCharsets.UTF_8, "utf8");
                 activeLayers.add(layer);
                 Function<String, String> inputTransform = s -> layer.processInput(s);

--- a/src/main/perl/lib/PerlIO/utf8_strict.pm
+++ b/src/main/perl/lib/PerlIO/utf8_strict.pm
@@ -1,0 +1,33 @@
+package PerlIO::utf8_strict;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.010';
+
+# In standard Perl, PerlIO::utf8_strict is an XS module that provides
+# a :utf8_strict PerlIO layer (a stricter UTF-8 layer that rejects
+# malformed sequences). In PerlOnJava, IO layers are handled by the
+# Java LayeredIOHandle implementation, which treats :utf8_strict as
+# an alias for :utf8 (the JVM's UTF-8 decoder already rejects malformed
+# input by default via CharsetDecoder, so the "strict" semantics are
+# effectively the default).
+#
+# This stub lets `use PerlIO::utf8_strict;` succeed so CPAN modules
+# whose prerequisite chain lists PerlIO::utf8_strict (e.g.
+# Mixin::Linewise -> Config::INI -> Config::INI::Reader::Ordered ->
+# Reply) can be loaded.
+
+1;
+__END__
+
+=head1 NAME
+
+PerlIO::utf8_strict - stub module for PerlOnJava
+
+=head1 DESCRIPTION
+
+Stub for PerlIO::utf8_strict. The C<:utf8_strict> layer is treated
+as an alias for C<:utf8> by PerlOnJava's LayeredIOHandle.
+
+=cut


### PR DESCRIPTION
## Summary

`./jcpan -t Reply` failed because `PerlIO::utf8_strict` (XS) has no Java implementation. It is pulled in by `Mixin::Linewise::Readers`, which `Config::INI::Reader` (and therefore `Config::INI::Reader::Ordered`, a direct prereq of `Reply`) requires at compile time. Without it, `Config::INI::Reader::Ordered`'s own test suite and most of `Reply`'s `t/00-compile.t` fail to load.

## Changes

- Add `src/main/perl/lib/PerlIO/utf8_strict.pm` as a load-only stub.
- Treat `:utf8_strict` as an alias for `:utf8` in `LayeredIOHandle.addLayer` — the JVM's UTF-8 `CharsetDecoder` already rejects malformed input, which matches the XS module's "strict" semantics.

## Not in this PR

`Reply::Plugin::LexicalPersistence` still fails its compile test because it `use`s `PadWalker` (XS lexical-pad introspection). `PadWalker`'s API cannot be meaningfully emulated without a real Perl-style pad model, so a stub would be misleading. Left out intentionally — only that one subtest of `t/00-compile.t` remains failing.

## Test plan

- [x] `make` — full unit test suite passes.
- [x] `./jcpan -t Reply` — `Config::INI::Reader::Ordered` 0.022 `t/reader-ordered.t` passes; `Reply` 0.42 `t/00-compile.t` goes from 5 failures down to 1 (the PadWalker one above).

Generated with [Devin](https://cli.devin.ai/docs)
