### PR TITLE
fix: Test::Unit::Lite — three bug fixes + caller() line-number for both backends

### DIFF
--- a/dev/cpan-reports/cpan-compatibility.md
+++ b/dev/cpan-reports/cpan-compatibility.md
@@ -3703,7 +3703,7 @@
 | Test::Override::UserAgent |  | Unknown test outcome | 2026-04-30 |
 | Test::Run |  | Unknown test outcome | 2026-04-30 |
 | Test::Script |  | Unknown test outcome | 2026-04-21 |
-| Test::Unit::Lite | PARTIAL | 37/39 pass; 2 fail due to `caller()` line-number off-by-one for multi-line calls (pre-existing limitation) | 2026-05-01 |
+| Test::Unit::Lite | PASS | 39/39 pass | 2026-05-01 |
 | Text::ASCIIMathML |  |  | 2026-04-30 |
 | Text::DelimMatch |  | Unknown test outcome | 2026-04-30 |
 | Text::FillIn |  | Unknown test outcome | 2026-04-12 |

--- a/dev/cpan-reports/cpan-compatibility.md
+++ b/dev/cpan-reports/cpan-compatibility.md
@@ -3703,7 +3703,7 @@
 | Test::Override::UserAgent |  | Unknown test outcome | 2026-04-30 |
 | Test::Run |  | Unknown test outcome | 2026-04-30 |
 | Test::Script |  | Unknown test outcome | 2026-04-21 |
-| Test::Unit::Lite |  |  | 2026-04-30 |
+| Test::Unit::Lite | PARTIAL | 37/39 pass; 2 fail due to `caller()` line-number off-by-one for multi-line calls (pre-existing limitation) | 2026-05-01 |
 | Text::ASCIIMathML |  |  | 2026-04-30 |
 | Text::DelimMatch |  | Unknown test outcome | 2026-04-30 |
 | Text::FillIn |  | Unknown test outcome | 2026-04-12 |

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
@@ -182,7 +182,14 @@ public class CompileBinaryOperator {
                 int rd = bytecodeCompiler.allocateOutputRegister();
 
                 // Emit CALL_SUB opcode
-                bytecodeCompiler.emit(Opcodes.CALL_SUB);
+                // Use emitWithToken so pcToTokenIndex maps the call instruction to the
+                // coderef's token index (call-site line), not the closing ')' line.
+                int callSiteToken = node.left.getIndex();
+                if (callSiteToken > 0) {
+                    bytecodeCompiler.emitWithToken(Opcodes.CALL_SUB, callSiteToken);
+                } else {
+                    bytecodeCompiler.emit(Opcodes.CALL_SUB);
+                }
                 bytecodeCompiler.emitReg(rd);
                 bytecodeCompiler.emitReg(coderefReg);
                 bytecodeCompiler.emitReg(argsReg);
@@ -246,7 +253,15 @@ public class CompileBinaryOperator {
                     int rd = bytecodeCompiler.allocateOutputRegister();
 
                     // Emit CALL_METHOD
-                    bytecodeCompiler.emit(Opcodes.CALL_METHOD);
+                    // Use emitWithToken so pcToTokenIndex maps the call instruction to the
+                    // invocant's token index (call-site line), not the closing ')' line.
+                    // This ensures caller() inside the called method reports the correct line.
+                    int callSiteToken = node.left.getIndex();
+                    if (callSiteToken > 0) {
+                        bytecodeCompiler.emitWithToken(Opcodes.CALL_METHOD, callSiteToken);
+                    } else {
+                        bytecodeCompiler.emit(Opcodes.CALL_METHOD);
+                    }
                     bytecodeCompiler.emitReg(rd);
                     bytecodeCompiler.emitReg(invocantReg);
                     bytecodeCompiler.emitReg(methodReg);
@@ -403,8 +418,12 @@ public class CompileBinaryOperator {
             boolean shareCallerArgs = node.getBooleanAnnotation("shareCallerArgs");
 
             // Emit CALL_SUB or CALL_SUB_SHARE_ARGS opcode
+            // Pass node.left.getIndex() so pcToTokenIndex maps the call to the function
+            // name / reference token index (call-site line) rather than the closing ')'.
+            int callSiteToken = (node.left != null && node.left.getIndex() > 0)
+                    ? node.left.getIndex() : node.getIndex();
             int rd = CompileBinaryOperatorHelper.compileBinaryOperatorSwitch(
-                    bytecodeCompiler, node.operator, rs1, rs2, node.getIndex(),
+                    bytecodeCompiler, node.operator, rs1, rs2, callSiteToken,
                     shareCallerArgs);
             bytecodeCompiler.lastResultReg = rd;
             return;

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperatorHelper.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperatorHelper.java
@@ -223,7 +223,11 @@ public class CompileBinaryOperatorHelper {
 
                 // Emit CALL_SUB: rd = coderef.apply(args, context)
                 // Use CALL_SUB_SHARE_ARGS for &func (no parens) to share caller's @_
-                bytecodeCompiler.emit(shareCallerArgs ? Opcodes.CALL_SUB_SHARE_ARGS : Opcodes.CALL_SUB);
+                // emitWithToken records tokenIndex in pcToTokenIndex so caller() sees the
+                // call-site line (tokenIndex was set to node.left.getIndex() by the caller).
+                bytecodeCompiler.emitWithToken(
+                        shareCallerArgs ? Opcodes.CALL_SUB_SHARE_ARGS : Opcodes.CALL_SUB,
+                        tokenIndex);
                 bytecodeCompiler.emitReg(rd);  // Result register
                 bytecodeCompiler.emitReg(rs1); // Code reference register
                 bytecodeCompiler.emitReg(rs2); // Arguments register (RuntimeList to be converted to RuntimeArray)

--- a/src/main/java/org/perlonjava/backend/jvm/Dereference.java
+++ b/src/main/java/org/perlonjava/backend/jvm/Dereference.java
@@ -972,6 +972,13 @@ public class Dereference {
 
             // Allocate a unique callsite ID for inline method caching
             int callsiteId = nextMethodCallsiteId++;
+            // Set debug line number to the call site (the object/receiver expression),
+            // so that caller() inside the called method reports the correct source line.
+            // Without this, the JVM frame reports the line of the closing ')' instead.
+            if (node.left.getIndex() > 0) {
+                ByteCodeSourceMapper.setDebugInfoLineNumber(emitterVisitor.ctx, node.left.getIndex());
+            }
+
             mv.visitLdcInsn(callsiteId);
             mv.visitVarInsn(Opcodes.ALOAD, objectSlot);
             mv.visitVarInsn(Opcodes.ALOAD, methodSlot);

--- a/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
@@ -701,6 +701,13 @@ public class EmitSubroutine {
             }
         }
 
+        // Set debug line number to the call site (the function name/reference expression),
+        // so that caller() inside the called subroutine reports the correct source line.
+        // Without this, the JVM frame reports the line of the closing ')' instead.
+        if (node.left != null && node.left.getIndex() > 0) {
+            ByteCodeSourceMapper.setDebugInfoLineNumber(emitterVisitor.ctx, node.left.getIndex());
+        }
+
         mv.visitVarInsn(Opcodes.ALOAD, codeRefSlot);
         mv.visitVarInsn(Opcodes.ALOAD, nameSlot);
         mv.visitVarInsn(Opcodes.ALOAD, argsArraySlot);

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -87,8 +87,21 @@ public class IOOperator {
         }
         // select FILEHANDLE (returns/sets current filehandle)
         RuntimeScalar fh = new RuntimeScalar(RuntimeIO.selectedHandle);
-        RuntimeIO.selectedHandle = runtimeList.getFirst().getRuntimeIO();
-        RuntimeIO.lastAccesseddHandle = RuntimeIO.selectedHandle;
+        RuntimeScalar fileHandleArg = runtimeList.getFirst();
+        RuntimeIO newIO = fileHandleArg.getRuntimeIO();
+        // Auto-vivify: when called with an undefined scalar, Perl creates a new anonymous
+        // GLOB reference and stores it back in the variable (like `open my $fh, ...` does).
+        // This enables the idiom:  select select my $fh_null;  tie *$fh_null, 'SomeClass';
+        if (newIO == null && !fileHandleArg.getDefinedBoolean()) {
+            RuntimeGlob anonGlob = new RuntimeGlob(null);
+            RuntimeIO anonIO = new RuntimeIO();
+            anonGlob.setIO(anonIO);
+            RuntimeScalar newGlobRef = anonGlob.createReference();
+            fileHandleArg.set(newGlobRef);
+            newIO = anonIO;
+        }
+        RuntimeIO.selectedHandle = newIO;
+        RuntimeIO.lastAccesseddHandle = newIO;
         return fh;
     }
 

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
@@ -445,7 +445,10 @@ public class FileSpec extends PerlModuleBase {
             }
             return new RuntimeList(new ArrayList<>());
         }
-        String[] dirs = directories.split(Pattern.quote(File.separator), -1);
+        // On Windows, File::Spec::Win32::splitdir splits on both '/' and '\'.
+        // On Unix, File::Spec::Unix::splitdir splits on '/'.
+        String splitPattern = File.separator.equals("\\") ? "[/\\\\]" : Pattern.quote(File.separator);
+        String[] dirs = directories.split(splitPattern, -1);
         // In scalar context, return the count — mirrors Perl's `split` returning
         // the number of fields when evaluated in scalar context (perlop "split").
         if (ctx == RuntimeContextType.SCALAR) {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
@@ -2,6 +2,7 @@ package org.perlonjava.runtime.perlmodule;
 
 import org.perlonjava.runtime.runtimetypes.GlobalVariable;
 import org.perlonjava.runtime.runtimetypes.RuntimeArray;
+import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
 import org.perlonjava.runtime.runtimetypes.RuntimeHash;
 import org.perlonjava.runtime.runtimetypes.RuntimeList;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
@@ -438,9 +439,18 @@ public class FileSpec extends PerlModuleBase {
         String directories = args.get(1).toString();
         // Empty string returns empty list (Perl 5 behavior)
         if (directories.isEmpty()) {
+            // In scalar context, return count (0) — mirrors Perl's split behaviour
+            if (ctx == RuntimeContextType.SCALAR) {
+                return new RuntimeScalar(0).getList();
+            }
             return new RuntimeList(new ArrayList<>());
         }
         String[] dirs = directories.split(Pattern.quote(File.separator), -1);
+        // In scalar context, return the count — mirrors Perl's `split` returning
+        // the number of fields when evaluated in scalar context (perlop "split").
+        if (ctx == RuntimeContextType.SCALAR) {
+            return new RuntimeScalar(dirs.length).getList();
+        }
         List<RuntimeScalar> dirList = new ArrayList<>();
         for (String dir : dirs) {
             dirList.add(new RuntimeScalar(dir));

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Symbol.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Symbol.java
@@ -164,10 +164,13 @@ public class Symbol extends PerlModuleBase {
         RuntimeScalar object = qualify(args, ctx).scalar();
         RuntimeScalar result;
         if (!object.isString()) {
+            // Already a glob reference or similar — return as-is
             result = object;
         } else {
-            // System.out.println("qualify_to_ref");
-            result = new RuntimeScalar().set(new RuntimeGlob(object.toString()));
+            // Create a named RuntimeGlob and return a GLOBREFERENCE to it.
+            // This mirrors Perl's \*{name}: the caller gets a reference whose
+            // hash slot (and other slots) delegate to the global symbol table.
+            result = new RuntimeGlob(object.toString()).createReference();
         }
         // System.out.println("qualify_to_ref returns " + result.type);
         RuntimeList list = new RuntimeList();

--- a/src/test/resources/unit/directory.t
+++ b/src/test/resources/unit/directory.t
@@ -1,7 +1,7 @@
 use 5.38.0;
 use strict;
 use warnings;
-use Test::More tests => 9;
+use Test::More tests => 12;
 use Cwd qw(getcwd abs_path);
 use File::Spec;
 
@@ -90,4 +90,16 @@ if (-d $test_dir) {
 # Verify cleanup (non-fatal - let END block try again if needed)
 if (-d $test_dir || -e "$test_dir/$test_file") {
     diag "Warning: Cleanup verification found leftover files (will retry in END block)";
+}
+
+# Test File::Spec->splitdir scalar context (mirrors Perl's `split` count semantics)
+{
+    my $count = scalar File::Spec->splitdir("a/b/c");
+    is($count, 3, 'scalar File::Spec->splitdir returns count of components');
+
+    my $count2 = scalar File::Spec->splitdir("t/tlib");
+    is($count2, 2, 'scalar File::Spec->splitdir("t/tlib") returns 2');
+
+    my $count3 = scalar File::Spec->splitdir("");
+    is($count3, 0, 'scalar File::Spec->splitdir("") returns 0 for empty string');
 }

--- a/src/test/resources/unit/typeglob.t
+++ b/src/test/resources/unit/typeglob.t
@@ -75,4 +75,26 @@ subtest 'References in package code slots' => sub {
     }
 };
 
+subtest 'Symbol::qualify_to_ref returns a glob reference' => sub {
+    use Symbol;
+
+    # qualify_to_ref must return a GLOB reference (ref eq "GLOB"), not the
+    # glob itself.  Perl's list_tests idiom relies on:
+    #   keys %{ *{ Symbol::qualify_to_ref("Pkg::") } }
+    # to inspect a package's symbol table.
+
+    package QTRTest;
+    sub qtr_method { 1 }
+
+    package main;
+
+    my $ref = Symbol::qualify_to_ref("QTRTest::");
+    like($ref, qr/^GLOB\(/, 'qualify_to_ref stringifies as GLOB(...)');
+    is(ref($ref), 'GLOB', 'qualify_to_ref returns a reference of type GLOB');
+
+    # Dereference to get the typeglob, then access its HASH slot (package stash)
+    my %stash = %{ *{$ref} };
+    ok(exists $stash{qtr_method}, 'hash slot of qualify_to_ref result contains package symbols');
+};
+
 done_testing();


### PR DESCRIPTION
## Summary

Fixes three bugs uncovered by `./jcpan -t Test::Unit::Lite`, plus the
underlying `caller()` line-number issue that prevented the last 2/39
subtests from passing. All 39/39 subtests now pass.

### Bug 1 — `File::Spec->splitdir` scalar context
`splitdir` was always returning a list; in scalar context it now returns
the count, matching Perl's behaviour.

### Bug 2 — `Symbol::qualify_to_ref` return type
Was returning a plain GLOB instead of a GLOB reference. Fixed to return
`\*{"pkg::name"}`.

### Bug 3 — `select` auto-vivification of undef scalar
`select select my $fh` now auto-vivifies `$fh` into an anonymous GLOB
reference (matching Perl's open-my-filehandle behaviour), so a
subsequent `tie *$fh, ...` works correctly.

### Bug 4 — `caller()` line numbers for multi-line calls (JVM backend)
`handleArrowOperator` (`Dereference.java`) and `handleApplyOperator`
(`EmitSubroutine.java`) emitted `callCached`/`apply` with the JVM
line-number attribute pointing to the closing `)` token, not the
call-site token. Added `ByteCodeSourceMapper.setDebugInfoLineNumber`
with `node.left.getIndex()` immediately before each call instruction.

### Bug 5 — same `caller()` fix for the interpreter backend
`CALL_METHOD` and `CALL_SUB` opcodes in `CompileBinaryOperator.java`
and `CompileBinaryOperatorHelper.java` were emitted without a
`pcToTokenIndex` entry, so `getCallSiteInfo()` fell back to the
statement-level entry (token after `)`). Changed to `emitWithToken`
using `node.left.getIndex()` at all three call-emit sites.

After both fixes, `./jperl` and `./jperl --interpreter` agree with
system Perl on the line reported by `caller()` inside a called
subroutine whose argument list spans multiple lines.

#### Test plan
- [x] `make` — all unit tests pass
- [x] `./jcpan -t Test::Unit::Lite` — **39/39** subtests pass (was 37/39)
- [x] Updated `dev/cpan-reports/cpan-compatibility.md`: PARTIAL → PASS

Generated with [Devin](https://cli.devin.ai/docs)
