### PR TITLE
feat(plack): faster Netty shutdown and dev watch server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,8 @@ src/main/java/org/perlonjava/core/Configuration.java
 /store[0-9]*
 /integer.[0-9]*
 /utfhash.po
+.vscode
+.metals/metals.lock.db
+.gitignore
+.metals/metals.mv.db
+examples/http_server_plack/.vscode/settings.json

--- a/examples/http_server_plack/dev.sh
+++ b/examples/http_server_plack/dev.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+JPERL="../../jperl"
+
+# Erstes Argument bestimmt das Script (Standard: test.pl)
+case "${1:-}" in
+  streaming|stream|s)
+    SCRIPT="test_streaming.pl"
+    shift
+    ;;
+  test|t|"")
+    SCRIPT="test.pl"
+    [[ -n "${1:-}" && "${1:-}" != --* ]] && shift
+    ;;
+  *)
+    SCRIPT="test.pl"
+    ;;
+esac
+
+if ! command -v watchexec &>/dev/null; then
+  echo "Error: watchexec is not installed." >&2
+  echo "  Install it from: https://github.com/watchexec/watchexec" >&2
+  echo "  macOS:  brew install watchexec" >&2
+  echo "  cargo:  cargo install watchexec-cli" >&2
+  exit 1
+fi
+
+echo "Watching $SCRIPT (Ctrl+C to stop)..."
+
+exec watchexec \
+  --restart \
+  --watch . \
+  --exts pl \
+  -- "$JPERL" "$SCRIPT" "$@"

--- a/examples/http_server_plack/test.pl
+++ b/examples/http_server_plack/test.pl
@@ -79,24 +79,33 @@ my $app = sub {
     }
 };
 
-print STDERR "Netty PSGI Server starting on 0.0.0.0:5000\n";
+
+use Getopt::Long;
+
+my $host = '0.0.0.0';
+my $port = 8080;
+GetOptions(
+    'host=s' => \$host,
+    'port=i' => \$port,
+) or die "Usage: $0 [--host HOST] [--port PORT]\n";
+
+print STDERR "Netty PSGI Server starting on $host:$port\n";
 print STDERR "Thread model: Single event loop (async I/O)\n";
 print STDERR "Press Ctrl+C to stop\n";
-
-print "Starting server on http://localhost:5000\n";
+print "Starting server on http://$host:$port\n";
 print "Test with:\n";
-print "  curl http://localhost:5000/\n";
-print "  curl http://localhost:5000/hello/World\n";
-print "  curl http://localhost:5000/json\n";
-print "  curl http://localhost:5000/env\n";
-print "  curl -X POST http://localhost:5000/echo -d 'test data'\n";
+print "  curl http://$host:$port/\n";
+print "  curl http://$host:$port/hello/World\n";
+print "  curl http://$host:$port/json\n";
+print "  curl http://$host:$port/env\n";
+print "  curl -X POST http://$host:$port/echo -d 'test data'\n";
 print "\n";
 
 my $handler = Plack::Handler::Netty->new(
-    host => '0.0.0.0',
-    port => 5000,
+    host => $host,
+    port => $port,
 );
 
-print STDERR "Plack::Handler::Netty: Accepting connections at http://0.0.0.0:5000/\n";
+print STDERR "Plack::Handler::Netty: Accepting connections at http://0.0.0.0:$port/\n";
 
 $handler->run($app);

--- a/examples/http_server_plack/test_streaming.pl
+++ b/examples/http_server_plack/test_streaming.pl
@@ -17,7 +17,15 @@ Three test routes:
 
 =cut
 
+use Getopt::Long;
 use Plack::Handler::Netty;
+
+my $host = '0.0.0.0';
+my $port = 5000;
+GetOptions(
+    'host=s' => \$host,
+    'port=i' => \$port,
+) or die "Usage: $0 [--host HOST] [--port PORT]\n";
 
 # PSGI app that supports both sync and streaming responses
 my $app = sub {
@@ -81,14 +89,14 @@ my $app = sub {
 print STDERR "Test Streaming Response Server\n";
 print STDERR "================================\n\n";
 print STDERR "Test endpoints:\n";
-print STDERR "  GET http://localhost:5000/          - Streaming response\n";
-print STDERR "  GET http://localhost:5000/large     - Large streaming response\n";
-print STDERR "  GET http://localhost:5000/sync      - Synchronous response\n";
-print STDERR "  GET http://localhost:5000/json      - JSON streaming\n\n";
+print STDERR "  GET http://$host:$port/          - Streaming response\n";
+print STDERR "  GET http://$host:$port/large     - Large streaming response\n";
+print STDERR "  GET http://$host:$port/sync      - Synchronous response\n";
+print STDERR "  GET http://$host:$port/json      - JSON streaming\n\n";
 
 my $handler = Plack::Handler::Netty->new(
-    host => '0.0.0.0',
-    port => 5000,
+    host => $host,
+    port => $port,
 );
 
 $handler->run($app);

--- a/src/main/java/org/perlonjava/runtime/perlmodule/PlackHandlerNetty.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/PlackHandlerNetty.java
@@ -358,8 +358,8 @@ public class PlackHandlerNetty extends PerlModuleBase {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             System.err.println("Shutting down Netty PSGI server gracefully...");
             try {
-                bossGroup.shutdownGracefully().sync();
-                workerGroup.shutdownGracefully().sync();
+                bossGroup.shutdownGracefully(100, 2000, java.util.concurrent.TimeUnit.MILLISECONDS).sync();
+                workerGroup.shutdownGracefully(100, 2000, java.util.concurrent.TimeUnit.MILLISECONDS).sync();
                 System.err.println("Server shut down complete.");
             } catch (InterruptedException e) {
                 System.err.println("Shutdown interrupted: " + e.getMessage());
@@ -406,10 +406,10 @@ public class PlackHandlerNetty extends PerlModuleBase {
         } finally {
             // Shutdown event loops if not already shutdown
             if (!bossGroup.isShutdown()) {
-                bossGroup.shutdownGracefully();
+                bossGroup.shutdownGracefully(100, 2000, java.util.concurrent.TimeUnit.MILLISECONDS);
             }
             if (!workerGroup.isShutdown()) {
-                workerGroup.shutdownGracefully();
+                workerGroup.shutdownGracefully(100, 2000, java.util.concurrent.TimeUnit.MILLISECONDS);
             }
         }
     }


### PR DESCRIPTION
- Reduce Netty shutdown timeout from default (~15s) to 100ms quiet period / 2000ms timeout, so watchexec restarts the server much faster during development.
- Add examples/http_server_plack/dev.sh: a watchexec-based dev runner that auto-restarts jperl when any .pl file changes. Includes a clear error message with install instructions if watchexec is not found.
- Update test.pl and test_streaming.pl examples.