### PR TITLE
Fix: shuffle @candidates to break alphabetical ordering in cpan_random_tester.pl

### DIFF
--- a/dev/tools/cpan_random_tester.pl
+++ b/dev/tools/cpan_random_tester.pl
@@ -178,6 +178,12 @@ if ($retest_age > 0) {
     printf "Candidates (not yet passing): %d\n", scalar @candidates;
 }
 
+# Shuffle candidates to ensure randomization (they may be in alphabetical order from @all_modules)
+for my $i (0 .. scalar(@candidates) - 1) {
+    my $j = $i + int(rand(scalar(@candidates) - $i));
+    @candidates[$i, $j] = @candidates[$j, $i];
+}
+
 if (!@candidates) {
     print "All modules have been tested! Use --report-only to regenerate the report.\n";
     generate_report();


### PR DESCRIPTION
## Summary

Fixes an issue where modules were being tested in alphabetical order instead of random order. The root cause: `@all_modules` is sorted (for determinism), and `@candidates` inherited that order. Even though the selection code uses Fisher-Yates shuffling, when count >= candidates, it would use the unsorted list directly.

## Changes

- Add Fisher-Yates shuffle to `@candidates` after building the list
- Ensures randomization regardless of how many modules are selected
- Maintains deterministic reporting while still testing in random order

## Impact

With this fix, the test order is truly random, which is critical for:
- Concurrent instances to minimize overlap (each picks from randomly-shuffled pool)
- Fair distribution across CI runs (no A modules always test first)
- Proper stress testing (not always hitting same modules in same order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)