### PR TITLE
fix: make jcpan CPAN::Changes corpus parsing pass

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
@@ -17,6 +17,7 @@ import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.perlonjava.frontend.parser.OperatorParser.dieWarnNode;
 import static org.perlonjava.frontend.parser.ParserNodeUtils.scalarUnderscore;
@@ -28,6 +29,18 @@ import static org.perlonjava.frontend.parser.TokenUtils.peek;
  * It handles various types of statements such as control structures, declarations, and expressions.
  */
 public class StatementResolver {
+
+    /**
+     * Builtins often followed by a string argument with no {@code ,} or {@code (} between
+     * (e.g. {@code like "...\x{100}" ...}). During {@link #isHashLiteral} pre-scan, the opening
+     * {@code "} must start quoted-string mode; otherwise {@code \x{...}} is seen as raw
+     * brace tokens, brace depth desynchronizes, and {@code =>} inside a later
+     * {@code map { sprintf "%s" => $_ }} is misread as a hash fat comma at depth 1.
+     */
+    private static final Set<String> IDENTIFIER_BEFORE_BARE_STRING_ARG = Set.of(
+            "like", "unlike", "ok", "is", "isnt", "cmp_ok", "can_ok", "isa_ok",
+            "pass", "fail", "require", "diag", "note", "explain",
+            "warning_like", "warning_is", "warnings_like");
 
     /**
      * Parses a single statement from the parser's token stream.
@@ -1021,7 +1034,8 @@ public class StatementResolver {
                         prevToken == null
                                 || (prevToken.type != LexerTokenType.IDENTIFIER
                                 && prevToken.type != LexerTokenType.NUMBER
-                                && prevToken.type != LexerTokenType.STRING);
+                                && prevToken.type != LexerTokenType.STRING)
+                                || IDENTIFIER_BEFORE_BARE_STRING_ARG.contains(prevToken.text);
                 if (!isLikelyOpeningQuote) {
                     continue;
                 }

--- a/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
@@ -916,6 +916,13 @@ public class StatementResolver {
                 break; // Let caller handle EOF error
             }
 
+            // Any non-trivial token means the brace pair is not literally `{}`, even when
+            // later branches `continue` (quote-like / string skip). Without this,
+            // `{ q=bar= }` never sets hasContent and wrongly hits the empty-hashref rule.
+            if (token.type != LexerTokenType.WHITESPACE && !token.text.equals("}")) {
+                hasContent = true;
+            }
+
             if (awaitingQuoteLikeDelimiter) {
                 if (token.type == LexerTokenType.WHITESPACE) {
                     continue;
@@ -972,10 +979,27 @@ public class StatementResolver {
 
             if (token.type == LexerTokenType.IDENTIFIER
                     && (token.text.equals("q") || token.text.equals("qq"))) {
-                // Skip quote-like payloads for q()/qq() so punctuation inside
-                // their bodies (for example ';') does not affect disambiguation.
-                awaitingQuoteLikeDelimiter = true;
-                continue;
+                // Only treat as quote-like operators when a real delimiter follows.
+                // Bareword `q` / `qq` before `,` / `=>` / `;` / closing paren is not q():
+                //   { q,'bar', }  { q   => 'bar' } first line is a block; second is a hash key.
+                int peekIdx = parser.tokenIndex;
+                while (peekIdx < parser.tokens.size()
+                        && parser.tokens.get(peekIdx).type == LexerTokenType.WHITESPACE) {
+                    peekIdx++;
+                }
+                if (peekIdx < parser.tokens.size()) {
+                    String nextText = parser.tokens.get(peekIdx).text;
+                    if (nextText.equals(",") || nextText.equals("=>") || nextText.equals(";")
+                            || nextText.equals(")") || nextText.equals("}")) {
+                        // Fall through: process `q` / `qq` like any other identifier.
+                    } else {
+                        awaitingQuoteLikeDelimiter = true;
+                        continue;
+                    }
+                } else {
+                    awaitingQuoteLikeDelimiter = true;
+                    continue;
+                }
             }
 
             // Enter simple quoted string scanning mode. This prevents punctuation
@@ -1008,11 +1032,6 @@ public class StatementResolver {
                 quoteEscapeNext = false;
                 if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("isHashLiteral entering quoted string with delimiter " + token.text);
                 continue;
-            }
-
-            // Track if we've seen any non-brace content
-            if (!token.text.equals("}")) {
-                hasContent = true;
             }
 
             // Update brace count based on token

--- a/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
@@ -858,6 +858,12 @@ public class StatementResolver {
         boolean hasBlockIndicator = false; // Found ;, or statement modifier
         boolean hasContent = false; // Track if we've seen any content
         boolean firstTokenIsSigil = false; // Track if first token is % or @ (hash/array)
+        boolean inQuotedString = false; // Ignore hash/block indicators inside simple quoted strings
+        String quoteDelimiter = null;
+        String quoteOpenDelimiter = null;
+        int quoteNesting = 0;
+        boolean quoteEscapeNext = false;
+        boolean awaitingQuoteLikeDelimiter = false;
 
         // Extra bits for the "{'a','b'}" / "{1,2}" / "{foo,1}" rule: real Perl
         // treats a braced expression as a hashref when the FIRST content token
@@ -910,6 +916,100 @@ public class StatementResolver {
                 break; // Let caller handle EOF error
             }
 
+            if (awaitingQuoteLikeDelimiter) {
+                if (token.type == LexerTokenType.WHITESPACE) {
+                    continue;
+                }
+                awaitingQuoteLikeDelimiter = false;
+                inQuotedString = true;
+                quoteOpenDelimiter = token.text;
+                quoteDelimiter = switch (token.text) {
+                    case "(" -> ")";
+                    case "[" -> "]";
+                    case "{" -> "}";
+                    case "<" -> ">";
+                    default -> token.text;
+                };
+                quoteNesting = quoteOpenDelimiter.equals(quoteDelimiter) ? 0 : 1;
+                quoteEscapeNext = false;
+                if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("isHashLiteral entering quote-like string with delimiters " + quoteOpenDelimiter + " ... " + quoteDelimiter);
+                continue;
+            }
+
+            // If we're currently scanning inside a simple quoted string, ignore all
+            // disambiguation signals until we reach the closing delimiter.
+            if (inQuotedString) {
+                if (quoteOpenDelimiter != null && !quoteOpenDelimiter.equals(quoteDelimiter)) {
+                    // Paired delimiter mode ((), {}, [], <>): track nesting.
+                    if (token.type == LexerTokenType.OPERATOR && token.text.equals(quoteOpenDelimiter)) {
+                        quoteNesting++;
+                    } else if (token.type == LexerTokenType.OPERATOR && token.text.equals(quoteDelimiter)) {
+                        quoteNesting--;
+                        if (quoteNesting <= 0) {
+                            inQuotedString = false;
+                            quoteDelimiter = null;
+                            quoteOpenDelimiter = null;
+                            quoteNesting = 0;
+                            quoteEscapeNext = false;
+                            if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("isHashLiteral leaving paired quoted string");
+                        }
+                    }
+                } else if (quoteEscapeNext) {
+                    quoteEscapeNext = false;
+                } else if (token.type == LexerTokenType.OPERATOR && token.text.equals("\\")) {
+                    quoteEscapeNext = true;
+                } else if (token.type == LexerTokenType.OPERATOR && token.text.equals(quoteDelimiter)) {
+                    // Single delimiter mode ("...", '...', `...`, /.../, etc.)
+                    inQuotedString = false;
+                    quoteDelimiter = null;
+                    quoteOpenDelimiter = null;
+                    quoteNesting = 0;
+                    quoteEscapeNext = false;
+                    if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("isHashLiteral leaving quoted string");
+                }
+                continue;
+            }
+
+            if (token.type == LexerTokenType.IDENTIFIER
+                    && (token.text.equals("q") || token.text.equals("qq"))) {
+                // Skip quote-like payloads for q()/qq() so punctuation inside
+                // their bodies (for example ';') does not affect disambiguation.
+                awaitingQuoteLikeDelimiter = true;
+                continue;
+            }
+
+            // Enter simple quoted string scanning mode. This prevents punctuation
+            // inside string literals (for example ';' in "x; y") from being
+            // misinterpreted as block syntax at depth 1.
+            if (token.type == LexerTokenType.OPERATOR
+                    && (token.text.equals("\"") || token.text.equals("'") || token.text.equals("`"))) {
+                int prevIndex = parser.tokenIndex - 2;
+                while (prevIndex >= currentIndex
+                        && parser.tokens.get(prevIndex).type == LexerTokenType.WHITESPACE) {
+                    prevIndex--;
+                }
+                LexerToken prevToken = prevIndex >= currentIndex ? parser.tokens.get(prevIndex) : null;
+
+                // Only treat quote as opening when context suggests a string start.
+                // This avoids latching onto trailing quote tokens emitted after
+                // already-parsed quoted keys/values.
+                boolean isLikelyOpeningQuote =
+                        prevToken == null
+                                || (prevToken.type != LexerTokenType.IDENTIFIER
+                                && prevToken.type != LexerTokenType.NUMBER
+                                && prevToken.type != LexerTokenType.STRING);
+                if (!isLikelyOpeningQuote) {
+                    continue;
+                }
+
+                inQuotedString = true;
+                quoteDelimiter = token.text;
+                quoteOpenDelimiter = token.text;
+                quoteEscapeNext = false;
+                if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("isHashLiteral entering quoted string with delimiter " + token.text);
+                continue;
+            }
+
             // Track if we've seen any non-brace content
             if (!token.text.equals("}")) {
                 hasContent = true;
@@ -943,6 +1043,17 @@ public class StatementResolver {
                         hasBlockIndicator = true;
                     }
                     case "=" -> {
+                        // Some lexer paths split fat-comma `=>` into separate `=` and `>` tokens.
+                        // In that case this is a hash key/value separator, not assignment.
+                        if (parser.tokenIndex < parser.tokens.size()) {
+                            LexerToken nextToken = parser.tokens.get(parser.tokenIndex);
+                            if (nextToken.text.equals(">")) {
+                                if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("isHashLiteral found = followed by > (fat comma split), treating as hash indicator");
+                                hasHashIndicator = true;
+                                break;
+                            }
+                        }
+
                         // Assign is a block indicator, but be more conservative
                         // Look at the tokens we've seen to determine if this might be a q-string pattern
                         boolean isQStringDelimiter = false;
@@ -996,7 +1107,10 @@ public class StatementResolver {
                         // Check if this is a hash key (followed by =>) or statement modifier
                         LexerToken nextToken = TokenUtils.peek(parser);
                         if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("isHashLiteral found keyword '" + token.text + "', next token: '" + nextToken.text + "'");
-                        if (!nextToken.text.equals("=>") && !nextToken.text.equals(",")) {
+                        // If we've already seen a fat-comma hash indicator at depth 1,
+                        // keep preferring hash interpretation. This avoids false block
+                        // classification when keyword-like words leak from quoted payload.
+                        if (!hasHashIndicator && !nextToken.text.equals("=>") && !nextToken.text.equals(",")) {
                             // Statement modifier - definitive block indicator
                             if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("isHashLiteral found statement modifier (block indicator)");
                             hasBlockIndicator = true;

--- a/src/test/resources/unit/hash_ref_disambiguation.t
+++ b/src/test/resources/unit/hash_ref_disambiguation.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
-use Test::More tests => 14;
+use Test::More tests => 18;
+use File::Temp qw(tempfile);
 
 # Regression tests for block-vs-hashref disambiguation inside `{ ... }`.
 # Real Perl treats `{ KEY, VALUE, ... }` as an anonymous hash when the
@@ -49,3 +50,53 @@ is(ref($r), 'HASH', 'return {...} still a hashref');
 # Block with a leading keyword and comma expression
 my @x = do { "foo", "bar" };
 is_deeply(\@x, ["foo","bar"], 'do { "foo", "bar" } is a block (list context)');
+
+# --- top-level do-file hashrefs ---
+
+{
+    my ($fh, $filename) = tempfile(SUFFIX => '.pl', UNLINK => 1);
+    print {$fh} "{\n";
+    print {$fh} "  \"a\" => \"x; y\",\n";
+    print {$fh} "  \"b\" => [1, 2],\n";
+    print {$fh} "}\n";
+    close $fh;
+
+    my $result = do $filename;
+    is(ref($result), 'HASH', 'do-file top-level hash with semicolon string is hashref');
+}
+
+{
+    my ($fh, $filename) = tempfile(SUFFIX => '.pl', UNLINK => 1);
+    print {$fh} "{\n";
+    print {$fh} "  \"if\" => \"literal { braces } while text\",\n";
+    print {$fh} "  \"k\" => \"v\",\n";
+    print {$fh} "}\n";
+    close $fh;
+
+    my $result = do $filename;
+    is(ref($result), 'HASH', 'do-file top-level hash with keyword-like text is hashref');
+}
+
+{
+    my ($fh, $filename) = tempfile(SUFFIX => '.pl', UNLINK => 1);
+    print {$fh} "{\n";
+    print {$fh} "  \"k\" => q(a; b),\n";
+    print {$fh} "  \"v\" => 1,\n";
+    print {$fh} "}\n";
+    close $fh;
+
+    my $result = do $filename;
+    is(ref($result), 'HASH', 'do-file top-level hash with q(...) payload is hashref');
+}
+
+{
+    my ($fh, $filename) = tempfile(SUFFIX => '.pl', UNLINK => 1);
+    print {$fh} "{\n";
+    print {$fh} "  \"k\" => qq(x; y),\n";
+    print {$fh} "  \"v\" => 1,\n";
+    print {$fh} "}\n";
+    close $fh;
+
+    my $result = do $filename;
+    is(ref($result), 'HASH', 'do-file top-level hash with qq(...) payload is hashref');
+}


### PR DESCRIPTION
## Summary
- Fix `StatementResolver.isHashLiteral` to ignore quote-like payload tokens (including `q(...)` and `qq(...)`) during block-vs-hashref disambiguation.
- Handle split `=>` tokenization (`=` followed by `>`) as a hash indicator to avoid false assignment/block classification.
- Add regression coverage in `src/test/resources/unit/hash_ref_disambiguation.t` for top-level `do $file` hashrefs with semicolons, keyword-like text, and `q/qq` payloads.

## Test plan
- [x] `perl src/test/resources/unit/hash_ref_disambiguation.t`
- [x] `perl src/test/resources/unit/bare_block_return.t`
- [x] `make`
- [x] `./jperl src/test/resources/unit/hash_ref_disambiguation.t`
- [x] `timeout 1800 ./jcpan -t CPAN::Changes`

Made with [Cursor](https://cursor.com)