### PR TITLE
fix: interpreter eval STRING variable attrs after RETRIEVE_BEGIN_* + SUPER stash

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -2645,6 +2645,15 @@ public class BytecodeCompiler implements Visitor {
                             default -> throwCompilerException("Unsupported variable type: " + sigil);
                         }
 
+                        // Match JVM EmitVariable: MODIFY_*_ATTRIBUTES must run for : ATTR(...)
+                        // declarations even when storage comes from RETRIEVE_BEGIN_* (closure
+                        // pre-registration). Skipping this left Class::Std broken under interpreter
+                        // eval STRING (attribute handlers and inside-out setup never ran).
+                        if ((op.equals("my") || op.equals("state"))
+                                && node.annotations != null && node.annotations.containsKey("attributes")) {
+                            emitVarAttrsIfNeeded(node, reg, sigil);
+                        }
+
                         // If this is a declared reference, create a reference to it
                         if (isDeclaredReference && currentCallContext != RuntimeContextType.VOID) {
                             int refReg = allocateRegister();

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
@@ -411,6 +411,9 @@ public class CompileAssignment {
                                 bytecodeCompiler.emitReg(valueReg);
 
                                 bytecodeCompiler.registerVariable(varName, reg);
+
+                                bytecodeCompiler.emitVarAttrsIfNeeded(leftOp, reg, "$");
+
                                 bytecodeCompiler.lastResultReg = reg;
                                 return;
                             }
@@ -499,6 +502,8 @@ public class CompileAssignment {
 
                                 bytecodeCompiler.registerVariable(varName, arrayReg);
 
+                                bytecodeCompiler.emitVarAttrsIfNeeded(leftOp, arrayReg, "@");
+
                                 if (rhsContext == RuntimeContextType.SCALAR) {
                                     int countReg = bytecodeCompiler.allocateRegister();
                                     bytecodeCompiler.emit(Opcodes.ARRAY_SIZE);
@@ -562,6 +567,9 @@ public class CompileAssignment {
                                 bytecodeCompiler.emitReg(listReg);
 
                                 bytecodeCompiler.registerVariable(varName, hashReg);
+
+                                bytecodeCompiler.emitVarAttrsIfNeeded(leftOp, hashReg, "%");
+
                                 bytecodeCompiler.lastResultReg = hashReg;
                                 return;
                             }

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
@@ -685,6 +685,10 @@ public class CompileAssignment {
                                             }
                                         }
                                         bytecodeCompiler.registerVariable(varName, varReg);
+                                        // Outer `my ($a,$b) : ATTR` puts attributes on the `my` node, not on
+                                        // each list slot; dispatching MODIFY_*_ once per RETRIEVE_BEGIN_* slot
+                                        // would duplicate calls. Variable attributes + RETRIEVE_BEGIN_* are
+                                        // fully handled for `my $x`, `my @x`, `my %x`, and `my $x=` forms above.
                                     } else {
                                         varReg = bytecodeCompiler.addVariable(varName, "my");
                                         switch (sigil) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/NextMethod.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/NextMethod.java
@@ -10,6 +10,21 @@ public class NextMethod {
     private static final boolean DEBUG_NEXT_METHOD = Boolean.getBoolean("debug.next.method");
 
     /**
+     * Package for SUPER / next::method resolution: named-glob installs ({@code *Pkg::m = sub {...}})
+     * record {@link RuntimeCode#stashInstallPackage}; anonymous bodies may still have the
+     * enclosing compile-time {@link RuntimeCode#packageName} (e.g. Class::Std wrappers).
+     */
+    private static String methodResolutionPackage(RuntimeCode code) {
+        if (code == null) {
+            return null;
+        }
+        if (code.stashInstallPackage != null && !code.stashInstallPackage.isEmpty()) {
+            return code.stashInstallPackage;
+        }
+        return code.packageName;
+    }
+
+    /**
      * next::method with proper context from currentSub
      */
     public static RuntimeList nextMethodWithContext(RuntimeArray args, RuntimeScalar currentSub, int ctx) {
@@ -28,8 +43,11 @@ public class NextMethod {
         }
 
         RuntimeCode code = (RuntimeCode) currentSub.value;
-        String callerPackage = code.packageName;
-        String methodName = code.subName;
+        String callerPackage = methodResolutionPackage(code);
+        String methodName =
+                code.stashInstallSub != null && !code.stashInstallSub.isEmpty()
+                        ? code.stashInstallSub
+                        : code.subName;
 
         if (code.installedViaAnonGlobAssign && !code.explicitlyRenamed) {
             throw new PerlCompilerException(
@@ -69,8 +87,11 @@ public class NextMethod {
         }
 
         RuntimeCode code = (RuntimeCode) currentSub.value;
-        String callerPackage = code.packageName;
-        String methodName = code.subName;
+        String callerPackage = methodResolutionPackage(code);
+        String methodName =
+                code.stashInstallSub != null && !code.stashInstallSub.isEmpty()
+                        ? code.stashInstallSub
+                        : code.subName;
 
         if (code.installedViaAnonGlobAssign && !code.explicitlyRenamed) {
             return scalarUndef.getList();
@@ -318,13 +339,12 @@ public class NextMethod {
 
     static RuntimeScalar superMethod(RuntimeScalar currentSub, String methodName, String fallbackPackage) {
         RuntimeScalar method;
-        String packageName;
-        if (currentSub.value != null) {
-            packageName = ((RuntimeCode) currentSub.value).packageName;
-        } else {
-            // At package level (outside any subroutine), currentSub.value is null.
-            // Fall back to using the invocant's class name as the calling package.
-            packageName = fallbackPackage;
+        String packageName = fallbackPackage;
+        if (currentSub != null && currentSub.value instanceof RuntimeCode code) {
+            String mrp = methodResolutionPackage(code);
+            if (mrp != null && !mrp.isEmpty()) {
+                packageName = mrp;
+            }
         }
         method = InheritanceResolver.findMethodInHierarchy(
                 methodName.substring(7),    // method name without SUPER:: prefix

--- a/src/test/resources/unit/eval_string_retrieve_begin_attrs.t
+++ b/src/test/resources/unit/eval_string_retrieve_begin_attrs.t
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl
+# Interpreter eval STRING: my %lex : ATTR(...) must still dispatch MODIFY_HASH_ATTRIBUTES
+# when the lexical cell is installed via RETRIEVE_BEGIN_* (named subs parsed later may
+# register evalBeginIds for the same OperatorNode before bytecode emission).
+
+use strict;
+use warnings;
+use Test::More;
+
+{
+    package RTBeginAttr;
+    our $modify_ran = 0;
+
+    sub MODIFY_HASH_ATTRIBUTES {
+        my ( $pkg, $ref, @attrs ) = @_;
+        $modify_ran = 1;
+        return ();
+    }
+}
+
+eval q{
+    package RTBeginAttr;
+    {
+        my %h : ATTR(test);
+        sub _probe { scalar keys %h }
+        1;
+    }
+} or die $@;
+
+is( $RTBeginAttr::modify_ran, 1,
+    'MODIFY_HASH_ATTRIBUTES runs for my %lex : ATTR under eval STRING (RETRIEVE_BEGIN path)' );
+
+done_testing();


### PR DESCRIPTION
## Summary

- **Interpreter `eval STRING`**: After `RETRIEVE_BEGIN_SCALAR|ARRAY|HASH`, emit `DISPATCH_VAR_ATTRS` when the declaration has non-builtin variable attributes, matching JVM `EmitVariable` (fixes `Class::Std` and similar `my %h : ATTR(...)` inside `eval q{}` without forcing `JPERL_EVAL_NO_INTERPRETER=1`).
- **`CompileAssignment`**: Same dispatch after retrieve paths for `my $x =`, `my @x =`, and `my %x =`.
- **`NextMethod`**: `SUPER::` / `next` use `stashInstallPackage` / `stashInstallSub` when present so glob-assigned wrappers resolve the correct MRO (Class::Std access patterns).
- **Tests**: New `src/test/resources/unit/eval_string_retrieve_begin_attrs.t`. Comment in `CompileAssignment` documents why `my ($a,$b)=` list slots do not emit per-slot variable-attr dispatch.

## Verification

- `make` (full unit parallel + shadowJar) passes.
- `eval_nested_lexicals.t` passes.
- Class::Std `t/runtime.t` with `-Ilib`: all executed assertions pass (upstream file still declares 45 tests but only contains 44).
