### PR TITLE
fix: list-context reverse must alias plain-array elements

### DIFF
--- a/src/main/java/org/perlonjava/runtime/operators/Operator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Operator.java
@@ -714,13 +714,16 @@ public class Operator {
         // Preserve null elements (deleted array elements) so that
         // @a = reverse @a maintains sparse array structure.
         // null = deleted (exists returns false), undef = defined but undef
+        //
+        // Keep the same RuntimeScalar (or other RuntimeBase) instances as the
+        // source array — Perl's list-context reverse only reverses order; it does
+        // not copy SVs. This matters for foreach: `for my $x (reverse @a) { ... }`
+        // aliases $x to each original slot so mutations (e.g. substr four-arg
+        // prepend on split whitespace chunks) update @a in place.
         RuntimeArray result = new RuntimeArray();
-        for (RuntimeBase element : array.elements) {
-            if (element != null) {
-                result.elements.add(new RuntimeScalar((RuntimeScalar) element));
-            } else {
-                result.elements.add(null);
-            }
+        for (RuntimeScalar element : array.elements) {
+            // Plain-array slots are RuntimeScalar or null (sparse hole).
+            result.elements.add(element);
         }
         Collections.reverse(result.elements);
         RuntimeList list = new RuntimeList();

--- a/src/test/resources/unit/reverse_list_alias.t
+++ b/src/test/resources/unit/reverse_list_alias.t
@@ -1,0 +1,44 @@
+use 5.32.0;
+use strict;
+use warnings;
+use Test::More;
+
+# List-context reverse must return the same SVs as the source array, only in
+# reversed order, so `foreach my $x (reverse @a)` aliases into @a. Copying
+# elements breaks in-place mutation (Text::Format __make_line / justify tests).
+
+{
+    my @a = qw(x y);
+    for my $x (reverse @a) {
+        $x .= 'Z';
+    }
+    is_deeply( \@a, [qw(xZ yZ)], 'foreach (reverse @lexical) mutates original scalars' );
+}
+
+{
+    my @a = (1, 2);
+    for my $x (reverse @a) {
+        $x++;
+    }
+    is_deeply( \@a, [ 2, 3 ], 'foreach (reverse @lexical) numeric mutator updates slots' );
+}
+
+{
+    my @words = split /(\s+)/, 'a b c';
+    my $width = 7;
+    my $spaces  = $width - length join '', @words;
+    my $ws      = int( $spaces / int( @words / 2 ) );
+    $spaces %= int( @words / 2 ) if $ws > 0;
+    for my $gap ( reverse @words ) {
+        next if $gap =~ /^\S/;
+        substr( $gap, 0, 0 ) = ' ' x $ws;
+        $spaces || next;
+        substr( $gap, 0, 0 ) = ' ';
+        --$spaces;
+    }
+    my $line = join '', @words;
+    is( length($line), $width, 'justify-style substr prepend via reverse foreach reaches target width' );
+    is( $line, 'a  b  c', 'justify-style gaps updated in original split list' );
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

- **Bug:** `reverse @plain_array` in list context built a reversed list using `new RuntimeScalar(element)` for each slot, so `for my $x (reverse @a)` did not alias into `@a`. Mutations (including `substr` four-argument prepend on elements from `split /(\s+)/`) left the original array unchanged.
- **Fix:** `reversePlainArray` now keeps the same `RuntimeScalar` instances in reversed order (still preserving `null` slots for sparse arrays).
- **Tests:** Add `src/test/resources/unit/reverse_list_alias.t` covering string/numeric mutation via `reverse` foreach and a minimal justify-style loop matching `Text::Format` behavior.

## Verification

- `make`
- `./jcpan -t Text::Format` (justify tests) passes with this change.
