### PR TITLE
fix: CPAN bzip2 handles, Net::hostent, CORE prototype shadowing

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/CoreOperatorResolver.java
+++ b/src/main/java/org/perlonjava/frontend/parser/CoreOperatorResolver.java
@@ -138,17 +138,20 @@ public class CoreOperatorResolver {
         String operator = token.text;
         String fq = parser.ctx.symbolTable.getCurrentPackage() + "::" + operator;
 
+        String coreProto = CORE_PROTOTYPES.get(operator);
         boolean packageSubOverrides = false;
-        String prototype = CORE_PROTOTYPES.get(operator);
+        String prototype = coreProto;
 
-        // A defined subroutine in the current package shadows CORE for compile-time
-        // prototype checking only when:
-        // (1) Perl has a CORE keyword with that name (CORE_PROTOTYPES contains it),
-        // (2) the package CV has an explicit prototype (e.g. Net::hostent's
-        //     gethostbyaddr ($;$) vs CORE's $$).
-        // Without (1), names like Exporter::export or constants like IS_WIN32 would
-        // wrongly go through this path when they carry an empty prototype "()", etc.
-        if (CORE_PROTOTYPES.containsKey(operator)
+        // Shadow CORE's compile-time prototype only for builtins that *have* a CORE
+        // prototype string (e.g. gethostbyaddr $$). Keywords listed under CORE_PROTOTYPES
+        // with a null entry (INIT, chomp, delete, …) are parsed/styled specially; a
+        // package subroutine or constant with the same name (use constant INIT => 5; sub
+        // INIT { }) must still resolve via SubroutineParser, not as OperatorNode — otherwise
+        // we emit bogus core ops ("INIT doesn't have JVM descriptor").
+        //
+        // When coreProto != null, a defined package CV with an explicit prototype overrides
+        // arity checking (Net::hostent gethostbyaddr ($;$) vs CORE $$).
+        if (coreProto != null
                 && GlobalVariable.existsGlobalCodeRef(fq)) {
             RuntimeScalar ref = GlobalVariable.getGlobalCodeRef(fq);
             if (ref.type == RuntimeScalarType.CODE && ref.value instanceof RuntimeCode code && code.defined()
@@ -158,8 +161,7 @@ public class CoreOperatorResolver {
             }
         }
 
-        boolean coreUsesPrototypeParsing =
-                CORE_PROTOTYPES.containsKey(operator) && CORE_PROTOTYPES.get(operator) != null;
+        boolean coreUsesPrototypeParsing = coreProto != null;
         if (!packageSubOverrides && !coreUsesPrototypeParsing) {
             return null;
         }

--- a/src/main/java/org/perlonjava/frontend/parser/CoreOperatorResolver.java
+++ b/src/main/java/org/perlonjava/frontend/parser/CoreOperatorResolver.java
@@ -5,7 +5,11 @@ import org.perlonjava.app.cli.CompilerOptions;
 import org.perlonjava.frontend.astnode.*;
 import org.perlonjava.frontend.lexer.LexerToken;
 import org.perlonjava.frontend.lexer.LexerTokenType;
+import org.perlonjava.runtime.runtimetypes.GlobalVariable;
 import org.perlonjava.runtime.runtimetypes.PerlJavaUnimplementedException;
+import org.perlonjava.runtime.runtimetypes.RuntimeCode;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalarType;
 
 import static org.perlonjava.frontend.parser.ParserTables.CORE_PROTOTYPES;
 import static org.perlonjava.frontend.parser.PrototypeArgs.consumeArgsWithPrototype;
@@ -132,22 +136,46 @@ public class CoreOperatorResolver {
 
     private static Node parseWithPrototype(Parser parser, LexerToken token, int currentIndex) {
         String operator = token.text;
+        String fq = parser.ctx.symbolTable.getCurrentPackage() + "::" + operator;
+
+        boolean packageSubOverrides = false;
         String prototype = CORE_PROTOTYPES.get(operator);
 
-        if (prototype != null) {
-            if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("CORE operator " + operator + " with prototype " + prototype);
-            // Set the operator name as the subroutine name for better error messages
-            String previousSubName = parser.ctx.symbolTable.getCurrentSubroutine();
-            parser.ctx.symbolTable.setCurrentSubroutine(operator);
-            try {
-                ListNode arguments = consumeArgsWithPrototype(parser, prototype);
-                return new OperatorNode(operator, arguments, currentIndex);
-            } finally {
-                // Restore the previous subroutine name
-                parser.ctx.symbolTable.setCurrentSubroutine(previousSubName);
+        // A defined subroutine in the current package shadows CORE for compile-time
+        // prototype checking only when:
+        // (1) Perl has a CORE keyword with that name (CORE_PROTOTYPES contains it),
+        // (2) the package CV has an explicit prototype (e.g. Net::hostent's
+        //     gethostbyaddr ($;$) vs CORE's $$).
+        // Without (1), names like Exporter::export or constants like IS_WIN32 would
+        // wrongly go through this path when they carry an empty prototype "()", etc.
+        if (CORE_PROTOTYPES.containsKey(operator)
+                && GlobalVariable.existsGlobalCodeRef(fq)) {
+            RuntimeScalar ref = GlobalVariable.getGlobalCodeRef(fq);
+            if (ref.type == RuntimeScalarType.CODE && ref.value instanceof RuntimeCode code && code.defined()
+                    && code.prototype != null) {
+                packageSubOverrides = true;
+                prototype = code.prototype;
             }
         }
-        return null;
+
+        boolean coreUsesPrototypeParsing =
+                CORE_PROTOTYPES.containsKey(operator) && CORE_PROTOTYPES.get(operator) != null;
+        if (!packageSubOverrides && !coreUsesPrototypeParsing) {
+            return null;
+        }
+
+        if (CompilerOptions.DEBUG_ENABLED) {
+            parser.ctx.logDebug("operator " + operator + " with prototype " + prototype
+                    + (packageSubOverrides ? " (package sub)" : " (CORE)"));
+        }
+        String previousSubName = parser.ctx.symbolTable.getCurrentSubroutine();
+        parser.ctx.symbolTable.setCurrentSubroutine(operator);
+        try {
+            ListNode arguments = consumeArgsWithPrototype(parser, prototype);
+            return new OperatorNode(operator, arguments, currentIndex);
+        } finally {
+            parser.ctx.symbolTable.setCurrentSubroutine(previousSubName);
+        }
     }
 
     private static void handleEmptyParentheses(Parser parser) {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/CompressBzip2BzFile.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/CompressBzip2BzFile.java
@@ -13,7 +13,10 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarUndef
  * bzeof / bzclose / bzerror methods, matching the OO API of the upstream
  * Compress::Bzip2 CPAN module.
  *
- * <p>Mirrors the pattern of {@link CompressZlibGzFile} for consistency.
+ * <p>Mirrors the pattern of {@link CompressZlibGzFile} for consistency. The
+ * {@code gz*} names match upstream Compress::Bzip2 (Zlib compatibility) and
+ * {@code CPAN::Tarzip}, which call {@code gzread} / {@code gzclose} on bzip2
+ * handles.
  */
 public class CompressBzip2BzFile extends PerlModuleBase {
 
@@ -33,6 +36,13 @@ public class CompressBzip2BzFile extends PerlModuleBase {
             bz.registerMethod("bzeof", null);
             bz.registerMethod("bzclose", null);
             bz.registerMethod("bzerror", null);
+            // Compress::Zlib-compatible aliases (used by CPAN::Tarzip for .bz2 handles)
+            bz.registerMethod("gzread", "bzread", null);
+            bz.registerMethod("gzwrite", "bzwrite", null);
+            bz.registerMethod("gzreadline", "bzreadline", null);
+            bz.registerMethod("gzeof", "bzeof", null);
+            bz.registerMethod("gzclose", "bzclose", null);
+            bz.registerMethod("gzerror", "bzerror", null);
         } catch (NoSuchMethodException e) {
             System.err.println("Warning: Missing Compress::Bzip2::bzFile method: " + e.getMessage());
         }

--- a/src/main/perl/lib/Net/hostent.pm
+++ b/src/main/perl/lib/Net/hostent.pm
@@ -1,0 +1,80 @@
+# -*- perl -*-
+# Synced from perl 5.34.0 lib/Net/hostent.pm — core-style Net::
+
+package Net::hostent;
+use strict;
+
+use 5.006_001;
+our $VERSION = '1.02';
+our (@EXPORT, @EXPORT_OK, %EXPORT_TAGS);
+our (
+ $h_name, @h_aliases,
+ $h_addrtype, $h_length,
+ @h_addr_list, $h_addr
+);
+
+BEGIN {
+ use Exporter ();
+ @EXPORT = qw(gethostbyname gethostbyaddr gethost);
+ @EXPORT_OK = qw(
+ $h_name @h_aliases
+ $h_addrtype $h_length
+ @h_addr_list $h_addr
+ );
+ %EXPORT_TAGS = ( FIELDS => [ @EXPORT_OK, @EXPORT ] );
+}
+
+# Class::Struct forbids use of @ISA
+sub import { goto &Exporter::import }
+
+use Class::Struct qw(struct);
+struct 'Net::hostent' => [
+ name => '$',
+ aliases => '@',
+ addrtype => '$',
+ 'length' => '$',
+ addr_list => '@',
+];
+
+sub addr { shift->addr_list->[0] }
+
+sub populate (@) {
+ return unless @_;
+ my $hob = new();
+ $h_name = $hob->[0] = $_[0];
+ @h_aliases = @{ $hob->[1] } = split ' ', $_[1];
+ $h_addrtype = $hob->[2] = $_[2];
+ $h_length = $hob->[3] = $_[3];
+ $h_addr = $_[4];
+ @h_addr_list = @{ $hob->[4] } = @_[ (4 .. $#_) ];
+ return $hob;
+}
+
+sub gethostbyname ($) { populate(CORE::gethostbyname(shift)) }
+
+sub gethostbyaddr ($;$) {
+ my ($addr, $addrtype);
+ $addr = shift;
+ require Socket unless @_;
+ $addrtype = @_ ? shift : Socket::AF_INET();
+ populate(CORE::gethostbyaddr($addr, $addrtype))
+}
+
+sub gethost($) {
+ if ($_[0] =~ /^\d+(?:\.\d+(?:\.\d+(?:\.\d+)?)?)?$/) {
+ require Socket;
+ &gethostbyaddr(Socket::inet_aton(shift));
+ } else {
+ &gethostbyname;
+ }
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Net::hostent - by-name interface to Perl's built-in gethost*() functions
+
+=cut


### PR DESCRIPTION
## Summary

Improves PerlOnJava compatibility with CPAN tooling and distributions that use **bzip2** archives, **`Net::hostent`**, and **imports that redefine CORE-named builtins with different prototypes**.

## Changes

1. **`Compress::Bzip2::bzFile`** — Register gzip-compat method names (`gzread`, `gzwrite`, `gzreadline`, `gzeof`, `gzclose`, `gzerror`) as aliases to the existing `bz*` implementations, matching upstream `Compress::Bzip2` and what `CPAN::Tarzip` calls on bzip2 file handles.

2. **`Net::hostent`** — Add the standard library module (synced from Perl 5.34) so code using the by-name `gethost*` interface can be loaded.

3. **`CoreOperatorResolver`** — When the current package has a **defined** subroutine whose name is a **CORE keyword** in `CORE_PROTOTYPES` and the `RuntimeCode` has a **non-null prototype**, use that prototype for parse-time argument checking. This matches Perl’s behavior for e.g. `use Net::hostent` (imported `gethostbyaddr ($;$)` vs CORE `($$)`). The check is restricted to CORE names so subs like `Exporter::export` still parse as normal subroutine calls.

## Motivation

Together these unblock `./jcpan` flows such as **`./jcpan -t Robotics`** past tarball extraction and module load (functional tests `00-load`, server/tecan tests pass; remaining failures are upstream POD/plan noise).

## Testing

- `make`
