### PR TITLE
Fix Clone::Choose scalar ref cycles

### DIFF
--- a/src/main/java/org/perlonjava/runtime/perlmodule/Clone.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Clone.java
@@ -132,9 +132,11 @@ public class Clone extends PerlModuleBase {
             }
             case RuntimeScalarType.REFERENCE -> {
                 RuntimeScalar origValue = (RuntimeScalar) scalar.value;
-                RuntimeScalar newValue = deepClone(origValue, cloned, nextDepth);
+                RuntimeScalar newValue = new RuntimeScalar();
                 RuntimeScalar newRef = newValue.createReference();
                 cloned.put(scalar.value, newRef);
+                RuntimeScalar clonedValue = deepClone(origValue, cloned, nextDepth);
+                copyScalarPayload(newValue, clonedValue);
 
                 if (blessId != 0) {
                     String className = NameNormalizer.getBlessStr(blessId);
@@ -170,5 +172,11 @@ public class Clone extends PerlModuleBase {
                 yield copy;
             }
         };
+    }
+
+    private static void copyScalarPayload(RuntimeScalar target, RuntimeScalar source) {
+        target.type = source.type;
+        target.value = source.value;
+        target.utf8UncheckedOctets = source.utf8UncheckedOctets;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Storable.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Storable.java
@@ -506,9 +506,11 @@ public class Storable extends PerlModuleBase {
             case RuntimeScalarType.REFERENCE -> {
                 // Scalar reference: clone the referenced value
                 RuntimeScalar origValue = (RuntimeScalar) scalar.value;
-                RuntimeScalar newValue = deepClone(origValue, cloned);
+                RuntimeScalar newValue = new RuntimeScalar();
                 RuntimeScalar newRef = newValue.createReference();
                 cloned.put(scalar.value, newRef);
+                RuntimeScalar clonedValue = deepClone(origValue, cloned);
+                copyScalarPayload(newValue, clonedValue);
 
                 // Preserve blessing
                 if (blessId != 0) {
@@ -548,6 +550,12 @@ public class Storable extends PerlModuleBase {
                 yield copy;
             }
         };
+    }
+
+    private static void copyScalarPayload(RuntimeScalar target, RuntimeScalar source) {
+        target.type = source.type;
+        target.value = source.value;
+        target.utf8UncheckedOctets = source.utf8UncheckedOctets;
     }
 
 }

--- a/src/test/resources/unit/clone.t
+++ b/src/test/resources/unit/clone.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+use Test::More;
+use Scalar::Util qw(refaddr);
+use Clone qw(clone);
+use Storable qw(dclone);
+
+subtest 'Clone handles self-referential scalar refs' => sub {
+    my $scalar = 'Scalar';
+    $scalar = \$scalar;
+
+    my $copy = clone($scalar);
+
+    isnt(refaddr($copy), refaddr($scalar), 'clone returns a distinct scalar ref');
+    is(refaddr($$copy), refaddr($copy), 'cloned scalar still points to itself');
+};
+
+subtest 'Storable dclone handles self-referential scalar refs' => sub {
+    my $scalar = 3.141;
+    $scalar = \$scalar;
+
+    my $copy = dclone($scalar);
+
+    isnt(refaddr($copy), refaddr($scalar), 'dclone returns a distinct scalar ref');
+    is(refaddr($$copy), refaddr($copy), 'dcloned scalar still points to itself');
+};
+
+subtest 'scalar ref clones are independent' => sub {
+    my $value = 42;
+    my $ref = \$value;
+
+    for my $cloner (
+        [ Clone => \&clone ],
+        [ Storable => \&dclone ],
+    ) {
+        my ($name, $code) = @$cloner;
+        my $copy = $code->($ref);
+
+        isnt(refaddr($copy), refaddr($ref), "$name returns a distinct scalar ref");
+        is($$copy, 42, "$name preserves scalar referent value");
+        $$copy = 99;
+        is($value, 42, "$name clone is independent of original scalar");
+    }
+};
+
+done_testing;


### PR DESCRIPTION
## Summary
- Fix scalar-reference cycle handling in Clone::clone and Storable::dclone by registering placeholders before recursive cloning.
- Add regression coverage for self-referential scalar refs and scalar-ref independence.

## Tests
- `make`
- `timeout 600 ./jcpan -t Clone::Choose`

Generated with [Codex](https://openai.com/codex)
