### PR TITLE
fix(cpan): preserve PERL5LIB in Module::Build and add File::Temp->flush

### DIFF
--- a/src/main/perl/lib/File/Temp.pm
+++ b/src/main/perl/lib/File/Temp.pm
@@ -211,6 +211,19 @@ sub DESTROY {
 }
 
 # Delegate IO methods to filehandle
+sub flush {
+    my $self = shift;
+    my $fh = $self->{_fh};
+    return 1 unless defined $fh;
+    # Select the filehandle and enable autoflush to flush any pending output
+    my $old_fh = select($fh);
+    my $prev_af = $|;
+    $| = 1;
+    $| = $prev_af;
+    select($old_fh);
+    return 1;
+}
+
 sub AUTOLOAD {
     my $self = shift;
     my $method = $File::Temp::AUTOLOAD;

--- a/src/main/perl/lib/Module/Build/Base.pm
+++ b/src/main/perl/lib/Module/Build/Base.pm
@@ -74,6 +74,26 @@ if (!$loaded) {
         }
         return $self->$orig_process_support_files(@_);
     };
+
+    # Preserve PERL5LIB that CPAN's set_perl5lib injects for tested-but-not-yet-installed
+    # dependencies.  The original run_perl_command sets PERL5LIB to only _added_to_INC,
+    # which clobbers any blib paths for peer modules (e.g. Pod::Wrap when testing Pod::Tidy).
+    no warnings 'redefine';
+    *Module::Build::Base::run_perl_command = sub {
+        my ($self, $args) = @_;
+        $args = [ $self->split_like_shell($args) ] unless ref($args);
+        my $perl = ref($self) ? $self->perl : $self->find_perl_interpreter;
+
+        # Merge our local blib additions with whatever PERL5LIB CPAN already set
+        my @added = $self->_added_to_INC;
+        my $sep   = $self->config('path_sep');
+        my @parts = @added;
+        push @parts, $ENV{PERL5LIB}
+            if defined $ENV{PERL5LIB} && length $ENV{PERL5LIB};
+        local $ENV{PERL5LIB} = join $sep, @parts;
+
+        return $self->do_system($perl, @$args);
+    };
 }
 
 1;


### PR DESCRIPTION
## Summary

Fixes two bugs that caused `./jcpan -t Pod::Tidy` to fail completely.

### Bug 1: `Module::Build::Base::run_perl_command` clobbers `PERL5LIB`

When CPAN tests a module that has tested-but-not-installed dependencies, it
calls `set_perl5lib` to inject those dependencies' `blib/lib` paths into
`PERL5LIB` before invoking `./Build test`.  The problem is that
`Module::Build::Base::run_perl_command` (line 5467 in the installed copy)
does:

```perl
local $ENV{PERL5LIB} = join $self->config('path_sep'), $self->_added_to_INC;
```

This **replaces** `PERL5LIB` with only the current module's own blib paths,
discarding the paths CPAN injected.  For Pod-Tidy, that meant Pod::Wrap's
`blib/lib` was lost before test scripts could see it, causing every test to
die with `Base class package "Pod::Wrap" is empty`.

**Fix** (`src/main/perl/lib/Module/Build/Base.pm`): override
`run_perl_command` to **prepend** `_added_to_INC` to the existing `PERL5LIB`
rather than replace it.

### Bug 2: `File::Temp->flush` not implemented

Tests t/04–t/09 called `$tmp->flush` on a `File::Temp` object.  The `AUTOLOAD`
delegate checked `UNIVERSAL::can($self->{_fh}, 'flush')`, but `_fh` is a
plain GLOB reference (not an IO::Handle object), so `can` returned false and
the call died with `Undefined method flush called on File::Temp object`.

**Fix** (`src/main/perl/lib/File/Temp.pm`): add an explicit `flush` sub that
uses `select`/`$|` to flush any buffered output before another process reads
the file.

## Test plan

- [x] `./jcpan -t Pod::Tidy` — all 10 tests pass (t/00 skipped: optional dep
  `Test::Distribution` not installed)
- [x] `make` — full unit test suite passes
- [x] Verified with Pod::Wrap **not** installed in `~/.perlonjava/lib` and
  CPAN build cache cleared, confirming the fix works end-to-end without any
  manual workarounds

Generated with [Devin](https://cli.devin.ai/docs)
