### PR TITLE
fix: IPC::Open3 inherit stdio for readonly FD literals (Test::Compile)

### DIFF
--- a/src/main/java/org/perlonjava/runtime/perlmodule/IPCOpen3.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/IPCOpen3.java
@@ -189,6 +189,27 @@ public class IPCOpen3 extends PerlModuleBase {
                             errRef.type == RuntimeScalarType.REFERENCE &&
                             rdrRef.value == errRef.value);
 
+            RuntimeScalar innerWtr = derefOpen3Slot(wtrRef);
+            RuntimeScalar innerRdr = derefOpen3Slot(rdrRef);
+            RuntimeScalar innerErr = derefOpen3Slot(errRef);
+
+            // Stock Perl's open3 inherits parent's std* when CHLD_* is a read-only
+            // false value (e.g. literal 0 / undef / "0") or FD integer 1/2 — see
+            // Test::Compile::Internal::_run_command (open3(0, $stdout, $stderr, ...)).
+            boolean inheritIn = shouldInheritStdin(innerWtr);
+            boolean inheritOut = shouldInheritStdout(innerRdr);
+            boolean inheritErr = !mergeStderr && errIsUsable && shouldInheritStderr(innerErr);
+
+            if (inheritIn) {
+                processBuilder.redirectInput(ProcessBuilder.Redirect.INHERIT);
+            }
+            if (inheritOut) {
+                processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+            }
+            if (inheritErr) {
+                processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
+            }
+
             if (mergeStderr) {
                 processBuilder.redirectErrorStream(true);
             }
@@ -219,7 +240,7 @@ public class IPCOpen3 extends PerlModuleBase {
             if (isInputRedirection(wtrRef)) {
                 // Input redirection - just close the process stdin
                 process.getOutputStream().close();
-            } else {
+            } else if (!inheritIn) {
                 setupWriteHandle(wtrRef, process.getOutputStream());
             }
 
@@ -229,7 +250,7 @@ public class IPCOpen3 extends PerlModuleBase {
             if (rdrIsRedirection) {
                 // Output redirection - pipe stdout to the named handle
                 handleOutputRedirection(rdrRef, process.getInputStream());
-            } else {
+            } else if (!inheritOut) {
                 setupReadHandle(rdrRef, process.getInputStream(), process);
             }
 
@@ -237,7 +258,7 @@ public class IPCOpen3 extends PerlModuleBase {
             if (!mergeStderr && errIsUsable) {
                 if (isOutputRedirection(errRef)) {
                     handleOutputRedirection(errRef, process.getErrorStream());
-                } else {
+                } else if (!inheritErr) {
                     setupReadHandle(errRef, process.getErrorStream(), process);
                 }
             }
@@ -252,6 +273,93 @@ public class IPCOpen3 extends PerlModuleBase {
             getGlobalVariable("main::!").set(e.getMessage());
             throw new RuntimeException("open3: " + e.getMessage());
         }
+    }
+
+    /**
+     * Referent of {@code \$_[n]} as passed from {@code IPC::Open3::open3} (one ref level).
+     */
+    private static RuntimeScalar derefOpen3Slot(RuntimeScalar handleRef) {
+        if (handleRef != null
+                && handleRef.type == RuntimeScalarType.REFERENCE
+                && handleRef.value instanceof RuntimeScalar ref) {
+            return ref;
+        }
+        return handleRef;
+    }
+
+    private static boolean isPerlReadonlyOpen3Target(RuntimeScalar slot) {
+        if (slot == null) {
+            return false;
+        }
+        if (slot instanceof RuntimeScalarReadOnly) {
+            return true;
+        }
+        return slot.type == RuntimeScalarType.READONLY_SCALAR;
+    }
+
+    /**
+     * True when {@code v} is the integer {@code n} or its string form ({@code "0"}, {@code "1"}, ...).
+     */
+    private static boolean matchesNumericOrString(RuntimeScalar v, int n) {
+        if (v == null) {
+            return false;
+        }
+        return switch (v.type) {
+            case RuntimeScalarType.INTEGER -> v.getInt() == n;
+            case RuntimeScalarType.DOUBLE -> Math.abs(v.getDouble() - n) < 1e-10;
+            case RuntimeScalarType.STRING, RuntimeScalarType.BYTE_STRING ->
+                    Integer.toString(n).equals(v.toString());
+            default -> {
+                try {
+                    yield v.getInt() == n;
+                } catch (Exception e) {
+                    yield false;
+                }
+            }
+        };
+    }
+
+    /**
+     * Read-only slot that means "inherit parent's STDIN" (Perl {@code open3(undef/0/0.0/"0", ...)}).
+     * Read-only empty string is excluded — stock Perl dies modifying it.
+     */
+    private static boolean shouldInheritStdin(RuntimeScalar slot) {
+        if (!isPerlReadonlyOpen3Target(slot)) {
+            return false;
+        }
+        if (!slot.getDefinedBoolean()) {
+            return true;
+        }
+        if (slot.type == RuntimeScalarType.STRING || slot.type == RuntimeScalarType.BYTE_STRING) {
+            String s = slot.toString();
+            if (s.isEmpty()) {
+                return false;
+            }
+            return "0".equals(s);
+        }
+        return matchesNumericOrString(slot, 0);
+    }
+
+    /** Read-only false value for STDOUT: {@code undef}, {@code 1}, {@code "1"}. */
+    private static boolean shouldInheritStdout(RuntimeScalar slot) {
+        if (!isPerlReadonlyOpen3Target(slot)) {
+            return false;
+        }
+        if (!slot.getDefinedBoolean()) {
+            return true;
+        }
+        return matchesNumericOrString(slot, 1);
+    }
+
+    /** Read-only STDERR FD {@code 2} / {@code "2"} — not {@code undef} (that merges streams). */
+    private static boolean shouldInheritStderr(RuntimeScalar slot) {
+        if (!isPerlReadonlyOpen3Target(slot)) {
+            return false;
+        }
+        if (!slot.getDefinedBoolean()) {
+            return false;
+        }
+        return matchesNumericOrString(slot, 2);
     }
 
     /**

--- a/src/main/perl/lib/IPC/Open3.pm
+++ b/src/main/perl/lib/IPC/Open3.pm
@@ -6,6 +6,7 @@ use warnings;
 use Exporter 'import';
 use Carp;
 use Symbol qw(gensym qualify);
+use Scalar::Util qw(readonly);
 
 our $VERSION = '1.24';
 our @EXPORT = qw(open3);
@@ -58,13 +59,15 @@ sub open3 {
     # Call the XS implementation
     my $pid = _open3($wtr_ref, $rdr_ref, $err_ref, @cmd);
 
-    # Update the caller's variables (but not if they were redirection directives)
-    $_[0] = $$wtr_ref unless $wtr_is_redirect;
-    $_[1] = $$rdr_ref unless $rdr_is_redirect;
-    $_[2] = $$err_ref if defined $err && !$err_is_redirect;
+    # Update the caller's variables (but not if they were redirection directives).
+    # Skip read-only slots (e.g. open3(0, $stdout, $stderr, ...) inherits stdin; the
+    # literal 0 cannot be assigned to). See Test::Compile::Internal::_run_command.
+    $_[0] = $$wtr_ref unless $wtr_is_redirect || readonly($_[0]);
+    $_[1] = $$rdr_ref unless $rdr_is_redirect || readonly($_[1]);
+    $_[2] = $$err_ref if defined $err && !$err_is_redirect && !readonly($_[2]);
 
-    # Turn on autoflush for the write handle
-    if (defined $_[0] && !$wtr_is_redirect) {
+    # Turn on autoflush for the write handle (skip inherited stdin / read-only slots)
+    if (defined $_[0] && !$wtr_is_redirect && !readonly($_[0])) {
         my $old = select($_[0]);
         $| = 1;
         select($old);


### PR DESCRIPTION
## Summary

Fixes `IPC::Open3` when callers pass **read-only FD-style literals** (e.g. `open3(0, $stdout, $stderr, ...)` as used by **Test::Compile**). Stock Perl inherits the parent’s stdio for those slots; we were still trying to assign into immutable scalars (`RuntimeScalarReadOnly`).

## Changes

- **Java (`IPCOpen3.java`):** Before `ProcessBuilder.start()`, set `redirectInput` / `redirectOutput` / `redirectError` to `INHERIT` when the corresponding `\$_[n]` referent is a Perl readonly literal with the expected FD semantics. After start, skip pipe setup for inherited streams. Treat both `RuntimeScalarReadOnly` and `READONLY_SCALAR` as readonly (aligned with `Scalar::Util::readonly` on this runtime).
- **Perl (`IPC/Open3.pm`):** Use `Scalar::Util::readonly` to skip `$_[i] = ...` and stdin autoflush `select()` when the slot cannot be assigned.

## Verification

- `make` (unit tests)
- `./jcpan -t Test::Compile` — all tests pass
