### PR TITLE
Fix Module::Find star prototype barewords

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
+++ b/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
@@ -727,7 +727,17 @@ public class PrototypeArgs {
             typeglobRef.setAnnotation("context", "SCALAR");
             args.elements.add(typeglobRef);
         } else if (expr instanceof IdentifierNode idNode) {
-            // Bareword - create a typeglob reference
+            if (!isBuiltinOperator(parser)) {
+                // User-defined `(*)` prototypes receive barewords as plain scalar
+                // strings. Builtins such as open/close keep the legacy bareword
+                // filehandle behavior handled below.
+                Node stringArg = new StringNode(idNode.name, idNode.getIndex());
+                stringArg.setAnnotation("context", "SCALAR");
+                args.elements.add(stringArg);
+                return 1;
+            }
+
+            // Builtin bareword filehandle - create a typeglob reference
 
             // autovivify the bareword handle
             GlobalVariable.getGlobalIO(FileHandle.normalizeBarewordHandle(parser, idNode.name));

--- a/src/test/resources/unit/subroutine_prototype.t
+++ b/src/test/resources/unit/subroutine_prototype.t
@@ -83,6 +83,7 @@ subtest "Plus (+) prototype behavior" => sub {
 
 subtest "Star (*) prototype behavior" => sub {
     sub star_proto (*) { ref( $_[0] ) || 'SCALAR' }
+    sub star_value (*) { ref( $_[0] ) || $_[0] }
 
     my @star_arr  = ( 1, 2, 3 );
     my %star_hash = ( a => 1 );
@@ -92,6 +93,7 @@ subtest "Star (*) prototype behavior" => sub {
     is( star_proto(@star_arr),     'SCALAR', "accepts array in scalar context" );
     is( star_proto(%star_hash),    'SCALAR', "accepts hash in scalar context" );
     is( star_proto($scalar),       'SCALAR', "accepts scalar" );
+    is( star_value(HANDLE),        'HANDLE', "accepts bareword as string" );
     is( star_proto(*HANDLE),       'GLOB',   "accepts typeglob" );
     is( star_proto( \@star_arr ),  'ARRAY',  "accepts array reference" );
     is( star_proto( \%star_hash ), 'HASH',   "accepts hash reference" );
@@ -159,4 +161,3 @@ subtest "Underscore (_) with optional parameters" => sub {
 };
 
 done_testing();
-


### PR DESCRIPTION
## Summary

- Fix user-defined `(*)` prototype handling so bareword arguments are passed as scalar strings, matching Perl.
- Preserve builtin bareword filehandle conversion for operators such as `open` and `close`.
- Add regression coverage for bareword strings in `subroutine_prototype.t`.

## Verification

- `make`
- `timeout 600 ./jcpan -t Module::Find`
