### PR TITLE
Fix Class::Accessor::Grouped eval string regressions

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -868,6 +868,7 @@ public class BytecodeCompiler implements Visitor {
         List<String> outerVarNames = new ArrayList<>();
         List<RuntimeBase> outerValues = new ArrayList<>();
         List<String> outerVarDecls = new ArrayList<>();
+        List<String> outerVarPackages = new ArrayList<>();
         capturedVarIndices = new HashMap<>();
 
         int reg = 3;
@@ -886,12 +887,18 @@ public class BytecodeCompiler implements Visitor {
             capturedVarIndices.put(name, reg);
             outerVarNames.add(name);
             outerVarDecls.add(entry.decl());
+            outerVarPackages.add(entry.perlPackage());
             outerValues.add(getVariableValueFromContext(name, ctx));
             reg++;
         }
 
         for (int i = 0; i < outerVarNames.size(); i++) {
-            symbolTable.addVariableWithIndex(outerVarNames.get(i), 3 + i, outerVarDecls.get(i));
+            String perlPackage = outerVarPackages.get(i);
+            if (perlPackage != null) {
+                symbolTable.addVariableWithIndex(outerVarNames.get(i), 3 + i, outerVarDecls.get(i), perlPackage);
+            } else {
+                symbolTable.addVariableWithIndex(outerVarNames.get(i), 3 + i, outerVarDecls.get(i));
+            }
         }
 
         // Reserve registers for captured variables so local my declarations don't collide

--- a/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
@@ -104,9 +104,37 @@ public class EvalStringHandler {
                                              Map<String, Integer> siteRegistry,
                                              int siteStrictOptions,
                                              int siteFeatureFlags) {
+        return evalStringList(perlCode, RuntimeScalarType.STRING, currentCode, registers,
+                sourceName, sourceLine, callContext, siteRegistry, siteStrictOptions, siteFeatureFlags);
+    }
+
+    public static RuntimeList evalStringList(RuntimeScalar codeScalar,
+                                             InterpretedCode currentCode,
+                                             RuntimeBase[] registers,
+                                             String sourceName,
+                                             int sourceLine,
+                                             int callContext,
+                                             Map<String, Integer> siteRegistry,
+                                             int siteStrictOptions,
+                                             int siteFeatureFlags) {
+        return evalStringList(codeScalar.toString(), codeScalar.type, currentCode, registers,
+                sourceName, sourceLine, callContext, siteRegistry, siteStrictOptions, siteFeatureFlags);
+    }
+
+    private static RuntimeList evalStringList(String perlCode,
+                                             int sourceType,
+                                             InterpretedCode currentCode,
+                                             RuntimeBase[] registers,
+                                             String sourceName,
+                                             int sourceLine,
+                                             int callContext,
+                                             Map<String, Integer> siteRegistry,
+                                             int siteStrictOptions,
+                                             int siteFeatureFlags) {
         try {
             evalTrace("EvalStringHandler enter ctx=" + callContext + " srcName=" + sourceName +
-                    " srcLine=" + sourceLine + " codeLen=" + (perlCode != null ? perlCode.length() : -1));
+                    " srcLine=" + sourceLine + " codeLen=" + (perlCode != null ? perlCode.length() : -1) +
+                    " sourceType=" + sourceType);
             // Step 1: Clear $@ at start of eval
             GlobalVariable.getGlobalVariable("main::@").set("");
 
@@ -124,6 +152,7 @@ public class EvalStringHandler {
 
             CompilerOptions opts = new CompilerOptions();
             opts.fileName = evalFileName;
+            configureEvalSourceOptions(opts, perlCode, sourceType);
             ScopedSymbolTable symbolTable = new ScopedSymbolTable();
 
             // Add standard variables that are always available in eval context.
@@ -367,6 +396,24 @@ public class EvalStringHandler {
         }
     }
 
+    private static void configureEvalSourceOptions(CompilerOptions opts,
+                                                   String perlCode,
+                                                   int sourceType) {
+        if (sourceType == RuntimeScalarType.BYTE_STRING) {
+            opts.isByteStringSource = true;
+            return;
+        }
+        if (perlCode == null) {
+            return;
+        }
+        for (int i = 0; i < perlCode.length(); i++) {
+            if (perlCode.charAt(i) > 127) {
+                opts.isUnicodeSource = true;
+                return;
+            }
+        }
+    }
+
     /**
      * Evaluate a Perl string with explicit variable capture.
      * <p>
@@ -395,6 +442,7 @@ public class EvalStringHandler {
 
             CompilerOptions opts = new CompilerOptions();
             opts.fileName = evalFileName;
+            configureEvalSourceOptions(opts, perlCode, RuntimeScalarType.STRING);
             ScopedSymbolTable symbolTable = new ScopedSymbolTable();
 
             // Add standard variables that are always available in eval context.

--- a/src/main/java/org/perlonjava/backend/bytecode/SlowOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/SlowOpcodeHandler.java
@@ -309,9 +309,9 @@ public class SlowOpcodeHandler {
         } else {
             codeScalar = codeValue.scalar();
         }
-        String perlCode = codeScalar.toString();
         evalTrace("EVAL_STRING opcode enter rd=r" + rd + " strReg=r" + stringReg +
                 " ctx=" + evalCallContext + " evalSite=" + evalSiteIndex +
+                " codeType=" + codeScalar.type + " codeLen=" + codeScalar.toString().length() +
                 " src=" + (code != null ? code.sourceName : "null"));
 
         int callContext = evalCallContext;
@@ -323,7 +323,7 @@ public class SlowOpcodeHandler {
 
         if (callContext == RuntimeContextType.LIST) {
             RuntimeList result = EvalStringHandler.evalStringList(
-                    perlCode,
+                    codeScalar,
                     code,
                     registers,
                     code.sourceName,
@@ -338,7 +338,7 @@ public class SlowOpcodeHandler {
                     " scalar=" + result.scalar().toString());
         } else {
             RuntimeScalar result = EvalStringHandler.evalStringList(
-                    perlCode,
+                    codeScalar,
                     code,
                     registers,
                     code.sourceName,

--- a/src/test/resources/unit/eval_string_source_types.t
+++ b/src/test/resources/unit/eval_string_source_types.t
@@ -1,0 +1,67 @@
+use strict;
+use warnings;
+
+print "1..8\n";
+
+my $test_number = 0;
+
+sub ok {
+    my ($pass, $name) = @_;
+    $test_number++;
+    print($pass ? "ok " : "not ok ", $test_number, " - ", $name, "\n");
+}
+
+sub is {
+    my ($got, $expected, $name) = @_;
+    ok(defined($got) && defined($expected) ? $got eq $expected : !defined($got) && !defined($expected), $name);
+}
+
+my $field = join q(), reverse map { chr($_) } 0..255;
+my $quoted = q{"} . quotemeta($field) . q{"};
+
+my $body = sprintf <<'EOS', q(simple), $quoted, q(simple), $quoted;
+@_ > 1
+  ? shift->set_%s(%s, @_)
+  : shift->get_%s(%s)
+EOS
+
+my $src = "sub { my \$dummy; sub { \$dummy if 0; $body } }";
+my $factory = eval $src;
+die $@ if $@;
+
+{
+    package EvalStringSourceTypes::Object;
+
+    sub set_simple {
+        $_[0]->{$_[1]} = $_[2];
+    }
+
+    sub get_simple {
+        $_[0]->{$_[1]};
+    }
+}
+
+my $obj = bless {}, 'EvalStringSourceTypes::Object';
+my $accessor = $factory->();
+
+is($accessor->($obj, 'a'), 'a', 'eval-generated accessor setter returns value');
+is($accessor->($obj), 'a', 'eval-generated accessor getter returns stored value');
+is($obj->{$field}, 'a', 'high-byte eval string literal is the expected hash key');
+
+my ($stored_key) = keys %$obj;
+is(length($stored_key), 256, 'stored high-byte key keeps character length');
+is(ord(substr($stored_key, 0, 1)), 255, 'stored high-byte key starts at chr 255');
+is(ord(substr($stored_key, -1)), 0, 'stored high-byte key ends at chr 0');
+ok($stored_key eq $field, 'stored high-byte key equals original field');
+
+{
+    package EvalStringSourceTypes::Goto;
+
+    our $target = sub {
+        return 'ok';
+    };
+
+    eval q{sub bounce { goto $target }; 1} or die $@;
+}
+
+is(EvalStringSourceTypes::Goto::bounce(), 'ok', 'eval named sub resolves goto package global coderef');


### PR DESCRIPTION
## Summary

- Preserve eval STRING scalar source type so byte-string eval code keeps high-byte literals intact.
- Preserve declaring package metadata for captured `our` variables in interpreter-compiled subroutines, fixing eval-created named subs that use dynamic `goto $coderef`.
- Add a focused regression test covering both `Class::Accessor::Grouped` failure modes.

## Tests

- `make`
- `./jcpan -t Class::Accessor::Grouped`
