### PR TITLE
Fix Class::C3::Componentised jcpan tests

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -397,8 +397,11 @@ public class StatementParser {
                 TokenUtils.consume(parser, LexerTokenType.OPERATOR, "}");
             }
 
+            // The generated wrapper is internal syntax for the try expression.
+            // Let it accept lvalue contexts so :lvalue subs can return aliases
+            // through try { ... } without failing the subroutine lvalue check.
             return new BinaryOperatorNode("->",
-                    new SubroutineNode(null, null, null,
+                    new SubroutineNode(null, null, List.of("lvalue"),
                             new BlockNode(List.of(
                                 new TryNode(tryBlock, catchParameter, catchBlock, finallyBlock, index)), index),
                         false, index),

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/NextMethod.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/NextMethod.java
@@ -9,6 +9,8 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarUndef
 public class NextMethod {
     private static final boolean DEBUG_NEXT_METHOD = Boolean.getBoolean("debug.next.method");
 
+    private record CallerMethod(String callerPackage, String methodName) {}
+
     /**
      * Package for SUPER / next::method resolution: named-glob installs ({@code *Pkg::m = sub {...}})
      * record {@link RuntimeCode#stashInstallPackage}; anonymous bodies may still have the
@@ -22,6 +24,43 @@ public class NextMethod {
             return code.stashInstallPackage;
         }
         return code.packageName;
+    }
+
+    private static CallerMethod resolveCallerMethodFromStack() {
+        for (int level = 0; level <= 5; level++) {
+            try {
+                RuntimeList levelArgs = new RuntimeScalar(level).getList();
+                RuntimeList callerInfo = RuntimeCode.caller(levelArgs, RuntimeContextType.LIST);
+
+                if (callerInfo.elements.size() >= 4) {
+                    String pkg = callerInfo.elements.get(0).toString();
+                    String filename = callerInfo.elements.get(1).toString();
+                    String subroutineName = callerInfo.elements.get(3).toString();
+
+                    if (!filename.contains(".java") && !pkg.isEmpty()
+                            && !subroutineName.isEmpty() && !subroutineName.equals("(eval)")
+                            && !subroutineName.endsWith("::__ANON__")) {
+                        String methodName;
+                        String callerPackage;
+                        int lastDoubleColon = subroutineName.lastIndexOf("::");
+                        if (lastDoubleColon >= 0) {
+                            methodName = subroutineName.substring(lastDoubleColon + 2);
+                            callerPackage = subroutineName.substring(0, lastDoubleColon);
+                        } else {
+                            methodName = subroutineName;
+                            callerPackage = pkg;
+                        }
+
+                        if (!methodName.isEmpty() && !methodName.equals("(eval)")) {
+                            return new CallerMethod(callerPackage, methodName);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                // Continue trying other levels.
+            }
+        }
+        return null;
     }
 
     /**
@@ -261,65 +300,28 @@ public class NextMethod {
             System.out.println("DEBUG: This should not be used in normal operation");
         }
 
-        // Original implementation as fallback
         if (args.size() == 0) {
             throw new PerlCompilerException("Can't call next::method on an empty argument list");
         }
 
-        // Try to get caller information from stack trace (original implementation)
-        // This is kept as a fallback but should rarely be used
-        String callerPackage = null;
-        String methodName = null;
-
-        // IMPROVED APPROACH: Use a more systematic way to find caller info
-        for (int level = 0; level <= 5; level++) {
-            try {
-                RuntimeList levelArgs = new RuntimeScalar(level).getList();
-                RuntimeList callerInfo = RuntimeCode.caller(levelArgs, RuntimeContextType.LIST);
-
-                if (callerInfo.elements.size() >= 4) {
-                    String pkg = callerInfo.elements.get(0).toString();
-                    String filename = callerInfo.elements.get(1).toString();
-                    String subroutineName = callerInfo.elements.get(3).toString();
-
-                    // Look for the actual Perl method call (not internal Java calls)
-                    if (!filename.contains(".java") && !pkg.isEmpty() &&
-                            !subroutineName.isEmpty() && !subroutineName.equals("(eval)") &&
-                            !subroutineName.endsWith("::__ANON__")) {
-
-                        // Extract method name from subroutine name
-                        if (subroutineName.contains("::")) {
-                            int lastDoubleColon = subroutineName.lastIndexOf("::");
-                            methodName = subroutineName.substring(lastDoubleColon + 2);
-                            callerPackage = subroutineName.substring(0, lastDoubleColon);
-                        } else {
-                            methodName = subroutineName;
-                            callerPackage = pkg;
-                        }
-
-                        // Make sure this is a reasonable method name
-                        if (!methodName.isEmpty() && !methodName.equals("(eval)")) {
-                            break;
-                        }
-                    }
-                }
-            } catch (Exception e) {
-                // Continue trying other levels
-            }
-        }
-
-        if (callerPackage == null || methodName == null) {
+        CallerMethod caller = resolveCallerMethodFromStack();
+        if (caller == null) {
             throw new PerlCompilerException("Can't resolve method name for next::method");
         }
 
-        return findAndCallNextMethod(args, callerPackage, methodName, ctx);
+        return findAndCallNextMethod(args, caller.callerPackage(), caller.methodName(), ctx);
     }
 
     public static RuntimeList nextCan(RuntimeArray args, int ctx) {
         try {
-            RuntimeScalar firstArg = args.get(0);
-            String searchClass = getSearchClass(firstArg);
-            RuntimeScalar nextMethod = findNextMethod(args, "unknown", "unknown", searchClass);
+            if (args.size() == 0) {
+                return scalarUndef.getList();
+            }
+            CallerMethod caller = resolveCallerMethodFromStack();
+            if (caller == null) {
+                return scalarUndef.getList();
+            }
+            RuntimeScalar nextMethod = findNextMethod(args, caller.callerPackage(), caller.methodName());
             return nextMethod != null ? nextMethod.getList() : scalarUndef.getList();
         } catch (Exception e) {
             if (DEBUG_NEXT_METHOD) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/OverloadContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/OverloadContext.java
@@ -155,6 +155,18 @@ public class OverloadContext {
                 && fallbackValue.getBoolean();
     }
 
+    private boolean deniesAutogeneration() {
+        return hasFallbackGlob
+                && fallbackValue != null
+                && fallbackValue.getDefinedBoolean()
+                && !fallbackValue.getBoolean();
+    }
+
+    private static void throwNoMethodFound(OverloadContext ctx, String methodName) {
+        throw new PerlCompilerException("Operation \"" + methodName + "\": no method found, "
+                + "argument in overloaded package " + ctx.perlClassName);
+    }
+
     /**
      * Factory method to create overload context if applicable for a given RuntimeScalar.
      * Checks if the scalar is a blessed object and has overloading enabled.
@@ -324,11 +336,8 @@ public class OverloadContext {
         // Enforce fallback=0 (explicitly deny autogeneration / native op)
         OverloadContext activeCtx = (ctx1 != null) ? ctx1 : ctx2;
         if (activeCtx != null) {
-            if (activeCtx.hasFallbackGlob && activeCtx.fallbackValue != null
-                    && activeCtx.fallbackValue.getDefinedBoolean() && !activeCtx.fallbackValue.getBoolean()) {
-                String className = activeCtx.perlClassName;
-                throw new PerlCompilerException("Operation \"" + methodName + "\": no method found, "
-                        + "argument in overloaded package " + className);
+            if (activeCtx.deniesAutogeneration()) {
+                throwNoMethodFound(activeCtx, methodName);
             }
         }
         return null;
@@ -359,7 +368,13 @@ public class OverloadContext {
             }
         }
 
+        OverloadContext activeCtx = (ctx1 != null) ? ctx1 : ctx2;
+
         // Try autogeneration: try alternative operator names (e.g., "+" for "+=")
+        // unless fallback => 0 explicitly denies it.
+        if (autogenNames != null && activeCtx != null && activeCtx.deniesAutogeneration()) {
+            throwNoMethodFound(activeCtx, methodName);
+        }
         if (autogenNames != null) {
             for (String autogenName : autogenNames) {
                 if (autogenName == null) continue;
@@ -394,14 +409,10 @@ public class OverloadContext {
         // Since callers (e.g., CompareOperators) handle autogeneration by calling us again
         // with the spaceship/cmp operator, we return null here to allow that attempt.
         // Only fallback=0 should block autogeneration and die immediately.
-        OverloadContext activeCtx = (ctx1 != null) ? ctx1 : ctx2;
         if (activeCtx != null) {
             // Check if fallback is explicitly false (fallback => 0): deny autogeneration, die
-            if (activeCtx.hasFallbackGlob && activeCtx.fallbackValue != null
-                    && activeCtx.fallbackValue.getDefinedBoolean() && !activeCtx.fallbackValue.getBoolean()) {
-                String className = activeCtx.perlClassName;
-                throw new PerlCompilerException("Operation \"" + methodName + "\": no method found, "
-                        + "argument in overloaded package " + className);
+            if (activeCtx.deniesAutogeneration()) {
+                throwNoMethodFound(activeCtx, methodName);
             }
             // fallback not specified, undef, or true: allow autogeneration / native fallback
             return null;
@@ -427,7 +438,7 @@ public class OverloadContext {
      */
     public RuntimeScalar tryOverloadFallback(RuntimeScalar runtimeScalar, String... fallbackMethods) {
         // Check if autogeneration is explicitly denied (fallback => 0)
-        if (hasFallbackGlob && fallbackValue != null && fallbackValue.getDefinedBoolean() && !fallbackValue.getBoolean()) {
+        if (deniesAutogeneration()) {
             return null;
         }
 

--- a/src/test/resources/unit/class_c3_componentised_regressions.t
+++ b/src/test/resources/unit/class_c3_componentised_regressions.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+use mro 'c3';
+
+{
+    package C3CompoundBase;
+    sub new { bless {}, shift }
+
+    package C3CompoundFallbackFalse;
+    our @ISA = ('C3CompoundBase');
+    use overload '+' => sub { die "called fallback false plus" },
+                 fallback => 0;
+
+    package C3CompoundFallbackFalseChild;
+    our @ISA = ('C3CompoundFallbackFalse');
+
+    package C3CompoundFallbackTrue;
+    our @ISA = ('C3CompoundBase');
+    use overload '+' => sub { die "called fallback true plus" },
+                 fallback => 1;
+
+    package C3CompoundFallbackTrueChild;
+    our @ISA = ('C3CompoundFallbackTrue');
+}
+
+my $false = C3CompoundFallbackFalseChild->new;
+eval { $false += 1 };
+like($@, qr/no method found/, '+= does not autogenerate from + when fallback is false');
+
+my $true = C3CompoundFallbackTrueChild->new;
+eval { $true += 1 };
+like($@, qr/called fallback true plus/, '+= still autogenerates from + when fallback is true');
+
+{
+    package C3NextCanProxy;
+    sub can_proxy { goto &next::can }
+
+    package C3NextCanBase;
+    our @ISA = qw();
+    sub quux { 242 }
+
+    package C3NextCanTop;
+    our @ISA = qw(C3NextCanBase);
+    sub quux { shift->C3NextCanProxy::can_proxy()->() }
+}
+
+is(C3NextCanTop->quux, 242, 'goto &next::can preserves caller method context');

--- a/src/test/resources/unit/try_catch.t
+++ b/src/test/resources/unit/try_catch.t
@@ -37,4 +37,24 @@ subtest 'try/catch basic functionality' => sub {
     is($try_no_error_result, "No error", 'try/catch with no error works');
 };
 
+subtest 'try expression preserves lvalue sub returns' => sub {
+    my $scalar;
+    sub try_lvalue_scalar :lvalue {
+        try { return $scalar }
+        catch ($e) { }
+    }
+
+    try_lvalue_scalar = 123;
+    is($scalar, 123, 'scalar lvalue return passes through try');
+
+    my @array;
+    sub try_lvalue_list :lvalue {
+        try { return @array }
+        catch ($e) { }
+    }
+
+    (try_lvalue_list) = (4, 5, 6);
+    is_deeply(\@array, [4, 5, 6], 'list lvalue return passes through try');
+};
+
 done_testing();


### PR DESCRIPTION
## Summary

- Fix `goto &next::can` proxy calls by resolving the caller method context from the stack.
- Respect `fallback => 0` before compound-assignment overload autogeneration tries the base operator.
- Add a focused regression test covering both `Class::C3` failures seen through `Class::C3::Componentised`.

## Tests

- `make`
- `./jcpan -t Class::C3::Componentised`
- focused `Class::C3` prerequisite tests:
  - `t/24_more_overload.t`
  - `t/36_next_goto.t`
