### PR TITLE
fix: prototype trailing comma across newline + PPI DESTROY/runtime (#737)

### DIFF
--- a/dev/modules/README.md
+++ b/dev/modules/README.md
@@ -20,6 +20,7 @@ This directory contains design documents and guides related to porting CPAN modu
 | [math_bigint_bignum.md](math_bigint_bignum.md) | Math::BigInt / BigFloat / BigRat / bignum support (in progress) |
 | [storable_binary_format.md](storable_binary_format.md) | Storable native Perl binary format — read + write paths landed; jperl ↔ system-perl files interoperate in both directions |
 | [unicode_collate.md](unicode_collate.md) | Unicode::Collate — plan: file-backed DUCET + Java XS surface (default); optional ICU path tradeoffs |
+| [ppi.md](ppi.md) | **PPI** — CPAN test status, RC1–RC4, refcount/`DESTROY` follow-ups (`t/04_element.t` `%_PARENT`) |
 
 ## Module Status Overview
 

--- a/dev/modules/ppi.md
+++ b/dev/modules/ppi.md
@@ -258,3 +258,77 @@ file before closing the phase.
 - Is the `return $r` bug a separate issue (return copy discipline) or a
   symptom of the same container-store miscount? Needs a separate minimal
   repro without containers.
+
+---
+
+## Future work — `t/04_element.t` and `%PPI::Singletons::_PARENT` (2026-05)
+
+Upstream PPI keeps a weak parent table: `weaken($_PARENT{refaddr $child} = $parent)`.
+`PPI::Element::DESTROY` deletes `$_PARENT{refaddr $_[0]}`.  
+`PPI/tests/t/04_element.t` asserts that after parsing a large document and
+destroying the root `PPI::Document`, `scalar keys %_PARENT` returns to the
+baseline count (tests **202** explicit `DESTROY`, **206** implicit scope exit).
+
+### Symptom on PerlOnJava (as of 2026-05)
+
+Those two subtests still fail: thousands of `_PARENT` keys remain after
+document teardown, i.e. many `PPI::Element` objects never run `DESTROY` (or
+equivalent cleanup). Other failures in `./jcpan -t PPI` (e.g. `t/07_token.t`,
+`t/08_regression.t`) may share refcount/DESTROY plumbing; treat them after
+`04_element` is green.
+
+### Fixes landed incrementally (see linked PR)
+
+1. **`InheritanceResolver`**: do **not** negative-cache a failed `DESTROY`
+   method lookup. During `require`/compile order, resolution can run before
+   a base class installs `DESTROY`; caching `null` would skip Perl destructors
+   for the rest of the process.
+2. **`DestroyDispatch.doCallDestroy`**: set `destroyFired` only **after** it
+   is known that a Perl `DESTROY` (or the no-DESTROY cleanup path) will run.
+   Setting it before the null-check could skip `PPI::Element::DESTROY` when
+   resolution transiently failed.
+3. **`RuntimeScalar.incrementRefCountForContainerStore`**: activate nested
+   referents at `refCount == -1` before incrementing (and refuse `MIN_VALUE` /
+   `WEAKLY_TRACKED`), so hash/array slot stores and `createReferenceWithTrackedElements`
+   paths can count anon containers consistently.
+
+These improve destructor reliability but **do not** yet pass tests 202/206 alone.
+
+### Next investigation steps (ordered)
+
+1. **Reproduce at scale**  
+   `./jperl -Ilib t/04_element.t` (or only the failing scope) with `PERL5LIB`
+   pointing at bundled `IO::File` etc. Use `timeout` on full `./jcpan -t PPI`
+   (see `AGENTS.md`).
+
+2. **Correlate stuck keys with JVM state**  
+   For one leaked element after `$doc->DESTROY`, check
+   `Internals::jperl_refstate`-style introspection (if available): `refCount`,
+   `refCountOwned`, whether the object is still reachable from a live
+   `RuntimeArray` slot (`{children}`) or from deferred mortal queues.
+
+3. **`PPI::Node::DESTROY` pattern**  
+   BFS: `unshift @queue, @{delete $_->{children}}` then `%$_ = ()`. Ensure
+   `RuntimeHash.delete` and bulk clear both drop nested refcount for **non-`refCountOwned`**
+   slot scalars where Perl still drops SV refcount (prior art: a narrowly scoped
+   `deferDecrementRecursive` or hash-delete helper broke unrelated tests when
+   too broad).
+
+4. **Hash / anon literal construction**  
+   JVM path uses `RuntimeHash.createHashRef` → `createReferenceWithTrackedElements`.
+   A mid-construction `MortalList.flush` could in theory destroy nested values
+   before container-store pins them; `suppressFlush` around **only** the hash-ref
+   construction sequence was attempted but caused regressions elsewhere — any
+   retry must be narrower than wrapping all `createHashRef` callers.
+
+5. **After `04_element` passes**  
+   Re-run full `./jcpan -t PPI`, refresh the failure table at the top of this
+   doc, then continue Phase 2/RC2 refcount parity work from "Next Steps" above
+   for lexer/`Structure::Condition` issues.
+
+### References
+
+- `lib/PPI/Node.pm` (`DESTROY`), `lib/PPI/Element.pm` (`DESTROY`),
+  `lib/PPI/Singletons.pm` (`%_PARENT`)
+- Runtime: `DestroyDispatch.java`, `MortalList.java`, `RuntimeHash.delete`,
+  `RuntimeScalar.incrementRefCountForContainerStore`

--- a/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
+++ b/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
@@ -253,10 +253,10 @@ public class PrototypeArgs {
                 List<LexerToken> tokens = parser.tokens;
                 int i = skipHorizontalWhitespaceTokens(tokens, parser.tokenIndex);
                 if (i < tokens.size() && isComma(tokens.get(i))) {
-                    int j = skipHorizontalWhitespaceTokens(tokens, i + 1);
+                    int j = skipHorizontalWhitespaceAndIgnorableNewlines(tokens, i + 1, parser);
                     LexerToken nextToken = tokenAtOrEof(tokens, j);
                     // Trailing comma before the newline that starts a pending << heredoc body is valid
-                    // (see op/exec.t package o block). A newline with no pending heredoc is an extra arg.
+                    // (see op/exec.t package o block).
                     boolean trailingCommaBeforeHeredoc =
                             nextToken.type == LexerTokenType.NEWLINE && !parser.getHeredocNodes().isEmpty();
                     if (!trailingCommaBeforeHeredoc
@@ -318,6 +318,26 @@ public class PrototypeArgs {
                 continue;
             }
             break;
+        }
+        return i;
+    }
+
+    /**
+     * After a comma in a parenthesis-free multi-arg prototype call, Perl allows a trailing comma
+     * before a statement terminator even when newlines appear before that terminator (e.g.
+     * {@code throws_ok BLOCK, qr//, 'msg',} then newline then {@code ;} in DBIx::Class tests).
+     * <p>
+     * We only skip NEWLINEs when no {@code <<} heredoc is pending — otherwise the newline may begin
+     * the heredoc body and must not be skipped for lookahead.
+     */
+    private static int skipHorizontalWhitespaceAndIgnorableNewlines(List<LexerToken> tokens, int i, Parser parser) {
+        i = skipHorizontalWhitespaceTokens(tokens, i);
+        while (i < tokens.size() && tokens.get(i).type == LexerTokenType.NEWLINE) {
+            if (!parser.getHeredocNodes().isEmpty()) {
+                break;
+            }
+            i++;
+            i = skipHorizontalWhitespaceTokens(tokens, i);
         }
         return i;
     }

--- a/src/main/java/org/perlonjava/runtime/mro/InheritanceResolver.java
+++ b/src/main/java/org/perlonjava/runtime/mro/InheritanceResolver.java
@@ -185,16 +185,32 @@ public class InheritanceResolver {
     }
 
     /**
-     * Invalidates negative and positive DESTROY entries in the method-resolution cache and
-     * DESTROY dispatch bookkeeping. Call when a {@code *Pkg::DESTROY} slot is installed,
-     * redefined, or removed so a prior "no DESTROY" cache entry cannot outlive a late CV.
+     * Drop method-resolution cache entries that depend on a given package sub's
+     * <em>leaf</em> name (stash key {@code My::Pkg::foo} &rarr; {@code foo}), including
+     * {@code \0noautoload} variants. Also clears {@link DestroyDispatch} bookkeeping
+     * when the leaf is {@code DESTROY}.
      */
-    public static void invalidateDestroyMethodLookupCaches() {
+    public static void invalidateMethodLookupCachesForStashSubKey(String stashFqn) {
+        if (stashFqn == null || stashFqn.isEmpty()) {
+            return;
+        }
+        int chop = stashFqn.lastIndexOf("::");
+        String leaf = chop < 0 ? stashFqn : stashFqn.substring(chop + 2);
+        if (leaf.isEmpty()) {
+            return;
+        }
+        String suffix = "::" + leaf;
+        String suffixNoAutoload = suffix + "\0noautoload";
         methodCache.entrySet().removeIf(e -> {
             String k = e.getKey();
-            return k.endsWith("::DESTROY") || k.contains("::DESTROY\0");
+            return k.endsWith(suffixNoAutoload)
+                    || k.endsWith(suffix)
+                    || k.equals(leaf)
+                    || k.equals(leaf + "\0noautoload");
         });
-        DestroyDispatch.invalidateCache();
+        if ("DESTROY".equals(leaf)) {
+            DestroyDispatch.invalidateCache();
+        }
     }
 
     /**
@@ -442,9 +458,9 @@ public class InheritanceResolver {
             }
         }
 
-        // Cache "method not found" as null, including for DESTROY. Late-installed
-        // DESTROY subs invalidate these entries via GlobalVariable.globalCodeRefs hooks
-        // and RuntimeScalar assignments to the *::DESTROY CV slot.
+        // Cache "method not found" as null. Late-installed or redefined package subs
+        // invalidate matching entries via GlobalVariable.globalCodeRefs and in-place CV
+        // updates on stash-backed RuntimeScalars (see globalCodeRefFqn).
         methodCache.put(cacheKey, null);
         return null;
     }

--- a/src/main/java/org/perlonjava/runtime/mro/InheritanceResolver.java
+++ b/src/main/java/org/perlonjava/runtime/mro/InheritanceResolver.java
@@ -185,6 +185,19 @@ public class InheritanceResolver {
     }
 
     /**
+     * Invalidates negative and positive DESTROY entries in the method-resolution cache and
+     * DESTROY dispatch bookkeeping. Call when a {@code *Pkg::DESTROY} slot is installed,
+     * redefined, or removed so a prior "no DESTROY" cache entry cannot outlive a late CV.
+     */
+    public static void invalidateDestroyMethodLookupCaches() {
+        methodCache.entrySet().removeIf(e -> {
+            String k = e.getKey();
+            return k.endsWith("::DESTROY") || k.contains("::DESTROY\0");
+        });
+        DestroyDispatch.invalidateCache();
+    }
+
+    /**
      * Retrieves a cached OverloadContext for the given blessing ID.
      *
      * @param blessId The blessing ID of the class.
@@ -429,15 +442,10 @@ public class InheritanceResolver {
             }
         }
 
-        // Normally cache "method not found" as null. Do NOT do this for DESTROY:
-        // during require/use, resolution can run while a package is still compiling
-        // (e.g. overload/bootstrap) before sub DESTROY is installed in a base class.
-        // A cached null then pins "no destructor" for that cache key until the next
-        // full invalidate — PPI's Element tree would skip Perl DESTROY and leak
-        // %PPI::Singletons::_PARENT keys (t/04_element.t).
-        if (!"DESTROY".equals(methodName)) {
-            methodCache.put(cacheKey, null);
-        }
+        // Cache "method not found" as null, including for DESTROY. Late-installed
+        // DESTROY subs invalidate these entries via GlobalVariable.globalCodeRefs hooks
+        // and RuntimeScalar assignments to the *::DESTROY CV slot.
+        methodCache.put(cacheKey, null);
         return null;
     }
 

--- a/src/main/java/org/perlonjava/runtime/mro/InheritanceResolver.java
+++ b/src/main/java/org/perlonjava/runtime/mro/InheritanceResolver.java
@@ -429,8 +429,15 @@ public class InheritanceResolver {
             }
         }
 
-        // Cache the fact that method was not found (using null)
-        methodCache.put(cacheKey, null);
+        // Normally cache "method not found" as null. Do NOT do this for DESTROY:
+        // during require/use, resolution can run while a package is still compiling
+        // (e.g. overload/bootstrap) before sub DESTROY is installed in a base class.
+        // A cached null then pins "no destructor" for that cache key until the next
+        // full invalidate — PPI's Element tree would skip Perl DESTROY and leak
+        // %PPI::Singletons::_PARENT keys (t/04_element.t).
+        if (!"DESTROY".equals(methodName)) {
+            methodCache.put(cacheKey, null);
+        }
         return null;
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/DestroyDispatch.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/DestroyDispatch.java
@@ -250,13 +250,6 @@ public class DestroyDispatch {
      * Perform the actual DESTROY method call.
      */
     private static void doCallDestroy(RuntimeBase referent, String className) {
-        // Mark as destroyed before running DESTROY — one-shot guard.
-        // Prevents re-entrant DESTROY if cascading cleanup brings this
-        // object's refCount to 0 again within the same call stack.
-        // Also prevents infinite DESTROY loops for rescued objects
-        // (destroyFired stays true after rescue — see note in rescue path).
-        referent.destroyFired = true;
-
         // Use cached method if available
         RuntimeScalar destroyMethod = destroyMethodCache.get(referent.blessId);
         if (destroyMethod == null) {
@@ -282,6 +275,13 @@ public class DestroyDispatch {
             }
             return;
         }
+
+        // Mark as destroyed only once we will run Perl DESTROY. Setting destroyFired
+        // before the null check above incorrectly skips PPI::Element::DESTROY (and
+        // any other Perl destructor) when method resolution transiently returned null
+        // or fell through without a CODE ref — leaving PPI::_PARENT keys orphaned.
+        // Prevents re-entrant Perl DESTROY for the same object; see callDestroy.
+        referent.destroyFired = true;
 
         // If findMethodInHierarchy returned an AUTOLOAD sub (because no explicit DESTROY
         // exists), we need to set $AUTOLOAD before calling it. The method resolver sets

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
@@ -114,26 +114,35 @@ public class GlobalVariable {
     }
 
     /**
-     * Tracks FQN on code-slot scalars and invalidates DESTROY method-resolution caches
-     * when {@code *Pkg::DESTROY} map entries change (see {@link
-     * InheritanceResolver#invalidateDestroyMethodLookupCaches}).
+     * Tracks FQN on stash-backed code scalars and invalidates method-resolution cache
+     * lines that depend on the sub's leaf name when the map entry is meaningfully
+     * created or replaced (see {@link InheritanceResolver#invalidateMethodLookupCachesForStashSubKey}).
      */
     private static final class GlobalCodeRefMap extends HashMap<String, RuntimeScalar> {
+        private static void maybeInvalidateMethodCacheForCodeRefPut(String key, RuntimeScalar previous, RuntimeScalar value) {
+            if (key == null || value == null) {
+                return;
+            }
+            boolean reseat = previous != null && previous != value;
+            boolean firstDefinedInstall = previous == null && RuntimeCode.isCodeDefined(value);
+            if (reseat || firstDefinedInstall) {
+                InheritanceResolver.invalidateMethodLookupCachesForStashSubKey(key);
+            }
+        }
+
         @Override
         public RuntimeScalar put(String key, RuntimeScalar value) {
             markPackageGlobalRoot(value);
-            RuntimeScalar prev = super.put(key, value);
+            RuntimeScalar old = super.put(key, value);
             invalidatePackageRootSnapshot();
-            if (prev != null && prev != value) {
-                prev.globalCodeRefFqn = null;
+            if (old != null && old != value) {
+                old.globalCodeRefFqn = null;
             }
             if (value != null) {
                 value.globalCodeRefFqn = key;
             }
-            if (isDestroyCodeSlotKey(key)) {
-                InheritanceResolver.invalidateDestroyMethodLookupCaches();
-            }
-            return prev;
+            maybeInvalidateMethodCacheForCodeRefPut(key, old, value);
+            return old;
         }
 
         @Override
@@ -153,8 +162,8 @@ public class GlobalVariable {
                 invalidatePackageRootSnapshot();
                 prev.globalCodeRefFqn = null;
             }
-            if (key instanceof String s && isDestroyCodeSlotKey(s)) {
-                InheritanceResolver.invalidateDestroyMethodLookupCaches();
+            if (key instanceof String s) {
+                InheritanceResolver.invalidateMethodLookupCachesForStashSubKey(s);
             }
             return prev;
         }
@@ -171,11 +180,6 @@ public class GlobalVariable {
             }
             super.clear();
         }
-    }
-
-    /** True for global code-ref keys that install Perl's destructor CV. */
-    static boolean isDestroyCodeSlotKey(String key) {
-        return key != null && (key.endsWith("::DESTROY") || key.equals("DESTROY"));
     }
 
     static <T extends RuntimeBase> T markPackageGlobalRoot(T root) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
@@ -32,7 +32,7 @@ public class GlobalVariable {
     // Maps fully-qualified names (package::subname) to indicate they should be called
     // as user-defined subroutines instead of built-in operators
     public static final Map<String, Boolean> isSubs = new HashMap<>();
-    public static final Map<String, RuntimeScalar> globalCodeRefs = new PackageRootMap<>();
+    public static final Map<String, RuntimeScalar> globalCodeRefs = new GlobalCodeRefMap();
     static final Map<String, RuntimeGlob> globalIORefs = new HashMap<>();
     static final Map<String, RuntimeFormat> globalFormatRefs = new HashMap<>();
 
@@ -111,6 +111,71 @@ public class GlobalVariable {
             }
             super.clear();
         }
+    }
+
+    /**
+     * Tracks FQN on code-slot scalars and invalidates DESTROY method-resolution caches
+     * when {@code *Pkg::DESTROY} map entries change (see {@link
+     * InheritanceResolver#invalidateDestroyMethodLookupCaches}).
+     */
+    private static final class GlobalCodeRefMap extends HashMap<String, RuntimeScalar> {
+        @Override
+        public RuntimeScalar put(String key, RuntimeScalar value) {
+            markPackageGlobalRoot(value);
+            RuntimeScalar prev = super.put(key, value);
+            invalidatePackageRootSnapshot();
+            if (prev != null && prev != value) {
+                prev.globalCodeRefFqn = null;
+            }
+            if (value != null) {
+                value.globalCodeRefFqn = key;
+            }
+            if (isDestroyCodeSlotKey(key)) {
+                InheritanceResolver.invalidateDestroyMethodLookupCaches();
+            }
+            return prev;
+        }
+
+        @Override
+        public RuntimeScalar putIfAbsent(String key, RuntimeScalar value) {
+            RuntimeScalar existing = get(key);
+            if (existing != null) {
+                markPackageGlobalRoot(existing);
+                return existing;
+            }
+            return put(key, value);
+        }
+
+        @Override
+        public RuntimeScalar remove(Object key) {
+            RuntimeScalar prev = super.remove(key);
+            if (prev != null) {
+                invalidatePackageRootSnapshot();
+                prev.globalCodeRefFqn = null;
+            }
+            if (key instanceof String s && isDestroyCodeSlotKey(s)) {
+                InheritanceResolver.invalidateDestroyMethodLookupCaches();
+            }
+            return prev;
+        }
+
+        @Override
+        public void clear() {
+            if (!isEmpty()) {
+                for (RuntimeScalar s : values()) {
+                    if (s != null) {
+                        s.globalCodeRefFqn = null;
+                    }
+                }
+                invalidatePackageRootSnapshot();
+            }
+            super.clear();
+        }
+    }
+
+    /** True for global code-ref keys that install Perl's destructor CV. */
+    static boolean isDestroyCodeSlotKey(String key) {
+        return key != null && (key.endsWith("::DESTROY") || key.equals("DESTROY"));
     }
 
     static <T extends RuntimeBase> T markPackageGlobalRoot(T root) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -942,19 +942,32 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
      * constructor, and their refCount was already incremented at creation time.
      */
     public static void incrementRefCountForContainerStore(RuntimeScalar scalar) {
-        if (scalar != null && !scalar.refCountOwned
-                && (scalar.type & REFERENCE_BIT) != 0 && scalar.value instanceof RuntimeBase base
-                && base.refCount >= 0) {
-            base.refCount++;
-            base.hadCountedReference = true;
-            base.recordOwner(scalar, "incrementRefCountForContainerStore");
-            base.recordActiveOwner(scalar);
-            scalar.refCountOwned = true;
-            // Phase B1 (refcount_alignment_52leaks_plan.md): track the
-            // container element so ReachabilityWalker can see it via
-            // ScalarRefRegistry.
-            ScalarRefRegistry.registerRef(scalar);
+        if (scalar == null || scalar.refCountOwned
+                || (scalar.type & REFERENCE_BIT) == 0
+                || !(scalar.value instanceof RuntimeBase base)) {
+            return;
         }
+        // Destroyed / weaken sentinel states must not be reactivated here.
+        if (base.refCount == Integer.MIN_VALUE
+                || base.refCount == WeakRefRegistry.WEAKLY_TRACKED) {
+            return;
+        }
+        // Anonymous nested containers start at refCount=-1 (untracked).
+        // bless {}'s retroactive pass and normal container stores must still count
+        // the hash slot as a strong ref, otherwise delete $h{k} / hash clear never
+        // drops the child (PPI::Node->{children}; cpan PPI t/04_element.t).
+        if (base.refCount < 0) {
+            base.refCount = 0;
+        }
+        base.refCount++;
+        base.hadCountedReference = true;
+        base.recordOwner(scalar, "incrementRefCountForContainerStore");
+        base.recordActiveOwner(scalar);
+        scalar.refCountOwned = true;
+        // Phase B1 (refcount_alignment_52leaks_plan.md): track the
+        // container element so ReachabilityWalker can see it via
+        // ScalarRefRegistry.
+        ScalarRefRegistry.registerRef(scalar);
     }
 
     private static boolean scalarReferenceContentsNeedRetain(RuntimeScalar value) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -79,6 +79,13 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     public boolean ioOwner;
 
     /**
+     * When this scalar is installed in {@link GlobalVariable#globalCodeRefs}, the map key
+     * (fully-qualified name such as {@code My::Pkg::foo}). Used to invalidate DESTROY
+     * method-resolution caches after in-place CV installation via {@link #set(RuntimeScalar)}.
+     */
+    public String globalCodeRefFqn;
+
+    /**
      * Number of closures that have captured this RuntimeScalar variable.
      * When {@code captureCount > 0}, {@link #scopeExitCleanup} skips the
      * blessed ref decrement because a closure still holds a reference to
@@ -1396,6 +1403,11 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                         " refCount=" + (oldBase != null ? oldBase.refCount : -1));
             }
             DestroyDispatch.clearRescuedWeakRefsTo(oldBase);
+        }
+
+        if (isPackageGlobalRoot && type == CODE && globalCodeRefFqn != null
+                && GlobalVariable.isDestroyCodeSlotKey(globalCodeRefFqn)) {
+            InheritanceResolver.invalidateDestroyMethodLookupCaches();
         }
 
         return this;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -964,7 +964,13 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         // bless {}'s retroactive pass and normal container stores must still count
         // the hash slot as a strong ref, otherwise delete $h{k} / hash clear never
         // drops the child (PPI::Node->{children}; cpan PPI t/04_element.t).
+        // Restrict promotion to real containers: doing this for arbitrary -1
+        // referents (e.g. refs to readonly scalars) breaks Moo weak_ref accessors
+        // (cpan Moo t/accessor-weaken.t).
         if (base.refCount < 0) {
+            if (!(base instanceof RuntimeHash) && !(base instanceof RuntimeArray)) {
+                return;
+            }
             base.refCount = 0;
         }
         base.refCount++;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -80,8 +80,9 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
 
     /**
      * When this scalar is installed in {@link GlobalVariable#globalCodeRefs}, the map key
-     * (fully-qualified name such as {@code My::Pkg::foo}). Used to invalidate DESTROY
-     * method-resolution caches after in-place CV installation via {@link #set(RuntimeScalar)}.
+     * (fully-qualified name such as {@code My::Pkg::foo}). Used to invalidate
+     * method-resolution cache lines for that sub's leaf name after in-place CV updates
+     * via {@link #set(RuntimeScalar)}.
      */
     public String globalCodeRefFqn;
 
@@ -1252,6 +1253,9 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             ScalarRefRegistry.registerRef(this);
         }
 
+        int preAssignType = this.type;
+        Object preAssignValue = this.value;
+
         // Do the assignment
         this.type = value.type;
         this.value = value.value;
@@ -1405,9 +1409,15 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             DestroyDispatch.clearRescuedWeakRefsTo(oldBase);
         }
 
-        if (isPackageGlobalRoot && type == CODE && globalCodeRefFqn != null
-                && GlobalVariable.isDestroyCodeSlotKey(globalCodeRefFqn)) {
-            InheritanceResolver.invalidateDestroyMethodLookupCaches();
+        if (isPackageGlobalRoot && globalCodeRefFqn != null) {
+            boolean invalidate = preAssignType != this.type || preAssignValue != this.value;
+            if (!invalidate && this.type == CODE && this.value instanceof RuntimeCode nc
+                    && preAssignType == CODE && preAssignValue instanceof RuntimeCode oc) {
+                invalidate = oc.defined() != nc.defined();
+            }
+            if (invalidate) {
+                InheritanceResolver.invalidateMethodLookupCachesForStashSubKey(globalCodeRefFqn);
+            }
         }
 
         return this;

--- a/src/test/resources/unit/subroutine_proto_trailing_comma_stmtend.t
+++ b/src/test/resources/unit/subroutine_proto_trailing_comma_stmtend.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+use Test::More;
+
+# Trailing comma before statement end, separated by newline (see DBIx::Class
+# t/storage/deprecated_exception_source_bind_attrs.t). Perl allows this for
+# parenthesis-free multi-arg prototype calls.
+
+sub proto22 ($$) { "$_[0]|$_[1]" }
+
+is(
+    scalar do {
+        proto22 11, 22,
+        ;
+    },
+    '11|22',
+    'trailing comma before semicolon across newline after prototype args'
+);
+
+# Same shape as Test::Exception::throws_ok (&$;$)
+sub proto_block_ok (&$;$) { 1 }
+
+ok(
+    scalar do {
+        proto_block_ok { 1 } qr/^$/,
+            'third arg with trailing comma',
+        ;
+    },
+    'ampersand-first prototype: trailing comma newline semicolon (throws_ok shape)'
+);
+
+done_testing;


### PR DESCRIPTION
## Summary

- **Parser:** Prototype argument parsing no longer treats a newline between a trailing comma and the statement terminator as an extra argument. Fixes CPAN failures such as DBIx::Class `t/storage/deprecated_exception_source_bind_attrs.t` (`Test::Exception` / `throws_ok` style calls).
- **Runtime (from #737):** Hardens DESTROY / method-cache invalidation and refcount handling around `PPI::Element` teardown (see linked PR for details), plus `dev/modules/ppi.md` plan notes.

## Test plan

- [x] `make` (unit tests / parallel shards)
- [ ] `timeout 120 ./jperl ...` against DBIx::Class `deprecated_exception_source_bind_attrs.t` in a jcpan tree (optional spot-check)
- [ ] CI green

Combines work from #737 so both areas are exercised in one CI run.
