### PR TITLE
fix: MIME::QuotedPrint empty EOL matches Perl (Data::ICal)

### DIFF
--- a/src/main/java/org/perlonjava/runtime/perlmodule/MIMEQuotedPrint.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/MIMEQuotedPrint.java
@@ -110,7 +110,8 @@ public class MIMEQuotedPrint extends PerlModuleBase {
 
             // Check if adding this token would make the line too long
             // We need to leave room for the '=' of a soft break, so max is 75
-            if (currentLength + token.length() > 75) {
+            // Empty EOL means Perl's "no soft breaks" mode (binary charset encoding only).
+            if (!eol.isEmpty() && currentLength + token.length() > 75) {
                 // Need to break the line
                 output.append(currentLine).append("=").append(eol);
                 currentLine = new StringBuilder(token);


### PR DESCRIPTION
## Summary

- Align `MIME::QuotedPrint::encode_qp` with Perl when the second argument is an empty string: do not insert quoted-printable soft line breaks (`=` + EOL); only apply the existing binary/control-character encoding behavior.
- Fixes `jcpan -t Data::ICal`, which calls `MIME::QuotedPrint::encode` with `''` for QUOTED-PRINTABLE values (`Data::ICal::Property`). Previously, spurious mid-string breaks turned `syncml` into `sy=ncml` and failed `t/09.mime.t` and `t/10.mime-vcal10.t`.

## Test plan

- [x] `make`
- [x] `timeout 600 ./jcpan -t Data::ICal`
