### PR TITLE
fix: stash hash assignment with numeric RHS

### DIFF
--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStashEntry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStashEntry.java
@@ -232,6 +232,16 @@ public class RuntimeStashEntry extends RuntimeGlob {
                 // TODO: Add "Undefined value assigned to typeglob" warning with proper guards
                 // to avoid false positives during module loading
                 return value;
+            case INTEGER:
+            case DOUBLE:
+            case BOOLEAN:
+            case VSTRING:
+            case DUALVAR:
+                // Stash-hash assignment with a numeric or other non-string scalar (e.g.
+                // `${"HTTP/Response::"}{VERSION} ||= -1` from Test::MockObject::fake_module)
+                // updates the GV's scalar slot, not subroutine prototype metadata — delegate
+                // to RuntimeGlob.
+                return super.set(value);
             case STRING:
             case BYTE_STRING:
                 // Assigning a string to a stash entry sets the prototype for that symbol


### PR DESCRIPTION
## Summary

- Handle `INTEGER`, `DOUBLE`, `BOOLEAN`, `VSTRING`, and `DUALVAR` stash assignments by delegating to `RuntimeGlob#set`, mirroring GV scalar-slot updates for normal typeglobs.
- Fixes `RuntimeStashEntry` throwing `typeglob assignment not implemented for 0` when modules use `Test::MockObject::fake_module`, which assigns `${ stash }{VERSION} ||= -1`.

## Test plan

- `make`
- `./jcpan -t Finance::Currency::Convert::WebserviceX` (formerly failed at `t/convert.t`; should pass).


Made with [Cursor](https://cursor.com)