### PR TITLE
Fix namespace::clean CPAN tests

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/FileHandle.java
+++ b/src/main/java/org/perlonjava/frontend/parser/FileHandle.java
@@ -198,7 +198,7 @@ public class FileHandle {
                     if (fileHandle == null
                             && name.matches("^[A-Z_][A-Z0-9_]*$")
                             && !isDoubleUnderscoreMagicBareword(name)) {
-                        GlobalVariable.getGlobalIO(normalizeBarewordHandle(parser, name));
+                        GlobalVariable.vivifyGlobalIO(normalizeBarewordHandle(parser, name));
                         fileHandle = parseBarewordHandle(parser, name);
                     }
                 }

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -145,7 +145,7 @@ public class OperatorParser {
                 parser.tokenIndex++; // consume NUMBER
                 TokenUtils.consume(parser); // consume '>'
                 String digitName = operand.text;
-                GlobalVariable.getGlobalIO(FileHandle.normalizeBarewordHandle(parser, digitName));
+                GlobalVariable.vivifyGlobalIO(FileHandle.normalizeBarewordHandle(parser, digitName));
                 Node globRef = FileHandle.parseBarewordHandle(parser, digitName);
                 if (globRef != null) {
                     BinaryOperatorNode readlineNode = new BinaryOperatorNode("readline",
@@ -710,7 +710,7 @@ public class OperatorParser {
             // select FILEHANDLE
             if (listNode1.elements.getFirst() instanceof IdentifierNode identifierNode) {
                 // Autovivify the filehandle IO slot so parseBarewordHandle succeeds
-                GlobalVariable.getGlobalIO(FileHandle.normalizeBarewordHandle(parser, identifierNode.name));
+                GlobalVariable.vivifyGlobalIO(FileHandle.normalizeBarewordHandle(parser, identifierNode.name));
                 Node handle = FileHandle.parseBarewordHandle(parser, identifierNode.name);
                 if (handle != null) {
                     // handle is Bareword
@@ -979,7 +979,7 @@ public class OperatorParser {
             if (name.matches("^[A-Z_][A-Z0-9_]*$")) {
                 TokenUtils.consume(parser);
                 // autovivify filehandle and convert to globref
-                GlobalVariable.getGlobalIO(FileHandle.normalizeBarewordHandle(parser, name));
+                GlobalVariable.vivifyGlobalIO(FileHandle.normalizeBarewordHandle(parser, name));
                 Node fh = FileHandle.parseBarewordHandle(parser, name);
                 Node operand = fh != null ? fh : new IdentifierNode(name, parser.tokenIndex);
                 if (paren) {

--- a/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
+++ b/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
@@ -632,7 +632,7 @@ public class PrototypeArgs {
                     }
                     // Not a known filehandle, but still allow bareword (will be treated as filename string)
                     // Autovivify the filehandle in case it's used later
-                    GlobalVariable.getGlobalIO(FileHandle.normalizeBarewordHandle(parser, idNode.name));
+                    GlobalVariable.vivifyGlobalIO(FileHandle.normalizeBarewordHandle(parser, idNode.name));
                 }
             }
             Node scalarArg = ParserNodeUtils.toScalarContext(arg);
@@ -740,7 +740,7 @@ public class PrototypeArgs {
             // Builtin bareword filehandle - create a typeglob reference
 
             // autovivify the bareword handle
-            GlobalVariable.getGlobalIO(FileHandle.normalizeBarewordHandle(parser, idNode.name));
+            GlobalVariable.vivifyGlobalIO(FileHandle.normalizeBarewordHandle(parser, idNode.name));
 
             Node typeglobRef = FileHandle.parseBarewordHandle(parser, idNode.name);
             args.elements.add(typeglobRef == null ? expr : typeglobRef);

--- a/src/main/java/org/perlonjava/frontend/parser/TokenUtils.java
+++ b/src/main/java/org/perlonjava/frontend/parser/TokenUtils.java
@@ -136,7 +136,7 @@ public class TokenUtils {
         LexerToken token = consume(parser);
         if (token.type != type) {
             throw new PerlCompilerException(
-                    parser.tokenIndex, "Expected token " + type + " but got " + token, parser.ctx.errorUtil);
+                    parser.tokenIndex, "syntax error", parser.ctx.errorUtil);
         }
         return token;
     }
@@ -155,7 +155,7 @@ public class TokenUtils {
         if (token.type != type || !token.text.equals(text)) {
             throw new PerlCompilerException(
                     parser.tokenIndex,
-                    "Expected token " + type + " with text " + text + " but got " + token,
+                    "syntax error",
                     parser.ctx.errorUtil);
         }
     }

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -634,7 +634,7 @@ public class IOOperator {
                 targetGlob = GlobalVariable.getGlobalIO(filehandleName);
             }
             if (targetGlob != null) {
-                targetGlob.setIO(oneFh);
+                targetGlob.openIO(oneFh);
                 // If args[0] is a writable scalar (not readonly), update it to point
                 // at the glob. We must NOT call set() on a readonly scalar (e.g. when
                 // args[0] is a numeric literal like in `open 0`).
@@ -851,7 +851,7 @@ public class IOOperator {
                         " ioHandleId=" + (fh != null && fh.ioHandle != null ? System.identityHashCode(fh.ioHandle) : 0));
                 System.err.flush();
             }
-            targetGlob.setIO(fh);
+            targetGlob.openIO(fh);
         } else {
             // Create a new anonymous GLOB and assign it to the lvalue
             RuntimeScalar newGlob = new RuntimeScalar();
@@ -1540,7 +1540,7 @@ public class IOOperator {
         }
 
         if (targetGlob != null) {
-            targetGlob.setIO(fh);
+            targetGlob.openIO(fh);
         } else {
             RuntimeScalar newGlob = new RuntimeScalar();
             newGlob.type = RuntimeScalarType.GLOBREFERENCE;

--- a/src/main/java/org/perlonjava/runtime/perlmodule/ScalarUtil.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/ScalarUtil.java
@@ -160,7 +160,14 @@ public class ScalarUtil extends PerlModuleBase {
             case ARRAYREFERENCE -> "ARRAY";
             case HASHREFERENCE -> "HASH";
             case CODE -> "CODE";
-            case GLOB, GLOBREFERENCE -> "GLOB";
+            case GLOB -> {
+                if (scalar.value instanceof RuntimeIO) yield "IO";
+                yield null;
+            }
+            case GLOBREFERENCE -> {
+                if (scalar.value instanceof RuntimeIO) yield "IO";
+                yield "GLOB";
+            }
             case FORMAT -> "FORMAT";
             case REGEX -> "REGEXP";
             default -> null;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
@@ -1290,6 +1290,21 @@ public class GlobalVariable {
     }
 
     /**
+     * Vivifies the IO slot for a bareword filehandle seen at compile time.
+     * Generic glob creation must not define {@code *name{IO}}, but Perl creates
+     * a PVIO object when it parses a bareword filehandle argument such as
+     * {@code open FH, ...}. BEGIN blocks can observe that placeholder before
+     * the runtime open call installs the real handle.
+     */
+    public static RuntimeGlob vivifyGlobalIO(String key) {
+        RuntimeGlob glob = getGlobalIO(key);
+        if (glob.IO == null || glob.IO.type == RuntimeScalarType.UNDEF || glob.IO.value == null) {
+            glob.setIO(new RuntimeIO());
+        }
+        return glob;
+    }
+
+    /**
      * Peek at a glob entry without vivifying it. Returns null if no glob has
      * been registered under this name. Used by anon-sub naming lookups
      * (see dev/modules/anon_sub_naming.md) to read *PKG::__ANON__'s

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
@@ -855,6 +855,22 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         return this;
     }
 
+    public RuntimeGlob openIO(RuntimeIO io) {
+        if (this.IO != null
+                && this.IO.type != RuntimeScalarType.TIED_SCALAR
+                && this.IO.value instanceof RuntimeIO existingIO
+                && existingIO != io) {
+            RuntimeIO oldSelected = existingIO == RuntimeIO.selectedHandle ? existingIO : null;
+            existingIO.replaceStateFrom(io);
+            existingIO.globName = this.globName;
+            if (oldSelected != null) {
+                RuntimeIO.selectedHandle = existingIO;
+            }
+            return this;
+        }
+        return setIO(io);
+    }
+
     /**
      * Counts the number of elements in the typeglob.
      *

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
@@ -423,6 +423,30 @@ public class RuntimeIO extends RuntimeScalar {
     }
 
     /**
+     * Replace this handle's runtime state with another handle while preserving
+     * object identity. Perl keeps the PVIO object stable across {@code open FH}
+     * on an already-vivified bareword handle, so values captured by
+     * {@code *FH{IO}} before the open see the newly opened stream.
+     */
+    public void replaceStateFrom(RuntimeIO other) {
+        if (other == null || other == this) {
+            return;
+        }
+
+        Integer fd = ioToFileno.remove(other);
+        if (fd != null) {
+            ioToFileno.put(this, fd);
+            filenoToIO.put(fd, this);
+        }
+
+        this.currentLineNumber = other.currentLineNumber;
+        this.ioHandle = other.ioHandle;
+        this.directoryIO = other.directoryIO;
+        this.needFlush = other.needFlush;
+        this.autoFlush = other.autoFlush;
+    }
+
+    /**
      * Checks if this handle is in byte mode (no encoding layers).
      *
      * <p>In Perl, reads from handles without encoding layers (e.g., :raw, :bytes,

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -2335,7 +2335,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 // PCS (Proxy Constant Subroutine) creation should only happen via direct
                 // stash hash assignment ($stash->{name} = \$scalar), handled by RuntimeStashEntry.set().
                 if (value instanceof RuntimeStashEntry stashEntry) {
-                    yield new RuntimeGlob(stashEntry.globName);
+                    yield GlobalVariable.getGlobalIO(stashEntry.globName);
                 }
                 yield (RuntimeGlob) value;
             }
@@ -2401,7 +2401,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 // When glob-dereferencing a stash entry, return a plain RuntimeGlob.
                 // This prevents *{$stash->{name}} = \$scalar from creating PCS constant subs.
                 if (value instanceof RuntimeStashEntry stashEntry) {
-                    yield new RuntimeGlob(stashEntry.globName);
+                    yield GlobalVariable.getGlobalIO(stashEntry.globName);
                 }
                 yield (RuntimeGlob) value;
             }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStashEntry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStashEntry.java
@@ -46,16 +46,12 @@ public class RuntimeStashEntry extends RuntimeGlob {
      */
     @Override
     public RuntimeGlob globDeref() {
-        RuntimeGlob pure = new RuntimeGlob(this.globName);
-        pure.IO = this.IO;
-        return pure;
+        return GlobalVariable.getGlobalIO(this.globName);
     }
 
     @Override
     public RuntimeGlob globDerefNonStrict(String packageName) {
-        RuntimeGlob pure = new RuntimeGlob(this.globName);
-        pure.IO = this.IO;
-        return pure;
+        return GlobalVariable.getGlobalIO(this.globName);
     }
 
 // Note on Stash Operations:

--- a/src/test/resources/unit/parser_syntax_error.t
+++ b/src/test/resources/unit/parser_syntax_error.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+use Test::More;
+
+eval q{sub parser_syntax_error_probe { if }};
+like($@, qr/\Asyntax error at /, 'unexpected token reports Perl syntax error');
+
+done_testing();

--- a/src/test/resources/unit/typeglob.t
+++ b/src/test/resources/unit/typeglob.t
@@ -45,6 +45,50 @@ subtest 'Scalar::Util::refaddr for named glob references' => sub {
         'different named glob refs report different refaddrs');
 };
 
+subtest 'Scalar::Util::reftype for glob IO slots' => sub {
+    require Scalar::Util;
+
+    open typeglob_reftype_io, '<', 'Makefile' or die "open Makefile: $!";
+    is(Scalar::Util::reftype(*typeglob_reftype_io{IO}), 'IO',
+        'IO slot reports reftype IO');
+    is(Scalar::Util::reftype(*typeglob_reftype_io), undef,
+        'bare typeglob is not a reference');
+};
+
+our $typeglob_compile_time_io;
+{
+    package TypeglobCompileTimeFH;
+    {
+        no warnings;
+        open foo, '<', 'Makefile' or die "open Makefile: $!";
+    }
+    BEGIN { $main::typeglob_compile_time_io = *foo{IO} }
+}
+
+subtest 'bareword open vivifies IO slot at compile time' => sub {
+    ok(defined $typeglob_compile_time_io, 'BEGIN sees IO slot for later bareword open');
+    is(*TypeglobCompileTimeFH::foo{IO}, $typeglob_compile_time_io,
+        'runtime open preserves compile-time IO slot identity');
+};
+
+subtest 'dynamic stash glob assignment restores IO slots' => sub {
+    require Package::Stash;
+
+    {
+        package TypeglobStashIO;
+        open foo, '<', 'Makefile' or die "open Makefile: $!";
+    }
+
+    my $stash = Package::Stash->new('TypeglobStashIO');
+    my $io = $stash->get_symbol('foo');
+    $stash->remove_glob('foo');
+    ok(!defined *TypeglobStashIO::foo{IO}, 'IO slot removed with glob');
+
+    $stash->add_symbol('foo', $io);
+    ok(defined *TypeglobStashIO::foo{IO}, 'IO slot restored through stash entry glob assignment');
+    is(*TypeglobStashIO::foo{IO}, $io, 'restored IO slot is the original handle');
+};
+
 subtest 'Using typeglobs as file handles' => sub {
     my $fh = *STDOUT;
     my $fh2 = \*STDOUT;


### PR DESCRIPTION
## Summary

- Normalize parser token-consume mismatches to Perl-style `syntax error` messages.
- Preserve bareword filehandle IO placeholder identity across `open FH`.
- Fix IO slot handling for `Scalar::Util::reftype(*FH{IO})` and `Package::Stash` dynamic glob restore.
- Add regressions for parser syntax errors and typeglob IO behavior.

## Tests

- `make`
- `timeout 900 ./jcpan -t namespace::clean`
