### PR TITLE
fix: export mktime and strftime from bare use POSIX

### DIFF
--- a/src/main/perl/lib/POSIX.pm
+++ b/src/main/perl/lib/POSIX.pm
@@ -55,6 +55,7 @@ our @EXPORT = qw(
     WNOHANG WUNTRACED
     SEEK_CUR SEEK_END SEEK_SET
     F_OK R_OK W_OK X_OK
+    mktime strftime
 );
 our @EXPORT_OK = qw(
     # Process functions


### PR DESCRIPTION
## Summary

Stock Perl’s `POSIX` module puts `mktime` in the default export list, so code that does `use POSIX` and calls bare `mktime` works. PerlOnJava’s `POSIX` used a trimmed `@EXPORT` and omitted `mktime`, which broke **Astro::SunTime** (`Undefined subroutine &Astro::SunTime::mktime`).

`strftime` is also a common default export on core Perl and is implemented here, so it is included for the same compatibility reason.

## Testing

- `make`
- `./jcpan -t Astro::SunTime` (all tests pass)
