### PR TITLE
Fix array-valued lvalue sub list assignment

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -6192,11 +6192,15 @@ public class BytecodeCompiler implements Visitor {
             return;
         }
 
+        int elementContext = currentCallContext == RuntimeContextType.LVALUE_LIST
+                ? RuntimeContextType.LVALUE_LIST
+                : RuntimeContextType.LIST;
+
         // Fast path: single element in LIST context
         // In list context, returns a RuntimeList with one element
         // List elements should be evaluated in LIST context
         if (node.elements.size() == 1) {
-            compileNode(node.elements.get(0), -1, RuntimeContextType.LIST);
+            compileNode(node.elements.get(0), -1, elementContext);
             int elemReg = lastResultReg;
 
             int listReg = allocateRegister();
@@ -6212,7 +6216,7 @@ public class BytecodeCompiler implements Visitor {
         // Evaluate each element into a register
         int[] elementRegs = new int[node.elements.size()];
         for (int i = 0; i < node.elements.size(); i++) {
-            compileNode(node.elements.get(i), -1, RuntimeContextType.LIST);
+            compileNode(node.elements.get(i), -1, elementContext);
             elementRegs[i] = lastResultReg;
         }
 

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -357,8 +357,8 @@ public class BytecodeInterpreter {
                                 if (retVal == null) {
                                     retVal = new RuntimeList();
                                 }
-                                RuntimeList retList = retVal.getList();
-                                RuntimeCode.materializeSpecialVarsInResult(retList);
+                                RuntimeList retList = RuntimeCode.returnList(retVal, callContext);
+                                RuntimeCode.materializeSpecialVarsInResult(retList, callContext);
 
                                 return retList;
                             }
@@ -372,8 +372,8 @@ public class BytecodeInterpreter {
                                 if (retVal == null) {
                                     retVal = new RuntimeList();
                                 }
-                                RuntimeList retList = retVal.getList();
-                                RuntimeCode.materializeSpecialVarsInResult(retList);
+                                RuntimeList retList = RuntimeCode.returnList(retVal, callContext);
+                                RuntimeCode.materializeSpecialVarsInResult(retList, callContext);
 
                                 return new RuntimeControlFlowList(retList, code.sourceName, code.sourceLine);
                             }

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
@@ -1850,9 +1850,9 @@ public class CompileAssignment {
                 bytecodeCompiler.emitReg(rhsListReg);
                 bytecodeCompiler.emitReg(rhsReg);
 
-                // Compile LHS ListNode in LIST context - this produces a RuntimeList of lvalues
+                // Compile LHS ListNode in list-lvalue context - this produces a RuntimeList of lvalues
                 // This follows the JVM backend approach (EmitVariable.java line 837)
-                bytecodeCompiler.compileNode(listNode, -1, RuntimeContextType.LIST);
+                bytecodeCompiler.compileNode(listNode, -1, RuntimeContextType.LVALUE_LIST);
                 int lhsListReg = bytecodeCompiler.lastResultReg;
 
                 // Call SET_FROM_LIST to assign RHS values to LHS lvalues

--- a/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
@@ -1009,9 +1009,9 @@ public class EmitVariable {
                 }
                 mv.visitVarInsn(Opcodes.ASTORE, rhsListSlot);
 
-                // For declared references, we need special handling
-                // The my operator needs to be processed to create the variables first
-                node.left.accept(emitterVisitor.with(RuntimeContextType.LIST));   // emit the variable (target)
+                // For declared references, we need special handling.
+                // The my operator needs to be processed to create the variables first.
+                node.left.accept(emitterVisitor.with(RuntimeContextType.LVALUE_LIST));   // emit the variable (target)
                 mv.visitVarInsn(Opcodes.ALOAD, rhsListSlot);                      // reload RHS list
                 mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/runtimetypes/RuntimeBase", "setFromList", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeList;)Lorg/perlonjava/runtime/runtimetypes/RuntimeArray;", false);
 

--- a/src/main/java/org/perlonjava/backend/jvm/EmitterMethodCreator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitterMethodCreator.java
@@ -780,7 +780,12 @@ public class EmitterMethodCreator implements Opcodes {
             // Transform the value in the stack to RuntimeList BEFORE local teardown.
             // Materialize it into a local slot immediately so all subsequent control-flow
             // checks operate from locals and join points don't depend on operand stack shape.
-            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/runtimetypes/RuntimeBase", "getList", "()Lorg/perlonjava/runtime/runtimetypes/RuntimeList;", false);
+            mv.visitVarInsn(Opcodes.ILOAD, 2);
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                    "org/perlonjava/runtime/runtimetypes/RuntimeCode",
+                    "returnList",
+                    "(Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;I)Lorg/perlonjava/runtime/runtimetypes/RuntimeList;",
+                    false);
             mv.visitVarInsn(Opcodes.ASTORE, returnListSlot);
 
             // (Return-path cleanup is emitted at each 'return' site in handleReturnOperator.)
@@ -1016,10 +1021,11 @@ public class EmitterMethodCreator implements Opcodes {
             // The return list may contain lazy ScalarSpecialVariable references; if we
             // restored first, they would resolve to the caller's (stale) values.
             mv.visitInsn(Opcodes.DUP);
+            mv.visitVarInsn(Opcodes.ILOAD, 2);
             mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                     "org/perlonjava/runtime/runtimetypes/RuntimeCode",
                     "materializeSpecialVarsInResult",
-                    "(Lorg/perlonjava/runtime/runtimetypes/RuntimeList;)V", false);
+                    "(Lorg/perlonjava/runtime/runtimetypes/RuntimeList;I)V", false);
 
             if (useTryCatch) {
                 // For eval BLOCK, wrap the teardown in a try-catch to catch exceptions

--- a/src/main/java/org/perlonjava/runtime/operators/Operator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Operator.java
@@ -806,7 +806,7 @@ public class Operator {
     }
 
     public static RuntimeScalar wantarray(int ctx) {
-        return ctx == RuntimeContextType.VOID ? scalarUndef : new RuntimeScalar(ctx == RuntimeContextType.LIST ? scalarTrue : scalarFalse);
+        return ctx == RuntimeContextType.VOID ? scalarUndef : new RuntimeScalar(RuntimeContextType.isListLike(ctx) ? scalarTrue : scalarFalse);
     }
 
     // Process-related operators

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -349,6 +349,19 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 : callContext;
     }
 
+    public static RuntimeList returnList(RuntimeBase retVal, int callContext) {
+        if (retVal == null) {
+            return new RuntimeList();
+        }
+        if (callContext == RuntimeContextType.LVALUE_LIST
+                && !(retVal instanceof RuntimeControlFlowList)) {
+            RuntimeList result = new RuntimeList();
+            result.add(retVal);
+            return result;
+        }
+        return retVal.getList();
+    }
+
     /**
      * Perl collapses a multi-value list returned from a subroutine when the callee runs in
      * scalar context: only the last element survives as the actual return SV. PerlOnJava
@@ -447,7 +460,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     public static void requireLvalueCallable(RuntimeCode code, int callContext, String subroutineName) {
-        if (callContext != RuntimeContextType.LVALUE || isLvalueCode(code)) {
+        if ((callContext != RuntimeContextType.LVALUE && callContext != RuntimeContextType.LVALUE_LIST)
+                || isLvalueCode(code)) {
             return;
         }
 
@@ -1988,7 +2002,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 }
 
                 // Return undef/empty list to signal compilation failure
-                if (callContext == RuntimeContextType.LIST) {
+                if (RuntimeContextType.isListLike(callContext)) {
                     return new RuntimeList();
                 } else {
                     return new RuntimeList(new RuntimeScalar());
@@ -2045,7 +2059,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 }
 
                 // Return undef/empty list
-                if (callContext == RuntimeContextType.LIST) {
+                if (RuntimeContextType.isListLike(callContext)) {
                     return new RuntimeList();
                 } else {
                     return new RuntimeList(new RuntimeScalar());
@@ -2057,7 +2071,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 WarnDie.catchEval(e);
 
                 // Return undef/empty list
-                if (callContext == RuntimeContextType.LIST) {
+                if (RuntimeContextType.isListLike(callContext)) {
                     return new RuntimeList();
                 } else {
                     return new RuntimeList(new RuntimeScalar());
@@ -3288,7 +3302,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 }
             }
 
-            if (callContext == RuntimeContextType.LIST) {
+            if (RuntimeContextType.isListLike(callContext)) {
                 return new RuntimeList();
             }
             return new RuntimeList(new RuntimeScalar());
@@ -3369,7 +3383,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         // This is a temporary workaround for the architectural limitation that eval        // contexts are captured at compile time.
         if (runtimeScalar.type == RuntimeScalarType.UNDEF) {
             // Return undef in appropriate context
-            if (callContext == RuntimeContextType.LIST) {
+            if (RuntimeContextType.isListLike(callContext)) {
                 return new RuntimeList();
             } else {
                 return new RuntimeList(new RuntimeScalar());
@@ -3620,7 +3634,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         // contexts are captured at compile time.
         if (runtimeScalar.type == RuntimeScalarType.UNDEF) {
             // Return undef in appropriate context
-            if (callContext == RuntimeContextType.LIST) {
+            if (RuntimeContextType.isListLike(callContext)) {
                 return new RuntimeList();
             } else {
                 return new RuntimeList(new RuntimeScalar());
@@ -3966,6 +3980,11 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * (original) values after the local scope exits.</p>
      */
     public static void materializeSpecialVarsInResult(RuntimeList result) {
+        materializeSpecialVarsInResult(result, RuntimeContextType.LIST);
+    }
+
+    public static void materializeSpecialVarsInResult(RuntimeList result, int callContext) {
+        boolean preserveAggregateLvalues = callContext == RuntimeContextType.LVALUE_LIST;
         List<RuntimeBase> elems = result.elements;
         for (int i = 0; i < elems.size(); i++) {
             RuntimeBase elem = elems.get(i);
@@ -3975,7 +3994,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 concrete.type = resolved.type;
                 concrete.value = resolved.value;
                 elems.set(i, concrete);
-            } else if (elem instanceof RuntimeArray arr) {
+            } else if (!preserveAggregateLvalues && elem instanceof RuntimeArray arr) {
                 // Copy array elements to ensure independence from local restoration.
                 // For tied arrays, use getList() which dispatches through FETCHSIZE/FETCH,
                 // since TieArray.elements (the ArrayList) is empty — data lives in the tied object.
@@ -3990,7 +4009,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     }
                     elems.set(i, copy);
                 }
-            } else if (elem instanceof RuntimeHash hash) {
+            } else if (!preserveAggregateLvalues && elem instanceof RuntimeHash hash) {
                 // Copy hash elements for the same reason as arrays.
                 // For tied hashes, use getList() which dispatches through FIRSTKEY/NEXTKEY/FETCH.
                 if (hash.type == RuntimeHash.TIED_HASH) {
@@ -4303,7 +4322,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * In scalar context, returns the entire output as a single scalar.
      */
     private static RuntimeList forkOpenOutputToList(String capturedOutput, int callContext) {
-        if (callContext == RuntimeContextType.LIST && capturedOutput != null && !capturedOutput.isEmpty()) {
+        if (RuntimeContextType.isListLike(callContext) && capturedOutput != null && !capturedOutput.isEmpty()) {
             // Split into lines preserving newlines (like Perl's <FH> in list context)
             RuntimeArray arr = new RuntimeArray();
             int start = 0;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeContextType.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeContextType.java
@@ -48,4 +48,16 @@ public class RuntimeContextType {
      * attribute before allowing assignment through its return value.
      */
     public static final int LVALUE = 4;
+
+    /**
+     * Represents list lvalue context for subroutine and method calls used as
+     * list-assignment targets. The callee sees list context for wantarray(),
+     * while the runtime verifies the :lvalue attribute and preserves returned
+     * aliases instead of copying list values.
+     */
+    public static final int LVALUE_LIST = 5;
+
+    public static boolean isListLike(int context) {
+        return context == LIST || context == LVALUE_LIST;
+    }
 }

--- a/src/test/resources/unit/lvalue_list_sub.t
+++ b/src/test/resources/unit/lvalue_list_sub.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+use Test::More;
+
+my @array;
+
+sub array_lvalue :lvalue {
+    @array
+}
+
+(array_lvalue()) = (1, 2);
+is_deeply([@array], [1, 2], 'array-valued lvalue sub is assignable');
+
+@array = ();
+my $orig = \&array_lvalue;
+
+sub wrapped_array_lvalue :lvalue {
+    $orig->(@_)
+}
+
+(wrapped_array_lvalue()) = (3, 4);
+is_deeply([@array], [3, 4], 'array-valued lvalue sub aliases through coderef wrapper');
+
+my $ctx = '';
+
+sub context_array_lvalue :lvalue {
+    $ctx = wantarray ? 'list' : defined(wantarray) ? 'scalar' : 'void';
+    @array
+}
+
+(context_array_lvalue()) = (5, 6);
+is($ctx, 'list', 'list assignment calls array-valued lvalue sub in list context');
+is_deeply([@array], [5, 6], 'array-valued lvalue sub remains assignable after wantarray check');
+
+done_testing;


### PR DESCRIPTION
## Summary

- Add a list-lvalue runtime context for `:lvalue` subroutine and method calls used as list assignment targets.
- Preserve aggregate array/hash lvalue returns during return materialization instead of copying them like ordinary list returns.
- Add a regression test for direct and wrapped array-valued `:lvalue` subs.

## Verification

- `make`
- `timeout 60 ./jperl -e 'my @array; sub array_lvalue :lvalue { @array } (array_lvalue()) = (1,2); print scalar(@array), qq{:}, join(q{,}, @array), qq{\n};'`
- `timeout 60 ./jperl --interpreter -e 'my @array; sub array_lvalue :lvalue { @array } (array_lvalue()) = (1,2); print scalar(@array), qq{:}, join(q{,}, @array), qq{\n};'`
- `timeout 600 ./jcpan -t Class::Method::Modifiers`
