### PR TITLE
Fix Path::Tiny jcpan tests

### DIFF
--- a/dev/import-perl5/config.yaml
+++ b/dev/import-perl5/config.yaml
@@ -55,6 +55,10 @@ imports:
     target: src/main/perl/lib/Memoize
     type: directory
 
+  # NEXT - legacy pseudo-class redispatch module used by perl5 mro tests
+  - source: perl5/cpan/NEXT/lib/NEXT.pm
+    target: src/main/perl/lib/NEXT.pm
+
   # Net::Ping - Network ping module (required by CPAN::Mirrors)
   - source: perl5/dist/Net-Ping/lib/Net/Ping.pm
     target: src/main/perl/lib/Net/Ping.pm

--- a/dev/import-perl5/config.yaml
+++ b/dev/import-perl5/config.yaml
@@ -328,6 +328,7 @@ imports:
   # From CPAN distribution
   - source: perl5/cpan/Module-Load-Conditional/lib/Module/Load/Conditional.pm
     target: src/main/perl/lib/Module/Load/Conditional.pm
+    patch: Module-Load-Conditional.pm.patch
 
   # Tests for distribution
   - source: perl5/cpan/Params-Check/t

--- a/dev/import-perl5/patches/Module-Load-Conditional.pm.patch
+++ b/dev/import-perl5/patches/Module-Load-Conditional.pm.patch
@@ -1,0 +1,17 @@
+--- perl5/cpan/Module-Load-Conditional/lib/Module/Load/Conditional.pm
++++ src/main/perl/lib/Module/Load/Conditional.pm
+@@ -218 +218 @@
+-                    ($fh) = $dir->($dir, $file);
++                    ($fh) = $dir->($dir, $file_inc);
+@@ -221 +221 @@
+-                    ($fh) = $dir->[0]->($dir, $file, @{$dir}{1..$#{$dir}})
++                    ($fh) = $dir->[0]->($dir, $file_inc, @{$dir}{1..$#{$dir}})
+@@ -224 +224 @@
+-                    ($fh) = $dir->INC($file);
++                    ($fh) = $dir->INC($file_inc);
+@@ -228 +228 @@
+-                    warn loc(q[Cannot open file '%1': %2], $file, $!)
++                    warn loc(q[Cannot open file '%1': %2], $file_inc, $!)
+@@ -233 +233 @@
+-                $filename = $INC{$file_inc} || $file;
++                $filename = $INC{$file_inc} || $file_inc;

--- a/src/main/java/org/perlonjava/runtime/nativ/NativeUtils.java
+++ b/src/main/java/org/perlonjava/runtime/nativ/NativeUtils.java
@@ -9,6 +9,7 @@ import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -24,18 +25,17 @@ public class NativeUtils {
             return new RuntimeScalar(0);
         }
 
-        String oldFile = RuntimeIO.resolvePath(args[0].toString()).toString();
-        String newFile = RuntimeIO.resolvePath(args[1].toString()).toString();
+        String oldFile = RuntimeIO.sanitizePathname("symlink", args[0].toString());
+        Path link = RuntimeIO.resolvePath(args[1].toString(), "symlink");
 
-        if (oldFile == null || newFile == null || oldFile.isEmpty() || newFile.isEmpty()) {
+        if (oldFile == null || link == null || oldFile.isEmpty()) {
             return new RuntimeScalar(0);
         }
 
         try {
             Path target = Paths.get(oldFile);
-            Path link = Paths.get(newFile);
 
-            if (Files.exists(link)) {
+            if (Files.exists(link, LinkOption.NOFOLLOW_LINKS)) {
                 GlobalVariable.getGlobalVariable("main::!").set("File exists");
                 return new RuntimeScalar(0);
             }

--- a/src/main/java/org/perlonjava/runtime/operators/Operator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Operator.java
@@ -906,12 +906,13 @@ public class Operator {
      * @return RuntimeScalar with link target or undef on error
      */
     public static RuntimeScalar readlink(int ctx, RuntimeBase... args) {
-        String path = args[0].getFirst().toString();
+        String path = args.length > 0
+                ? args[0].getFirst().toString()
+                : getGlobalVariable("main::_").toString();
         try {
             Path linkPath = RuntimeIO.resolvePath(path);
 
-            // Check if file exists first
-            if (!Files.exists(linkPath)) {
+            if (linkPath == null || !Files.exists(linkPath, LinkOption.NOFOLLOW_LINKS)) {
                 // Set $! to "No such file or directory"
                 getGlobalVariable("main::!").set("No such file or directory");
                 return RuntimeScalar.undef();

--- a/src/main/java/org/perlonjava/runtime/operators/UnlinkOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/UnlinkOperator.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.nio.file.*;
 
 import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalVariable;
-import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.getScalarBoolean;
 
 /**
  * Implementation of Perl's unlink operator for PerlOnJava
@@ -43,13 +42,7 @@ public class UnlinkOperator {
             }
         }
 
-        // In scalar context, return true if all files were deleted
-        // In list context, return the count of successfully deleted files
-        if (ctx == RuntimeContextType.SCALAR) {
-            return getScalarBoolean(successCount == fileList.size());
-        } else {
-            return new RuntimeScalar(successCount);
-        }
+        return new RuntimeScalar(successCount);
     }
 
     /**
@@ -59,6 +52,11 @@ public class UnlinkOperator {
         try {
             Path path = RuntimeIO.resolvePath(fileName, "unlink");
             if (path == null) {
+                return false;
+            }
+
+            if (Files.isDirectory(path, LinkOption.NOFOLLOW_LINKS)) {
+                getGlobalVariable("main::!").set("Is a directory");
                 return false;
             }
 

--- a/src/main/java/org/perlonjava/runtime/operators/UtimeOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/UtimeOperator.java
@@ -65,10 +65,11 @@ public class UtimeOperator {
                 return changeFilehandleTimes(fileArg, accessTime, modTime);
             }
 
-            String filename = RuntimeIO.sanitizePathname("utime", fileArg.toString());
-            if (filename == null || filename.isEmpty()) {
+            Path path = RuntimeIO.resolvePath(fileArg.toString(), "utime");
+            if (path == null || path.toString().isEmpty()) {
                 return false;
             }
+            String filename = path.toString();
 
             if (IS_WINDOWS) {
                 return changeFileTimesWindows(filename, accessTime, modTime);

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
@@ -87,32 +87,38 @@ public class FileSpec extends PerlModuleBase {
             return new RuntimeScalar("").getList();
         }
         
-        // Implement Perl 5's File::Spec::Unix::canonpath logic:
-        // 1. Collapse multiple slashes into one
-        // 2. Collapse /./  and also /. at end of string
-        // 3. Remove leading ./  (unless path is exactly "./")
-        // 4. Remove trailing /  (unless path is exactly "/")
-        String sep = File.separator;
-        String quotedSep = Pattern.quote(sep);
-        String replSep = Matcher.quoteReplacement(sep);
-        
-        // Collapse multiple separators into one
-        String canonPath = path.replaceAll("[/\\\\]+", replSep);
-        
-        // Collapse /./ and /. at end: (?:/\.)+(?:/|$) -> /
-        // This handles both /./bar -> /bar and foo/. -> foo
-        canonPath = canonPath.replaceAll("(?:" + quotedSep + "\\.)+(?=" + quotedSep + "|$)", "");
-        
-        // Remove leading ./ unless the path is exactly "./" or "."
-        if (!canonPath.equals("." + sep) && !canonPath.equals(".")) {
-            while (canonPath.startsWith("." + sep)) {
-                canonPath = canonPath.substring(1 + sep.length());
+        String canonPath;
+        if (SystemUtils.osIsWindows()) {
+            String sep = File.separator;
+            String quotedSep = Pattern.quote(sep);
+            String replSep = Matcher.quoteReplacement(sep);
+
+            canonPath = path.replaceAll("[/\\\\]+", replSep);
+            canonPath = canonPath.replaceAll("(?:" + quotedSep + "\\.)+(?:"
+                    + quotedSep + "|$)", replSep);
+
+            if (!canonPath.equals("." + sep) && !canonPath.equals(".")) {
+                while (canonPath.startsWith("." + sep)) {
+                    canonPath = canonPath.substring(1 + sep.length());
+                }
             }
-        }
-        
-        // Remove trailing / unless the path is exactly "/"
-        if (!canonPath.equals(sep) && canonPath.endsWith(sep)) {
-            canonPath = canonPath.substring(0, canonPath.length() - sep.length());
+
+            if (!canonPath.equals(sep) && canonPath.endsWith(sep)) {
+                canonPath = canonPath.substring(0, canonPath.length() - sep.length());
+            }
+        } else {
+            // Match File::Spec::Unix::canonpath. Backslash is a literal path
+            // character on Unix, not a directory separator.
+            canonPath = path.replaceAll("/{2,}", "/");
+            canonPath = canonPath.replaceAll("(?:/\\.)+(?:/|$)", "/");
+            if (!canonPath.equals("./")) {
+                canonPath = canonPath.replaceFirst("^(?:\\./)+", "");
+            }
+            canonPath = canonPath.replaceFirst("^/(?:\\.\\./)+", "/");
+            canonPath = canonPath.replaceFirst("^/\\.\\.$", "/");
+            if (!canonPath.equals("/") && canonPath.endsWith("/")) {
+                canonPath = canonPath.substring(0, canonPath.length() - 1);
+            }
         }
         
         // If we reduced to empty string from a non-empty input, return "."

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FileTemp.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FileTemp.java
@@ -1,6 +1,7 @@
 package org.perlonjava.runtime.perlmodule;
 
 import org.perlonjava.runtime.runtimetypes.RuntimeArray;
+import org.perlonjava.runtime.runtimetypes.RuntimeIO;
 import org.perlonjava.runtime.runtimetypes.RuntimeList;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 import org.perlonjava.runtime.runtimetypes.SystemUtils;
@@ -119,7 +120,7 @@ public class FileTemp extends PerlModuleBase {
      * Register a temporary file for cleanup
      */
     public static RuntimeList _register_temp_file(RuntimeArray args, int ctx) {
-        if (args.size() != 1) {
+        if (args.size() != 2) {
             throw new IllegalStateException("Bad number of arguments for _register_temp_file");
         }
 
@@ -233,6 +234,7 @@ public class FileTemp extends PerlModuleBase {
                 String randomPart = generateRandomString(xCount);
                 String fileName = namePrefix + randomPart + suffix;
                 Path filePath = dir.resolve(fileName);
+                Path ioFilePath = resolveForIO(filePath);
 
                 try {
                     // Create file with restrictive permissions
@@ -246,18 +248,18 @@ public class FileTemp extends PerlModuleBase {
 
                     // Try to create with POSIX permissions, fall back if not supported
                     try {
-                        Files.newByteChannel(filePath, options, attr).close();
+                        Files.newByteChannel(ioFilePath, options, attr).close();
                     } catch (UnsupportedOperationException e) {
                         // Windows doesn't support POSIX permissions
-                        Files.newByteChannel(filePath, options).close();
+                        Files.newByteChannel(ioFilePath, options).close();
                     }
 
                     // Register for cleanup
                     long pid = ProcessHandle.current().pid();
-                    TEMP_FILES.computeIfAbsent(pid, k -> new HashSet<>()).add(filePath);
+                    TEMP_FILES.computeIfAbsent(pid, k -> new HashSet<>()).add(ioFilePath);
 
                     // Return file descriptor and path
-                    int fd = openFile ? openFileDescriptor(filePath) : -1;
+                    int fd = openFile ? openFileDescriptor(ioFilePath) : -1;
                     return new RuntimeList(
                             new RuntimeScalar(fd),
                             new RuntimeScalar(filePath.toString())
@@ -327,21 +329,22 @@ public class FileTemp extends PerlModuleBase {
                 String randomPart = generateRandomString(xCount);
                 String dirName = namePrefix + randomPart;
                 Path dirPath = parentDir.resolve(dirName);
+                Path ioDirPath = resolveForIO(dirPath);
 
                 try {
                     // Create directory with restrictive permissions
                     try {
                         Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwx------");
                         FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(perms);
-                        Files.createDirectory(dirPath, attr);
+                        Files.createDirectory(ioDirPath, attr);
                     } catch (UnsupportedOperationException e) {
                         // Windows doesn't support POSIX permissions
-                        Files.createDirectory(dirPath);
+                        Files.createDirectory(ioDirPath);
                     }
 
                     // Register for cleanup
                     long pid = ProcessHandle.current().pid();
-                    TEMP_DIRS.computeIfAbsent(pid, k -> new HashSet<>()).add(dirPath);
+                    TEMP_DIRS.computeIfAbsent(pid, k -> new HashSet<>()).add(ioDirPath);
 
                     return dirPath;
 
@@ -366,6 +369,13 @@ public class FileTemp extends PerlModuleBase {
             sb.append(TEMPLATE_CHARS.charAt(RANDOM.nextInt(TEMPLATE_CHARS.length())));
         }
         return sb.toString();
+    }
+
+    private static Path resolveForIO(Path path) {
+        if (path.isAbsolute()) {
+            return path.toAbsolutePath();
+        }
+        return RuntimeIO.resolvePath(path.toString(), "File::Temp");
     }
 
     private static String getTempDir() {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
@@ -35,6 +35,7 @@ public class GlobalVariable {
     public static final Map<String, RuntimeScalar> globalCodeRefs = new GlobalCodeRefMap();
     static final Map<String, RuntimeGlob> globalIORefs = new HashMap<>();
     static final Map<String, RuntimeFormat> globalFormatRefs = new HashMap<>();
+    private static final Map<String, Integer> localizedCodeRefDepth = new HashMap<>();
 
     // Pinned code references: RuntimeScalars that were accessed at compile time
     // and should survive stash deletion. This matches Perl's behavior where
@@ -999,6 +1000,30 @@ public class GlobalVariable {
         if (pinnedCodeRefs.containsKey(key)) {
             pinnedCodeRefs.put(key, codeRef);
         }
+    }
+
+    static void enterLocalizedCodeRef(String key) {
+        localizedCodeRefDepth.merge(key, 1, Integer::sum);
+    }
+
+    static void exitLocalizedCodeRef(String key) {
+        Integer depth = localizedCodeRefDepth.get(key);
+        if (depth == null) {
+            return;
+        }
+        if (depth <= 1) {
+            localizedCodeRefDepth.remove(key);
+        } else {
+            localizedCodeRefDepth.put(key, depth - 1);
+        }
+    }
+
+    public static RuntimeScalar getLocalizedCodeRefForDirectCall(String key, RuntimeScalar fallback) {
+        if (key == null || key.isEmpty() || !localizedCodeRefDepth.containsKey(key)) {
+            return fallback;
+        }
+        RuntimeScalar localized = globalCodeRefs.get(key);
+        return localized != null ? localized : fallback;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -367,7 +367,37 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         if (effectiveContext == RuntimeContextType.SCALAR && result.elements.size() > 1) {
             return new RuntimeList(result.scalar());
         }
-        return result;
+        return copyReadonlyListReturns(result, effectiveContext);
+    }
+
+    private static RuntimeList copyReadonlyListReturns(RuntimeList result, int effectiveContext) {
+        if (effectiveContext != RuntimeContextType.LIST) {
+            return result;
+        }
+
+        RuntimeList copy = null;
+        for (int i = 0; i < result.elements.size(); i++) {
+            RuntimeBase value = result.elements.get(i);
+            RuntimeBase replacement = value;
+
+            if (value instanceof RuntimeScalarReadOnly ro && !(value instanceof ReadOnlyAlias)) {
+                RuntimeScalar scalar = new RuntimeScalar();
+                scalar.type = ro.type;
+                scalar.value = ro.value;
+                scalar.blessId = ro.blessId;
+                replacement = scalar;
+            }
+
+            if (replacement != value && copy == null) {
+                copy = new RuntimeList();
+                copy.elements.addAll(result.elements.subList(0, i));
+            }
+            if (copy != null) {
+                copy.elements.add(replacement);
+            }
+        }
+
+        return copy != null ? copy : result;
     }
 
     /**
@@ -784,6 +814,14 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 && code.defined();
     }
 
+    private static RuntimeScalar resolveDirectCallTarget(RuntimeScalar runtimeScalar, String subroutineName) {
+        String lookupName = subroutineName;
+        if ((lookupName == null || lookupName.isEmpty()) && runtimeScalar != null) {
+            lookupName = runtimeScalar.globalCodeRefFqn;
+        }
+        return GlobalVariable.getLocalizedCodeRefForDirectCall(lookupName, runtimeScalar);
+    }
+
     /**
      * Preflight for generated direct subroutine calls. Perl reports an
      * undefined direct call at the line containing the function token, but
@@ -793,7 +831,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * call-site line.
      */
     public static void throwIfDirectCallUndefined(RuntimeScalar runtimeScalar, String subroutineName) {
-        RuntimeScalar curScalar = runtimeScalar;
+        RuntimeScalar curScalar = resolveDirectCallTarget(runtimeScalar, subroutineName);
 
         while (curScalar != null) {
             if (curScalar.type == RuntimeScalarType.TIED_SCALAR) {
@@ -3316,6 +3354,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
 
     // Method to apply (execute) a subroutine reference using native array for parameters
     public static RuntimeList apply(RuntimeScalar runtimeScalar, String subroutineName, RuntimeBase[] args, int callContext) {
+        runtimeScalar = resolveDirectCallTarget(runtimeScalar, subroutineName);
+
         // Handle tied scalars - fetch the underlying value first
         if (runtimeScalar.type == RuntimeScalarType.TIED_SCALAR) {
             return apply(runtimeScalar.tiedFetch(), subroutineName, args, callContext);
@@ -3563,6 +3603,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     private static RuntimeList applyImpl(RuntimeScalar runtimeScalar, String subroutineName, RuntimeBase list, int callContext) {
+        runtimeScalar = resolveDirectCallTarget(runtimeScalar, subroutineName);
 
         // Handle tied scalars - fetch the underlying value first
         if (runtimeScalar.type == RuntimeScalarType.TIED_SCALAR) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
@@ -1181,6 +1181,7 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         // assignments during the local scope would mutate the saved snapshot instead
         // of the new empty code, making the restore a no-op.
         GlobalVariable.replacePinnedCodeRef(this.globName, newCode);
+        GlobalVariable.enterLocalizedCodeRef(this.globName);
         GlobalVariable.getGlobalFormatRef(this.globName).dynamicSaveState();
 
         // Create a NEW RuntimeGlob for the local scope and install it in globalIORefs.
@@ -1284,6 +1285,7 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         // Also restore the pinned code ref so getGlobalCodeRef() returns the
         // original code object again.
         GlobalVariable.replacePinnedCodeRef(snap.globName, snap.code);
+        GlobalVariable.exitLocalizedCodeRef(snap.globName);
         InheritanceResolver.invalidateCache();
 
         GlobalVariable.getGlobalFormatRef(snap.globName).dynamicRestoreState();

--- a/src/main/perl/lib/File/Glob.pm
+++ b/src/main/perl/lib/File/Glob.pm
@@ -59,20 +59,60 @@ use constant {
     GLOB_ALTDIRFUNC => 1024,
 };
 
-# bsd_glob implementation - use Perl's built-in glob for now
 sub bsd_glob {
     my $pattern = shift;
     my $flags = shift || 0;
-    
-    # For now, just use Perl's built-in glob
-    # In the future, we could implement the flags properly
-    return CORE::glob($pattern);
+
+    return unless defined $pattern;
+
+    if ($pattern eq '~' || $pattern =~ m{^~/}) {
+        my @matches = CORE::glob($pattern);
+        @matches = map { _dequote($_) } @matches;
+        return wantarray ? @matches : $matches[0];
+    }
+
+    if (! _has_glob_magic($pattern)) {
+        my $literal = _dequote($pattern);
+        return wantarray ? ($literal) : $literal;
+    }
+
+    my @matches = CORE::glob($pattern);
+    @matches = map { _dequote($_) } @matches;
+
+    if (!@matches && ($flags & GLOB_NOCHECK)) {
+        @matches = (_dequote($pattern));
+    }
+
+    return wantarray ? @matches : $matches[0];
 }
 
 # Regular glob - just use built-in
 sub glob {
     my $pattern = shift;
     return CORE::glob($pattern);
+}
+
+sub _has_glob_magic {
+    my ($pattern) = @_;
+    my $escaped = 0;
+    for my $ch (split //, $pattern) {
+        if ($escaped) {
+            $escaped = 0;
+            next;
+        }
+        if ($ch eq '\\') {
+            $escaped = 1;
+            next;
+        }
+        return 1 if $ch eq '*' || $ch eq '?' || $ch eq '[' || $ch eq '{';
+    }
+    return 0;
+}
+
+sub _dequote {
+    my ($pattern) = @_;
+    $pattern =~ s/\\(.)/$1/gs;
+    return $pattern;
 }
 
 1;
@@ -117,4 +157,3 @@ Various GLOB_* constants are exported for compatibility.
 PerlOnJava Project
 
 =cut
-

--- a/src/main/perl/lib/File/Path.pm
+++ b/src/main/perl/lib/File/Path.pm
@@ -120,9 +120,11 @@ sub _remove_dir_recursive {
             if (defined $mode) {
                 my $current_mode = $mode & 07777;
                 my $wanted = $current_mode | 0700;
-                if ($wanted != $current_mode && chmod($wanted, $dir)) {
+                if (chmod($wanted, $dir)) {
                     $restore_mode = $current_mode;
                 }
+            } else {
+                chmod(0700, $dir);
             }
         }
         opendir($dh, $dir) or croak "opendir $dir: $!";
@@ -145,13 +147,17 @@ sub _remove_dir_recursive {
 
     my $removed = rmdir($dir);
     if (!$removed && !$safe) {
+        my $retry_restore_mode;
         my $mode = (lstat($dir))[2];
         if (defined $mode) {
             my $current_mode = $mode & 07777;
             my $wanted = $current_mode | 0700;
-            chmod($wanted, $dir) if $wanted != $current_mode;
+            $retry_restore_mode = $current_mode if chmod($wanted, $dir);
+        } else {
+            chmod(0700, $dir);
         }
         $removed = rmdir($dir);
+        chmod($retry_restore_mode, $dir) if defined $retry_restore_mode && !$removed;
     }
 
     chmod($restore_mode, $dir) if defined $restore_mode && !$removed;

--- a/src/main/perl/lib/File/Path.pm
+++ b/src/main/perl/lib/File/Path.pm
@@ -143,9 +143,20 @@ sub _remove_dir_recursive {
         }
     }
 
-    chmod($restore_mode, $dir) if defined $restore_mode;
+    my $removed = rmdir($dir);
+    if (!$removed && !$safe) {
+        my $mode = (lstat($dir))[2];
+        if (defined $mode) {
+            my $current_mode = $mode & 07777;
+            my $wanted = $current_mode | 0700;
+            chmod($wanted, $dir) if $wanted != $current_mode;
+        }
+        $removed = rmdir($dir);
+    }
 
-    if (rmdir($dir)) {
+    chmod($restore_mode, $dir) if defined $restore_mode && !$removed;
+
+    if ($removed) {
         $count++;
         print "rmdir $dir\n" if $verbose;
     }

--- a/src/main/perl/lib/File/Path.pm
+++ b/src/main/perl/lib/File/Path.pm
@@ -92,10 +92,10 @@ sub _remove_tree_perl {
     for my $path (@paths) {
         next unless defined $path && length $path;
 
-        if (-d $path) {
+        if (-d $path && !-l $path) {
             # Simple recursive removal
             $count += _remove_dir_recursive($path, $verbose, $opts->{safe});
-        } elsif (-f $path) {
+        } elsif (-f $path || -l $path) {
             if (unlink($path)) {
                 $count++;
                 print "unlink $path\n" if $verbose;
@@ -133,7 +133,7 @@ sub _remove_dir_recursive {
 
     for my $entry (@entries) {
         my $path = "$dir/$entry";
-        if (-d $path) {
+        if (-d $path && !-l $path) {
             $count += _remove_dir_recursive($path, $verbose, $safe);
         } else {
             if (unlink($path)) {

--- a/src/main/perl/lib/File/Temp.pm
+++ b/src/main/perl/lib/File/Temp.pm
@@ -60,6 +60,10 @@ sub new {
     return $self;
 }
 
+package File::Temp::Dir;
+
+our @ISA = ('File::Temp');
+
 package File::Temp;
 
 # Set up overloading at package level
@@ -84,14 +88,19 @@ sub new {
     # Default arguments
     $args{UNLINK} = 1 unless exists $args{UNLINK};
 
-    # Create temp file
-    my ($fh, $filename) = tempfile(
-        $args{TEMPLATE} || undef,
+    my @temp_args = (
         DIR    => $args{DIR},
         SUFFIX => $args{SUFFIX},
         UNLINK => $args{UNLINK},
         EXLOCK => $args{EXLOCK},
         PERMS  => $args{PERMS},
+    );
+    push @temp_args, TMPDIR => $args{TMPDIR} if exists $args{TMPDIR};
+
+    # Create temp file
+    my ($fh, $filename) = tempfile(
+        defined $args{TEMPLATE} ? $args{TEMPLATE} : undef,
+        @temp_args,
     );
 
     # Create object
@@ -107,25 +116,23 @@ sub new {
 # Create temporary directory object
 sub newdir {
     my $class = shift;
-    my $template;
-    my %args;
+    my $leading_template = (scalar(@_) % 2 == 1 ? shift(@_) : undef);
+    my %args = @_;
 
-    if (@_ == 1 && !ref $_[0]) {
-        $template = shift;
-    } else {
-        %args = @_;
-        $template = delete $args{TEMPLATE};
-    }
+    $args{TEMPLATE} = $leading_template
+        if defined $leading_template && !exists $args{TEMPLATE};
 
     # Default to cleanup
     $args{CLEANUP} = 1 unless exists $args{CLEANUP};
 
-    my $dir = tempdir($template || undef, %args);
+    my @temp_args;
+    push @temp_args, delete $args{TEMPLATE} if exists $args{TEMPLATE};
+    my $dir = tempdir(@temp_args, %args);
 
     my $self = bless {
         _dirname => $dir,
         _cleanup => $args{CLEANUP},
-    }, $class;
+    }, 'File::Temp::Dir';
 
     return $self;
 }

--- a/src/main/perl/lib/Module/Load/Conditional.pm
+++ b/src/main/perl/lib/Module/Load/Conditional.pm
@@ -215,22 +215,22 @@ sub check_install {
                 my $existed_in_inc = $INC{$file_inc};
 
                 if (UNIVERSAL::isa($dir, 'CODE')) {
-                    ($fh) = $dir->($dir, $file);
+                    ($fh) = $dir->($dir, $file_inc);
 
                 } elsif (UNIVERSAL::isa($dir, 'ARRAY')) {
-                    ($fh) = $dir->[0]->($dir, $file, @{$dir}{1..$#{$dir}})
+                    ($fh) = $dir->[0]->($dir, $file_inc, @{$dir}{1..$#{$dir}})
 
                 } elsif (UNIVERSAL::can($dir, 'INC')) {
-                    ($fh) = $dir->INC($file);
+                    ($fh) = $dir->INC($file_inc);
                 }
 
                 if (!UNIVERSAL::isa($fh, 'GLOB')) {
-                    warn loc(q[Cannot open file '%1': %2], $file, $!)
+                    warn loc(q[Cannot open file '%1': %2], $file_inc, $!)
                             if $args->{verbose};
                     next;
                 }
 
-                $filename = $INC{$file_inc} || $file;
+                $filename = $INC{$file_inc} || $file_inc;
 
                 delete $INC{$file_inc} if not $existed_in_inc;
 

--- a/src/main/perl/lib/NEXT.pm
+++ b/src/main/perl/lib/NEXT.pm
@@ -1,0 +1,579 @@
+package NEXT;
+
+use Carp;
+use strict;
+use warnings;
+use overload ();
+
+our $VERSION = '0.69';
+
+sub NEXT::ELSEWHERE::ancestors
+{
+	my @inlist = shift;
+	my @outlist = ();
+	while (my $next = shift @inlist) {
+		push @outlist, $next;
+		no strict 'refs';
+		unshift @inlist, @{"$outlist[-1]::ISA"};
+	}
+	return @outlist;
+}
+
+sub NEXT::ELSEWHERE::ordered_ancestors
+{
+	my @inlist = shift;
+	my @outlist = ();
+	while (my $next = shift @inlist) {
+		push @outlist, $next;
+		no strict 'refs';
+		push @inlist, @{"$outlist[-1]::ISA"};
+	}
+	return sort { $a->isa($b) ? -1
+	            : $b->isa($a) ? +1
+	            :                0 } @outlist;
+}
+
+sub NEXT::ELSEWHERE::buildAUTOLOAD
+{
+    my $autoload_name = caller() . '::AUTOLOAD';
+
+    no strict 'refs';
+    *{$autoload_name} = sub {
+        my ($self) = @_;
+        my $depth = 1;
+        until (((caller($depth))[3]||q{}) !~ /^\(eval\)$/) { $depth++ }
+        my $caller = (caller($depth))[3];
+        my $wanted = $NEXT::AUTOLOAD || $autoload_name;
+        undef $NEXT::AUTOLOAD;
+        my ($caller_class, $caller_method) = do { $caller =~ m{(.*)::(.*)}g };
+        my ($wanted_class, $wanted_method) = do { $wanted =~ m{(.*)::(.*)}g };
+        croak "Can't call $wanted from $caller"
+            unless $caller_method eq $wanted_method;
+
+        my $key = ref $self && overload::Overloaded($self)
+            ? overload::StrVal($self) : $self;
+
+        local ($NEXT::NEXT{$key,$wanted_method}, $NEXT::SEEN) =
+            ($NEXT::NEXT{$key,$wanted_method}, $NEXT::SEEN);
+
+        unless ($NEXT::NEXT{$key,$wanted_method}) {
+            my @forebears =
+                NEXT::ELSEWHERE::ancestors ref $self || $self,
+                            $wanted_class;
+            while (@forebears) {
+                last if shift @forebears eq $caller_class
+            }
+            no strict 'refs';
+            # Use *{"..."} when first accessing the CODE slot, to make sure
+            # any typeglob stub is upgraded to a full typeglob.
+            @{$NEXT::NEXT{$key,$wanted_method}} =
+                map {
+                    my $stash = \%{"${_}::"};
+                    ($stash->{$caller_method} && (*{"${_}::$caller_method"}{CODE}))
+                        ? *{$stash->{$caller_method}}{CODE}
+                        : () } @forebears
+                    unless $wanted_method eq 'AUTOLOAD';
+            @{$NEXT::NEXT{$key,$wanted_method}} =
+                map {
+                    my $stash = \%{"${_}::"};
+                    ($stash->{AUTOLOAD} && (*{"${_}::AUTOLOAD"}{CODE}))
+                        ? "${_}::AUTOLOAD"
+                        : () } @forebears
+                    unless @{$NEXT::NEXT{$key,$wanted_method}||[]};
+            $NEXT::SEEN->{$key,*{$caller}{CODE}}++;
+        }
+        my $call_method = shift @{$NEXT::NEXT{$key,$wanted_method}};
+        while (do { $wanted_class =~ /^NEXT\b.*\b(UNSEEN|DISTINCT)\b/ }
+            && defined $call_method
+            && $NEXT::SEEN->{$key,$call_method}++) {
+            $call_method = shift @{$NEXT::NEXT{$key,$wanted_method}};
+        }
+        unless (defined $call_method) {
+            return unless do { $wanted_class =~ /^NEXT:.*:ACTUAL/ };
+            (local $Carp::CarpLevel)++;
+            croak qq(Can't locate object method "$wanted_method" ),
+                qq(via package "$caller_class");
+        };
+        return $self->$call_method(@_[1..$#_]) if ref $call_method eq 'CODE';
+        no strict 'refs';
+        do { ($wanted_method=${$caller_class."::AUTOLOAD"}) =~ s/.*::// }
+            if $wanted_method eq 'AUTOLOAD';
+        $$call_method = $caller_class."::NEXT::".$wanted_method;
+        return $call_method->(@_);
+    };
+}
+
+no strict 'vars';
+package NEXT;                                  NEXT::ELSEWHERE::buildAUTOLOAD();
+package NEXT::UNSEEN;		@ISA = 'NEXT';     NEXT::ELSEWHERE::buildAUTOLOAD();
+package NEXT::DISTINCT;		@ISA = 'NEXT';     NEXT::ELSEWHERE::buildAUTOLOAD();
+package NEXT::ACTUAL;		@ISA = 'NEXT';     NEXT::ELSEWHERE::buildAUTOLOAD();
+package NEXT::ACTUAL::UNSEEN;	@ISA = 'NEXT'; NEXT::ELSEWHERE::buildAUTOLOAD();
+package NEXT::ACTUAL::DISTINCT;	@ISA = 'NEXT'; NEXT::ELSEWHERE::buildAUTOLOAD();
+package NEXT::UNSEEN::ACTUAL;	@ISA = 'NEXT'; NEXT::ELSEWHERE::buildAUTOLOAD();
+package NEXT::DISTINCT::ACTUAL;	@ISA = 'NEXT'; NEXT::ELSEWHERE::buildAUTOLOAD();
+
+package
+    EVERY;
+
+sub EVERY::ELSEWHERE::buildAUTOLOAD {
+    my $autoload_name = caller() . '::AUTOLOAD';
+
+    no strict 'refs';
+    *{$autoload_name} = sub {
+        my ($self) = @_;
+        my $depth = 1;
+        until (((caller($depth))[3]||q{}) !~ /^\(eval\)$/) { $depth++ }
+        my $caller = (caller($depth))[3];
+        my $wanted = $EVERY::AUTOLOAD || $autoload_name;
+        undef $EVERY::AUTOLOAD;
+        my ($wanted_class, $wanted_method) = do { $wanted =~ m{(.*)::(.*)}g };
+
+        my $key = ref($self) && overload::Overloaded($self)
+            ? overload::StrVal($self) : $self;
+
+        local $NEXT::ALREADY_IN_EVERY{$key,$wanted_method} =
+            $NEXT::ALREADY_IN_EVERY{$key,$wanted_method};
+
+        return if $NEXT::ALREADY_IN_EVERY{$key,$wanted_method}++;
+
+        my @forebears = NEXT::ELSEWHERE::ordered_ancestors ref $self || $self,
+                                        $wanted_class;
+        @forebears = reverse @forebears if do { $wanted_class =~ /\bLAST\b/ };
+        no strict 'refs';
+        my %seen;
+        my @every = map { my $sub = "${_}::$wanted_method";
+                    !*{$sub}{CODE} || $seen{$sub}++ ? () : $sub
+                    } @forebears
+                    unless $wanted_method eq 'AUTOLOAD';
+
+        my $want = wantarray;
+        if (@every) {
+            if ($want) {
+                return map {($_, [$self->$_(@_[1..$#_])])} @every;
+            }
+            elsif (defined $want) {
+                return { map {($_, scalar($self->$_(@_[1..$#_])))}
+                        @every
+                    };
+            }
+            else {
+                $self->$_(@_[1..$#_]) for @every;
+                return;
+            }
+        }
+
+        @every = map { my $sub = "${_}::AUTOLOAD";
+                !*{$sub}{CODE} || $seen{$sub}++ ? () : "${_}::AUTOLOAD"
+                } @forebears;
+        if ($want) {
+            return map { $$_ = ref($self)."::EVERY::".$wanted_method;
+                    ($_, [$self->$_(@_[1..$#_])]);
+                } @every;
+        }
+        elsif (defined $want) {
+            return { map { $$_ = ref($self)."::EVERY::".$wanted_method;
+                    ($_, scalar($self->$_(@_[1..$#_])))
+                    } @every
+                };
+        }
+        else {
+            for (@every) {
+                $$_ = ref($self)."::EVERY::".$wanted_method;
+                $self->$_(@_[1..$#_]);
+            }
+            return;
+        }
+    };
+}
+
+package EVERY::LAST;   @ISA = 'EVERY';   EVERY::ELSEWHERE::buildAUTOLOAD();
+package
+    EVERY;             @ISA = 'NEXT';    EVERY::ELSEWHERE::buildAUTOLOAD();
+
+1;
+
+__END__
+
+=head1 NAME
+
+NEXT - Provide a pseudo-class NEXT (et al) that allows method redispatch
+
+=head1 SYNOPSIS
+
+    use NEXT;
+
+    package P;
+    sub P::method   { print "$_[0]: P method\n";   $_[0]->NEXT::method() }
+    sub P::DESTROY  { print "$_[0]: P dtor\n";     $_[0]->NEXT::DESTROY() }
+
+    package Q;
+    use base qw( P );
+    sub Q::AUTOLOAD { print "$_[0]: Q AUTOLOAD\n"; $_[0]->NEXT::AUTOLOAD() }
+    sub Q::DESTROY  { print "$_[0]: Q dtor\n";     $_[0]->NEXT::DESTROY() }
+
+    package R;
+    sub R::method   { print "$_[0]: R method\n";   $_[0]->NEXT::method() }
+    sub R::AUTOLOAD { print "$_[0]: R AUTOLOAD\n"; $_[0]->NEXT::AUTOLOAD() }
+    sub R::DESTROY  { print "$_[0]: R dtor\n";     $_[0]->NEXT::DESTROY() }
+
+    package S;
+    use base qw( Q R );
+    sub S::method   { print "$_[0]: S method\n";   $_[0]->NEXT::method() }
+    sub S::AUTOLOAD { print "$_[0]: S AUTOLOAD\n"; $_[0]->NEXT::AUTOLOAD() }
+    sub S::DESTROY  { print "$_[0]: S dtor\n";     $_[0]->NEXT::DESTROY() }
+
+    package main;
+
+    my $obj = bless {}, "S";
+
+    $obj->method();		# Calls S::method, P::method, R::method
+    $obj->missing_method(); # Calls S::AUTOLOAD, Q::AUTOLOAD, R::AUTOLOAD
+
+    # Clean-up calls S::DESTROY, Q::DESTROY, P::DESTROY, R::DESTROY
+
+
+
+=head1 DESCRIPTION
+
+The C<NEXT> module adds a pseudoclass named C<NEXT> to any program
+that uses it. If a method C<m> calls C<$self-E<gt>NEXT::m()>, the call to
+C<m> is redispatched as if the calling method had not originally been found.
+
+B<Note:> before using this module,
+you should look at L<next::method|https://metacpan.org/pod/mro#next::method>
+in the core L<mro> module.
+C<mro> has been a core module since Perl 5.9.5.
+
+In other words, a call to C<$self-E<gt>NEXT::m()> resumes the depth-first,
+left-to-right search of C<$self>'s class hierarchy that resulted in the
+original call to C<m>.
+
+Note that this is not the same thing as C<$self-E<gt>SUPER::m()>, which
+begins a new dispatch that is restricted to searching the ancestors
+of the current class. C<$self-E<gt>NEXT::m()> can backtrack
+past the current class -- to look for a suitable method in other
+ancestors of C<$self> -- whereas C<$self-E<gt>SUPER::m()> cannot.
+
+A typical use would be in the destructors of a class hierarchy,
+as illustrated in the SYNOPSIS above. Each class in the hierarchy
+has a DESTROY method that performs some class-specific action
+and then redispatches the call up the hierarchy. As a result,
+when an object of class S is destroyed, the destructors of I<all>
+its parent classes are called (in depth-first, left-to-right order).
+
+Another typical use of redispatch would be in C<AUTOLOAD>'ed methods.
+If such a method determined that it was not able to handle a
+particular call, it might choose to redispatch that call, in the
+hope that some other C<AUTOLOAD> (above it, or to its left) might
+do better.
+
+By default, if a redispatch attempt fails to find another method
+elsewhere in the objects class hierarchy, it quietly gives up and does
+nothing (but see L<"Enforcing redispatch">). This gracious acquiescence
+is also unlike the (generally annoying) behaviour of C<SUPER>, which
+throws an exception if it cannot redispatch.
+
+Note that it is a fatal error for any method (including C<AUTOLOAD>)
+to attempt to redispatch any method that does not have the
+same name. For example:
+
+        sub S::oops { print "oops!\n"; $_[0]->NEXT::other_method() }
+
+
+=head2 Enforcing redispatch
+
+It is possible to make C<NEXT> redispatch more demandingly (i.e. like
+C<SUPER> does), so that the redispatch throws an exception if it cannot
+find a "next" method to call.
+
+To do this, simple invoke the redispatch as:
+
+	$self->NEXT::ACTUAL::method();
+
+rather than:
+
+	$self->NEXT::method();
+
+The C<ACTUAL> tells C<NEXT> that there must actually be a next method to call,
+or it should throw an exception.
+
+C<NEXT::ACTUAL> is most commonly used in C<AUTOLOAD> methods, as a means to
+decline an C<AUTOLOAD> request, but preserve the normal exception-on-failure 
+semantics:
+
+	sub AUTOLOAD {
+		if ($AUTOLOAD =~ /foo|bar/) {
+			# handle here
+		}
+		else {  # try elsewhere
+			shift()->NEXT::ACTUAL::AUTOLOAD(@_);
+		}
+	}
+
+By using C<NEXT::ACTUAL>, if there is no other C<AUTOLOAD> to handle the
+method call, an exception will be thrown (as usually happens in the absence of
+a suitable C<AUTOLOAD>).
+
+
+=head2 Avoiding repetitions
+
+If C<NEXT> redispatching is used in the methods of a "diamond" class hierarchy:
+
+	#     A   B
+	#    / \ /
+	#   C   D
+	#    \ /
+	#     E
+
+	use NEXT;
+
+	package A;                 
+	sub foo { print "called A::foo\n"; shift->NEXT::foo() }
+
+	package B;                 
+	sub foo { print "called B::foo\n"; shift->NEXT::foo() }
+
+	package C; @ISA = qw( A );
+	sub foo { print "called C::foo\n"; shift->NEXT::foo() }
+
+	package D; @ISA = qw(A B);
+	sub foo { print "called D::foo\n"; shift->NEXT::foo() }
+
+	package E; @ISA = qw(C D);
+	sub foo { print "called E::foo\n"; shift->NEXT::foo() }
+
+	E->foo();
+
+then derived classes may (re-)inherit base-class methods through two or
+more distinct paths (e.g. in the way C<E> inherits C<A::foo> twice --
+through C<C> and C<D>). In such cases, a sequence of C<NEXT> redispatches
+will invoke the multiply inherited method as many times as it is
+inherited. For example, the above code prints:
+
+        called E::foo
+        called C::foo
+        called A::foo
+        called D::foo
+        called A::foo
+        called B::foo
+
+(i.e. C<A::foo> is called twice).
+
+In some cases this I<may> be the desired effect within a diamond hierarchy,
+but in others (e.g. for destructors) it may be more appropriate to 
+call each method only once during a sequence of redispatches.
+
+To cover such cases, you can redispatch methods via:
+
+        $self->NEXT::DISTINCT::method();
+
+rather than:
+
+        $self->NEXT::method();
+
+This causes the redispatcher to only visit each distinct C<method> method
+once. That is, to skip any classes in the hierarchy that it has
+already visited during redispatch. So, for example, if the
+previous example were rewritten:
+
+        package A;                 
+        sub foo { print "called A::foo\n"; shift->NEXT::DISTINCT::foo() }
+
+        package B;                 
+        sub foo { print "called B::foo\n"; shift->NEXT::DISTINCT::foo() }
+
+        package C; @ISA = qw( A );
+        sub foo { print "called C::foo\n"; shift->NEXT::DISTINCT::foo() }
+
+        package D; @ISA = qw(A B);
+        sub foo { print "called D::foo\n"; shift->NEXT::DISTINCT::foo() }
+
+        package E; @ISA = qw(C D);
+        sub foo { print "called E::foo\n"; shift->NEXT::DISTINCT::foo() }
+
+        E->foo();
+
+then it would print:
+
+        called E::foo
+        called C::foo
+        called A::foo
+        called D::foo
+        called B::foo
+
+and omit the second call to C<A::foo> (since it would not be distinct
+from the first call to C<A::foo>).
+
+Note that you can also use:
+
+        $self->NEXT::DISTINCT::ACTUAL::method();
+
+or:
+
+        $self->NEXT::ACTUAL::DISTINCT::method();
+
+to get both unique invocation I<and> exception-on-failure.
+
+Note that, for historical compatibility, you can also use
+C<NEXT::UNSEEN> instead of C<NEXT::DISTINCT>.
+
+
+=head2 Invoking all versions of a method with a single call
+
+Yet another pseudo-class that C<NEXT> provides is C<EVERY>.
+Its behaviour is considerably simpler than that of the C<NEXT> family.
+A call to:
+
+	$obj->EVERY::foo();
+
+calls I<every> method named C<foo> that the object in C<$obj> has inherited.
+That is:
+
+	use NEXT;
+
+	package A; @ISA = qw(B D X);
+	sub foo { print "A::foo " }
+
+	package B; @ISA = qw(D X);
+	sub foo { print "B::foo " }
+
+	package X; @ISA = qw(D);
+	sub foo { print "X::foo " }
+
+	package D;
+	sub foo { print "D::foo " }
+
+	package main;
+
+	my $obj = bless {}, 'A';
+	$obj->EVERY::foo();        # prints" A::foo B::foo X::foo D::foo
+
+Prefixing a method call with C<EVERY::> causes every method in the
+object's hierarchy with that name to be invoked. As the above example
+illustrates, they are not called in Perl's usual "left-most-depth-first"
+order. Instead, they are called "breadth-first-dependency-wise".
+
+That means that the inheritance tree of the object is traversed breadth-first
+and the resulting order of classes is used as the sequence in which methods
+are called. However, that sequence is modified by imposing a rule that the
+appropriate method of a derived class must be called before the same method of
+any ancestral class. That's why, in the above example, C<X::foo> is called
+before C<D::foo>, even though C<D> comes before C<X> in C<@B::ISA>.
+
+In general, there's no need to worry about the order of calls. They will be
+left-to-right, breadth-first, most-derived-first. This works perfectly for
+most inherited methods (including destructors), but is inappropriate for
+some kinds of methods (such as constructors, cloners, debuggers, and
+initializers) where it's more appropriate that the least-derived methods be
+called first (as more-derived methods may rely on the behaviour of their
+"ancestors"). In that case, instead of using the C<EVERY> pseudo-class:
+
+	$obj->EVERY::foo();        # prints" A::foo B::foo X::foo D::foo      
+
+you can use the C<EVERY::LAST> pseudo-class:
+
+	$obj->EVERY::LAST::foo();  # prints" D::foo X::foo B::foo A::foo      
+
+which reverses the order of method call.
+
+Whichever version is used, the actual methods are called in the same
+context (list, scalar, or void) as the original call via C<EVERY>, and return:
+
+=over
+
+=item *
+
+A hash of array references in list context. Each entry of the hash has the
+fully qualified method name as its key and a reference to an array containing
+the method's list-context return values as its value.
+
+=item *
+
+A reference to a hash of scalar values in scalar context. Each entry of the hash has the
+fully qualified method name as its key and the method's scalar-context return values as its value.
+
+=item *
+
+Nothing in void context (obviously).
+
+=back
+
+=head2 Using C<EVERY> methods
+
+The typical way to use an C<EVERY> call is to wrap it in another base
+method, that all classes inherit. For example, to ensure that every
+destructor an object inherits is actually called (as opposed to just the
+left-most-depth-first-est one):
+
+        package Base;
+        sub DESTROY { $_[0]->EVERY::Destroy }
+
+        package Derived1; 
+        use base 'Base';
+        sub Destroy {...}
+
+        package Derived2; 
+        use base 'Base', 'Derived1';
+        sub Destroy {...}
+
+et cetera. Every derived class than needs its own clean-up
+behaviour simply adds its own C<Destroy> method (I<not> a C<DESTROY> method),
+which the call to C<EVERY::LAST::Destroy> in the inherited destructor
+then correctly picks up.
+
+Likewise, to create a class hierarchy in which every initializer inherited by
+a new object is invoked:
+
+        package Base;
+        sub new {
+		my ($class, %args) = @_;
+		my $obj = bless {}, $class;
+		$obj->EVERY::LAST::Init(\%args);
+	}
+
+        package Derived1; 
+        use base 'Base';
+        sub Init {
+		my ($argsref) = @_;
+		...
+	}
+
+        package Derived2; 
+        use base 'Base', 'Derived1';
+        sub Init {
+		my ($argsref) = @_;
+		...
+	}
+
+et cetera. Every derived class than needs some additional initialization
+behaviour simply adds its own C<Init> method (I<not> a C<new> method),
+which the call to C<EVERY::LAST::Init> in the inherited constructor
+then correctly picks up.
+
+=head1 SEE ALSO
+
+L<mro>
+(in particular L<next::method|https://metacpan.org/pod/mro#next::method>),
+which has been a core module since Perl 5.9.5.
+
+=head1 AUTHOR
+
+Damian Conway (damian@conway.org)
+
+=head1 BUGS AND IRRITATIONS
+
+Because it's a module, not an integral part of the interpreter, C<NEXT>
+has to guess where the surrounding call was found in the method
+look-up sequence. In the presence of diamond inheritance patterns
+it occasionally guesses wrong.
+
+It's also too slow (despite caching).
+
+Comment, suggestions, and patches welcome.
+
+=head1 COPYRIGHT
+
+ Copyright (c) 2000-2001, Damian Conway. All Rights Reserved.
+ This module is free software. It may be used, redistributed
+    and/or modified under the same terms as Perl itself.

--- a/src/main/perl/lib/open.pm
+++ b/src/main/perl/lib/open.pm
@@ -61,6 +61,8 @@ sub import {
     }
 
     ${^OPEN} = join( "\0", defined $in ? $in : '', defined $out ? $out : '' );
+    $^H{'open<'} = $in  if defined $in;
+    $^H{'open>'} = $out if defined $out;
 
     if ($std) {
         binmode( \*STDIN,  $in )  if $in;

--- a/src/test/resources/unit/next_module_prereq.t
+++ b/src/test/resources/unit/next_module_prereq.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+use NEXT;
+
+{
+    package NextPrereq::Foo;
+    use mro 'c3';
+    sub foo { 'Foo::foo' }
+
+    package NextPrereq::Fuz;
+    use mro 'c3';
+    use base 'NextPrereq::Foo';
+    sub foo { 'Fuz::foo => ' . (shift)->next::method }
+
+    package NextPrereq::Bar;
+    use mro 'c3';
+    use base 'NextPrereq::Foo';
+    sub foo { 'Bar::foo => ' . (shift)->next::method }
+
+    package NextPrereq::Baz;
+    use base 'NextPrereq::Bar', 'NextPrereq::Fuz';
+    sub foo { 'Baz::foo => ' . (shift)->NEXT::foo }
+}
+
+is(NextPrereq::Foo->foo, 'Foo::foo', 'NEXT.pm is loadable');
+is(NextPrereq::Fuz->foo, 'Fuz::foo => Foo::foo', 'next::method still works');
+is(NextPrereq::Bar->foo, 'Bar::foo => Foo::foo', 'next::method works in sibling class');
+is(NextPrereq::Baz->foo, 'Baz::foo => Bar::foo => Fuz::foo => Foo::foo',
+    'NEXT redispatch works with c3 next::method');

--- a/src/test/resources/unit/path_tiny_runtime_prereqs.t
+++ b/src/test/resources/unit/path_tiny_runtime_prereqs.t
@@ -6,12 +6,16 @@ use File::Glob ();
 use File::Spec;
 use File::Temp qw(tempdir);
 
-is(File::Spec->canonpath('~idontthinkso\\*'), '~idontthinkso\\*',
-    'File::Spec::Unix canonpath treats backslash as literal');
-is(File::Spec->canonpath('/../../'), '/', 'canonpath clamps absolute updirs at root');
-is(File::Spec->canonpath('/../..'), '/', 'canonpath clamps absolute terminal updirs at root');
-is(File::Spec->canonpath('///../../..//./././a//b/.././c/././'), '/a/b/../c',
-    'canonpath matches File::Spec::Unix absolute cleanup');
+SKIP: {
+    skip 'Unix File::Spec canonpath cases', 4 if $^O eq 'MSWin32';
+
+    is(File::Spec->canonpath('~idontthinkso\\*'), '~idontthinkso\\*',
+        'File::Spec::Unix canonpath treats backslash as literal');
+    is(File::Spec->canonpath('/../../'), '/', 'canonpath clamps absolute updirs at root');
+    is(File::Spec->canonpath('/../..'), '/', 'canonpath clamps absolute terminal updirs at root');
+    is(File::Spec->canonpath('///../../..//./././a//b/.././c/././'), '/a/b/../c',
+        'canonpath matches File::Spec::Unix absolute cleanup');
+}
 
 is_deeply([File::Glob::bsd_glob('~blah blah')], ['~blah blah'],
     'File::Glob::bsd_glob keeps whitespace in one literal pattern');
@@ -20,7 +24,8 @@ is_deeply([File::Glob::bsd_glob('~idontthinkso\\*')], ['~idontthinkso*'],
 is_deeply([File::Glob::bsd_glob('~i\\{dont,think}so',
     File::Glob::GLOB_NOCHECK() | File::Glob::GLOB_BRACE() | File::Glob::GLOB_QUOTE())],
     ['~i{dont,think}so'], 'File::Glob::bsd_glob dequotes no-check literals');
-like((File::Glob::bsd_glob('~'))[0], qr{^/}, 'File::Glob::bsd_glob expands bare tilde');
+my ($glob_home) = File::Glob::bsd_glob('~');
+ok(defined($glob_home) && $glob_home ne '~', 'File::Glob::bsd_glob expands bare tilde');
 
 {
     package PathTinyLocalizedCodeSlot;
@@ -86,7 +91,7 @@ like((File::Glob::bsd_glob('~'))[0], qr{^/}, 'File::Glob::bsd_glob expands bare 
     mkdir 'nested' or die "mkdir nested: $!";
     open my $fh, '>', 'nested/file.txt' or die "open nested/file.txt: $!";
     close $fh;
-    ok(utime undef, undef, 'nested/file.txt', 'utime resolves relative to Perl cwd');
+    ok(utime(undef, undef, 'nested/file.txt'), 'utime resolves relative to Perl cwd');
     chdir $old or die "chdir $old: $!";
 }
 

--- a/src/test/resources/unit/path_tiny_runtime_prereqs.t
+++ b/src/test/resources/unit/path_tiny_runtime_prereqs.t
@@ -105,10 +105,11 @@ SKIP: {
     unlink "$dir/subprobe";
 
     mkdir "$dir/sub" or die "mkdir $dir/sub: $!";
+    my $expected_target = $^O eq 'MSWin32' ? '..\\target' : '../target';
     ok(symlink('../target', "$dir/sub/link"), 'relative symlink created');
-    is(readlink("$dir/sub/link"), '../target', 'readlink preserves relative target');
+    is(readlink("$dir/sub/link"), $expected_target, 'readlink preserves relative target');
     unlink $target or die "unlink $target: $!";
-    is(readlink("$dir/sub/link"), '../target', 'readlink works for broken symlink');
+    is(readlink("$dir/sub/link"), $expected_target, 'readlink works for broken symlink');
     ok(unlink("$dir/sub/link"), 'unlink removes broken symlink');
     ok(!unlink($dir), 'unlink does not remove directories');
 }

--- a/src/test/resources/unit/path_tiny_runtime_prereqs.t
+++ b/src/test/resources/unit/path_tiny_runtime_prereqs.t
@@ -1,0 +1,111 @@
+use strict;
+use warnings;
+use Test::More;
+use Cwd ();
+use File::Glob ();
+use File::Spec;
+use File::Temp qw(tempdir);
+
+is(File::Spec->canonpath('~idontthinkso\\*'), '~idontthinkso\\*',
+    'File::Spec::Unix canonpath treats backslash as literal');
+is(File::Spec->canonpath('/../../'), '/', 'canonpath clamps absolute updirs at root');
+is(File::Spec->canonpath('/../..'), '/', 'canonpath clamps absolute terminal updirs at root');
+is(File::Spec->canonpath('///../../..//./././a//b/.././c/././'), '/a/b/../c',
+    'canonpath matches File::Spec::Unix absolute cleanup');
+
+is_deeply([File::Glob::bsd_glob('~blah blah')], ['~blah blah'],
+    'File::Glob::bsd_glob keeps whitespace in one literal pattern');
+is_deeply([File::Glob::bsd_glob('~idontthinkso\\*')], ['~idontthinkso*'],
+    'File::Glob::bsd_glob dequotes escaped glob metacharacters');
+is_deeply([File::Glob::bsd_glob('~i\\{dont,think}so',
+    File::Glob::GLOB_NOCHECK() | File::Glob::GLOB_BRACE() | File::Glob::GLOB_QUOTE())],
+    ['~i{dont,think}so'], 'File::Glob::bsd_glob dequotes no-check literals');
+like((File::Glob::bsd_glob('~'))[0], qr{^/}, 'File::Glob::bsd_glob expands bare tilde');
+
+{
+    package PathTinyLocalizedCodeSlot;
+    sub target { 'old' }
+    package main;
+    my $orig = \&PathTinyLocalizedCodeSlot::target;
+    {
+        no warnings 'redefine';
+        local *PathTinyLocalizedCodeSlot::target = sub { 'new' };
+        is(PathTinyLocalizedCodeSlot::target(), 'new',
+            'direct named calls see localized CODE glob slots');
+        is($orig->(), 'old', 'saved coderef keeps original CODE value');
+    }
+    is(PathTinyLocalizedCodeSlot::target(), 'old',
+        'localized CODE glob slot restores after scope exit');
+}
+
+{
+    my $dir = File::Temp->newdir('helloXXXXX', TMPDIR => 1);
+    isa_ok($dir, 'File::Temp::Dir');
+    like("$dir", qr/hello/, 'File::Temp->newdir keeps leading template with options');
+}
+
+{
+    my $file = File::Temp->new(TEMPLATE => 'helloXXXXX', TMPDIR => 1);
+    like("$file", qr/hello/, 'File::Temp->new keeps TMPDIR template');
+}
+
+{
+    my $dir = tempdir(CLEANUP => 1);
+    my $old = Cwd::getcwd();
+    chdir $dir or die "chdir $dir: $!";
+    my $file = File::Temp->new(DIR => '.', TMPDIR => 1);
+    ok(-e "$file", 'File::Temp->new creates relative DIR files under Perl cwd');
+    close $file;
+    chdir $old or die "chdir $old: $!";
+}
+
+{
+    package PathTinyHintProbe;
+    sub hints {
+        my $h = (caller(0))[10] || {};
+        return ($h->{'open<'}, $h->{'open>'});
+    }
+    package main;
+    {
+        use open IO => ':utf8';
+        is_deeply([PathTinyHintProbe::hints()], [':utf8', ':utf8'],
+            'open pragma stores caller hinthash entries');
+    }
+}
+
+{
+    sub _poj_path_tiny_lines { ("Line1\r\n", "Line2\n") }
+    my @got = map { s/[\r\n]+\z//; $_ } _poj_path_tiny_lines();
+    is_deeply(\@got, ['Line1', 'Line2'], 'sub-returned constants are mutable map temporaries');
+}
+
+{
+    my $dir = tempdir(CLEANUP => 1);
+    my $old = Cwd::getcwd();
+    chdir $dir or die "chdir $dir: $!";
+    mkdir 'nested' or die "mkdir nested: $!";
+    open my $fh, '>', 'nested/file.txt' or die "open nested/file.txt: $!";
+    close $fh;
+    ok(utime undef, undef, 'nested/file.txt', 'utime resolves relative to Perl cwd');
+    chdir $old or die "chdir $old: $!";
+}
+
+SKIP: {
+    my $dir = tempdir(CLEANUP => 1);
+    my $target = "$dir/target";
+    open my $fh, '>', $target or die "open $target: $!";
+    close $fh;
+
+    skip 'symlink not available', 5 unless symlink '../target', "$dir/subprobe";
+    unlink "$dir/subprobe";
+
+    mkdir "$dir/sub" or die "mkdir $dir/sub: $!";
+    ok(symlink('../target', "$dir/sub/link"), 'relative symlink created');
+    is(readlink("$dir/sub/link"), '../target', 'readlink preserves relative target');
+    unlink $target or die "unlink $target: $!";
+    is(readlink("$dir/sub/link"), '../target', 'readlink works for broken symlink');
+    ok(unlink("$dir/sub/link"), 'unlink removes broken symlink');
+    ok(!unlink($dir), 'unlink does not remove directories');
+}
+
+done_testing;


### PR DESCRIPTION
## Summary

- Fix runtime and bundled-module gaps exposed by `./jcpan -t Path::Tiny`
- Add focused regressions for Path::Tiny prerequisites, including localized CODE glob dispatch
- Improve File::Spec, File::Temp, File::Glob, symlink/readlink, unlink, utime, open hints, and subroutine list-return behavior

## Test plan

- `make`
- `timeout 900 ./jcpan -t Path::Tiny`

Both passed locally.
