### PR TITLE
fix: preserve @_ aliasing across `goto &SUB` tail calls

### DIFF
--- a/src/main/java/org/perlonjava/backend/jvm/EmitControlFlow.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitControlFlow.java
@@ -317,13 +317,14 @@ public class EmitControlFlow {
         ctx.mv.visitVarInsn(Opcodes.ASTORE, codeRefSlot);
 
         argsNode.accept(emitterVisitor.with(RuntimeContextType.LIST));
+        // Call getArrayOfAlias() directly on the RuntimeBase value: going through
+        // getList() would force RuntimeArray.getList() to copy each element with
+        // `new RuntimeScalar(element)`, which destroys aliasing of @_ across the
+        // tail call. `goto &SUB` is required to pass the caller's @_ aliased to
+        // the target sub so that `$_[N] = ...` mutations propagate. (See
+        // JSON::Validator::Schema::_validate_type_boolean which relies on this.)
         ctx.mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
                 "org/perlonjava/runtime/runtimetypes/RuntimeBase",
-                "getList",
-                "()Lorg/perlonjava/runtime/runtimetypes/RuntimeList;",
-                false);
-        ctx.mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
-                "org/perlonjava/runtime/runtimetypes/RuntimeList",
                 "getArrayOfAlias",
                 "()Lorg/perlonjava/runtime/runtimetypes/RuntimeArray;",
                 false);
@@ -406,13 +407,9 @@ public class EmitControlFlow {
 
         // Build the args array
         argsNode.accept(emitterVisitor.with(RuntimeContextType.LIST));
+        // See note in handleGotoSubroutine: skip getList() to preserve @_ aliasing.
         ctx.mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
                 "org/perlonjava/runtime/runtimetypes/RuntimeBase",
-                "getList",
-                "()Lorg/perlonjava/runtime/runtimetypes/RuntimeList;",
-                false);
-        ctx.mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
-                "org/perlonjava/runtime/runtimetypes/RuntimeList",
                 "getArrayOfAlias",
                 "()Lorg/perlonjava/runtime/runtimetypes/RuntimeArray;",
                 false);

--- a/src/main/java/org/perlonjava/core/Configuration.java
+++ b/src/main/java/org/perlonjava/core/Configuration.java
@@ -33,7 +33,7 @@ public final class Configuration {
      * Automatically populated by Gradle/Maven during build.
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String gitCommitId = "0416ffb3b";
+    public static final String gitCommitId = "eddceb611";
 
     /**
      * Git commit date of the build (ISO format: YYYY-MM-DD).
@@ -48,7 +48,7 @@ public final class Configuration {
      * Parsed by App::perlbrew and other tools via: perl -V | grep "Compiled at"
      * DO NOT EDIT MANUALLY - this value is replaced at build time.
      */
-    public static final String buildTimestamp = "Apr 30 2026 16:17:32";
+    public static final String buildTimestamp = "Apr 30 2026 16:52:57";
 
     // Prevent instantiation
     private Configuration() {

--- a/src/main/perl/lib/CPAN/Distribution.pm
+++ b/src/main/perl/lib/CPAN/Distribution.pm
@@ -11,7 +11,13 @@ use POSIX ":sys_wait_h";
 use vars qw($VERSION);
 $VERSION = "2.34";
 
-my $run_allow_installing_within_test = 1; # boolean; either in test or in install, there is no third option
+my $run_allow_installing_within_test = 0; # boolean; either in test or in install, there is no third option
+# PerlOnJava: defer the "may downgrade / may install outdated dist" checks to
+# the install phase so that `jcpan -t Module::Name` can test older releases
+# that contain modules no longer indexed under the same distribution (e.g.
+# JSON::Validator::Ref only exists in JSON-Validator-4.25 even though the
+# current indexed JSON::Validator dist is 5.15). For full installs the check
+# still fires at install time.
 
 # no prepare, because prepare is not a command on the shell command line
 # TODO: clear instance cache on reload

--- a/src/test/resources/unit/tail_calls.t
+++ b/src/test/resources/unit/tail_calls.t
@@ -48,5 +48,51 @@ SKIP: {
     }
 }
 
+###################
+# @_ aliasing across goto &SUB
+# Regression test: goto &SUB must pass the caller's @_ aliased to the
+# target sub's @_, so that `$_[N] = ...` in the target sub mutates the
+# caller's variable. Previously the bytecode emitted
+# `argsValue.getList().getArrayOfAlias()`, and RuntimeArray.getList()
+# deep-copied each element via `new RuntimeScalar(element)` — which
+# silently broke aliasing across the tail call. JSON::Validator's
+# coerce/boolean validators (and many other CPAN modules) depend on it.
+
+# Test 5: goto &NAME preserves $_[0] aliasing to caller's variable
+{
+    sub mutator_target { $_[0] = "MUTATED" }
+    sub mutator_via_goto { goto &mutator_target }
+    my $x = "orig";
+    mutator_via_goto($x);
+    is($x, "MUTATED", 'goto &NAME preserves @_ aliasing (single arg)');
+}
+
+# Test 6: aliasing survives nested goto &NAME chains and method dispatch
+{
+    package GotoAliasObj;
+    sub new        { bless {}, shift }
+    sub mutate     { $_[1] = "M" }
+    sub via_goto1  { goto &GotoAliasObj::via_goto2 }
+    sub via_goto2  { my $self = shift; $self->mutate($_[0]) }
+    sub entry      { my $self = shift; $self->via_goto1($_[0]) }
+    package main;
+    my $y = "orig";
+    GotoAliasObj->new->entry($y);
+    is($y, "M", 'goto &NAME preserves @_ aliasing across method dispatch chain');
+}
+
+# Test 7: goto __SUB__ also preserves aliasing
+{
+    my $hits = 0;
+    sub recursive_mutator {
+        $hits++;
+        if ($hits < 3) { goto __SUB__ }
+        $_[0] = "DONE";
+    }
+    my $z = "orig";
+    recursive_mutator($z);
+    is($z, "DONE", 'goto __SUB__ preserves @_ aliasing');
+}
+
 done_testing();
 


### PR DESCRIPTION
## Summary

Two issues exposed by `./jcpan -t JSON::Validator::Ref`:

1. **`goto &SUB` no longer preserves `@_` aliasing.**
   The bytecode for tail calls was emitting `argsValue.getList().getArrayOfAlias()`. `RuntimeArray.getList()` deep-copies every element via `new RuntimeScalar(element)`, so by the time the target sub sees `@_` the elements are no longer aliased to the caller's variables. As a result `$_[N] = ...` in the target sub silently failed to mutate the caller, even though direct (non-`goto`) calls work fine. JSON::Validator's coerce/boolean validators (and many other CPAN modules) depend on this. Fix: skip `getList()` and call `getArrayOfAlias()` directly on the `RuntimeBase` value, matching the pattern already used by `EmitBlock` for `for` loops. Applied to both `handleGotoSubroutine` and `handleGotoSubroutineBlock`.

2. **`jcpan -t Module::Name` couldn't test older releases.**
   `_allow_installing` was running before the test phase (`$run_allow_installing_within_test = 1`), so `jcpan -t` aborted with a "downgrade / outdated dist" stop for any module whose only available release is older than what's already installed (e.g. `JSON::Validator::Ref` only exists in JSON-Validator-4.25 even though `JSON::Validator` is now indexed at 5.15). The check is now deferred to the install phase; full installs still prompt.

## Effect on `jcpan -t JSON::Validator::Ref`

| | Before | After |
|---|---|---|
| Test files failed | 19/77 | 17/77 |
| Subtests failed | 65/824 | 14/824 |
| `coerce.t` | 3/48 ok | 48/48 ok |
| `jv-array.t` | 33/35 ok | 35/35 ok |
| `jv-boolean.t` | 46/56 ok | 50/56 ok |

Remaining failures are unrelated root causes (Mojo::IOLoop shim returning undef for `io`/`timer`, YAML::XS checksum, openapiv3 explode edge case) and out of scope.

#### Test plan

- [x] Repro confirmed: `sub bar { $_[0] = "X" } sub foo { goto &bar } my $x = "orig"; foo($x); print $x` printed `orig` before, `X` after.
- [x] `make` (full unit-test suite) passes.
- [x] `t/coerce.t`, `t/jv-array.t` from JSON-Validator-4.25 now fully pass; `t/jv-boolean.t` improved.

Generated with [Devin](https://cli.devin.ai/docs)
