### PR TITLE
Fix Class::Tiny jcpan tests

### DIFF
--- a/src/main/java/org/perlonjava/runtime/operators/ListOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ListOperators.java
@@ -45,6 +45,9 @@ public class ListOperators {
         List<RuntimeBase> transformedElements = new ArrayList<>();
 
         RuntimeScalar saveValue = getGlobalVariable("main::_");
+        // Map results are captured by the caller after the operator returns;
+        // flushing between iterations can destroy blessed return values early.
+        boolean wasFlushing = MortalList.suppressFlush(true);
 
         try {
             // Use the outer @_ instead of an empty array
@@ -87,6 +90,7 @@ public class ListOperators {
                 return transformedList;
             }
         } finally {
+            MortalList.suppressFlush(wasFlushing);
             GlobalVariable.aliasGlobalVariable("main::_", saveValue);
             releaseEphemeralCaptures(perlMapClosure);
         }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Subs.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Subs.java
@@ -19,6 +19,7 @@ public class Subs extends PerlModuleBase {
     public static void initialize() {
         Subs subs = new Subs();
         try {
+            GlobalVariable.getGlobalVariable("subs::VERSION").set(new RuntimeScalar("1.04"));
             subs.registerMethod("import", "importSubs", ";$");
             subs.registerMethod("mark_overridable", "markOverridable", "$$");
         } catch (NoSuchMethodException e) {
@@ -45,7 +46,10 @@ public class Subs extends PerlModuleBase {
         for (RuntimeScalar variableObj : args.elements) {
             String variableString = variableObj.toString();
             String fullName = caller + "::" + variableString;
-            GlobalVariable.getGlobalCodeRef(fullName);
+            RuntimeScalar codeRef = GlobalVariable.getGlobalCodeRef(fullName);
+            if (codeRef.value instanceof RuntimeCode code) {
+                code.isDeclared = true;
+            }
             GlobalVariable.isSubs.put(fullName, true);
         }
 

--- a/src/main/perl/lib/subs.pm
+++ b/src/main/perl/lib/subs.pm
@@ -1,0 +1,37 @@
+package subs;
+
+use strict;
+use warnings;
+
+our $VERSION = '1.04';
+
+sub import {
+    my $callpack = caller;
+    shift;
+
+    for my $sym (@_) {
+        no strict 'refs';
+        *{"${callpack}::$sym"} = \&{"${callpack}::$sym"};
+    }
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+subs - Perl pragma to predeclare subroutine names
+
+=head1 SYNOPSIS
+
+    use subs qw(foo bar);
+
+=head1 DESCRIPTION
+
+Predeclares package subroutine names by creating CODE slots in the caller's
+stash.  This matches the core pragma behavior used by modules that want to
+install generated methods only when a custom method has not already been
+declared.
+
+=cut

--- a/src/test/resources/unit/refcount/map_return_destroy.t
+++ b/src/test/resources/unit/refcount/map_return_destroy.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+    package MapReturnDestroy;
+    our $counter = 0;
+    sub new {
+        my $class = shift;
+        my $self = bless {}, $class;
+        $counter++;
+        return $self;
+    }
+    sub DESTROY {
+        $counter-- if $counter > 0;
+    }
+}
+
+my @objs = map { MapReturnDestroy->new } 1 .. 3;
+is($MapReturnDestroy::counter, 3, "map-returned objects survive until caller captures list");
+
+@objs = ();
+is($MapReturnDestroy::counter, 0, "map-returned objects are destroyed when array is cleared");
+
+done_testing;

--- a/src/test/resources/unit/subs_pragma.t
+++ b/src/test/resources/unit/subs_pragma.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Test::More;
+
+our @warnings;
+BEGIN { $SIG{__WARN__} = sub { push @main::warnings, @_ } }
+
+{
+    package SubsPragmaCustom;
+    use strict;
+    use warnings;
+
+    use subs qw(foo);
+
+    BEGIN {
+        no strict 'refs';
+        *{"SubsPragmaCustom::foo"} = sub { "generated" }
+            unless *{"SubsPragmaCustom::foo"}{CODE};
+    }
+
+    sub foo { "custom" }
+}
+
+is(SubsPragmaCustom::foo(), "custom", "predeclared sub can be custom-defined later");
+{
+    no strict 'refs';
+    ok(*{"SubsPragmaCustom::foo"}{CODE}, "predeclared sub has a visible CODE slot");
+}
+is_deeply(\@warnings, [], "predeclared custom sub does not warn as redefined");
+
+done_testing;


### PR DESCRIPTION
## Summary

- implement the bundled `subs` pragma version/declaration behavior that Class::Tiny uses for custom accessors
- prevent `map` from flushing mortal blessed return values before the caller captures the result list
- add focused regressions for `use subs` predeclarations and `map { Class->new }` destructor lifetime

## Verification

- `make`
- `timeout 600 ./jcpan -t Class::Tiny`

Generated with [Codex](https://openai.com/codex)
