### PR TITLE
fix: overloaded / and % under use integer (Date::ISO8601)

### DIFF
--- a/dev/tools/perl_test_runner.pl
+++ b/dev/tools/perl_test_runner.pl
@@ -161,26 +161,22 @@ sub run_tests_parallel {
 sub process_test_result {
     my ($test_info, $test_dir) = @_;
 
-    # Look for result file from child
-    my $temp_pattern = "/tmp/perl_test_*";
-    my @temp_files = glob($temp_pattern);
-
+    # Each child writes one JSON blob to a path keyed by its PID — no fragile
+    # glob+scan of /tmp across parallel forks (would mis-assign results under
+    # load when multiple temp files coexist or decode attempts leave stale refs).
+    my $child_pid = $test_info->{child_pid};
+    my $result_path = "/tmp/perl_test_runner_result_$child_pid";
     my $result_data;
-    for my $temp_file (@temp_files) {
-        if (-f $temp_file && open my $fh, '<', $temp_file) {
-            local $/;
-            my $json_data = <$fh>;
-            close $fh;
-
-            eval {
-                $result_data = JSON::PP->new->decode($json_data);
-            };
-
-            if ($result_data && $result_data->{test_file} eq $test_info->{test_file}) {
-                unlink $temp_file;
-                last;
-            }
-        }
+    if (defined $child_pid && -f $result_path && open my $fh, '<', $result_path) {
+        local $/;
+        my $json_data = <$fh>;
+        close $fh;
+        unlink $result_path;
+        eval {
+            $result_data = JSON::PP->new->decode($json_data);
+            1;
+        };
+        $result_data = undef unless $result_data;
     }
 
     # Fallback if we couldn't read the result
@@ -403,9 +399,10 @@ sub start_test_job {
         # Child process
         my $result = run_single_test($test_file);
 
-        # Write result to temporary file for parent to read
-        my $temp_file = "/tmp/perl_test_$$" . "_" . time() . "_" . rand(1000);
-        if (open my $fh, '>', $temp_file) {
+        # Exactly one canonical path per child PID so the parent's waitpid reap
+        # reads the matching JSON — never scan shared /tmp/perl_test_* blobs.
+        my $result_path = "/tmp/perl_test_runner_result_$$";
+        if (open my $fh, '>', $result_path) {
             print $fh JSON::PP->new->encode({
                 test_file => $test_file,
                 test_index => $test_index,
@@ -421,6 +418,7 @@ sub start_test_job {
             test_file => $test_file,
             test_index => $test_index,
             start_time => time(),
+            child_pid => $pid,
         };
     }
 }

--- a/src/main/java/org/perlonjava/runtime/operators/MathOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/MathOperators.java
@@ -812,6 +812,18 @@ public class MathOperators {
      * @return A new RuntimeScalar representing the integer division result.
      */
     public static RuntimeScalar integerDivide(RuntimeScalar arg1, RuntimeScalar arg2) {
+        // Like divide(): overloaded packages (Math::BigInt, Math::BigRat, …) still receive
+        // operator dispatch under "use integer"; native IV division must not bypass overload.
+        int blessId = blessedId(arg1);
+        int blessId2 = blessedId(arg2);
+        if (blessId < 0 || blessId2 < 0) {
+            RuntimeScalar result =
+                    OverloadContext.tryTwoArgumentOverload(arg1, arg2, blessId, blessId2, "(/", "/");
+            if (result != null) {
+                return result;
+            }
+        }
+
         long dividend = arg1.getLong();
         long divisor = arg2.getLong();
 
@@ -832,6 +844,16 @@ public class MathOperators {
      * @return A new RuntimeScalar representing the integer division result.
      */
     public static RuntimeScalar integerDivideWarn(RuntimeScalar arg1, RuntimeScalar arg2) {
+        int blessId = blessedId(arg1);
+        int blessId2 = blessedId(arg2);
+        if (blessId < 0 || blessId2 < 0) {
+            RuntimeScalar result =
+                    OverloadContext.tryTwoArgumentOverload(arg1, arg2, blessId, blessId2, "(/", "/");
+            if (result != null) {
+                return result;
+            }
+        }
+
         // Convert to number with warning for uninitialized values
         arg1 = arg1.getNumberWarn("integer division (/)");
         arg2 = arg2.getNumberWarn("integer division (/)");
@@ -873,6 +895,16 @@ public class MathOperators {
      * @return A new RuntimeScalar representing the integer modulus.
      */
     public static RuntimeScalar integerModulus(RuntimeScalar arg1, RuntimeScalar arg2) {
+        int blessId = blessedId(arg1);
+        int blessId2 = blessedId(arg2);
+        if (blessId < 0 || blessId2 < 0) {
+            RuntimeScalar result =
+                    OverloadContext.tryTwoArgumentOverload(arg1, arg2, blessId, blessId2, "(%", "%");
+            if (result != null) {
+                return result;
+            }
+        }
+
         long dividend = arg1.getLong();
         long divisor = arg2.getLong();
 


### PR DESCRIPTION
## Summary

Under `use integer`, binary `/` and `%` still dispatch overloaded methods when either operand is a blessed overloaded object (for example `Math::BigInt`). The JVM backend skipped overload for the integer-specific helpers and coerced operands with native integer conversion, which stripped BigInt/BigRat results and broke modules such as Date::ISO8601.

Parallel `perl_test_runner.pl` previously globbed `/tmp/perl_test_*` to find each child’s JSON summary; under load that could associate the wrong TAP with the wrong `.t`, producing bogus regressions in saved logs (for example `op/exec.t` incomplete, spurious `comp/` failures). That made `compare_test_logs.pl` deltas unreliable for merge gating.

## Changes

1. **Runtime — `MathOperators`:** `integerDivide`, `integerDivideWarn`, and `integerModulus` call `OverloadContext.tryTwoArgumentOverload` when either side is overloaded, matching non-integer `divide`/`modulus` before falling back to IV arithmetic.

2. **`dev/tools/perl_test_runner.pl`:** Each child writes results to `/tmp/perl_test_runner_result_<PID>`; the parent reads that path for the reaped PID (no shared glob scan).

## Verification

- `make`
- `timeout 600 ./jcpan -t Date::ISO8601` (PASS)
- `perl dev/tools/perl_test_runner.pl --jobs 10 perl5_t/t/comp perl5_t/t/op/exec.t` — `bproto.t`, `filter_exception.t`, `exec.t` report full pass counts after the harness fix

**Note:** [PR 731](https://github.com/fglock/PerlOnJava/pull/731) duplicates the harness commit only; merge this PR (`#729`) first and close `#731` when appropriate.
