### PR TITLE
fix(parser): numeric filehandle diamond \<N\> (Acme::Buffy, open 0)

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/FileHandle.java
+++ b/src/main/java/org/perlonjava/frontend/parser/FileHandle.java
@@ -271,13 +271,32 @@ public class FileHandle {
 
         // Check if this is a known file handle in the global I/O table
         // This helps distinguish between file handles and other barewords
-        if (GlobalVariable.existsGlobalIO(name) || isStandardFilehandle(name)) {
+        if (GlobalVariable.existsGlobalIO(name) || isStandardFilehandle(name)
+                || isAllDigitGlobName(name)) {
             // Create a GLOB reference for the file handle, like `\*FH`
             return new OperatorNode("\\",
                     new OperatorNode("*",
                             new IdentifierNode(name, parser.tokenIndex), parser.tokenIndex), parser.tokenIndex);
         }
         return null;
+    }
+
+    /**
+     * Perl allows numeric typeglob names such as {@code open 0; print <0>}, where filehandle
+     * {@code 0} shares the {@code *0} stash entry with {@code $0} (program name).
+     */
+    private static boolean isAllDigitGlobName(String normalizedName) {
+        int idx = normalizedName.lastIndexOf("::");
+        String base = idx >= 0 ? normalizedName.substring(idx + 2) : normalizedName;
+        if (base.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < base.length(); i++) {
+            if (!Character.isDigit(base.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -139,6 +139,24 @@ public class OperatorParser {
                 return diamond;
             }
 
+            // <0>, <1>, … — numeric filehandles (e.g. Acme::Buffy "open 0" reads $0)
+            if (operand.type == NUMBER && tokenText.matches("[0-9]+")
+                    && parser.tokens.get(parser.tokenIndex + 1).text.equals(">")) {
+                parser.tokenIndex++; // consume NUMBER
+                TokenUtils.consume(parser); // consume '>'
+                String digitName = operand.text;
+                GlobalVariable.getGlobalIO(FileHandle.normalizeBarewordHandle(parser, digitName));
+                Node globRef = FileHandle.parseBarewordHandle(parser, digitName);
+                if (globRef != null) {
+                    BinaryOperatorNode readlineNode = new BinaryOperatorNode("readline",
+                            globRef,
+                            new ListNode(parser.tokenIndex), currentTokenIndex);
+                    readlineNode.setAnnotation("handleName", digitName);
+                    return readlineNode;
+                }
+                parser.tokenIndex = currentTokenIndex;
+            }
+
             // Check if the token looks like a Bareword file handle
             if (operand.type == IDENTIFIER) {
                 Node fileHandle = FileHandle.parseFileHandle(parser);


### PR DESCRIPTION
## Summary

- Parse `<digits>` in the diamond / readline position as **readline on the numeric typeglob** (`*0`, `*1`, …), not as a quote-like string. The lexer emits `NUMBER` for `0`, so `<0>` previously fell through to `parseRawString` and became the one-character string `"0"`, which broke any `open 0; ... <0>` pattern (notably Acme::Buffy).

- In `parseBarewordHandle`, treat **all-digit** glob names (e.g. `main::0`) as valid bareword handles so `<0>` matches Perl’s `open 0` / `$0` script-read idiom without requiring a prior `existsGlobalIO` entry.

## Test plan

- [x] `make` (unit tests)
- [x] `timeout 600 ./jcpan -t Acme::Buffy` — passes (`t/buffy.t`)
- [x] Ad hoc: `jperl -e 'open 0; print length join "", <0>'` on a script file matches reading full source length


Made with [Cursor](https://cursor.com)