### PR TITLE
Fix rand scalar context for Randomize

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -970,8 +970,9 @@ public class CompileOperator {
             }
             case "rand" -> {
                 int rd = bytecodeCompiler.allocateOutputRegister();
-                if (node.operand != null) {
-                    node.operand.accept(bytecodeCompiler);
+                if (node.operand != null
+                        && !(node.operand instanceof ListNode listNode && listNode.elements.isEmpty())) {
+                    compileScalarOperand(bytecodeCompiler, node, "rand");
                     int maxReg = bytecodeCompiler.lastResultReg;
                     bytecodeCompiler.emit(Opcodes.RAND);
                     bytecodeCompiler.emitReg(rd);

--- a/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
@@ -1003,7 +1003,7 @@ public class InlineOpcodeHandler {
         int rd = bytecode[pc++];
         int maxReg = bytecode[pc++];
 
-        RuntimeScalar max = (RuntimeScalar) registers[maxReg];
+        RuntimeScalar max = registers[maxReg].scalar();
         registers[rd] = Random.rand(max);
         return pc;
     }

--- a/src/test/resources/unit/rand_scalar_context.t
+++ b/src/test/resources/unit/rand_scalar_context.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+my @values = qw(a b c d);
+my $limit = rand @values;
+ok($limit >= 0 && $limit < @values, 'rand uses array argument in scalar context');
+
+my $aref = [qw(a b c d)];
+my $picked = $aref->[rand @$aref];
+my $found = grep { $_ eq $picked } @$aref;
+ok($found, 'rand uses array dereference argument in scalar context');
+
+my $code = q{
+    sub {
+        my %retval = @_;
+        my $stuff;
+        $stuff = ["aaa".."aaj"];
+        $retval{Alpha} ||= $stuff->[rand @$stuff];
+        return \%retval;
+    }
+};
+
+my $generate = eval $code;
+ok($generate, 'eval-generated sub with rand array dereference compiles');
+
+my $thing = $generate->();
+like($thing->{Alpha}, qr/^aa[a-j]$/, 'eval-generated rand array dereference returns an element');


### PR DESCRIPTION
## Summary

- Compile bytecode `rand` operands in scalar context so `rand @$array_ref` uses the array length
- Scalarize the interpreter RAND opcode input defensively for eval-generated bytecode
- Add regression coverage for the Randomize eval-generated sub failure path

## Tests

- `make`
- `timeout 60 ./jperl src/test/resources/unit/rand_scalar_context.t`
- `timeout 600 ./jcpan -t Randomize`

Note: Randomize still prints legacy `not ok 46-50` lines from raw Data::Dumper hash-key ordering comparisons, but its CPAN `make test` exits OK. Native Perl shows the same brittle ordering issue.
