### PR TITLE
Fix Test::Without::Module jcpan run

### DIFF
--- a/dev/import-perl5/config.yaml
+++ b/dev/import-perl5/config.yaml
@@ -313,6 +313,18 @@ imports:
   - source: perl5/cpan/Params-Check/lib/Params/Check.pm
     target: src/main/perl/lib/Params/Check.pm
 
+  # From CPAN distribution
+  - source: perl5/cpan/Module-Load/lib/Module/Load.pm
+    target: src/main/perl/lib/Module/Load.pm
+
+  # From CPAN distribution
+  - source: perl5/cpan/Module-Metadata/lib/Module/Metadata.pm
+    target: src/main/perl/lib/Module/Metadata.pm
+
+  # From CPAN distribution
+  - source: perl5/cpan/Module-Load-Conditional/lib/Module/Load/Conditional.pm
+    target: src/main/perl/lib/Module/Load/Conditional.pm
+
   # Tests for distribution
   - source: perl5/cpan/Params-Check/t
     target: perl5_t/Params-Check
@@ -1062,4 +1074,3 @@ imports:
   # - source: perl5/some_directory
   #   target: target_directory
   #   type: directory
-

--- a/src/main/perl/lib/Module/Load.pm
+++ b/src/main/perl/lib/Module/Load.pm
@@ -1,0 +1,373 @@
+package Module::Load;
+
+use strict;
+use warnings;
+use File::Spec ();
+
+our $VERSION = '0.36';
+
+
+sub import {
+    my $who = _who();
+    my $h; shift;
+
+    {   no strict 'refs';
+
+        @_ or (
+            *{"${who}::load"} = \&load, # compat to prev version
+            *{"${who}::autoload"} = \&autoload,
+            return
+        );
+
+        map { $h->{$_} = () if defined $_ } @_;
+
+        (exists $h->{none} or exists $h->{''})
+            and shift, last;
+
+        ((exists $h->{autoload} and shift,1) or (exists $h->{all} and shift))
+            and *{"${who}::autoload"} = \&autoload;
+
+        ((exists $h->{load} and shift,1) or exists $h->{all})
+            and *{"${who}::load"} = \&load;
+
+        ((exists $h->{load_remote} and shift,1) or exists $h->{all})
+            and *{"${who}::load_remote"} = \&load_remote;
+
+        ((exists $h->{autoload_remote} and shift,1) or exists $h->{all})
+            and *{"${who}::autoload_remote"} = \&autoload_remote;
+
+    }
+
+}
+
+sub load(*;@){
+    goto &_load;
+}
+
+sub autoload(*;@){
+    unshift @_, 'autoimport';
+    goto &_load;
+}
+
+sub load_remote($$;@){
+    my ($dst, $src, @exp) = @_;
+
+    eval "package $dst;Module::Load::load('$src', qw/@exp/);";
+    $@ && die "$@";
+}
+
+sub autoload_remote($$;@){
+    my ($dst, $src, @exp) = @_;
+
+    eval "package $dst;Module::Load::autoload('$src', qw/@exp/);";
+    $@ && die "$@";
+}
+
+sub _load{
+    my $autoimport = $_[0] eq 'autoimport' and shift;
+    my $mod = shift or return;
+    my $who = _who();
+
+    if( _is_file( $mod ) ) {
+        require $mod;
+    } else {
+        LOAD: {
+            my $err;
+            for my $flag ( qw[1 0] ) {
+                my $file = _to_file( $mod, $flag);
+                eval { require $file };
+                $@ ? $err .= $@ : last LOAD;
+            }
+            die $err if $err;
+        }
+    }
+
+    ### This addresses #41883: Module::Load cannot import
+    ### non-Exporter module. ->import() routines weren't
+    ### properly called when load() was used.
+
+    {   no strict 'refs';
+        my $import;
+
+    ((@_ or $autoimport) and (
+        $import = $mod->can('import')
+        ) and (
+        unshift(@_, $mod),
+        goto &$import
+        )
+    );
+    }
+
+}
+
+sub _to_file{
+    local $_    = shift;
+    my $pm      = shift || '';
+
+    ## trailing blanks ignored by default. [rt #69886]
+    my @parts = split /::|'/, $_, -1;
+    ## make sure that we can't hop out of @INC
+    shift @parts if @parts && !$parts[0];
+
+    ### because of [perl #19213], see caveats ###
+    my $file = $^O eq 'MSWin32'
+                    ? join "/", @parts
+                    : File::Spec->catfile( @parts );
+
+    $file   .= '.pm' if $pm;
+
+    ### on perl's before 5.10 (5.9.5@31746) if you require
+    ### a file in VMS format, it's stored in %INC in VMS
+    ### format. Therefor, better unixify it first
+    ### Patch in reply to John Malmbergs patch (as mentioned
+    ### above) on p5p Tue 21 Aug 2007 04:55:07
+    $file = VMS::Filespec::unixify($file) if $^O eq 'VMS';
+
+    return $file;
+}
+
+sub _who { (caller(1))[0] }
+
+sub _is_file {
+    local $_ = shift;
+    return  /^\./               ? 1 :
+            /[^\w:']/           ? 1 :
+            undef
+    #' silly bbedit..
+}
+
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+Module::Load - runtime require of both modules and files
+
+=head1 SYNOPSIS
+
+  use Module::Load;
+
+  my $module = 'Data::Dumper';
+
+  load Data::Dumper;     # loads that module, but not import any functions
+                         # -> cannot use 'Dumper' function
+
+  load 'Data::Dumper';   # ditto
+  load $module           # tritto
+
+  autoload Data::Dumper; # loads that module and imports the default functions
+                         # -> can use 'Dumper' function
+
+  my $script = 'some/script.pl'
+  load $script;
+  load 'some/script.pl';  # use quotes because of punctuations
+
+  load thing;             # try 'thing' first, then 'thing.pm'
+
+  load CGI, ':all';       # like 'use CGI qw[:standard]'
+
+=head1 DESCRIPTION
+
+C<Module::Load> eliminates the need to know whether you are trying
+to require either a file or a module.
+
+If you consult C<perldoc -f require> you will see that C<require> will
+behave differently when given a bareword or a string.
+
+In the case of a string, C<require> assumes you are wanting to load a
+file. But in the case of a bareword, it assumes you mean a module.
+
+This gives nasty overhead when you are trying to dynamically require
+modules at runtime, since you will need to change the module notation
+(C<Acme::Comment>) to a file notation fitting the particular platform
+you are on.
+
+C<Module::Load> eliminates the need for this overhead and will
+just DWYM.
+
+=head2 Difference between C<load> and C<autoload>
+
+C<Module::Load> imports the two functions - C<load> and C<autoload>
+
+C<autoload> imports the default functions automatically,
+but C<load> do not import any functions.
+
+C<autoload> is usable under C<BEGIN{};>.
+
+Both the functions can import the functions that are specified.
+
+Following codes are same.
+
+  load File::Spec::Functions, qw/splitpath/;
+
+  autoload File::Spec::Functions, qw/splitpath/;
+
+=head1 FUNCTIONS
+
+=over 4
+
+=item load
+
+Loads a specified module.
+
+See L</Rules> for detailed loading rule.
+
+=item autoload
+
+Loads a specified module and imports the default functions.
+
+Except importing the functions, 'autoload' is same as 'load'.
+
+=item load_remote
+
+Loads a specified module to the specified package.
+
+  use Module::Load 'load_remote';
+
+  my $pkg = 'Other::Package';
+
+  load_remote $pkg, 'Data::Dumper'; # load a module to 'Other::Package'
+                                    # but do not import 'Dumper' function
+
+A module for loading must be quoted.
+
+Except specifing the package and quoting module name,
+'load_remote' is same as 'load'.
+
+=item autoload_remote
+
+Loads a specified module and imports the default functions to the specified package.
+
+  use Module::Load 'autoload_remote';
+
+  my $pkg = 'Other::Package';
+
+  autoload_remote $pkg, 'Data::Dumper'; # load a module to 'Other::Package'
+                                        # and imports 'Dumper' function
+
+A module for loading must be quoted.
+
+Except specifing the package and quoting module name,
+'autoload_remote' is same as 'load_remote'.
+
+=back
+
+=head1 Rules
+
+All functions have the following rules to decide what it thinks
+you want:
+
+=over 4
+
+=item *
+
+If the argument has any characters in it other than those matching
+C<\w>, C<:> or C<'>, it must be a file
+
+=item *
+
+If the argument matches only C<[\w:']>, it must be a module
+
+=item *
+
+If the argument matches only C<\w>, it could either be a module or a
+file. We will try to find C<file.pm> first in C<@INC> and if that
+fails, we will try to find C<file> in @INC.  If both fail, we die with
+the respective error messages.
+
+=back
+
+=head1 IMPORTS THE FUNCTIONS
+
+'load' and 'autoload' are imported by default, but 'load_remote' and
+'autoload_remote' are not imported.
+
+To use 'load_remote' or 'autoload_remote', specify at 'use'.
+
+=over 4
+
+=item "load","autoload","load_remote","autoload_remote"
+
+Imports the selected functions.
+
+  # imports 'load' and 'autoload' (default)
+  use Module::Load;
+
+  # imports 'autoload' only
+  use Module::Load 'autoload';
+
+  # imports 'autoload' and 'autoload_remote', but don't import 'load';
+  use Module::Load qw/autoload autoload_remote/;
+
+=item 'all'
+
+Imports all the functions.
+
+  use Module::Load 'all'; # imports load, autoload, load_remote, autoload_remote
+
+=item '','none',undef
+
+Not import any functions (C<load> and C<autoload> are not imported).
+
+  use Module::Load '';
+
+  use Module::Load 'none';
+
+  use Module::Load undef;
+
+=back
+
+=head1 Caveats
+
+Because of a bug in perl (#19213), at least in version 5.6.1, we have
+to hardcode the path separator for a require on Win32 to be C</>, like
+on Unix rather than the Win32 C<\>. Otherwise perl will not read its
+own %INC accurately double load files if they are required again, or
+in the worst case, core dump.
+
+C<Module::Load> cannot do implicit imports, only explicit imports.
+(in other words, you always have to specify explicitly what you wish
+to import from a module, even if the functions are in that modules'
+C<@EXPORT>)
+
+=head1 SEE ALSO
+
+L<Module::Runtime> provides functions for loading modules,
+checking the validity of a module name,
+converting a module name to partial C<.pm> path,
+and related utility functions.
+
+L<"require" in perlfunc|https://metacpan.org/pod/perlfunc#require>
+and
+L<"use" in perlfunc|https://metacpan.org/pod/perlfunc#use>.
+
+L<Mojo::Loader> is a "class loader and plugin framework",
+and is included in the
+L<Mojolicious|https://metacpan.org/release/Mojolicious> distribution.
+
+L<Module::Loader> is a module for finding and loading modules
+in a given namespace, inspired by C<Mojo::Loader>.
+
+
+=head1 ACKNOWLEDGEMENTS
+
+Thanks to Jonas B. Nielsen for making explicit imports work.
+
+=head1 BUG REPORTS
+
+Please report bugs or other issues to E<lt>bug-module-load@rt.cpan.orgE<gt>.
+
+=head1 AUTHOR
+
+This module by Jos Boumans E<lt>kane@cpan.orgE<gt>.
+
+=head1 COPYRIGHT
+
+This library is free software; you may redistribute and/or modify it
+under the same terms as Perl itself.
+
+=cut

--- a/src/main/perl/lib/Module/Load/Conditional.pm
+++ b/src/main/perl/lib/Module/Load/Conditional.pm
@@ -1,0 +1,624 @@
+package Module::Load::Conditional;
+
+use strict;
+
+use Module::Load qw/load autoload_remote/;
+use Params::Check                       qw[check];
+use Locale::Maketext::Simple Style  => 'gettext';
+
+use Carp        ();
+use File::Spec  ();
+use FileHandle  ();
+use version;
+
+use Module::Metadata ();
+
+use constant ON_VMS   => $^O eq 'VMS';
+use constant ON_WIN32 => $^O eq 'MSWin32' ? 1 : 0;
+use constant QUOTE    => do { ON_WIN32 ? q["] : q['] };
+
+BEGIN {
+    use vars        qw[ $VERSION @ISA $VERBOSE $CACHE @EXPORT_OK $DEPRECATED
+                        $FIND_VERSION $ERROR $CHECK_INC_HASH $FORCE_SAFE_INC ];
+    use Exporter;
+    @ISA            = qw[Exporter];
+    $VERSION        = '0.74';
+    $VERBOSE        = 0;
+    $DEPRECATED     = 0;
+    $FIND_VERSION   = 1;
+    $CHECK_INC_HASH = 0;
+    $FORCE_SAFE_INC = 0;
+    @EXPORT_OK      = qw[check_install can_load requires];
+}
+
+=pod
+
+=head1 NAME
+
+Module::Load::Conditional - Looking up module information / loading at runtime
+
+=head1 SYNOPSIS
+
+    use Module::Load::Conditional qw[can_load check_install requires];
+
+
+    my $use_list = {
+            CPANPLUS        => 0.05,
+            LWP             => 5.60,
+            'Test::More'    => undef,
+    };
+
+    print can_load( modules => $use_list )
+            ? 'all modules loaded successfully'
+            : 'failed to load required modules';
+
+
+    my $rv = check_install( module => 'LWP', version => 5.60 )
+                or print 'LWP is not installed!';
+
+    print 'LWP up to date' if $rv->{uptodate};
+    print "LWP version is $rv->{version}\n";
+    print "LWP is installed as file $rv->{file}\n";
+
+
+    print "LWP requires the following modules to be installed:\n";
+    print join "\n", requires('LWP');
+
+    ### allow M::L::C to peek in your %INC rather than just
+    ### scanning @INC
+    $Module::Load::Conditional::CHECK_INC_HASH = 1;
+
+    ### reset the 'can_load' cache
+    undef $Module::Load::Conditional::CACHE;
+
+    ### don't have Module::Load::Conditional issue warnings --
+    ### default is '1'
+    $Module::Load::Conditional::VERBOSE = 0;
+
+    ### The last error that happened during a call to 'can_load'
+    my $err = $Module::Load::Conditional::ERROR;
+
+
+=head1 DESCRIPTION
+
+Module::Load::Conditional provides simple ways to query and possibly load any of
+the modules you have installed on your system during runtime.
+
+It is able to load multiple modules at once or none at all if one of
+them was not able to load. It also takes care of any error checking
+and so forth.
+
+=head1 Methods
+
+=head2 $href = check_install( module => NAME [, version => VERSION, verbose => BOOL ] );
+
+C<check_install> allows you to verify if a certain module is installed
+or not. You may call it with the following arguments:
+
+=over 4
+
+=item module
+
+The name of the module you wish to verify -- this is a required key
+
+=item version
+
+The version this module needs to be -- this is optional
+
+=item verbose
+
+Whether or not to be verbose about what it is doing -- it will default
+to $Module::Load::Conditional::VERBOSE
+
+=back
+
+It will return undef if it was not able to find where the module was
+installed, or a hash reference with the following keys if it was able
+to find the file:
+
+=over 4
+
+=item file
+
+Full path to the file that contains the module
+
+=item dir
+
+Directory, or more exact the C<@INC> entry, where the module was
+loaded from.
+
+=item version
+
+The version number of the installed module - this will be C<undef> if
+the module had no (or unparsable) version number, or if the variable
+C<$Module::Load::Conditional::FIND_VERSION> was set to true.
+(See the C<GLOBAL VARIABLES> section below for details)
+
+=item uptodate
+
+A boolean value indicating whether or not the module was found to be
+at least the version you specified. If you did not specify a version,
+uptodate will always be true if the module was found.
+If no parsable version was found in the module, uptodate will also be
+true, since C<check_install> had no way to verify clearly.
+
+See also C<$Module::Load::Conditional::DEPRECATED>, which affects
+the outcome of this value.
+
+=back
+
+=cut
+
+### this checks if a certain module is installed already ###
+### if it returns true, the module in question is already installed
+### or we found the file, but couldn't open it, OR there was no version
+### to be found in the module
+### it will return 0 if the version in the module is LOWER then the one
+### we are looking for, or if we couldn't find the desired module to begin with
+### if the installed version is higher or equal to the one we want, it will return
+### a hashref with he module name and version in it.. so 'true' as well.
+sub check_install {
+    my %hash = @_;
+
+    my $tmpl = {
+            version => { default    => '0.0'    },
+            module  => { required   => 1        },
+            verbose => { default    => $VERBOSE },
+    };
+
+    my $args;
+    unless( $args = check( $tmpl, \%hash, $VERBOSE ) ) {
+        warn loc( q[A problem occurred checking arguments] ) if $VERBOSE;
+        return;
+    }
+
+    my $file     = File::Spec->catfile( split /::/, $args->{module} ) . '.pm';
+    my $file_inc = File::Spec::Unix->catfile(
+                        split /::/, $args->{module}
+                    ) . '.pm';
+
+    ### where we store the return value ###
+    my $href = {
+            file        => undef,
+            version     => undef,
+            uptodate    => undef,
+    };
+
+    my $filename;
+
+    ### check the inc hash if we're allowed to
+    if( $CHECK_INC_HASH ) {
+        $filename = $href->{'file'} =
+            $INC{ $file_inc } if defined $INC{ $file_inc };
+
+        ### find the version by inspecting the package
+        if( defined $filename && $FIND_VERSION ) {
+            no strict 'refs';
+            $href->{version} = ${ "$args->{module}"."::VERSION" };
+        }
+    }
+
+    ### we didn't find the filename yet by looking in %INC,
+    ### so scan the dirs
+    unless( $filename ) {
+
+        local @INC = @INC[0..$#INC-1] if $FORCE_SAFE_INC && $INC[-1] eq '.';
+
+        DIR: for my $dir ( @INC ) {
+
+            my $fh;
+
+            if ( ref $dir ) {
+                ### @INC hook -- we invoke it and get the filehandle back
+                ### this is actually documented behaviour as of 5.8 ;)
+
+                my $existed_in_inc = $INC{$file_inc};
+
+                if (UNIVERSAL::isa($dir, 'CODE')) {
+                    ($fh) = $dir->($dir, $file);
+
+                } elsif (UNIVERSAL::isa($dir, 'ARRAY')) {
+                    ($fh) = $dir->[0]->($dir, $file, @{$dir}{1..$#{$dir}})
+
+                } elsif (UNIVERSAL::can($dir, 'INC')) {
+                    ($fh) = $dir->INC($file);
+                }
+
+                if (!UNIVERSAL::isa($fh, 'GLOB')) {
+                    warn loc(q[Cannot open file '%1': %2], $file, $!)
+                            if $args->{verbose};
+                    next;
+                }
+
+                $filename = $INC{$file_inc} || $file;
+
+                delete $INC{$file_inc} if not $existed_in_inc;
+
+            } else {
+                $filename = File::Spec->catfile($dir, $file);
+                next unless -e $filename;
+
+                $fh = FileHandle->new();
+                if (!$fh->open($filename)) {
+                    warn loc(q[Cannot open file '%1': %2], $file, $!)
+                            if $args->{verbose};
+                    next;
+                }
+            }
+
+            ### store the directory we found the file in
+            $href->{dir} = $dir;
+
+            ### files need to be in unix format under vms,
+            ### or they might be loaded twice
+            $href->{file} = ON_VMS
+                ? VMS::Filespec::unixify( $filename )
+                : $filename;
+
+            ### if we don't need the version, we're done
+            last DIR unless $FIND_VERSION;
+
+            ### otherwise, the user wants us to find the version from files
+
+            {
+              local $SIG{__WARN__} = sub {};
+              my $ver = eval {
+                my $mod_info = Module::Metadata->new_from_handle( $fh, $filename );
+                $mod_info->version( $args->{module} );
+              };
+
+              if( defined $ver ) {
+                  $href->{version} = $ver;
+
+                  last DIR;
+              }
+            }
+        }
+    }
+
+    ### if we couldn't find the file, return undef ###
+    return unless defined $href->{file};
+
+    ### only complain if we're expected to find a version higher than 0.0 anyway
+    if( $FIND_VERSION and not defined $href->{version} ) {
+        {   ### don't warn about the 'not numeric' stuff ###
+            local $^W;
+
+            ### if we got here, we didn't find the version
+            warn loc(q[Could not check version on '%1'], $args->{module} )
+                    if $args->{verbose} and $args->{version} > 0;
+        }
+        $href->{uptodate} = 1;
+
+    } else {
+        ### don't warn about the 'not numeric' stuff ###
+        local $^W;
+
+        ### use qv(), as it will deal with developer release number
+        ### ie ones containing _ as well. This addresses bug report
+        ### #29348: Version compare logic doesn't handle alphas?
+        ###
+        ### Update from JPeacock: apparently qv() and version->new
+        ### are different things, and we *must* use version->new
+        ### here, or things like #30056 might start happening
+
+        ### We have to wrap this in an eval as version-0.82 raises
+        ### exceptions and not warnings now *sigh*
+
+        eval {
+
+          $href->{uptodate} =
+            version->new( $args->{version} ) <= version->new( $href->{version} )
+                ? 1
+                : 0;
+
+        };
+    }
+
+    if ( $DEPRECATED and "$]" >= 5.011 ) {
+        local @INC = @INC[0..$#INC-1] if $FORCE_SAFE_INC && $INC[-1] eq '.';
+        require Module::CoreList;
+        require Config;
+
+        no warnings 'once';
+        $href->{uptodate} = 0 if
+           exists $Module::CoreList::version{ 0+$] }{ $args->{module} } and
+           Module::CoreList::is_deprecated( $args->{module} ) and
+           $Config::Config{privlibexp} eq $href->{dir}
+           and $Config::Config{privlibexp} ne $Config::Config{sitelibexp};
+    }
+
+    return $href;
+}
+
+=head2 $bool = can_load( modules => { NAME => VERSION [,NAME => VERSION] }, [verbose => BOOL, nocache => BOOL, autoload => BOOL] )
+
+C<can_load> will take a list of modules, optionally with version
+numbers and determine if it is able to load them. If it can load *ALL*
+of them, it will. If one or more are unloadable, none will be loaded.
+
+This is particularly useful if you have More Than One Way (tm) to
+solve a problem in a program, and only wish to continue down a path
+if all modules could be loaded, and not load them if they couldn't.
+
+This function uses the C<load> function or the C<autoload_remote> function
+from Module::Load under the hood.
+
+C<can_load> takes the following arguments:
+
+=over 4
+
+=item modules
+
+This is a hashref of module/version pairs. The version indicates the
+minimum version to load. If no version is provided, any version is
+assumed to be good enough.
+
+=item verbose
+
+This controls whether warnings should be printed if a module failed
+to load.
+The default is to use the value of $Module::Load::Conditional::VERBOSE.
+
+=item nocache
+
+C<can_load> keeps its results in a cache, so it will not load the
+same module twice, nor will it attempt to load a module that has
+already failed to load before. By default, C<can_load> will check its
+cache, but you can override that by setting C<nocache> to true.
+
+=item autoload
+
+This controls whether imports the functions of a loaded modules to the caller package. The default is no importing any functions.
+
+See the C<autoload> function and the C<autoload_remote> function from L<Module::Load> for details.
+
+=cut
+
+sub can_load {
+    my %hash = @_;
+
+    my $tmpl = {
+        modules     => { default => {}, strict_type => 1 },
+        verbose     => { default => $VERBOSE },
+        nocache     => { default => 0 },
+        autoload    => { default => 0 },
+    };
+
+    my $args;
+
+    unless( $args = check( $tmpl, \%hash, $VERBOSE ) ) {
+        $ERROR = loc(q[Problem validating arguments!]);
+        warn $ERROR if $VERBOSE;
+        return;
+    }
+
+    ### layout of $CACHE:
+    ### $CACHE = {
+    ###     $ module => {
+    ###             usable  => BOOL,
+    ###             version => \d,
+    ###             file    => /path/to/file,
+    ###     },
+    ### };
+
+    $CACHE ||= {}; # in case it was undef'd
+
+    my $error;
+    BLOCK: {
+        my $href = $args->{modules};
+
+        my @load;
+        for my $mod ( keys %$href ) {
+
+            next if $CACHE->{$mod}->{usable} && !$args->{nocache};
+
+            ### else, check if the hash key is defined already,
+            ### meaning $mod => 0,
+            ### indicating UNSUCCESSFUL prior attempt of usage
+
+            ### use qv(), as it will deal with developer release number
+            ### ie ones containing _ as well. This addresses bug report
+            ### #29348: Version compare logic doesn't handle alphas?
+            ###
+            ### Update from JPeacock: apparently qv() and version->new
+            ### are different things, and we *must* use version->new
+            ### here, or things like #30056 might start happening
+            if (    !$args->{nocache}
+                    && defined $CACHE->{$mod}->{usable}
+                    && (version->new( $CACHE->{$mod}->{version}||0 )
+                        >= version->new( $href->{$mod} ) )
+            ) {
+                $error = loc( q[Already tried to use '%1', which was unsuccessful], $mod);
+                last BLOCK;
+            }
+
+            my $mod_data = check_install(
+                                    module  => $mod,
+                                    version => $href->{$mod}
+                                );
+
+            if( !$mod_data or !defined $mod_data->{file} ) {
+                $error = loc(q[Could not find or check module '%1'], $mod);
+                $CACHE->{$mod}->{usable} = 0;
+                last BLOCK;
+            }
+
+            map {
+                $CACHE->{$mod}->{$_} = $mod_data->{$_}
+            } qw[version file uptodate];
+
+            push @load, $mod;
+        }
+
+        for my $mod ( @load ) {
+
+            if ( $CACHE->{$mod}->{uptodate} ) {
+
+                local @INC = @INC[0..$#INC-1] if $FORCE_SAFE_INC && $INC[-1] eq '.';
+
+                if ( $args->{autoload} ) {
+                    my $who = (caller())[0];
+                    eval { autoload_remote $who, $mod };
+                } else {
+                    eval { load $mod };
+                }
+
+                ### in case anything goes wrong, log the error, the fact
+                ### we tried to use this module and return 0;
+                if( $@ ) {
+                    $error = $@;
+                    $CACHE->{$mod}->{usable} = 0;
+                    last BLOCK;
+                } else {
+                    $CACHE->{$mod}->{usable} = 1;
+                }
+
+            ### module not found in @INC, store the result in
+            ### $CACHE and return 0
+            } else {
+
+                $error = loc(q[Module '%1' is not uptodate!], $mod);
+                $CACHE->{$mod}->{usable} = 0;
+                last BLOCK;
+            }
+        }
+
+    } # BLOCK
+
+    if( defined $error ) {
+        $ERROR = $error;
+        Carp::carp( loc(q|%1 [THIS MAY BE A PROBLEM!]|,$error) ) if $args->{verbose};
+        return;
+    } else {
+        return 1;
+    }
+}
+
+=back
+
+=head2 @list = requires( MODULE );
+
+C<requires> can tell you what other modules a particular module
+requires. This is particularly useful when you're intending to write
+a module for public release and are listing its prerequisites.
+
+C<requires> takes but one argument: the name of a module.
+It will then first check if it can actually load this module, and
+return undef if it can't.
+Otherwise, it will return a list of modules and pragmas that would
+have been loaded on the module's behalf.
+
+Note: The list C<require> returns has originated from your current
+perl and your current install.
+
+=cut
+
+sub requires {
+    my $who = shift;
+
+    unless( check_install( module => $who ) ) {
+        warn loc(q[You do not have module '%1' installed], $who) if $VERBOSE;
+        return undef;
+    }
+
+    local @INC = @INC[0..$#INC-1] if $FORCE_SAFE_INC && $INC[-1] eq '.';
+
+    my $lib = join " ", map { qq["-I$_"] } @INC;
+    my $oneliner = 'print(join(qq[\n],map{qq[BONG=$_]}keys(%INC)),qq[\n])';
+    my $cmd = join '', qq["$^X" $lib -M$who -e], QUOTE, $oneliner, QUOTE;
+
+    return  sort
+                grep { !/^$who$/  }
+                map  { chomp; s|/|::|g; $_ }
+                grep { s|\.pm$||i; }
+                map  { s!^BONG\=!!; $_ }
+                grep { m!^BONG\=! }
+            `$cmd`;
+}
+
+1;
+
+__END__
+
+=head1 Global Variables
+
+The behaviour of Module::Load::Conditional can be altered by changing the
+following global variables:
+
+=head2 $Module::Load::Conditional::VERBOSE
+
+This controls whether Module::Load::Conditional will issue warnings and
+explanations as to why certain things may have failed. If you set it
+to 0, Module::Load::Conditional will not output any warnings.
+The default is 0;
+
+=head2 $Module::Load::Conditional::FIND_VERSION
+
+This controls whether Module::Load::Conditional will try to parse
+(and eval) the version from the module you're trying to load.
+
+If you don't wish to do this, set this variable to C<false>. Understand
+then that version comparisons are not possible, and Module::Load::Conditional
+can not tell you what module version you have installed.
+This may be desirable from a security or performance point of view.
+Note that C<$FIND_VERSION> code runs safely under C<taint mode>.
+
+The default is 1;
+
+=head2 $Module::Load::Conditional::CHECK_INC_HASH
+
+This controls whether C<Module::Load::Conditional> checks your
+C<%INC> hash to see if a module is available. By default, only
+C<@INC> is scanned to see if a module is physically on your
+filesystem, or available via an C<@INC-hook>. Setting this variable
+to C<true> will trust any entries in C<%INC> and return them for
+you.
+
+The default is 0;
+
+=head2 $Module::Load::Conditional::FORCE_SAFE_INC
+
+This controls whether C<Module::Load::Conditional> sanitises C<@INC>
+by removing "C<.>". The current default setting is C<0>, but this
+may change in a future release.
+
+=head2 $Module::Load::Conditional::CACHE
+
+This holds the cache of the C<can_load> function. If you explicitly
+want to remove the current cache, you can set this variable to
+C<undef>
+
+=head2 $Module::Load::Conditional::ERROR
+
+This holds a string of the last error that happened during a call to
+C<can_load>. It is useful to inspect this when C<can_load> returns
+C<undef>.
+
+=head2 $Module::Load::Conditional::DEPRECATED
+
+This controls whether C<Module::Load::Conditional> checks if
+a dual-life core module has been deprecated. If this is set to
+true C<check_install> will return false to C<uptodate>, if
+a dual-life module is found to be loaded from C<$Config{privlibexp}>
+
+The default is 0;
+
+=head1 See Also
+
+C<Module::Load>
+
+=head1 BUG REPORTS
+
+Please report bugs or other issues to E<lt>bug-module-load-conditional@rt.cpan.orgE<gt>.
+
+=head1 AUTHOR
+
+This module by Jos Boumans E<lt>kane@cpan.orgE<gt>.
+
+=head1 COPYRIGHT
+
+This library is free software; you may redistribute and/or modify it
+under the same terms as Perl itself.
+
+=cut

--- a/src/main/perl/lib/Module/Metadata.pm
+++ b/src/main/perl/lib/Module/Metadata.pm
@@ -1,0 +1,1219 @@
+# -*- mode: cperl; tab-width: 8; indent-tabs-mode: nil; basic-offset: 2 -*-
+# vim:ts=8:sw=2:et:sta:sts=2:tw=78
+package Module::Metadata; # git description: v1.000038-5-g7f7baae
+# ABSTRACT: Gather package and POD information from perl module files
+
+# Adapted from Perl-licensed code originally distributed with
+# Module-Build by Ken Williams
+
+# This module provides routines to gather information about
+# perl modules (assuming this may be expanded in the distant
+# parrot future to look at other types of modules).
+
+sub __clean_eval { eval $_[0] }
+use strict;
+use warnings;
+
+our $VERSION = '1.000039';
+
+use Carp qw/croak/;
+use File::Spec;
+BEGIN {
+       # Try really hard to not depend ony any DynaLoaded module, such as IO::File or Fcntl
+       eval {
+               require Fcntl; Fcntl->import('SEEK_SET'); 1;
+       } or *SEEK_SET = sub { 0 }
+}
+use version 0.87;
+BEGIN {
+  if ($INC{'Log/Contextual.pm'}) {
+    require "Log/Contextual/WarnLogger.pm"; # Hide from AutoPrereqs
+    Log::Contextual->import('log_info',
+      '-default_logger' => Log::Contextual::WarnLogger->new({ env_prefix => 'MODULE_METADATA', }),
+    );
+  }
+  else {
+    *log_info = sub (&) { warn $_[0]->() };
+  }
+}
+use File::Find qw(find);
+
+my $V_NUM_REGEXP = qr{v?[0-9._]+};  # crudely, a v-string or decimal
+
+my $PKG_FIRST_WORD_REGEXP = qr{ # the FIRST word in a package name
+  [a-zA-Z_]                     # the first word CANNOT start with a digit
+    (?:
+      [\w']?                    # can contain letters, digits, _, or ticks
+      \w                        # But, NO multi-ticks or trailing ticks
+    )*
+}x;
+
+my $PKG_ADDL_WORD_REGEXP = qr{ # the 2nd+ word in a package name
+  \w                           # the 2nd+ word CAN start with digits
+    (?:
+      [\w']?                   # and can contain letters or ticks
+      \w                       # But, NO multi-ticks or trailing ticks
+    )*
+}x;
+
+my $PKG_NAME_REGEXP = qr{ # match a package name
+  (?: :: )?               # a pkg name can start with arisdottle
+  $PKG_FIRST_WORD_REGEXP  # a package word
+  (?:
+    (?: :: )+             ### arisdottle (allow one or many times)
+    $PKG_ADDL_WORD_REGEXP ### a package word
+  )*                      # ^ zero, one or many times
+  (?:
+    ::                    # allow trailing arisdottle
+  )?
+}x;
+
+my $PKG_REGEXP  = qr{   # match a package declaration
+  ^[\s\{;]*             # intro chars on a line
+  package               # the word 'package'
+  \s+                   # whitespace
+  ($PKG_NAME_REGEXP)    # a package name
+  \s*                   # optional whitespace
+  ($V_NUM_REGEXP)?      # optional version number
+  \s*                   # optional whitespace
+  [;\{]                 # semicolon line terminator or block start (since 5.16)
+}x;
+
+my $CLASS_REGEXP = qr{  # match a class declaration (core since 5.38)
+  ^[\s\{;]*             # intro chars on a line
+  class                 # the word 'class'
+  \s+                   # whitespace
+  ($PKG_NAME_REGEXP)    # a package name
+  \s*                   # optional whitespace
+  ($V_NUM_REGEXP)?      # optional version number
+  \s*                   # optional whitespace
+  [:;\{]                # attribute start, semicolon line terminator or block start
+}x;
+
+my $VARNAME_REGEXP = qr{ # match fully-qualified VERSION name
+  ([\$*])         # sigil - $ or *
+  (
+    (             # optional leading package name
+      (?:::|\')?  # possibly starting like just :: (a la $::VERSION)
+      (?:\w+(?:::|\'))*  # Foo::Bar:: ...
+    )?
+    VERSION
+  )\b
+}x;
+
+my $VERS_REGEXP = qr{ # match a VERSION definition
+  (?:
+    \(\s*$VARNAME_REGEXP\s*\) # with parens
+  |
+    $VARNAME_REGEXP           # without parens
+  )
+  \s*
+  =[^=~>]  # = but not ==, nor =~, nor =>
+}x;
+
+sub new_from_file {
+  my $class    = shift;
+  my $filename = File::Spec->rel2abs( shift );
+
+  return undef unless defined( $filename ) && -f $filename;
+  return $class->_init(undef, $filename, @_);
+}
+
+sub new_from_handle {
+  my $class    = shift;
+  my $handle   = shift;
+  my $filename = shift;
+  return undef unless defined($handle) && defined($filename);
+  $filename = File::Spec->rel2abs( $filename );
+
+  return $class->_init(undef, $filename, @_, handle => $handle);
+
+}
+
+
+sub new_from_module {
+  my $class   = shift;
+  my $module  = shift;
+  my %props   = @_;
+
+  $props{inc} ||= \@INC;
+  my $filename = $class->find_module_by_name( $module, $props{inc} );
+  return undef unless defined( $filename ) && -f $filename;
+  return $class->_init($module, $filename, %props);
+}
+
+{
+
+  my $compare_versions = sub {
+    my ($v1, $op, $v2) = @_;
+    $v1 = version->new($v1)
+      unless UNIVERSAL::isa($v1,'version');
+
+    my $eval_str = "\$v1 $op \$v2";
+    my $result   = eval $eval_str;
+    log_info { "error comparing versions: '$eval_str' $@" } if $@;
+
+    return $result;
+  };
+
+  my $normalize_version = sub {
+    my ($version) = @_;
+    if ( $version =~ /[=<>!,]/ ) { # logic, not just version
+      # take as is without modification
+    }
+    elsif ( ref $version eq 'version' ) { # version objects
+      $version = $version->is_qv ? $version->normal : $version->stringify;
+    }
+    elsif ( $version =~ /^[^v][^.]*\.[^.]+\./ ) { # no leading v, multiple dots
+      # normalize string tuples without "v": "1.2.3" -> "v1.2.3"
+      $version = "v$version";
+    }
+    else {
+      # leave alone
+    }
+    return $version;
+  };
+
+  # separate out some of the conflict resolution logic
+
+  my $resolve_module_versions = sub {
+    my $packages = shift;
+
+    my( $file, $version );
+    my $err = '';
+      foreach my $p ( @$packages ) {
+        if ( defined( $p->{version} ) ) {
+          if ( defined( $version ) ) {
+            if ( $compare_versions->( $version, '!=', $p->{version} ) ) {
+              $err .= "  $p->{file} ($p->{version})\n";
+            }
+            else {
+              # same version declared multiple times, ignore
+            }
+          }
+          else {
+            $file    = $p->{file};
+            $version = $p->{version};
+          }
+        }
+      $file ||= $p->{file} if defined( $p->{file} );
+    }
+
+    if ( $err ) {
+      $err = "  $file ($version)\n" . $err;
+    }
+
+    my %result = (
+      file    => $file,
+      version => $version,
+      err     => $err
+    );
+
+    return \%result;
+  };
+
+  sub provides {
+    my $class = shift;
+
+    croak "provides() requires key/value pairs \n" if @_ % 2;
+    my %args = @_;
+
+    croak "provides() takes only one of 'dir' or 'files'\n"
+      if $args{dir} && $args{files};
+
+    croak "provides() requires a 'version' argument"
+      unless defined $args{version};
+
+    croak "provides() does not support version '$args{version}' metadata"
+        unless grep $args{version} eq $_, qw/1.4 2/;
+
+    $args{prefix} = 'lib' unless defined $args{prefix};
+
+    my $p;
+    if ( $args{dir} ) {
+      $p = $class->package_versions_from_directory($args{dir});
+    }
+    else {
+      croak "provides() requires 'files' to be an array reference\n"
+        unless ref $args{files} eq 'ARRAY';
+      $p = $class->package_versions_from_directory($args{files});
+    }
+
+    # Now, fix up files with prefix
+    if ( length $args{prefix} ) { # check in case disabled with q{}
+      $args{prefix} =~ s{/$}{};
+      for my $v ( values %$p ) {
+        $v->{file} = "$args{prefix}/$v->{file}";
+      }
+    }
+
+    return $p
+  }
+
+  sub package_versions_from_directory {
+    my ( $class, $dir, $files ) = @_;
+
+    my @files;
+
+    if ( $files ) {
+      @files = @$files;
+    }
+    else {
+      find( {
+        wanted => sub {
+          push @files, $_ if -f $_ && /\.pm$/;
+        },
+        no_chdir => 1,
+      }, $dir );
+    }
+
+    # First, we enumerate all packages & versions,
+    # separating into primary & alternative candidates
+    my( %prime, %alt );
+    foreach my $file (@files) {
+      my $mapped_filename = File::Spec->abs2rel( $file, $dir );
+      my @path = File::Spec->splitdir( $mapped_filename );
+      (my $prime_package = join( '::', @path )) =~ s/\.pm$//;
+
+      my $pm_info = $class->new_from_file( $file );
+
+      foreach my $package ( $pm_info->packages_inside ) {
+        next if $package eq 'main';  # main can appear numerous times, ignore
+        next if $package eq 'DB';    # special debugging package, ignore
+        next if grep /^_/, split( /::/, $package ); # private package, ignore
+
+        my $version = $pm_info->version( $package );
+
+        $prime_package = $package if lc($prime_package) eq lc($package);
+        if ( $package eq $prime_package ) {
+          if ( exists( $prime{$package} ) ) {
+            croak "Unexpected conflict in '$package'; multiple versions found.\n";
+          }
+          else {
+            $mapped_filename = "$package.pm" if lc("$package.pm") eq lc($mapped_filename);
+            $prime{$package}{file} = $mapped_filename;
+            $prime{$package}{version} = $version if defined( $version );
+          }
+        }
+        else {
+          push( @{$alt{$package}}, {
+                                    file    => $mapped_filename,
+                                    version => $version,
+                                   } );
+        }
+      }
+    }
+
+    # Then we iterate over all the packages found above, identifying conflicts
+    # and selecting the "best" candidate for recording the file & version
+    # for each package.
+    foreach my $package ( keys( %alt ) ) {
+      my $result = $resolve_module_versions->( $alt{$package} );
+
+      if ( exists( $prime{$package} ) ) { # primary package selected
+
+        if ( $result->{err} ) {
+        # Use the selected primary package, but there are conflicting
+        # errors among multiple alternative packages that need to be
+        # reported
+          log_info {
+            "Found conflicting versions for package '$package'\n" .
+            "  $prime{$package}{file} ($prime{$package}{version})\n" .
+            $result->{err}
+          };
+
+        }
+        elsif ( defined( $result->{version} ) ) {
+        # There is a primary package selected, and exactly one
+        # alternative package
+
+        if ( exists( $prime{$package}{version} ) &&
+             defined( $prime{$package}{version} ) ) {
+          # Unless the version of the primary package agrees with the
+          # version of the alternative package, report a conflict
+        if ( $compare_versions->(
+                 $prime{$package}{version}, '!=', $result->{version}
+               )
+             ) {
+
+            log_info {
+              "Found conflicting versions for package '$package'\n" .
+              "  $prime{$package}{file} ($prime{$package}{version})\n" .
+              "  $result->{file} ($result->{version})\n"
+            };
+          }
+
+        }
+        else {
+          # The prime package selected has no version so, we choose to
+          # use any alternative package that does have a version
+          $prime{$package}{file}    = $result->{file};
+          $prime{$package}{version} = $result->{version};
+        }
+
+        }
+        else {
+        # no alt package found with a version, but we have a prime
+        # package so we use it whether it has a version or not
+        }
+
+      }
+      else { # No primary package was selected, use the best alternative
+
+        if ( $result->{err} ) {
+          log_info {
+            "Found conflicting versions for package '$package'\n" .
+            $result->{err}
+          };
+        }
+
+        # Despite possible conflicting versions, we choose to record
+        # something rather than nothing
+        $prime{$package}{file}    = $result->{file};
+        $prime{$package}{version} = $result->{version}
+          if defined( $result->{version} );
+      }
+    }
+
+    # Normalize versions.  Can't use exists() here because of bug in YAML::Node.
+    # XXX "bug in YAML::Node" comment seems irrelevant -- dagolden, 2009-05-18
+    for (grep defined $_->{version}, values %prime) {
+      $_->{version} = $normalize_version->( $_->{version} );
+    }
+
+    return \%prime;
+  }
+}
+
+
+sub _init {
+  my $class    = shift;
+  my $module   = shift;
+  my $filename = shift;
+  my %props = @_;
+
+  my $handle = delete $props{handle};
+  my( %valid_props, @valid_props );
+  @valid_props = qw( collect_pod inc decode_pod );
+  @valid_props{@valid_props} = delete( @props{@valid_props} );
+  warn "Unknown properties: @{[keys %props]}\n" if scalar( %props );
+
+  my %data = (
+    module       => $module,
+    filename     => $filename,
+    version      => undef,
+    packages     => [],
+    versions     => {},
+    pod          => {},
+    pod_headings => [],
+    collect_pod  => 0,
+
+    %valid_props,
+  );
+
+  my $self = bless(\%data, $class);
+
+  if ( not $handle ) {
+    my $filename = $self->{filename};
+    open $handle, '<', $filename
+      or croak( "Can't open '$filename': $!" );
+
+    $self->_handle_bom($handle, $filename);
+  }
+  $self->_parse_fh($handle);
+
+  @{$self->{packages}} = __uniq(@{$self->{packages}});
+
+  unless($self->{module} and length($self->{module})) {
+    # CAVEAT (possible TODO): .pmc files not treated the same as .pm
+    if ($self->{filename} =~ /\.pm$/) {
+      my ($v, $d, $f) = File::Spec->splitpath($self->{filename});
+      $f =~ s/\..+$//;
+      my @candidates = grep /(^|::)$f$/, @{$self->{packages}};
+      $self->{module} = shift(@candidates); # this may be undef
+    }
+    else {
+      # this seems like an atrocious heuristic, albeit marginally better than
+      # what was here before. It should be rewritten entirely to be more like
+      # "if it's not a .pm file, it's not require()able as a name, therefore
+      # name() should be undef."
+      if ((grep /main/, @{$self->{packages}})
+          or (grep /main/, keys %{$self->{versions}})) {
+        $self->{module} = 'main';
+      }
+      else {
+        # TODO: this should maybe default to undef instead
+        $self->{module} = $self->{packages}[0] || '';
+      }
+    }
+  }
+
+  $self->{version} = $self->{versions}{$self->{module}}
+    if defined( $self->{module} );
+
+  return $self;
+}
+
+# class method
+sub _do_find_module {
+  my $class   = shift;
+  my $module  = shift || croak 'find_module_by_name() requires a package name';
+  my $dirs    = shift || \@INC;
+
+  my $file = File::Spec->catfile(split( /::/, $module));
+  foreach my $dir ( @$dirs ) {
+    my $testfile = File::Spec->catfile($dir, $file);
+    return [ File::Spec->rel2abs( $testfile ), $dir ]
+      if -e $testfile and !-d _;  # For stuff like ExtUtils::xsubpp
+    # CAVEAT (possible TODO): .pmc files are not discoverable here
+    $testfile .= '.pm';
+    return [ File::Spec->rel2abs( $testfile ), $dir ]
+      if -e $testfile;
+  }
+  return;
+}
+
+# class method
+sub find_module_by_name {
+  my $found = shift()->_do_find_module(@_) or return;
+  return $found->[0];
+}
+
+# class method
+sub find_module_dir_by_name {
+  my $found = shift()->_do_find_module(@_) or return;
+  return $found->[1];
+}
+
+
+# given a line of perl code, attempt to parse it if it looks like a
+# $VERSION assignment, returning sigil, full name, & package name
+sub _parse_version_expression {
+  my $self = shift;
+  my $line = shift;
+
+  my( $sigil, $variable_name, $package);
+  if ( $line =~ /$VERS_REGEXP/o ) {
+    ( $sigil, $variable_name, $package) = $2 ? ( $1, $2, $3 ) : ( $4, $5, $6 );
+    if ( $package ) {
+      $package = ($package eq '::') ? 'main' : $package;
+      $package =~ s/::$//;
+    }
+  }
+
+  return ( $sigil, $variable_name, $package );
+}
+
+# Look for a UTF-8/UTF-16BE/UTF-16LE BOM at the beginning of the stream.
+# If there's one, then skip it and set the :encoding layer appropriately.
+sub _handle_bom {
+  my ($self, $fh, $filename) = @_;
+
+  my $pos = tell $fh;
+  return unless defined $pos;
+
+  my $buf = ' ' x 2;
+  my $count = read $fh, $buf, length $buf;
+  return unless defined $count and $count >= 2;
+
+  my $encoding;
+  if ( $buf eq "\x{FE}\x{FF}" ) {
+    $encoding = 'UTF-16BE';
+  }
+  elsif ( $buf eq "\x{FF}\x{FE}" ) {
+    $encoding = 'UTF-16LE';
+  }
+  elsif ( $buf eq "\x{EF}\x{BB}" ) {
+    $buf = ' ';
+    $count = read $fh, $buf, length $buf;
+    if ( defined $count and $count >= 1 and $buf eq "\x{BF}" ) {
+      $encoding = 'UTF-8';
+    }
+  }
+
+  if ( defined $encoding ) {
+    if ( "$]" >= 5.008 ) {
+      binmode( $fh, ":encoding($encoding)" );
+    }
+  }
+  else {
+    seek $fh, $pos, SEEK_SET
+      or croak( sprintf "Can't reset position to the top of '$filename'" );
+  }
+
+  return $encoding;
+}
+
+sub _parse_fh {
+  my ($self, $fh) = @_;
+
+  my( $in_pod, $seen_end, $need_vers ) = ( 0, 0, 0 );
+  my( @packages, %vers, %pod, @pod );
+  my $package = 'main';
+  my $pod_sect = '';
+  my $pod_data = '';
+  my $in_end = 0;
+  my $encoding = '';
+
+  while (defined( my $line = <$fh> )) {
+    my $line_num = $.;
+
+    chomp( $line );
+
+    # From toke.c : any line that begins by "=X", where X is an alphabetic
+    # character, introduces a POD segment.
+    my $is_cut;
+    if ( $line =~ /^=([a-zA-Z].*)/ ) {
+      my $cmd = $1;
+      # Then it goes back to Perl code for "=cutX" where X is a non-alphabetic
+      # character (which includes the newline, but here we chomped it away).
+      $is_cut = $cmd =~ /^cut(?:[^a-zA-Z]|$)/;
+      $in_pod = !$is_cut;
+    }
+
+    if ( $in_pod ) {
+
+      if ( $line =~ /^=head[1-4]\s+(.+)\s*$/ ) {
+        push( @pod, $1 );
+        if ( $self->{collect_pod} && length( $pod_data ) ) {
+          $pod{$pod_sect} = $pod_data;
+          $pod_data = '';
+        }
+        $pod_sect = $1;
+      }
+      elsif ( $self->{collect_pod} ) {
+        if ( $self->{decode_pod} && $line =~ /^=encoding ([\w-]+)/ ) {
+          $encoding = $1;
+        }
+        $pod_data .= "$line\n";
+      }
+      next;
+    }
+    elsif ( $is_cut ) {
+      if ( $self->{collect_pod} && length( $pod_data ) ) {
+        $pod{$pod_sect} = $pod_data;
+        $pod_data = '';
+      }
+      $pod_sect = '';
+      next;
+    }
+
+    # Skip after __END__
+    next if $in_end;
+
+    # Skip comments in code
+    next if $line =~ /^\s*#/;
+
+    # Would be nice if we could also check $in_string or something too
+    if ($line eq '__END__') {
+      $in_end++;
+      next;
+    }
+
+    last if $line eq '__DATA__';
+
+    # parse $line to see if it's a $VERSION declaration
+    my( $version_sigil, $version_fullname, $version_package ) =
+      index($line, 'VERSION') >= 1
+        ? $self->_parse_version_expression( $line )
+        : ();
+
+    if ( $line =~ /$PKG_REGEXP/o or $line =~ /$CLASS_REGEXP/ ) {
+      $package = $1;
+      my $version = $2;
+      push( @packages, $package ) unless grep( $package eq $_, @packages );
+      $need_vers = defined $version ? 0 : 1;
+
+      if ( not exists $vers{$package} and defined $version ){
+        # Upgrade to a version object.
+        my $dwim_version = eval { _dwim_version($version) };
+        croak "Version '$version' from $self->{filename} does not appear to be valid:\n$line\n\nThe fatal error was: $@\n"
+          unless defined $dwim_version;  # "0" is OK!
+        $vers{$package} = $dwim_version;
+      }
+    }
+
+    # VERSION defined with full package spec, i.e. $Module::VERSION
+    elsif ( $version_fullname && $version_package ) {
+      # we do NOT save this package in found @packages
+      $need_vers = 0 if $version_package eq $package;
+
+      unless ( defined $vers{$version_package} && length $vers{$version_package} ) {
+        $vers{$version_package} = $self->_evaluate_version_line( $version_sigil, $version_fullname, $line );
+      }
+    }
+
+    # first non-comment line in undeclared package main is VERSION
+    elsif ( $package eq 'main' && $version_fullname && !exists($vers{main}) ) {
+      $need_vers = 0;
+      my $v = $self->_evaluate_version_line( $version_sigil, $version_fullname, $line );
+      $vers{$package} = $v;
+      push( @packages, 'main' );
+    }
+
+    # first non-comment line in undeclared package defines package main
+    elsif ( $package eq 'main' && !exists($vers{main}) && $line =~ /\w/ ) {
+      $need_vers = 1;
+      $vers{main} = '';
+      push( @packages, 'main' );
+    }
+
+    # only keep if this is the first $VERSION seen
+    elsif ( $version_fullname && $need_vers ) {
+      $need_vers = 0;
+      my $v = $self->_evaluate_version_line( $version_sigil, $version_fullname, $line );
+
+      unless ( defined $vers{$package} && length $vers{$package} ) {
+        $vers{$package} = $v;
+      }
+    }
+  } # end loop over each line
+
+  if ( $self->{collect_pod} && length($pod_data) ) {
+    $pod{$pod_sect} = $pod_data;
+  }
+
+  if ( $self->{decode_pod} && $encoding ) {
+    require Encode;
+    $_ = Encode::decode( $encoding, $_ ) for values %pod;
+  }
+
+  $self->{versions} = \%vers;
+  $self->{packages} = \@packages;
+  $self->{pod} = \%pod;
+  $self->{pod_headings} = \@pod;
+}
+
+sub __uniq (@)
+{
+    my (%seen, $key);
+    grep !$seen{ $key = $_ }++, @_;
+}
+
+{
+my $pn = 0;
+sub _evaluate_version_line {
+  my $self = shift;
+  my( $sigil, $variable_name, $line ) = @_;
+
+  # We compile into a local sub because 'use version' would cause
+  # compiletime/runtime issues with local()
+  $pn++; # everybody gets their own package
+  my $eval = qq{ my \$dummy = q#  Hide from _packages_inside()
+    #; package Module::Metadata::_version::p${pn};
+    use version;
+    sub {
+      local $sigil$variable_name;
+      $line;
+      return \$$variable_name if defined \$$variable_name;
+      return \$Module::Metadata::_version::p${pn}::$variable_name;
+    };
+  };
+
+  $eval = $1 if $eval =~ m{^(.+)}s;
+
+  local $^W;
+  # Try to get the $VERSION
+  my $vsub = __clean_eval($eval);
+  # some modules say $VERSION <equal sign> $Foo::Bar::VERSION, but Foo::Bar isn't
+  # installed, so we need to hunt in ./lib for it
+  if ( $@ =~ /Can't locate/ && -d 'lib' ) {
+    local @INC = ('lib',@INC);
+    $vsub = __clean_eval($eval);
+  }
+  warn "Error evaling version line '$eval' in $self->{filename}: $@\n"
+    if $@;
+
+  (ref($vsub) eq 'CODE') or
+    croak "failed to build version sub for $self->{filename}";
+
+  my $result = eval { $vsub->() };
+  # FIXME: $eval is not the right thing to print here
+  croak "Could not get version from $self->{filename} by executing:\n$eval\n\nThe fatal error was: $@\n"
+    if $@;
+
+  # Upgrade it into a version object
+  my $version = eval { _dwim_version($result) };
+
+  # FIXME: $eval is not the right thing to print here
+  croak "Version '$result' from $self->{filename} does not appear to be valid:\n$eval\n\nThe fatal error was: $@\n"
+    unless defined $version; # "0" is OK!
+
+  return $version;
+}
+}
+
+# Try to DWIM when things fail the lax version test in obvious ways
+{
+  my @version_prep = (
+    # Best case, it just works
+    sub { return shift },
+
+    # If we still don't have a version, try stripping any
+    # trailing junk that is prohibited by lax rules
+    sub {
+      my $v = shift;
+      $v =~ s{([0-9])[a-z-].*$}{$1}i; # 1.23-alpha or 1.23b
+      return $v;
+    },
+
+    # Activestate apparently creates custom versions like '1.23_45_01', which
+    # cause version.pm to think it's an invalid alpha.  So check for that
+    # and strip them
+    sub {
+      my $v = shift;
+      my $num_dots = () = $v =~ m{(\.)}g;
+      my $num_unders = () = $v =~ m{(_)}g;
+      my $leading_v = substr($v,0,1) eq 'v';
+      if ( ! $leading_v && $num_dots < 2 && $num_unders > 1 ) {
+        $v =~ s{_}{}g;
+        $num_unders = () = $v =~ m{(_)}g;
+      }
+      return $v;
+    },
+
+    # Worst case, try numifying it like we would have before version objects
+    sub {
+      my $v = shift;
+      no warnings 'numeric';
+      return 0 + $v;
+    },
+
+  );
+
+  sub _dwim_version {
+    my ($result) = shift;
+
+    return $result if ref($result) eq 'version';
+
+    my ($version, $error);
+    for my $f (@version_prep) {
+      $result = $f->($result);
+      $version = eval { version->new($result) };
+      $error ||= $@ if $@; # capture first failure
+      last if defined $version;
+    }
+
+    croak $error unless defined $version;
+
+    return $version;
+  }
+}
+
+############################################################
+
+# accessors
+sub name            { $_[0]->{module}            }
+
+sub filename        { $_[0]->{filename}          }
+sub packages_inside { @{$_[0]->{packages}}       }
+sub pod_inside      { @{$_[0]->{pod_headings}}   }
+sub contains_pod    { 0+@{$_[0]->{pod_headings}} }
+
+sub version {
+    my $self = shift;
+    my $mod  = shift || $self->{module};
+    my $vers;
+    if ( defined( $mod ) && length( $mod ) &&
+         exists( $self->{versions}{$mod} ) ) {
+        return $self->{versions}{$mod};
+    }
+    else {
+        return undef;
+    }
+}
+
+sub pod {
+    my $self = shift;
+    my $sect = shift;
+    if ( defined( $sect ) && length( $sect ) &&
+         exists( $self->{pod}{$sect} ) ) {
+        return $self->{pod}{$sect};
+    }
+    else {
+        return undef;
+    }
+}
+
+sub is_indexable {
+  my ($self, $package) = @_;
+
+  my @indexable_packages = grep $_ ne 'main', $self->packages_inside;
+
+  # check for specific package, if provided
+  return !! grep $_ eq $package, @indexable_packages if $package;
+
+  # otherwise, check for any indexable packages at all
+  return !! @indexable_packages;
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Module::Metadata - Gather package and POD information from perl module files
+
+=head1 VERSION
+
+version 1.000039
+
+=head1 SYNOPSIS
+
+  use Module::Metadata;
+
+  # information about a .pm file
+  my $info = Module::Metadata->new_from_file( $file );
+  my $version = $info->version;
+
+  # CPAN META 'provides' field for .pm files in a directory
+  my $provides = Module::Metadata->provides(
+    dir => 'lib', version => 2
+  );
+
+=head1 DESCRIPTION
+
+This module provides a standard way to gather metadata about a .pm file through
+(mostly) static analysis and (some) code execution.  When determining the
+version of a module, the C<$VERSION> assignment is C<eval>ed, as is traditional
+in the CPAN toolchain.
+
+=head1 CLASS METHODS
+
+=head2 C<< new_from_file($filename, collect_pod => 1, decode_pod => 1) >>
+
+Constructs a C<Module::Metadata> object given the path to a file.  Returns
+undef if the filename does not exist.
+
+C<collect_pod> is a optional boolean argument that determines whether POD
+data is collected and stored for reference.  POD data is not collected by
+default.  POD headings are always collected.
+
+If the file begins by an UTF-8, UTF-16BE or UTF-16LE byte-order mark, then
+it is skipped before processing, and the content of the file is also decoded
+appropriately starting from perl 5.8.
+
+Alternatively, if C<decode_pod> is set, it will decode the collected pod
+sections according to the C<=encoding> declaration.
+
+=head2 C<< new_from_handle($handle, $filename, collect_pod => 1, decode_pod => 1) >>
+
+This works just like C<new_from_file>, except that a handle can be provided
+as the first argument.
+
+Note that there is no validation to confirm that the handle is a handle or
+something that can act like one.  Passing something that isn't a handle will
+cause a exception when trying to read from it.  The C<filename> argument is
+mandatory or undef will be returned.
+
+You are responsible for setting the decoding layers on C<$handle> if
+required.
+
+=head2 C<< new_from_module($module, collect_pod => 1, inc => \@dirs, decode_pod => 1) >>
+
+Constructs a C<Module::Metadata> object given a module or package name.
+Returns undef if the module cannot be found.
+
+In addition to accepting the C<collect_pod> and C<decode_pod> arguments as
+described above, this method accepts a C<inc> argument which is a reference to
+an array of directories to search for the module.  If none are given, the
+default is @INC.
+
+If the file that contains the module begins by an UTF-8, UTF-16BE or
+UTF-16LE byte-order mark, then it is skipped before processing, and the
+content of the file is also decoded appropriately starting from perl 5.8.
+
+=head2 C<< find_module_by_name($module, \@dirs) >>
+
+Returns the path to a module given the module or package name. A list
+of directories can be passed in as an optional parameter, otherwise
+@INC is searched.
+
+Can be called as either an object or a class method.
+
+=head2 C<< find_module_dir_by_name($module, \@dirs) >>
+
+Returns the entry in C<@dirs> (or C<@INC> by default) that contains
+the module C<$module>. A list of directories can be passed in as an
+optional parameter, otherwise @INC is searched.
+
+Can be called as either an object or a class method.
+
+=head2 C<< provides( %options ) >>
+
+This is a convenience wrapper around C<package_versions_from_directory>
+to generate a CPAN META C<provides> data structure.  It takes key/value
+pairs.  Valid option keys include:
+
+=over
+
+=item version B<(required)>
+
+Specifies which version of the L<CPAN::Meta::Spec> should be used as
+the format of the C<provides> output.  Currently only '1.4' and '2'
+are supported (and their format is identical).  This may change in
+the future as the definition of C<provides> changes.
+
+The C<version> option is required.  If it is omitted or if
+an unsupported version is given, then C<provides> will throw an error.
+
+=item dir
+
+Directory to search recursively for F<.pm> files.  May not be specified with
+C<files>.
+
+=item files
+
+Array reference of files to examine.  May not be specified with C<dir>.
+
+=item prefix
+
+String to prepend to the C<file> field of the resulting output. This defaults
+to F<lib>, which is the common case for most CPAN distributions with their
+F<.pm> files in F<lib>.  This option ensures the META information has the
+correct relative path even when the C<dir> or C<files> arguments are
+absolute or have relative paths from a location other than the distribution
+root.
+
+=back
+
+For example, given C<dir> of 'lib' and C<prefix> of 'lib', the return value
+is a hashref of the form:
+
+  {
+    'Package::Name' => {
+      version => '0.123',
+      file => 'lib/Package/Name.pm'
+    },
+    'OtherPackage::Name' => ...
+  }
+
+=head2 C<< package_versions_from_directory($dir, \@files?) >>
+
+Scans C<$dir> for .pm files (unless C<@files> is given, in which case looks
+for those files in C<$dir> - and reads each file for packages and versions,
+returning a hashref of the form:
+
+  {
+    'Package::Name' => {
+      version => '0.123',
+      file => 'Package/Name.pm'
+    },
+    'OtherPackage::Name' => ...
+  }
+
+The C<DB> and C<main> packages are always omitted, as are any "private"
+packages that have leading underscores in the namespace (e.g.
+C<Foo::_private>)
+
+Note that the file path is relative to C<$dir> if that is specified.
+This B<must not> be used directly for CPAN META C<provides>.  See
+the C<provides> method instead.
+
+=head2 C<< log_info (internal) >>
+
+Used internally to perform logging; imported from Log::Contextual if
+Log::Contextual has already been loaded, otherwise simply calls warn.
+
+=head1 OBJECT METHODS
+
+=head2 C<< name() >>
+
+Returns the name of the package represented by this module. If there
+is more than one package, it makes a best guess based on the
+filename. If it's a script (i.e. not a *.pm) the package name is
+'main'.
+
+=head2 C<< version($package) >>
+
+Returns the version as defined by the $VERSION variable for the
+package as returned by the C<name> method if no arguments are
+given. If given the name of a package it will attempt to return the
+version of that package if it is specified in the file.
+
+=head2 C<< filename() >>
+
+Returns the absolute path to the file.
+Note that this file may not actually exist on disk yet, e.g. if the module was read from an in-memory filehandle.
+
+=head2 C<< packages_inside() >>
+
+Returns a list of packages. Note: this is a raw list of packages
+discovered (or assumed, in the case of C<main>).  It is not
+filtered for C<DB>, C<main> or private packages the way the
+C<provides> method does.  Invalid package names are not returned,
+for example "Foo:Bar".  Strange but valid package names are
+returned, for example "Foo::Bar::", and are left up to the caller
+on how to handle.
+
+=head2 C<< pod_inside() >>
+
+Returns a list of POD sections.
+
+=head2 C<< contains_pod() >>
+
+Returns true if there is any POD in the file.
+
+=head2 C<< pod($section) >>
+
+Returns the POD data in the given section.
+
+=head2 C<< is_indexable($package) >> or C<< is_indexable() >>
+
+Available since version 1.000020.
+
+Returns a boolean indicating whether the package (if provided) or any package
+(otherwise) is eligible for indexing by PAUSE, the Perl Authors Upload Server.
+Note This only checks for valid C<package> declarations, and does not take any
+ownership information into account.
+
+=head1 GIVING THANKS
+
+=for stopwords MetaCPAN GitHub
+
+If you found this module to be useful, please show your appreciation by
+adding a +1 in L<MetaCPAN|https://metacpan.org/dist/Module-Metadata>
+and a star in L<GitHub|https://github.com/Perl-Toolchain-Gang/Module-Metadata>.
+
+=head1 SUPPORT
+
+Bugs may be submitted through L<the RT bug tracker|https://rt.cpan.org/Public/Dist/Display.html?Name=Module-Metadata>
+(or L<bug-Module-Metadata@rt.cpan.org|mailto:bug-Module-Metadata@rt.cpan.org>).
+
+There is also a mailing list available for users of this distribution, at
+L<http://lists.perl.org/list/cpan-workers.html>.
+
+There is also an irc channel available for users of this distribution, at
+L<C<#toolchain> on C<irc.perl.org>|irc://irc.perl.org/#toolchain>.
+
+=head1 AUTHOR
+
+Original code from Module::Build::ModuleInfo by Ken Williams
+<kwilliams@cpan.org>, Randy W. Sims <RandyS@ThePierianSpring.org>
+
+Released as Module::Metadata by Matt S Trout (mst) <mst@shadowcat.co.uk> with
+assistance from David Golden (xdg) <dagolden@cpan.org>.
+
+=head1 CONTRIBUTORS
+
+=for stopwords Karen Etheridge David Golden Vincent Pit Matt S Trout Chris Nehren Graham Knop Olivier Mengué Tomas Doran Christian Walde Craig A. Berry Tatsuhiko Miyagawa tokuhirom 'BinGOs' Williams Mitchell Steinbrunner Edward Zborowski Erik Huelsmann Gareth Harper James Raspass Jerry D. Hedden Josh Jore Kent Fredric Leon Timmermans Peter Rabbitson Steve Hay
+
+=over 4
+
+=item *
+
+Karen Etheridge <ether@cpan.org>
+
+=item *
+
+David Golden <dagolden@cpan.org>
+
+=item *
+
+Vincent Pit <perl@profvince.com>
+
+=item *
+
+Matt S Trout <mst@shadowcat.co.uk>
+
+=item *
+
+Chris Nehren <apeiron@cpan.org>
+
+=item *
+
+Graham Knop <haarg@haarg.org>
+
+=item *
+
+Olivier Mengué <dolmen@cpan.org>
+
+=item *
+
+Tomas Doran <bobtfish@bobtfish.net>
+
+=item *
+
+Christian Walde <walde.christian@googlemail.com>
+
+=item *
+
+Craig A. Berry <cberry@cpan.org>
+
+=item *
+
+Tatsuhiko Miyagawa <miyagawa@bulknews.net>
+
+=item *
+
+tokuhirom <tokuhirom@gmail.com>
+
+=item *
+
+Chris 'BinGOs' Williams <chris@bingosnet.co.uk>
+
+=item *
+
+David Mitchell <davem@iabyn.com>
+
+=item *
+
+David Steinbrunner <dsteinbrunner@pobox.com>
+
+=item *
+
+Edward Zborowski <ed@rubensteintech.com>
+
+=item *
+
+Erik Huelsmann <ehuels@gmail.com>
+
+=item *
+
+Gareth Harper <gareth@broadbean.com>
+
+=item *
+
+James Raspass <jraspass@gmail.com>
+
+=item *
+
+Jerry D. Hedden <jdhedden@cpan.org>
+
+=item *
+
+Josh Jore <jjore@cpan.org>
+
+=item *
+
+Kent Fredric <kentnl@cpan.org>
+
+=item *
+
+Leon Timmermans <fawaka@gmail.com>
+
+=item *
+
+Peter Rabbitson <ribasushi@cpan.org>
+
+=item *
+
+Steve Hay <steve.m.hay@googlemail.com>
+
+=back
+
+=head1 COPYRIGHT & LICENSE
+
+Original code Copyright (c) 2001-2011 Ken Williams.
+Additional code Copyright (c) 2010-2011 Matt Trout and David Golden.
+All rights reserved.
+
+This library is free software; you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+=cut

--- a/src/test/resources/unit/module_load_conditional.t
+++ b/src/test/resources/unit/module_load_conditional.t
@@ -1,0 +1,38 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+my $loaded = eval { require Module::Load::Conditional; 1 };
+ok($loaded, 'Module::Load::Conditional loads')
+    or diag $@;
+
+my $hook_called = 0;
+my $hook = sub {
+    my (undef, $file) = @_;
+    return unless $file eq 'Test/More.pm';
+
+    $hook_called++;
+    die "hidden $file\n";
+};
+
+my $result;
+my $lived;
+{
+    local @INC = ($hook, @INC);
+    local $Module::Load::Conditional::CACHE = {};
+
+    $lived = eval {
+        $result = Module::Load::Conditional::can_load(
+            modules => {
+                'Test::More' => undef,
+            },
+            nocache => 1,
+        );
+        1;
+    };
+}
+
+ok(!$lived, 'dying @INC hook aborts Module::Load::Conditional lookup');
+like($@, qr/hidden Test\/More\.pm/, 'hook error is preserved');
+is($hook_called, 1, '@INC hook was consulted exactly once');


### PR DESCRIPTION
## Summary

- import Module::Load, Module::Metadata, and Module::Load::Conditional from perl5 via dev/import-perl5/sync.pl
- add a focused Module::Load::Conditional regression for dying @INC hooks
- fixes `./jcpan -t Test::Without::Module`

## Verification

- `./jperl src/test/resources/unit/module_load_conditional.t`
- `make`
- `./jcpan -t Test::Without::Module`
