### PR TITLE
Fix numeric variable interpolation before package separators

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
@@ -403,11 +403,18 @@ public class IdentifierParser {
                     }
                     return prefix;
                 }
+                if (isFirstToken && token.type == LexerTokenType.NUMBER) {
+                    // Numeric variables like $0, $1, and @0 are never package-qualified.
+                    // In strings, "$0::Foo" is $0 followed by literal "::Foo".
+                    variableName.append(token.text);
+                    parser.tokenIndex++;
+                    return variableName.toString();
+                }
                 if (token.text.equals("$") && (nextToken.text.equals("$")
                         || nextToken.text.equals("{")
                         || nextToken.type == LexerTokenType.IDENTIFIER
-                        || nextToken.type == LexerTokenType.NUMBER)
-                        || nextToken.text.equals("::")) {
+                        || nextToken.type == LexerTokenType.NUMBER
+                        || nextToken.text.equals("::"))) {
                     // `@$` can't be followed by `$`, `{`, `::`, name or number
                     // `@{${...}` should fall back to block parsing
                     return null;
@@ -426,13 +433,6 @@ public class IdentifierParser {
 
                     return variableName.toString();
                 }
-                if (isFirstToken && token.type == LexerTokenType.NUMBER) {
-                    // Finish because $1 can't be followed by `::`
-                    variableName.append(token.text);
-                    parser.tokenIndex++;
-                    return variableName.toString();
-                }
-
                 // Handle single quote as package separator (legacy Perl syntax)
                 if (token.text.equals("'") && isSingleQuotePackageSeparator(parser, variableName)) {
                     // Perl only adds a BEGIN stash entry for this legacy syntax when the

--- a/src/test/resources/unit/string_interpolation.t
+++ b/src/test/resources/unit/string_interpolation.t
@@ -165,6 +165,22 @@ subtest 'Multiple dollar signs and complex expressions' => sub {
     is("$${\\\"literal\"}", "literal", "String literal in braces");
 };
 
+subtest 'Numeric variables followed by package separators' => sub {
+    is("$0::Statistics::Regression", $0 . "::Statistics::Regression",
+       '$0 followed by :: keeps :: as literal string text');
+
+    "abc" =~ /(b)/;
+    is("$1::tail", "b::tail",
+       '$1 followed by :: keeps :: as literal string text');
+
+    {
+        no strict 'vars';
+        local @0 = (4, 5, 6);
+        is("@0::X", "4 5 6::X",
+           '@0 followed by :: keeps :: as literal string text');
+    }
+};
+
 subtest 'Array length operations' => sub {
     my @arr = (1, 2, 3, 4, 5);
     
@@ -360,4 +376,3 @@ EOT
 }
 
 done_testing();
-


### PR DESCRIPTION
## Summary

- Stop first-token numeric variables such as `$0`, `$1`, and `@0` immediately after the number.
- Leave following `::` text as literal string content during interpolation.
- Add regression tests for `$0::...`, `$1::...`, and `@0::...`.

## Verification

- `timeout 120 ./jperl src/test/resources/unit/string_interpolation.t`
- `timeout 1200 make`
- `timeout 600 ./jcpan -t Statistics::Regression`
