### PR TITLE
Fix CPAN::Meta::Check -Mblib compile test

### DIFF
--- a/src/main/perl/lib/ExtUtils/MakeMaker.pm
+++ b/src/main/perl/lib/ExtUtils/MakeMaker.pm
@@ -608,6 +608,7 @@ sub _create_install_makefile {
     # Get INST_LIB and installation directories
     # Use INSTALL_BASE for consistency with where we actually install modules
     my $inst_lib = $args->{INST_LIB} || 'blib/lib';
+    my $inst_archlib = $args->{INST_ARCHLIB} || 'blib/arch';
     my $installsitelib = $args->{INSTALLSITELIB};
     my $siteprefix = $args->{SITEPREFIX} || $args->{PREFIX};
     
@@ -782,7 +783,7 @@ FULLPERLRUN = \$(FULLPERL)
 PERLRUNINST = \$(PERLRUN) -I\$(INST_ARCHLIB) -I\$(INST_LIB)
 INSTALLDIRS = site
 INST_LIB = $inst_lib
-INST_ARCHLIB = $inst_lib
+INST_ARCHLIB = $inst_archlib
 INST_LIBDIR = \$(INST_LIB)
 INST_ARCHLIBDIR = \$(INST_ARCHLIB)
 $siteprefix_var

--- a/src/test/resources/unit/makemaker_blib_arch.t
+++ b/src/test/resources/unit/makemaker_blib_arch.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+use Test::More;
+use Cwd qw(getcwd);
+use File::Path qw(make_path);
+use File::Temp qw(tempdir);
+
+my $orig_dir = getcwd();
+my $tmpdir = tempdir(CLEANUP => 1);
+
+END {
+    chdir $orig_dir if defined $orig_dir;
+}
+
+chdir $tmpdir or die "chdir $tmpdir: $!";
+make_path('lib/Local') or die "make_path lib/Local: $!";
+
+open my $pm, '>', 'lib/Local/BlibArch.pm'
+    or die "create test module: $!";
+print {$pm} "package Local::BlibArch;\n1;\n";
+close $pm or die "close test module: $!";
+
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME    => 'Local::BlibArch',
+    VERSION => '0.001',
+    PM      => {
+        'lib/Local/BlibArch.pm' => '$(INST_LIB)/Local/BlibArch.pm',
+    },
+);
+
+open my $mf, '<', 'Makefile' or die "open generated Makefile: $!";
+my $makefile = do { local $/; <$mf> };
+close $mf or die "close generated Makefile: $!";
+
+like($makefile, qr/^INST_LIB = blib\/lib$/m, 'INST_LIB defaults to blib/lib');
+like($makefile, qr/^INST_ARCHLIB = blib\/arch$/m, 'INST_ARCHLIB defaults to blib/arch');
+like(
+    $makefile,
+    qr/^\t\@mkdir -p \$\(INST_ARCHLIB\)$/m,
+    'pm_to_blib creates INST_ARCHLIB for -Mblib',
+);
+
+done_testing();


### PR DESCRIPTION
## Summary

- Fix PerlOnJava MakeMaker output so `INST_ARCHLIB` defaults to `blib/arch`
- Preserve explicit `INST_ARCHLIB` overrides from `WriteMakefile`
- Add a regression test for generated Makefiles used by `-Mblib`

## Verification

- `timeout 60 ./jperl -I src/main/perl/lib src/test/resources/unit/makemaker_blib_arch.t`
- `timeout 1200 make`
- `timeout 600 ./jcpan -t CPAN::Meta::Check`
