### PR TITLE
fix: handle `use vN;` (single-component v-string version)

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "6d1d90197";
+    public static final String gitCommitId = "b5ff444f5";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 30 2026 15:01:59";
+    public static final String buildTimestamp = "Apr 30 2026 15:38:13";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -707,7 +707,7 @@ public class StatementParser {
                         // ":5.34"
                         String[] parts = normalizeVersion(versionScalar).split("\\.");
                         int majorVersion = Integer.parseInt(parts[0]);
-                        int minorVersion = Integer.parseInt(parts[1]);
+                        int minorVersion = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
 
                         // If the minor version is odd, increment it to make it the next even version
                         if (minorVersion % 2 != 0) {


### PR DESCRIPTION
## Summary

Fix `Index 1 out of bounds for length 1` crash when parsing `use vN;` (single-component v-string version declaration).

`Future::Queue-0.52`'s `Build.PL` starts with `use v5;`, which broke `./jcpan -t Future::Queue`. `StatementParser.parseUseDeclaration` did `Integer.parseInt(parts[1])` after splitting the normalized version on `.`, but for a single-component v-string (`v5`) `normalizeVersion` returns just `"5"`, so `parts[1]` threw.

The fix defaults `minorVersion` to `0` when only one component is present.

#### Test plan

- [x] `make` (full unit test suite passes)
- [x] `./jcpan -t Future::Queue` now passes all 36 tests across 7 test files
- [x] No regressions on existing version-handling tests

Generated with [Devin](https://cli.devin.ai/docs)
