### PR TITLE
Fix SQL::Abstract CPAN test failures

### DIFF
--- a/src/main/java/org/perlonjava/runtime/runtimetypes/OverloadContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/OverloadContext.java
@@ -400,21 +400,14 @@ public class OverloadContext {
             if (result != null) return result;
         }
 
-        // All overload attempts failed. Check fallback semantics.
-        // Perl overload fallback rules:
-        //   fallback=0 (explicitly false): deny autogeneration, die immediately
-        //   fallback=undef/not specified:  allow autogeneration, die only if autogeneration also fails
-        //   fallback=1 (true):             allow autogeneration, use native op if all else fails
-        //
-        // Since callers (e.g., CompareOperators) handle autogeneration by calling us again
-        // with the spaceship/cmp operator, we return null here to allow that attempt.
-        // Only fallback=0 should block autogeneration and die immediately.
+        // All overload attempts failed. Only `fallback => 1` or a package with
+        // no actual operator overloads may fall through to the native operator.
+        // With fallback undef/missing, Perl reports "no method found" once the
+        // requested op and explicit autogeneration candidates have failed.
         if (activeCtx != null) {
-            // Check if fallback is explicitly false (fallback => 0): deny autogeneration, die
-            if (activeCtx.deniesAutogeneration()) {
+            if (!activeCtx.allowsFallbackAutogen()) {
                 throwNoMethodFound(activeCtx, methodName);
             }
-            // fallback not specified, undef, or true: allow autogeneration / native fallback
             return null;
         }
         return null;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStashEntry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStashEntry.java
@@ -90,6 +90,13 @@ public class RuntimeStashEntry extends RuntimeGlob {
         if (value.type == REFERENCE) {
             if (value.value instanceof RuntimeScalar) {
                 RuntimeScalar deref = value.scalarDeref();
+                RuntimeScalar existingScalar = GlobalVariable.globalVariables.get(this.globName);
+                if (existingScalar != null
+                        && existingScalar.getDefinedBoolean()
+                        && deref.type != READONLY_SCALAR
+                        && !(deref instanceof RuntimeScalarReadOnly)) {
+                    super.set(value);
+                }
                 if (deref.type == CODE) {
                     // `$stash->{foo} = \&bar` creates a constant subroutine returning the code reference
                     RuntimeCode code = new RuntimeCode("", null);

--- a/src/test/resources/unit/overload_fallback_undef_binary_math.t
+++ b/src/test/resources/unit/overload_fallback_undef_binary_math.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+{
+    package FallbackUndefBoolOnly;
+    use overload bool => sub { ${ $_[0] } };
+}
+
+{
+    package FallbackUndefNumifyOnly;
+    use overload '0+' => sub { ${ $_[0] } };
+}
+
+{
+    package FallbackTrueNumifyOnly;
+    use overload '0+' => sub { ${ $_[0] } }, fallback => 1;
+}
+
+my $bool_only = bless(\do { my $v = 42 }, 'FallbackUndefBoolOnly');
+my $num_only = bless(\do { my $v = 42 }, 'FallbackUndefNumifyOnly');
+my $fallback_true = bless(\do { my $v = 42 }, 'FallbackTrueNumifyOnly');
+
+ok(!eval { ($bool_only + 1) == 43 }, 'bool-only overload without fallback does not fall through to native plus');
+like($@, qr/no method found/, 'bool-only plus reports missing overload method');
+
+ok(!eval { ($num_only + 1) == 43 }, 'numify-only overload without fallback does not autogenerate binary plus');
+is($fallback_true + 1, 43, 'fallback true allows binary plus via numification');

--- a/src/test/resources/unit/stash_scalar_ref_assignment.t
+++ b/src/test/resources/unit/stash_scalar_ref_assignment.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+{
+    package StashScalarRefTarget;
+    our $x = 0;
+    our $y = 0;
+}
+
+my $name = 'x';
+${*StashScalarRefTarget::}{$name} = \do { my $v = 1 };
+
+is($StashScalarRefTarget::x, 1, 'stash scalar-ref assignment updates existing scalar slot');
+is(${${*StashScalarRefTarget::}{$name}}, 1, 'stash entry scalar slot sees aliased value');
+is(StashScalarRefTarget::x(), 1, 'stash scalar-ref assignment preserves constant-style code slot');
+
+$StashScalarRefTarget::{y} = \do { my $v = 2 };
+is($StashScalarRefTarget::y, 2, 'direct stash scalar-ref assignment updates existing scalar slot');


### PR DESCRIPTION
## Summary

- Update stash scalar-ref assignment so existing package scalar options can be updated via stash entries while preserving constant-style bareword behavior.
- Tighten overload fallback handling so missing binary math overloads with fallback undef report no method found instead of falling through to native math.
- Add focused regression tests for both SQL::Abstract failure modes.

## Tests

- `make`
- `timeout 900 ./jcpan -t SQL::Abstract`
