### PR TITLE
fix(cli): print perl -c success line on stderr

### DIFF
--- a/src/main/java/org/perlonjava/app/cli/Main.java
+++ b/src/main/java/org/perlonjava/app/cli/Main.java
@@ -96,7 +96,8 @@ public class Main {
             PerlLanguageProvider.executePerlCode(parsedArgs, true);
 
             if (parsedArgs.compileOnly) {
-                System.out.println(parsedArgs.fileName + " syntax OK");
+                // Match system perl: `perl -c` prints this line to stderr (Test::Script relies on it).
+                System.err.println(parsedArgs.fileName + " syntax OK");
             }
 
             // Match system perl behavior:


### PR DESCRIPTION
## Summary

`jperl -c` printed the `file syntax OK` line on stdout. System `perl -c` prints it on stderr, and `Test::Script::script_compiles` (used by many CPAN distributions) only accepts success when stderr matches that pattern.

## Fix

Emit the compile-only success message with `System.err.println` instead of `System.out.println`.

## Verification

- `make` (unit tests)
- `./jcpan -t HTML::FromText` — previously failed `t/00-compile.t` (`text2html script compiles`); now all 60 subtests pass.
