### PR TITLE
docs: remove outdated HTTPS/streaming comments from Plack::Handler::Netty

### DIFF
--- a/examples/http_server_plack/README.md
+++ b/examples/http_server_plack/README.md
@@ -209,7 +209,6 @@ This design avoids PerlOnJava's thread-safety constraints while still providing 
 ## Limitations
 
 - **Single-threaded** - CPU-intensive handlers block other requests
-- **Streaming responses** - Phase 3 adds support for PSGI streaming
 
 ## Performance
 

--- a/src/main/perl/lib/Plack/Handler/Netty.pm
+++ b/src/main/perl/lib/Plack/Handler/Netty.pm
@@ -536,7 +536,7 @@ Configure your load balancer to distribute across all instances.
 
 =item * B<PerlOnJava specific> - Requires PerlOnJava runtime, won't work with standard Perl.
 
-=item * B<No HTTPS yet> - TLS/SSL support planned for future release. Use reverse proxy for HTTPS now.
+=item * B<Single-threaded> - CPU-bound request handlers block other requests. Offload heavy computation to background workers.
 
 =back
 


### PR DESCRIPTION
Remove outdated documentation comments that claimed HTTPS and streaming support were not yet implemented, when in fact both features are already fully complete and documented.

**Changes:**
- Remove 'No HTTPS yet' caveat from Netty.pm (HTTPS/TLS fully implemented via Netty's SslHandler)
- Remove 'Streaming responses - Phase 3 adds support' from README (streaming already complete)
- Keep CAVEATS section focused on actual limitations (single-threaded model, no fork support)