### PR TITLE
Preserve CPAN dependency blibs for resumed tests

### DIFF
--- a/src/main/perl/lib/CPAN/Distribution.pm
+++ b/src/main/perl/lib/CPAN/Distribution.pm
@@ -3859,6 +3859,11 @@ sub test {
     $self->debug("Changed directory to $self->{build_dir}")
         if $CPAN::DEBUG;
 
+    if (open my $perlonjava_perl5lib_fh, ">", ".perlonjava-cpan-perl5lib") {
+        print {$perlonjava_perl5lib_fh} $ENV{PERL5LIB} || "";
+        close $perlonjava_perl5lib_fh;
+    }
+
     if ($^O eq 'MacOS') {
         Mac::BuildTools::make_test($self);
         $self->post_test();

--- a/src/main/perl/lib/ExtUtils/MM_PerlOnJava.pm
+++ b/src/main/perl/lib/ExtUtils/MM_PerlOnJava.pm
@@ -102,16 +102,21 @@ sub test {
     
     return '' unless $tests;
     
-    # Set PERL5LIB to add blib/lib and blib/arch to @INC for test subprocesses
+    # Set PERL5LIB to add blib/lib and blib/arch to @INC for test subprocesses.
+    # CPAN.pm also writes .perlonjava-cpan-perl5lib during jcpan test runs so
+    # resumed/manual make test invocations keep tested-but-not-installed deps.
     # Test::Harness runs each test file as a subprocess, so we need PERL5LIB
     # Use "undef *Test::Harness::Switches" to disable the default -w switch,
     # matching standard ExtUtils::MakeMaker behavior (MM_Any::test_via_harness)
     return <<"MAKE_FRAG";
+PERLONJAVA_CPAN_PERL5LIB = \$(shell test -f .perlonjava-cpan-perl5lib && cat .perlonjava-cpan-perl5lib)
+PERLONJAVA_TEST_PERL5LIB = \$(INST_LIB):\$(INST_ARCHLIB):\$(PERLONJAVA_CPAN_PERL5LIB):\$\$PERL5LIB
+
 test :: pure_all
-	PERL5LIB="\$(INST_LIB):\$(INST_ARCHLIB):\$\$PERL5LIB" \$(FULLPERL) "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(\$(TEST_VERBOSE), '\$(INST_LIB)', '\$(INST_ARCHLIB)')" $tests
+	PERL5LIB="\$(PERLONJAVA_TEST_PERL5LIB)" \$(FULLPERL) "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(\$(TEST_VERBOSE), '\$(INST_LIB)', '\$(INST_ARCHLIB)')" $tests
 
 test_dynamic :: pure_all
-	PERL5LIB="\$(INST_LIB):\$(INST_ARCHLIB):\$\$PERL5LIB" \$(FULLPERL) "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(\$(TEST_VERBOSE), '\$(INST_LIB)', '\$(INST_ARCHLIB)')" $tests
+	PERL5LIB="\$(PERLONJAVA_TEST_PERL5LIB)" \$(FULLPERL) "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(\$(TEST_VERBOSE), '\$(INST_LIB)', '\$(INST_ARCHLIB)')" $tests
 
 test_static ::
 	\@echo "No static tests for PerlOnJava"

--- a/src/main/perl/lib/ExtUtils/MakeMaker.pm
+++ b/src/main/perl/lib/ExtUtils/MakeMaker.pm
@@ -603,10 +603,10 @@ sub _create_install_makefile {
     } elsif ($test_glob) {
         # Use ExtUtils::Command::MM::test_harness with undef *Test::Harness::Switches
         # to disable the default -w switch, matching standard MakeMaker behavior
-        $test_cmd = qq{PERL5LIB="\$(INST_LIB):\$(INST_ARCHLIB):\$\$PERL5LIB" $perl "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, '\$(INST_LIB)', '\$(INST_ARCHLIB)')" $test_glob};
+        $test_cmd = qq{PERL5LIB="\$(PERLONJAVA_TEST_PERL5LIB)" $perl "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, '\$(INST_LIB)', '\$(INST_ARCHLIB)')" $test_glob};
     } elsif (-f 'test.pl') {
         # Legacy convention: some older CPAN dists use test.pl instead of t/*.t
-        $test_cmd = qq{PERL5LIB="\$(INST_LIB):\$(INST_ARCHLIB):\$\$PERL5LIB" $perl test.pl};
+        $test_cmd = qq{PERL5LIB="\$(PERLONJAVA_TEST_PERL5LIB)" $perl test.pl};
     } else {
         $test_cmd = qq{$perl -e "print qq{PerlOnJava: No tests found (no t/ directory)\\n}"};
     }
@@ -795,6 +795,8 @@ INST_LIB = $inst_lib
 INST_ARCHLIB = $inst_archlib
 INST_LIBDIR = \$(INST_LIB)
 INST_ARCHLIBDIR = \$(INST_ARCHLIB)
+PERLONJAVA_CPAN_PERL5LIB = \$(shell test -f .perlonjava-cpan-perl5lib && cat .perlonjava-cpan-perl5lib)
+PERLONJAVA_TEST_PERL5LIB = \$(INST_LIB):\$(INST_ARCHLIB):\$(PERLONJAVA_CPAN_PERL5LIB):\$\$PERL5LIB
 $siteprefix_var
 INSTALLSITELIB = $installsitelib
 NOECHO = \@


### PR DESCRIPTION
## Summary

- Persist CPAN's effective dependency `PERL5LIB` into `.perlonjava-cpan-perl5lib` before `make test` runs.
- Teach generated PerlOnJava Makefiles to include that saved dependency path for resumed or manual `make test` invocations.
- Keep the existing local `blib/lib` and `blib/arch` precedence for the distribution under test.

## Test Plan

- `make`
