### PR TITLE
Fix deprecated URL constructors in XMLLibXML.java

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -482,7 +482,10 @@ sub update_to_latest_versions {
     # Update Gradle dependencies using version catalog
     if (-f 'build.gradle') {
         print "Updating Gradle dependencies to latest versions using version catalog...\n";
-        my $gradle_output = `./gradlew versionCatalogUpdate`;
+        # Disable configuration cache for versionCatalogUpdate: the plugin invokes Task.project at execution time,
+        # which is incompatible with Gradle's configuration cache. This flag prevents cache errors during upgrades.
+        # Regular builds keep the cache enabled for performance; only upgrade operations bypass it.
+        my $gradle_output = `./gradlew versionCatalogUpdate --no-configuration-cache`;
         my $gradle_status = $? >> 8;
         if ($gradle_status != 0) {
             warn "Failed to update Gradle dependencies. Exit status: $gradle_status\n";

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
-# Enable Gradle configuration cache for faster builds
+# Enable Gradle configuration cache for faster builds and parallel tests
 org.gradle.configuration-cache=true
+# Warn about cache incompatibilities instead of failing (versionCatalogUpdate accesses Task.project at execution time)
+org.gradle.configuration-cache.problems=warn

--- a/src/main/java/org/perlonjava/runtime/perlmodule/XMLLibXML.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/XMLLibXML.java
@@ -2018,9 +2018,9 @@ public class XMLLibXML extends PerlModuleBase {
             String baseUri = parent.getDocumentURI();
             URL url;
             if (baseUri != null) {
-                url = new URL(new URL(baseUri), href);
+                url = new URI(baseUri).resolve(href).toURL();
             } else if (href.contains("://") || href.startsWith("file:")) {
-                url = new URL(href);
+                url = new URI(href).toURL();
             } else {
                 // Relative path without a base URI — cannot resolve
                 return null;


### PR DESCRIPTION
## Summary
Fix deprecation warnings and Gradle configuration cache incompatibility.

## Changes
- **XMLLibXML.java**: Replace deprecated URL constructors with the modern `URI.resolve().toURL()` pattern to eliminate deprecation warnings that appear with Java 20+
- **gradle.properties**: Enable configuration cache but suppress incompatibility warnings (versionCatalogUpdate plugin accesses Task.project at execution time)
- **Configure.pl**: Pass `--no-configuration-cache` flag to Gradle during dependency upgrades to avoid cache errors

## Details
- Use `URI(baseUri).resolve(href).toURL()` instead of `new URL(new URL(baseUri), href)`
- Use `URI(href).toURL()` instead of `new URL(href)`
- Configuration cache stays enabled for regular builds (parallel tests work), only disabled during `./Configure.pl --upgrade`

🤖 Generated with [Claude Code](https://claude.com/claude-code)