### PR TITLE
Fix Role::Basic nested eval runtime context

### DIFF
--- a/dev/modules/role_basic.md
+++ b/dev/modules/role_basic.md
@@ -1,6 +1,6 @@
 # Role::Basic (CPAN) on PerlOnJava
 
-Documentation-only deliverable: this file is the **plan** (symptom, bisection, hypothesized fix, verification). Landing the **`RuntimeCode` `EvalRuntimeContext` stack** (or another confirmed fix) is a **follow-up** change once `timeout 600 ./jcpan -t Role::Basic` passes.
+Implemented deliverable: `Role::Basic` passes under PerlOnJava after fixing nested eval runtime context handling in `RuntimeCode`.
 
 ## Acceptance
 
@@ -23,7 +23,7 @@ Upstream logic (simplified): after `eval "use $role $version"`, code does `retur
 - Bisection on a forked `Role/Basic.pm`: removing the stash preamble (`my $stash = do { no strict 'refs'; \%{"${role}::"} };` and related `%INC` logic) made jperl match stock perl — implicating **interaction** of that block with **nested compilation**, not `"\%{"${role}::"}"` vs `$role . '::'` alone (a minimal two-level reentrancy test with only interpolation can still pass).
 - Copying stash keys in `HashSpecialVariable.getStash` / `GlobalVariable.getGlobalHash` did **not** fix jcpan; treat as unrelated unless a future test proves otherwise.
 
-## Root cause (target fix)
+## Root Cause And Fix
 
 **Nested `eval STRING` compilation** uses a single `ThreadLocal` for `EvalRuntimeContext` in [`RuntimeCode.java`](../../src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java): inner `evalStringHelper` / `evalStringWithInterpreter` **overwrites** the context and the outer `finally` block calls **`remove()`**, dropping the outer eval’s context while outer compilation may still run (e.g. `use` during compile → nested `_load_role` → nested `eval`). That matches the BEGIN-alias cleanup comment in the same file about **recursive** eval corrupting globals.
 
@@ -35,6 +35,8 @@ Upstream logic (simplified): after `eval "use $role $version"`, code does `retur
 - `clearCaches()` → `evalRuntimeContextStack.remove()`  
 
 Apply consistently in both `evalStringHelper` and `evalStringWithInterpreter`.
+
+The passing implementation also tracks the BEGIN-package aliases installed for eval parsing and deactivates them when `saveAndClearEvalRuntimeContext()` is used around `require` / `do` compilation. The stack alone preserves the runtime context, but Role::Basic also needed those temporary aliases hidden while a `use $role` compile re-enters `_load_role`; otherwise the inner call retrieves and mutates the outer eval's `$role` scalar.
 
 ## Neutral regression tests
 
@@ -54,8 +56,27 @@ Apply consistently in both `evalStringHelper` and `evalStringWithInterpreter`.
 4. Branch from `master`, commit with [AI_POLICY.md](../AI_POLICY.md) attribution (`git commit -F file`).  
 5. Push and `gh pr create --body-file /tmp/pr_body.md` (never `--body` with inline backticks).
 
-## Progress
+## Progress Tracking
 
-| Date       | Status |
-|------------|--------|
-| 2026-05-08 | Plan documented in-repo (`role_basic.md` only). Runtime fix pending (jcpan still fails `t/exceptions.t` test 1 until verified). |
+### Current Status: Completed 2026-05-08
+
+### Completed Work
+
+- [x] Implemented eval runtime context stack in [`RuntimeCode.java`](../../src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java)
+- [x] Tracked eval BEGIN aliases so they can be temporarily hidden around nested module compilation
+- [x] Added neutral regression test [`eval_context_stack_reentrancy.t`](../../src/test/resources/unit/eval_context_stack_reentrancy.t)
+
+### Verification
+
+- `make` -> pass
+- `timeout 60 ./jperl src/test/resources/unit/eval_context_stack_reentrancy.t` -> pass
+- `timeout 600 ./jcpan -t Role::Basic` -> pass, 16 files / 304 tests
+
+### Next Steps
+
+1. Commit the fix on `fix/role-basic-eval-context-stack`.
+2. Open a PR with the verification above.
+
+### Open Questions
+
+- None.

--- a/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
+++ b/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
@@ -96,7 +96,7 @@ public class PerlLanguageProvider {
         // local variables in required modules to the eval's captured variables when
         // they share the same name (e.g., $caller in constant.pm vs $caller in eval scope).
         RuntimeCode.EvalRuntimeContext savedEvalRuntimeContext =
-                RuntimeCode.saveAndClearEvalRuntimeContext();
+                RuntimeCode.saveAndClearEvalRuntimeContextAndAliases();
 
         // Store the isMainProgram flag in CompilerOptions for use during code generation
         compilerOptions.isMainProgram = isTopLevelScript;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -699,9 +699,16 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             return null;
         }
         EvalRuntimeContext saved = stack.removeFirst();
-        deactivateEvalRuntimeAliases(saved);
         if (stack.isEmpty()) {
             evalRuntimeContextStack.remove();
+        }
+        return saved;
+    }
+
+    public static EvalRuntimeContext saveAndClearEvalRuntimeContextAndAliases() {
+        EvalRuntimeContext saved = saveAndClearEvalRuntimeContext();
+        if (saved != null) {
+            deactivateEvalRuntimeAliases(saved);
         }
         return saved;
     }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -78,7 +78,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     public static final boolean EVAL_TRACE =
             System.getenv("JPERL_EVAL_TRACE") != null;
     /**
-     * ThreadLocal storage for runtime values of captured variables during eval STRING compilation.
+     * ThreadLocal stack for runtime values of captured variables during eval STRING compilation.
      * <p>
      * PROBLEM: In perl5, BEGIN blocks inside eval STRING can access outer lexical variables' runtime values:
      * my @imports = qw(a b);
@@ -87,7 +87,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * In PerlOnJava, BEGIN blocks execute during parsing (before the eval class is instantiated),
      * so they couldn't access runtime values - they would see empty variables.
      * <p>
-     * SOLUTION: When evalStringHelper() is called, the runtime values are stored in this ThreadLocal.
+     * SOLUTION: When evalStringHelper() is called, the runtime values are pushed onto this ThreadLocal stack.
      * During parsing, when SpecialBlockParser sets up BEGIN blocks, it can access these runtime values
      * and use them to initialize the special globals that lexical variables become in BEGIN blocks.
      * <p>
@@ -97,10 +97,12 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * - runtimeValues: Object[] of captured variable values
      * - capturedEnv: String[] of captured variable names (matching array indices)
      * <p>
-     * Thread-safety: Each thread's eval compilation uses its own ThreadLocal storage, so parallel
-     * eval compilations don't interfere with each other.
+     * Thread-safety: Each thread's eval compilation uses its own ThreadLocal stack, so parallel
+     * eval compilations don't interfere with each other. A stack is required because eval STRING
+     * compilation can re-enter eval STRING compilation via BEGIN/use/require.
      */
-    private static final ThreadLocal<EvalRuntimeContext> evalRuntimeContext = new ThreadLocal<>();
+    private static final ThreadLocal<ArrayDeque<EvalRuntimeContext>> evalRuntimeContextStack =
+            ThreadLocal.withInitial(ArrayDeque::new);
     // Cache for memoization of evalStringHelper results
     private static final int CLASS_CACHE_SIZE = 100;
     private static final Map<String, Class<?>> evalCache = new LinkedHashMap<String, Class<?>>(CLASS_CACHE_SIZE, 0.75f, true) {
@@ -680,7 +682,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * @return The current eval runtime context, or null if not in eval STRING compilation
      */
     public static EvalRuntimeContext getEvalRuntimeContext() {
-        return evalRuntimeContext.get();
+        ArrayDeque<EvalRuntimeContext> stack = evalRuntimeContextStack.get();
+        return stack.isEmpty() ? null : stack.peekFirst();
     }
 
     /**
@@ -691,9 +694,14 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * @return The saved eval runtime context (may be null)
      */
     public static EvalRuntimeContext saveAndClearEvalRuntimeContext() {
-        EvalRuntimeContext saved = evalRuntimeContext.get();
-        if (saved != null) {
-            evalRuntimeContext.remove();
+        ArrayDeque<EvalRuntimeContext> stack = evalRuntimeContextStack.get();
+        if (stack.isEmpty()) {
+            return null;
+        }
+        EvalRuntimeContext saved = stack.removeFirst();
+        deactivateEvalRuntimeAliases(saved);
+        if (stack.isEmpty()) {
+            evalRuntimeContextStack.remove();
         }
         return saved;
     }
@@ -705,7 +713,79 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      */
     public static void restoreEvalRuntimeContext(EvalRuntimeContext saved) {
         if (saved != null) {
-            evalRuntimeContext.set(saved);
+            evalRuntimeContextStack.get().addFirst(saved);
+            reactivateEvalRuntimeAliases(saved);
+        }
+    }
+
+    private static void pushEvalRuntimeContext(EvalRuntimeContext context) {
+        evalRuntimeContextStack.get().addFirst(context);
+    }
+
+    private static void popEvalRuntimeContext(EvalRuntimeContext context) {
+        ArrayDeque<EvalRuntimeContext> stack = evalRuntimeContextStack.get();
+        if (!stack.isEmpty()) {
+            if (stack.peekFirst() == context) {
+                stack.removeFirst();
+            } else {
+                for (Iterator<EvalRuntimeContext> it = stack.iterator(); it.hasNext(); ) {
+                    if (it.next() == context) {
+                        it.remove();
+                        break;
+                    }
+                }
+            }
+        }
+        if (stack.isEmpty()) {
+            evalRuntimeContextStack.remove();
+        }
+    }
+
+    private static void registerEvalRuntimeAlias(EvalRuntimeContext context, char sigil, String fullName, RuntimeBase value) {
+        context.aliases().add(new EvalRuntimeAlias(sigil, fullName, value));
+    }
+
+    private static void deactivateEvalRuntimeAliases(EvalRuntimeContext context) {
+        for (EvalRuntimeAlias alias : context.aliases()) {
+            if (!alias.active) {
+                continue;
+            }
+            switch (alias.sigil) {
+                case '$' -> {
+                    if (GlobalVariable.globalVariables.get(alias.fullName) == alias.value) {
+                        GlobalVariable.globalVariables.remove(alias.fullName);
+                    }
+                }
+                case '@' -> {
+                    if (GlobalVariable.globalArrays.get(alias.fullName) == alias.value) {
+                        GlobalVariable.globalArrays.remove(alias.fullName);
+                    }
+                }
+                case '%' -> {
+                    if (GlobalVariable.globalHashes.get(alias.fullName) == alias.value) {
+                        GlobalVariable.globalHashes.remove(alias.fullName);
+                    }
+                }
+            }
+            alias.active = false;
+        }
+    }
+
+    private static void reactivateEvalRuntimeAliases(EvalRuntimeContext context) {
+        for (EvalRuntimeAlias alias : context.aliases()) {
+            if (alias.active) {
+                continue;
+            }
+            boolean installed = switch (alias.sigil) {
+                case '$' -> alias.value instanceof RuntimeScalar scalar
+                        && GlobalVariable.globalVariables.putIfAbsent(alias.fullName, scalar) == null;
+                case '@' -> alias.value instanceof RuntimeArray array
+                        && GlobalVariable.globalArrays.putIfAbsent(alias.fullName, array) == null;
+                case '%' -> alias.value instanceof RuntimeHash hash
+                        && GlobalVariable.globalHashes.putIfAbsent(alias.fullName, hash) == null;
+                default -> false;
+            };
+            alias.active = installed;
         }
     }
 
@@ -726,7 +806,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         anonSubs.clear();
         interpretedSubs.clear();
         evalContext.clear();
-        evalRuntimeContext.remove();
+        evalRuntimeContextStack.remove();
     }
 
     public static void copy(RuntimeCode code, RuntimeCode codeFrom) {
@@ -814,7 +894,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 ctx.capturedEnv,  // Variable names in same order as runtimeValues
                 evalTag
         );
-        evalRuntimeContext.set(runtimeCtx);
+        pushEvalRuntimeContext(runtimeCtx);
 
         try {
             // Check if the eval string contains non-ASCII characters
@@ -925,7 +1005,6 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             // We create: globalArrays["BEGIN_PKG_x::@arr"] = (the runtime @arr object)
             // Then when "say @arr" is parsed in the BEGIN, it resolves to BEGIN_PKG_x::@arr
             // which is aliased to the runtime array with values (a, b).
-            List<String> evalAliasKeys = new ArrayList<>();
             Map<Integer, SymbolTable.SymbolEntry> capturedVars = capturedSymbolTable.getAllVisibleVariables();
             for (SymbolTable.SymbolEntry entry : capturedVars.values()) {
                 if (!entry.name().equals("@_") && !entry.decl().isEmpty() && !entry.name().startsWith("&")) {
@@ -964,7 +1043,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                                     }
                                 }
                                 if (installed) {
-                                    evalAliasKeys.add(entry.name().charAt(0) + fullName);
+                                    registerEvalRuntimeAlias(runtimeCtx, entry.name().charAt(0), fullName, (RuntimeBase) runtimeValue);
                                 }
                             }
                         }
@@ -1103,14 +1182,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 // if a recursive call re-enters the same function and its `my` declaration
                 // calls retrieveBeginScalar, finding the stale alias instead of creating
                 // a fresh variable.
-                for (String key : evalAliasKeys) {
-                    String fullName = key.substring(1);
-                    switch (key.charAt(0)) {
-                        case '$' -> GlobalVariable.globalVariables.remove(fullName);
-                        case '@' -> GlobalVariable.globalArrays.remove(fullName);
-                        case '%' -> GlobalVariable.globalHashes.remove(fullName);
-                    }
-                }
+                deactivateEvalRuntimeAliases(runtimeCtx);
+                runtimeCtx.aliases().clear();
 
                 // Store source lines in symbol table if $^P flags are set
                 // Do this on both success and failure paths when flags require retention
@@ -1132,11 +1205,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             // This MUST be in the outer finally to handle both cache hits and compilation paths.
             setCurrentScope(savedCurrentScope);
 
-            // Clean up ThreadLocal to prevent memory leaks
-            // IMPORTANT: Always clean up ThreadLocal in finally block to ensure it's removed
-            // even if compilation fails. Failure to do so could cause memory leaks in
-            // long-running applications with thread pools.
-            evalRuntimeContext.remove();
+            // Clean up this eval's ThreadLocal stack entry to prevent memory leaks.
+            // IMPORTANT: Always pop in the finally block even if compilation fails.
+            popEvalRuntimeContext(runtimeCtx);
         }
     }
 
@@ -1302,7 +1373,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 ctx.capturedEnv,
                 evalTag
         );
-        evalRuntimeContext.set(runtimeCtx);
+        pushEvalRuntimeContext(runtimeCtx);
 
         InterpretedCode interpretedCode = null;
         RuntimeList result;
@@ -1310,7 +1381,6 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         // Declare these outside try block so they're accessible in finally block for debugger support
         Node ast = null;
         List<LexerToken> tokens = null;
-        List<String> evalAliasKeys = new ArrayList<>();
 
         // Save dynamic variable level to restore after eval.
         // IMPORTANT: Scope InterpreterState.currentPackage around eval execution.
@@ -1401,7 +1471,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                                     }
                                 }
                                 if (installed) {
-                                    evalAliasKeys.add(entry.name().charAt(0) + fullName);
+                                    registerEvalRuntimeAlias(runtimeCtx, entry.name().charAt(0), fullName, (RuntimeBase) runtimeValue);
                                 }
                             }
                         }
@@ -1586,15 +1656,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             // GlobalVariable during execution, a recursive call that re-enters the same
             // function would find the alias via retrieveBeginScalar, sharing the same
             // RuntimeScalar object instead of creating a fresh one.
-            for (String key : evalAliasKeys) {
-                String fullName = key.substring(1);
-                switch (key.charAt(0)) {
-                    case '$' -> GlobalVariable.globalVariables.remove(fullName);
-                    case '@' -> GlobalVariable.globalArrays.remove(fullName);
-                    case '%' -> GlobalVariable.globalHashes.remove(fullName);
-                }
-            }
-            evalAliasKeys.clear();
+            deactivateEvalRuntimeAliases(runtimeCtx);
+            runtimeCtx.aliases().clear();
 
             // Execute the interpreted code
             // Track eval depth for $^S support
@@ -1678,8 +1741,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 storeSourceLines(code.toString(), evalFilename, ast, tokens);
             }
 
-            // Clean up ThreadLocal
-            evalRuntimeContext.remove();
+            // Clean up this eval's ThreadLocal stack entry.
+            popEvalRuntimeContext(runtimeCtx);
         }
     }
 
@@ -3939,34 +4002,55 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     /**
-         * Container for runtime context during eval STRING compilation.
-         * Holds both the runtime values and variable names so SpecialBlockParser can
-         * match variables to their values.
-         */
-        public record EvalRuntimeContext(Object[] runtimeValues, String[] capturedEnv, String evalTag) {
+     * Tracks one temporary BEGIN-package alias installed for eval STRING parsing.
+     */
+    public static final class EvalRuntimeAlias {
+        final char sigil;
+        final String fullName;
+        final RuntimeBase value;
+        boolean active = true;
+
+        EvalRuntimeAlias(char sigil, String fullName, RuntimeBase value) {
+            this.sigil = sigil;
+            this.fullName = fullName;
+            this.value = value;
+        }
+    }
+
+    /**
+     * Container for runtime context during eval STRING compilation.
+     * Holds both the runtime values and variable names so SpecialBlockParser can
+     * match variables to their values.
+     */
+    public record EvalRuntimeContext(Object[] runtimeValues, String[] capturedEnv, String evalTag,
+                                     List<EvalRuntimeAlias> aliases) {
+
+        public EvalRuntimeContext(Object[] runtimeValues, String[] capturedEnv, String evalTag) {
+            this(runtimeValues, capturedEnv, evalTag, new ArrayList<>());
+        }
 
         /**
-             * Get the runtime value for a variable by name.
-             * <p>
-             * IMPORTANT: The capturedEnv array includes all variables (including 'this', '@_', 'wantarray'),
-             * but runtimeValues array skips the first skipVariables (currently 3).
-             * So if @imports is at capturedEnv[5], its value is at runtimeValues[5-3=2].
-             *
-             * @param varName The variable name (e.g., "@imports", "$scalar")
-             * @return The runtime value, or null if not found
-             */
-            public Object getRuntimeValue(String varName) {
-                int skipVariables = 3; // 'this', '@_', 'wantarray'
-                for (int i = skipVariables; i < capturedEnv.length; i++) {
-                    if (varName.equals(capturedEnv[i])) {
-                        int runtimeIndex = i - skipVariables;
-                        if (runtimeIndex >= 0 && runtimeIndex < runtimeValues.length) {
-                            return runtimeValues[runtimeIndex];
-                        }
+         * Get the runtime value for a variable by name.
+         * <p>
+         * IMPORTANT: The capturedEnv array includes all variables (including 'this', '@_', 'wantarray'),
+         * but runtimeValues array skips the first skipVariables (currently 3).
+         * So if @imports is at capturedEnv[5], its value is at runtimeValues[5-3=2].
+         *
+         * @param varName The variable name (e.g., "@imports", "$scalar")
+         * @return The runtime value, or null if not found
+         */
+        public Object getRuntimeValue(String varName) {
+            int skipVariables = 3; // 'this', '@_', 'wantarray'
+            for (int i = skipVariables; i < capturedEnv.length; i++) {
+                if (varName.equals(capturedEnv[i])) {
+                    int runtimeIndex = i - skipVariables;
+                    if (runtimeIndex >= 0 && runtimeIndex < runtimeValues.length) {
+                        return runtimeValues[runtimeIndex];
                     }
                 }
-                return null;
             }
+            return null;
         }
+    }
 
 }

--- a/src/test/resources/unit/eval_context_stack_reentrancy.t
+++ b/src/test/resources/unit/eval_context_stack_reentrancy.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 2;
+use Test::More tests => 3;
 use File::Path qw(make_path);
 
 BEGIN {
@@ -121,3 +121,13 @@ like(
     "after eval role=[$EvalContextStackRepro::Registry::AFTER_EVAL_ROLE], "
       . "early return role=[$EvalContextStackRepro::Registry::EARLY_RETURN_ROLE]"
 );
+
+my @begin_seen;
+eval q{
+    BEGIN { @begin_seen = map { $_ => eval { die } || -1 } qw(ABC XYZ); }
+};
+is(
+    "@begin_seen",
+    "ABC -1 XYZ -1",
+    'BEGIN execution keeps eval lexical aliases visible'
+) or diag $@;

--- a/src/test/resources/unit/eval_context_stack_reentrancy.t
+++ b/src/test/resources/unit/eval_context_stack_reentrancy.t
@@ -1,0 +1,123 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+use File::Path qw(make_path);
+
+BEGIN {
+    $INC{'EvalContextStackRepro/Registry.pm'} = __FILE__;
+}
+
+package EvalContextStackRepro::Registry;
+
+use strict;
+use warnings;
+use Carp ();
+
+my %IS_ROLE;
+our ( $AFTER_EVAL_ROLE, $EARLY_RETURN_ROLE );
+
+sub import {
+    my $class  = shift;
+    my $target = caller;
+
+    if ( @_ == 1 && $_[0] eq 'with' ) {
+        no strict 'refs';
+        *{ $target . '::with' } = sub {
+            $class->apply_roles_to_package( $target, @_ );
+        };
+        return;
+    }
+
+    $class->_declare_role($target);
+}
+
+sub _declare_role {
+    my ( $class, $target ) = @_;
+    $IS_ROLE{$target} = 1;
+    no strict 'refs';
+    *{ $target . '::requires' } = sub { return };
+}
+
+sub apply_roles_to_package {
+    my ( $class, $target, @roles ) = @_;
+    $class->_load_role($_) for @roles;
+}
+
+sub _load_role {
+    my ( $class, $role, $version ) = @_;
+
+    $version ||= '';
+    my $stash = do { no strict 'refs'; \%{"${role}::"} };
+    if ( exists $stash->{requires} ) {
+        my $package = $role;
+        $package =~ s{::}{/}g;
+        $package .= '.pm';
+        $INC{$package} ||= "added to inc by $class";
+    }
+
+    eval "use $role $version";
+    Carp::confess($@) if $@;
+
+    $AFTER_EVAL_ROLE = $role;
+    if ( $IS_ROLE{$role} ) {
+        $EARLY_RETURN_ROLE = $role;
+        return 1;
+    }
+
+    my $requires = $role->can('requires');
+    if ( !$requires ) {
+        Carp::confess(
+            "Only roles defined with $class may be loaded with _load_role. '$role' is not allowed."
+        );
+    }
+
+    $IS_ROLE{$role} = 1;
+    return 1;
+}
+
+package main;
+
+sub write_file {
+    my ( $path, $body ) = @_;
+    open my $fh, '>', $path or die "open $path: $!";
+    print {$fh} $body or die "write $path: $!";
+    close $fh or die "close $path: $!";
+}
+
+my $root = "/tmp/perlonjava-eval-context-stack-$$";
+my $lib  = "$root/lib";
+make_path("$lib/EvalContextStackRepro");
+unshift @INC, $lib;
+
+write_file(
+    "$lib/EvalContextStackRepro/Plugin.pm",
+    <<'PLUGIN'
+package EvalContextStackRepro::Plugin;
+use EvalContextStackRepro::Registry;
+1;
+PLUGIN
+);
+
+write_file(
+    "$lib/EvalContextStackRepro/Host.pm",
+    <<'HOST'
+package EvalContextStackRepro::Host;
+use EvalContextStackRepro::Registry 'with';
+with 'EvalContextStackRepro::Plugin';
+sub required_method {}
+1;
+HOST
+);
+
+eval { EvalContextStackRepro::Registry->_load_role('EvalContextStackRepro::Plugin') };
+ok( !$@, 'loading a marked package succeeds' ) or diag $@;
+
+eval { EvalContextStackRepro::Registry->_load_role('EvalContextStackRepro::Host') };
+like(
+    $@,
+    qr/Only roles defined with EvalContextStackRepro::Registry may be loaded/,
+    'outer eval role name survives nested eval use'
+) or diag(
+    "after eval role=[$EvalContextStackRepro::Registry::AFTER_EVAL_ROLE], "
+      . "early return role=[$EvalContextStackRepro::Registry::EARLY_RETURN_ROLE]"
+);


### PR DESCRIPTION
## Summary

- Preserve nested eval STRING runtime contexts with a per-thread stack
- Track and temporarily hide eval BEGIN-package aliases around nested require/do compilation
- Add a Role::Basic-shaped regression test and update the module implementation notes

## Verification

- `make`
- `timeout 60 ./jperl src/test/resources/unit/eval_context_stack_reentrancy.t`
- `timeout 600 ./jcpan -t Role::Basic`

Generated with [Codex](https://openai.com/codex)
