### PR TITLE
fix: support EXPR labels for loop control flow

### DIFF
--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -478,7 +478,7 @@ my @copy = @{$z};         # ERROR
 - ✅  **`goto` operator**: `goto LABEL` with literal labels and `goto EXPR` with dynamic expressions are implemented.
 - ✅  **`goto &name`**: Tail call optimization with trampoline is implemented.
 - ✅  **`goto __SUB__`**: Recursive tail call is implemented.
-- ❌  **loop control operators**: `next EXPR`, `last EXPR`, `redo EXPR` with dynamic expressions (e.g., `$label = "OUTER"; next $label`) are not implemented.
+- ✅  **loop control operators**: `next EXPR`, `last EXPR`, `redo EXPR` with dynamic expressions (e.g., `$label = "OUTER"; next $label`) are implemented.
 - ✅  **setting `$_` in `while` loop with `<>`**: automatic setting `$_` in `while` loops is implemented.
 - ✅  **`do BLOCK while`**: `do` executes once before the conditional is evaluated.
 - ✅  **`...` ellipsis statement**: `...` is supported.

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -6242,6 +6242,11 @@ public class BytecodeCompiler implements Visitor {
             Node arg = labelNode.elements.getFirst();
             if (arg instanceof IdentifierNode) {
                 labelStr = ((IdentifierNode) arg).name;
+            } else if (arg instanceof StringNode stringNode) {
+                // Constant string label expression (e.g. next "LOOP")
+                // is equivalent to a static label and should not force
+                // dynamic non-local control flow.
+                labelStr = stringNode.value;
             } else {
                 // Dynamic label: last EXPR, next EXPR, redo EXPR
                 // Evaluate expression at runtime to get label string
@@ -6253,6 +6258,38 @@ public class BytecodeCompiler implements Visitor {
 
         // Dynamic label always uses non-local control flow
         if (isDynamicLabel) {
+            // Dynamic label expression:
+            // 1) Try matching in-scope labeled true loops at runtime.
+            // 2) If no match, propagate non-local control flow marker.
+            List<Integer> localMatchPatchPositions = new ArrayList<>();
+            List<LoopInfo> localMatchLoops = new ArrayList<>();
+            for (int i = loopStack.size() - 1; i >= 0; i--) {
+                LoopInfo loop = loopStack.get(i);
+                if (!loop.isTrueLoop || loop.label == null) {
+                    continue;
+                }
+
+                int labelConstReg = allocateRegister();
+                emit(Opcodes.LOAD_STRING);
+                emitReg(labelConstReg);
+                emit(addToStringPool(loop.label));
+
+                int eqReg = allocateRegister();
+                emit(Opcodes.EQ_STR);
+                emitReg(eqReg);
+                emitReg(dynamicLabelReg);
+                emitReg(labelConstReg);
+
+                emit(Opcodes.GOTO_IF_TRUE);
+                emitReg(eqReg);
+                int matchPatchPos = bytecode.size();
+                emitInt(0); // patched to local handler for this matched label
+
+                localMatchPatchPositions.add(matchPatchPos);
+                localMatchLoops.add(loop);
+            }
+
+            // Fallback: non-local control flow marker when no local loop label matches.
             short createDynOp = op.equals("last") ? Opcodes.CREATE_LAST_DYNAMIC
                     : op.equals("next") ? Opcodes.CREATE_NEXT_DYNAMIC
                     : Opcodes.CREATE_REDO_DYNAMIC;
@@ -6262,6 +6299,28 @@ public class BytecodeCompiler implements Visitor {
             emitReg(dynamicLabelReg);
             emit(Opcodes.RETURN);
             emitReg(rd);
+
+            // Local handlers for each runtime-matched label.
+            short localOpcode = op.equals("last") ? Opcodes.LAST
+                    : op.equals("next") ? Opcodes.NEXT
+                    : Opcodes.REDO;
+            for (int i = 0; i < localMatchPatchPositions.size(); i++) {
+                int matchPatchPos = localMatchPatchPositions.get(i);
+                LoopInfo targetLoop = localMatchLoops.get(i);
+                patchJump(matchPatchPos, bytecode.size());
+
+                emitWithToken(localOpcode, node.getIndex());
+                int patchPc = bytecode.size();
+                emitInt(0); // patched when loop boundaries are finalized
+
+                if (op.equals("last")) {
+                    targetLoop.breakPcs.add(patchPc);
+                } else if (op.equals("next")) {
+                    targetLoop.nextPcs.add(patchPc);
+                } else {
+                    targetLoop.redoPcs.add(patchPc);
+                }
+            }
             return;
         }
 

--- a/src/test/resources/unit/loop_label.t
+++ b/src/test/resources/unit/loop_label.t
@@ -25,6 +25,23 @@ OUTER_LOOP: for my $x (1..3) {
 }
 ok(!($counter != 9), '`next LABEL` in nested `for` loop <$counter>');
 
+# Test `next EXPR` with a constant string label
+my @expr_label_seen;
+LOOP_EXPR: for my $n (1..3) {
+    push @expr_label_seen, $n;
+    next "LOOP_EXPR";
+}
+is_deeply(\@expr_label_seen, [1, 2, 3], '`next "LABEL"` uses label expression correctly');
+
+# Test `next EXPR` with a dynamic label variable
+my $dyn_label = 'LOOP_DYN';
+my @dyn_label_seen;
+LOOP_DYN: for my $n (1..3) {
+    push @dyn_label_seen, $n;
+    next $dyn_label;
+}
+is_deeply(\@dyn_label_seen, [1, 2, 3], '`next $label` uses dynamic label expression correctly');
+
 ###################
 # Perl `redo` Tests
 
@@ -36,6 +53,16 @@ for my $i (1..3) {
     last if $redo_count == 3;  # Exit loop when count reaches 3
 }
 ok(!($redo_count != 3), 'Simple `redo` in `for` loop');
+
+# Test `redo EXPR` with a dynamic label variable
+my $redo_label = 'REDO_LOOP';
+my @redo_expr_seen;
+my $redo_once = 0;
+REDO_LOOP: for my $n (1..3) {
+    push @redo_expr_seen, $n;
+    redo $redo_label if $n == 2 && !$redo_once++;
+}
+is_deeply(\@redo_expr_seen, [1, 2, 2, 3], '`redo $label` uses dynamic label expression correctly');
 
 ###################
 # Perl `last` Tests
@@ -57,5 +84,27 @@ OUTER_LOOP: for my $a (1..3) {
     }
 }
 ok(!($last_count != 2), '`last LABEL` in nested loop');
+
+# Test `last EXPR` with a dynamic label variable
+my $last_label = 'LAST_LOOP';
+my @last_expr_seen;
+LAST_LOOP: for my $n (1..5) {
+    push @last_expr_seen, $n;
+    last $last_label if $n == 3;
+}
+is_deeply(\@last_expr_seen, [1, 2, 3], '`last $label` uses dynamic label expression correctly');
+
+###################
+# Perl `goto` Tests
+
+# Test `goto EXPR` with a dynamic label variable
+my $goto_label = 'GOTO_TARGET';
+my @goto_expr_seen;
+push @goto_expr_seen, 'before';
+goto $goto_label;
+push @goto_expr_seen, 'skipped';
+GOTO_TARGET:
+push @goto_expr_seen, 'after';
+is_deeply(\@goto_expr_seen, ['before', 'after'], '`goto $label` uses dynamic label expression correctly');
 
 done_testing();


### PR DESCRIPTION
## Summary
- Treat constant-string loop-control labels (`next "LABEL"`) as static labels in interpreter bytecode compilation.
- Implement runtime local-label resolution for dynamic `next/last/redo EXPR`, falling back to non-local control-flow markers only when no in-scope loop label matches.
- Add unit coverage for `next/last/redo/goto EXPR` in `src/test/resources/unit/loop_label.t` and update `docs/reference/feature-matrix.md`.

## Test plan
- [x] `make`
- [x] `perl src/test/resources/unit/loop_label.t`
- [x] `./jperl src/test/resources/unit/loop_label.t`
- [x] `./jperl --interpreter -e 'my $label="LOOP"; LOOP: for (1,2,3) { print "$_\n"; next $label }'`
- [x] `./jperl --interpreter -e 'my $label="LOOP"; my @o; LOOP: for (1,2,3,4,5) { push @o, $_; last $label if $_==3 } print join(q{,},@o),qq{\n};'`
- [x] `./jperl --interpreter -e 'my $label="LOOP"; my @o; my $once=0; LOOP: for (1,2,3) { push @o, $_; redo $label if $_==2 && !$once++; } print join(q{,},@o),qq{\n};'`
- [x] `./jperl --interpreter -e 'my $label="SKIP"; my @o; push @o, "a"; goto $label; push @o, "b"; SKIP: push @o, "c"; print join(q{,},@o),qq{\n};'`

Made with [Cursor](https://cursor.com)