### PR TITLE
Fix DBIx::Class ordered test CODE weaken GC stall

### DIFF
--- a/src/main/java/org/perlonjava/runtime/runtimetypes/WeakRefRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/WeakRefRegistry.java
@@ -188,17 +188,23 @@ public class WeakRefRegistry {
             ref.refCountOwned = false;
             base.refCount = WEAKLY_TRACKED;
         }
-        boolean shouldSweepLiveCodeRef = weakenedLiveCodeRef
+        boolean shouldCheckLiveCodeRef = weakenedLiveCodeRef
                 && codeRefHasCountedOwners(base)
                 && !ModuleInitGuard.inModuleInit();
         if (base instanceof RuntimeCode code
                 && code.refCount >= 0
                 && weakRefsExist
-                && (shouldSweepLiveCodeRef
+                && (shouldCheckLiveCodeRef
                 || (code.hadStashRef
                 && code.stashRefCount <= 0
                 && !isInstalledGlobalCodeRef(code)))) {
-            ReachabilityWalker.sweepWeakRefs(true);
+            // Keep this path targeted to the CODE referent. DBIC weakens
+            // callback CODE refs in hot cursor paths; running a full
+            // ReachabilityWalker sweep here forces repeated System.gc() calls.
+            // The CODE-specific stale-ref decision below is enough: live CODE
+            // refs are protected by clearWeakRefsTo()/shouldKeepCodeWeakRefs,
+            // while expired anonymous or former-stash CODE refs can still clear
+            // their weak registry entries immediately.
             if (hasWeakRefsTo(code)
                     && code.stashRefCount <= 0
                     && !isInstalledGlobalCodeRef(code)


### PR DESCRIPTION
## Summary

- Avoid running a full weak-ref reachability sweep from the hot `weaken(CODE)` path.
- Keep the existing CODE-specific stale weak-ref cleanup for expired anonymous or former-stash CODE refs.
- Fixes the `DBIx::Class` `t/87ordered.t` stall caused by repeated explicit old-GC cycles.

## Investigation

`jstack` on the stuck `t/87ordered.t` child showed the main thread inside:

```text
Runtime.gc
ScalarRefRegistry.forceGcAndSnapshot
ReachabilityWalker.sweepWeakRefs
WeakRefRegistry.weaken
Scalar::Util::weaken
DBIx::Class::Storage::BlockRunner
```

JFR confirmed the process was not blocked in SQL or DBIC logic: a 20s recording had 519 `System.gc()` / old-GC events.

## Verification

- `make`
- `timeout 120 ./jperl src/test/resources/unit/refcount/subquote_defer_weak_cleanup.t`
- `timeout 120 ./jperl src/test/resources/unit/refcount/weaken_closure_argument.t`
- `timeout 600 ./jperl -Iblib/lib -Iblib/arch t/87ordered.t` from the DBIx-Class build dir

The direct DBIC check passed `1..1271` with `Auto checked 5 references for leaks - none detected`.
