### PR TITLE
Fix Test::Reporter test by filtering unstable java.vm.compressedOopsMode from -V output

### DIFF
--- a/src/main/java/org/perlonjava/app/cli/ArgumentParser.java
+++ b/src/main/java/org/perlonjava/app/cli/ArgumentParser.java
@@ -863,8 +863,12 @@ public class ArgumentParser {
             System.out.println("  Compiled at " + Configuration.buildTimestamp);
 
             System.out.println("  JVM properties:");
-            System.getProperties().forEach((key, value) ->
-                    System.out.println("    " + key + ": " + value));
+            System.getProperties().forEach((key, value) -> {
+                // Filter out unstable JVM properties that change between runs - this is needed by Test::Reporter
+                if (!key.equals("java.vm.compressedOopsMode")) {
+                    System.out.println("    " + key + ": " + value);
+                }
+            });
 
             // Print environment variables
             System.out.println("  %ENV:");


### PR DESCRIPTION
The JVM property java.vm.compressedOopsMode changes between runs, causing Test::Reporter test to fail when comparing _myconfig from different perl_version calls. This commit filters out this unstable property from the -V output to make it stable.