### PR TITLE
feat: add YAML::XS shim that delegates to bundled YAML::PP

### DIFF
--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "c5509171f";
+    public static final String gitCommitId = "0416ffb3b";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 30 2026 15:47:59";
+    public static final String buildTimestamp = "Apr 30 2026 16:17:32";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/perl/lib/YAML/XS.pm
+++ b/src/main/perl/lib/YAML/XS.pm
@@ -1,0 +1,87 @@
+package YAML::XS;
+
+#
+# PerlOnJava shim for YAML::XS.
+#
+# The real YAML::XS distribution wraps libyaml via XS. PerlOnJava cannot
+# load XS, so this module re-implements YAML::XS' public API on top of
+# the bundled YAML::PP (backed by SnakeYAML on the JVM).
+#
+# This shim is bundled with PerlOnJava so `use YAML::XS;` works out of
+# the box. If jcpan installs the upstream YAML::XS.pm into
+# ~/.perlonjava/lib, that copy will be picked up first, but it relies on
+# YAML::XS::LibYAML which we also provide as a shim.
+#
+# Limitations:
+#  - YAML::XS configuration globals ($Boolean, $Indent, $LoadCode,
+#    $DumpCode, $UseCode, $LoadBlessed, $ForbidDuplicateKeys,
+#    $QuoteNumericStrings, $coderef2text, $glob2hash) are accepted but
+#    have no effect.
+#  - !!perl/code, !!perl/regexp and !!perl/glob round-tripping is not
+#    supported.
+#
+
+use strict;
+use warnings;
+
+our $VERSION = '0.906.0';
+
+use base 'Exporter';
+our @EXPORT    = qw(Load Dump);
+our @EXPORT_OK = qw(Load Dump LoadFile DumpFile);
+our %EXPORT_TAGS = ( all => [qw(Load Dump LoadFile DumpFile)] );
+
+our (
+    $Boolean,
+    $DumpCode,
+    $ForbidDuplicateKeys,
+    $Indent,
+    $LoadBlessed,
+    $LoadCode,
+    $UseCode,
+    $QuoteNumericStrings,
+    $coderef2text,
+    $glob2hash,
+);
+$ForbidDuplicateKeys = 0;
+$QuoteNumericStrings = 1;
+
+use YAML::PP ();
+use Scalar::Util qw(openhandle);
+
+sub Load { YAML::PP::Load(@_) }
+sub Dump { YAML::PP::Dump(@_) }
+
+sub LoadFile {
+    my $filename = shift;
+    my $IN;
+    if (openhandle($filename)) {
+        $IN = $filename;
+    }
+    else {
+        open $IN, '<', $filename
+            or die "Can't open '$filename' for input:\n$!";
+    }
+    my $yaml = do { local $/; scalar <$IN> };
+    return YAML::PP::Load($yaml);
+}
+
+sub DumpFile {
+    my $filename = shift;
+    my $OUT;
+    if (openhandle($filename)) {
+        $OUT = $filename;
+    }
+    else {
+        my $mode = '>';
+        if ($filename =~ /^\s*(>{1,2})\s*(.*)$/) {
+            ($mode, $filename) = ($1, $2);
+        }
+        open $OUT, $mode, $filename
+            or die "Can't open '$filename' for output:\n$!";
+    }
+    local $/ = "\n";
+    print $OUT YAML::PP::Dump(@_);
+}
+
+1;

--- a/src/main/perl/lib/YAML/XS/LibYAML.pm
+++ b/src/main/perl/lib/YAML/XS/LibYAML.pm
@@ -1,0 +1,40 @@
+package YAML::XS::LibYAML;
+
+#
+# PerlOnJava shim for YAML::XS::LibYAML.
+#
+# The CPAN distribution YAML::XS (a.k.a. YAML-LibYAML) ships an XS module
+# called YAML::XS::LibYAML which wraps the C libyaml library. PerlOnJava
+# cannot load XS, so we provide this pure-Perl stub that exports Load/Dump
+# by delegating to the bundled YAML::PP implementation (backed by
+# SnakeYAML on the JVM). This lets `use YAML::XS;` work for the common
+# Load/Dump round-trip use cases.
+#
+# Limitations:
+#  - YAML::XS-specific globals such as $YAML::XS::Boolean, $LoadCode,
+#    $DumpCode, $UseCode, $LoadBlessed, $ForbidDuplicateKeys, $Indent
+#    are accepted (the upstream YAML::XS.pm declares them) but are not
+#    honoured here.
+#  - Code, regexp and glob round-tripping (the !!perl/code, !!perl/regexp,
+#    !!perl/glob tags) is not supported.
+#
+
+use strict;
+use warnings;
+
+our $VERSION = '0.906.0';
+
+use base 'Exporter';
+our @EXPORT_OK = qw(Load Dump);
+
+use YAML::PP ();
+
+sub Load {
+    return YAML::PP::Load(@_);
+}
+
+sub Dump {
+    return YAML::PP::Dump(@_);
+}
+
+1;


### PR DESCRIPTION
## Summary

`./jcpan -t YAML::XS` previously failed catastrophically. The CPAN distribution `YAML::XS` (a.k.a. `YAML-LibYAML`) is an XS wrapper around libyaml, and PerlOnJava cannot load XS, so every test died with:

```
Can't locate YAML/XS/LibYAML.pm in @INC
```

We already bundle a JVM-backed `YAML::PP` (SnakeYAML under the hood), so this PR adds two pure-Perl shims that re-expose `YAML::PP` under the `YAML::XS` namespace:

- `src/main/perl/lib/YAML/XS/LibYAML.pm` — minimal stub exporting `Load`/`Dump`, used by the cpan-installed upstream `YAML/XS.pm` in `~/.perlonjava/lib`.
- `src/main/perl/lib/YAML/XS.pm` — bundled fallback so `use YAML::XS;` works out of the box without first running `jcpan`. Implements `Load` / `Dump` / `LoadFile` / `DumpFile` and declares the standard `YAML::XS` package globals.

#### Test plan

- [x] `make` (full unit test suite) passes.
- [x] `./jperl -e 'use YAML::XS qw(Load Dump); print Dump(Load("a: 1\nb: [1,2,3]\n"))'` round-trips correctly.
- [x] `./jcpan -t YAML::XS` now configures, builds, and runs the test suite. Test programs go from **0/49 running** to **17/49 passing** (**192/283 subtests** pass).

#### Out of scope

The remaining `YAML::XS` test failures are all YAML::PP / SnakeYAML feature gaps, not shim bugs:

- booleans (`$YAML::XS::Boolean` modes, JSON::PP boolean round-tripping)
- blessed / tied refs
- `!!perl/code`, `!!perl/regexp`, `!!perl/glob` round-tripping
- exact alias output formatting and upstream error-message wording
- `$Indent` / `$QuoteNumericStrings` and other config globals (accepted but not honoured by the shim)

Fixing those would require enhancing `YAML::PP` itself.

Generated with [Devin](https://cli.devin.ai/docs)
