### PR TITLE
Fix File::ShareDir jcpan cleanup

### DIFF
--- a/src/main/perl/lib/File/Path.pm
+++ b/src/main/perl/lib/File/Path.pm
@@ -94,7 +94,7 @@ sub _remove_tree_perl {
 
         if (-d $path) {
             # Simple recursive removal
-            $count += _remove_dir_recursive($path, $verbose);
+            $count += _remove_dir_recursive($path, $verbose, $opts->{safe});
         } elsif (-f $path) {
             if (unlink($path)) {
                 $count++;
@@ -109,17 +109,32 @@ sub _remove_tree_perl {
 }
 
 sub _remove_dir_recursive {
-    my ($dir, $verbose) = @_;
+    my ($dir, $verbose, $safe) = @_;
     my $count = 0;
+    my $dh;
+    my $restore_mode;
 
-    opendir(my $dh, $dir) or croak "opendir $dir: $!";
+    unless (opendir($dh, $dir)) {
+        if (!$safe) {
+            my $mode = (lstat($dir))[2];
+            if (defined $mode) {
+                my $current_mode = $mode & 07777;
+                my $wanted = $current_mode | 0700;
+                if ($wanted != $current_mode && chmod($wanted, $dir)) {
+                    $restore_mode = $current_mode;
+                }
+            }
+        }
+        opendir($dh, $dir) or croak "opendir $dir: $!";
+    }
+
     my @entries = grep { $_ ne '.' && $_ ne '..' } readdir($dh);
     closedir($dh);
 
     for my $entry (@entries) {
         my $path = "$dir/$entry";
         if (-d $path) {
-            $count += _remove_dir_recursive($path, $verbose);
+            $count += _remove_dir_recursive($path, $verbose, $safe);
         } else {
             if (unlink($path)) {
                 $count++;
@@ -127,6 +142,8 @@ sub _remove_dir_recursive {
             }
         }
     }
+
+    chmod($restore_mode, $dir) if defined $restore_mode;
 
     if (rmdir($dir)) {
         $count++;

--- a/src/test/resources/unit/file_path_remove_tree.t
+++ b/src/test/resources/unit/file_path_remove_tree.t
@@ -1,0 +1,25 @@
+use 5.38.0;
+use strict;
+use warnings;
+use Test::More tests => 2;
+use File::Path qw(remove_tree);
+
+my $root = "/tmp/perlonjava-file-path-remove-tree-$$-" . time();
+my $child = "$root/unreadable";
+
+END {
+    chmod 0700, $child if defined $child && -e $child;
+    chmod 0700, $root  if defined $root  && -e $root;
+    rmdir $child if defined $child;
+    rmdir $root  if defined $root;
+}
+
+mkdir($root, 0700) or die "mkdir $root: $!";
+mkdir($child, 0100) or die "mkdir $child: $!";
+chmod(0100, $child) or die "chmod $child: $!";
+
+my $removed = eval { remove_tree($root) };
+my $err = $@;
+
+is($err, '', 'remove_tree does not die on unreadable child directories');
+ok(!-e $root, 'remove_tree removes unreadable child directories');


### PR DESCRIPTION
## Summary

- Update the bundled `File::Path` shim so `remove_tree` can clean unreadable child directories by temporarily adding owner `0700` permissions outside `safe` mode.
- Restore the original directory mode before `rmdir`, matching the relevant standard Perl `File::Path` behavior.
- Add a focused regression test for unreadable child directory cleanup.

## Verification

- `timeout 60 ./jperl -Isrc/main/perl/lib src/test/resources/unit/file_path_remove_tree.t`
- `perl src/test/resources/unit/file_path_remove_tree.t`
- `make`
- `timeout 600 ./jcpan -t File::ShareDir`
