### PR TITLE
Fix Test::Warn warning category masks

### DIFF
--- a/src/main/perl/lib/warnings.pm
+++ b/src/main/perl/lib/warnings.pm
@@ -101,6 +101,59 @@ our %Offsets = (
     'experimental::bitwise'		=> 160,
 );
 
+# Warning category masks - public compatibility data used by modules such as
+# Test::Warn. Offsets are bit positions, where the even bit enables a category
+# and the following odd bit marks it fatal.
+my %CategoryChildren = (
+    'all' => [qw(
+        closure deprecated exiting experimental glob imprecision io locale misc
+        missing numeric once overflow pack portable recursion redefine redundant
+        regexp scalar severe shadow signal substr syntax taint threads
+        uninitialized unpack untie utf8 void
+    )],
+    'deprecated' => [qw(
+        deprecated::goto_construct deprecated::unicode_property_name
+        deprecated::dot_in_inc deprecated::version_downgrade
+        deprecated::delimiter_will_be_paired
+        deprecated::missing_import_called_with_args
+        deprecated::subsequent_use_version
+    )],
+    'experimental' => [qw(
+        experimental::regex_sets experimental::re_strict
+        experimental::refaliasing experimental::declared_refs
+        experimental::private_use experimental::uniprop_wildcards
+        experimental::vlb experimental::try
+        experimental::args_array_with_signatures experimental::builtin
+        experimental::defer experimental::extra_paired_delimiters
+        experimental::class experimental::keyword_all experimental::keyword_any
+        experimental::bitwise
+    )],
+    'io'     => [qw(closed exec layer newline pipe unopened syscalls)],
+    'severe' => [qw(debugging inplace internal malloc)],
+    'syntax' => [qw(
+        ambiguous bareword digit parenthesis precedence printf prototype qw
+        reserved semicolon illegalproto
+    )],
+    'utf8'   => [qw(non_unicode nonchar surrogate)],
+);
+
+sub _mk_warning_mask {
+    my ($fatal_bit, @categories) = @_;
+    my $mask = "\0" x $BYTES;
+    my %seen;
+    while (@categories) {
+        my $category = shift @categories;
+        next if $seen{$category}++;
+        next unless exists $Offsets{$category};
+        vec($mask, $Offsets{$category} + $fatal_bit, 1) = 1;
+        push @categories, @{ $CategoryChildren{$category} || [] };
+    }
+    return $mask;
+}
+
+our %Bits     = map { $_ => _mk_warning_mask(0, $_) } keys %Offsets;
+our %DeadBits = map { $_ => _mk_warning_mask(1, $_) } keys %Offsets;
+
 # NoOp warnings - warnings that have been removed but kept for compatibility
 our %NoOp = ();
 

--- a/src/test/resources/unit/warnings_bits.t
+++ b/src/test/resources/unit/warnings_bits.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use Test::More tests => 5;
+
+ok exists $warnings::Bits{uninitialized}, '%warnings::Bits exposes uninitialized';
+is vec($warnings::Bits{uninitialized}, $warnings::Offsets{uninitialized}, 1),
+    1, 'uninitialized enabled bit is set';
+is vec($warnings::DeadBits{uninitialized}, $warnings::Offsets{uninitialized} + 1, 1),
+    1, 'uninitialized fatal bit is set';
+is vec($warnings::Bits{all}, $warnings::Offsets{uninitialized}, 1),
+    1, 'all includes uninitialized';
+is vec($warnings::Bits{syntax}, $warnings::Offsets{illegalproto}, 1),
+    1, 'syntax includes illegalproto';


### PR DESCRIPTION
## Summary

- Populate `%warnings::Bits` and `%warnings::DeadBits` from bundled warning offsets.
- Include parent category masks so modules like `Test::Warn` can classify `uninitialized` warnings.
- Add a unit regression for the warning bit tables.

## Verification

- `timeout 60 ./jperl src/test/resources/unit/warnings_bits.t`
- `timeout 600 ./jcpan -t Test::Warn`
- `timeout 1200 make`
