### PR TITLE
Fix Params::ValidationCompiler test regressions

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -2570,7 +2570,9 @@ public class BytecodeInterpreter {
                 // would incorrectly decrement refCounts, causing premature DESTROY.
                 BitSet myVars = code.myVarRegisters;
                 boolean needsFlush = false;
-                for (int i = myVars.nextSetBit(firstMyVarReg); i >= 0; i = myVars.nextSetBit(i + 1)) {
+                for (int i = myVars.nextSetBit(firstMyVarReg);
+                     i >= 0 && i < registers.length;
+                     i = myVars.nextSetBit(i + 1)) {
                     RuntimeBase reg = registers[i];
                     if (reg == null) continue;
                     if (reg instanceof RuntimeScalar rs) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ExceptionFormatter.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ExceptionFormatter.java
@@ -214,9 +214,14 @@ public class ExceptionFormatter {
                         }
 
                         String subName = frame.subroutineName();
-                        // Don't add package prefix if subName already contains "::" or is a special name like "(eval)"
+                        // Don't add package prefix if subName already contains "::" or is a special name like "(eval)".
+                        // Explicitly renamed eval closures keep their original source package for location
+                        // reporting, but caller()[3] must use the rename target's package.
                         if (subName != null && !subName.isEmpty() && !subName.contains("::") && !subName.startsWith("(")) {
-                            subName = pkg + "::" + subName;
+                            String subPkg = frame.code().explicitlyRenamed
+                                    ? (frame.packageName() != null ? frame.packageName() : "main")
+                                    : pkg;
+                            subName = subPkg + "::" + subName;
                         }
 
                         var entry = new ArrayList<String>();

--- a/src/test/resources/unit/caller_line_number.t
+++ b/src/test/resources/unit/caller_line_number.t
@@ -1,7 +1,9 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use Test::More tests => 11;
+use Test::More tests => 12;
+use Eval::Closure qw(eval_closure);
+use Sub::Util qw(set_subname);
 
 # Test caller() returns correct line numbers, especially for deeper stack frames.
 # This tests the fix for the bug where caller($level) with level > 1 returned
@@ -111,5 +113,13 @@ eval {
 like($@,
      qr/Undefined subroutine &CallerLineNumber::Missing::for_line_test called at .* line $expected_line_11\./,
      "undefined multiline direct call reports function line");
+
+my $renamed_eval_closure = eval_closure(
+    source => q{sub { return (caller(0))[3] }},
+);
+set_subname( 'Other::Renamed', $renamed_eval_closure );
+is( $renamed_eval_closure->(),
+    'Other::Renamed',
+    'caller(0)[3] uses explicit set_subname package for eval closures' );
 
 # End of tests


### PR DESCRIPTION
## Summary

- prevent interpreter exception cleanup from reading past the active register array
- make `caller()[3]` honor explicit `Sub::Util::set_subname` package renames for eval closures
- add regression coverage for renamed eval-closure caller metadata

## Testing

- `make`
- `./jcpan -t Params::ValidationCompiler`
