### PR TITLE
Fix File::Which catpath compatibility

### DIFF
--- a/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
@@ -475,47 +475,84 @@ public class FileSpec extends PerlModuleBase {
      * @return A {@link RuntimeList} containing the constructed path.
      */
     public static RuntimeList catpath(RuntimeArray args, int ctx) {
-        if (args.size() != 4) {
+        if (args.size() > 4) {
             throw new IllegalStateException("Bad number of arguments for catpath() method");
         }
 
-        String volume = args.get(1).toString();
-        String directory = args.get(2).toString();
-        String file = args.get(3).toString();
+        String volume = args.size() > 1 ? args.get(1).toString() : "";
+        String directory = args.size() > 2 ? args.get(2).toString() : "";
+        String file = args.size() > 3 ? args.get(3).toString() : "";
 
-        StringBuilder fullPath = new StringBuilder();
+        if (SystemUtils.osIsWindows()) {
+            StringBuilder fullPath = new StringBuilder(volume);
 
-        // Add volume (for Windows drive letters)
-        if (!volume.isEmpty()) {
-            fullPath.append(volume);
-            // Ensure volume ends with colon on Windows
-            if (SystemUtils.osIsWindows() && !volume.endsWith(":")) {
-                fullPath.append(":");
+            if (isUncVolume(volume) && startsWithoutSeparator(directory)) {
+                fullPath.append(volume.charAt(0));
             }
-        }
 
-        // Add directory
-        if (!directory.isEmpty()) {
             fullPath.append(directory);
-            // Ensure directory ends with separator if file is provided
-            if (!file.isEmpty()) {
-                char lastChar = directory.charAt(directory.length() - 1);
-                if (lastChar != '/' && lastChar != '\\') {
-                    fullPath.append(File.separator);
-                }
+
+            if (!isDriveVolumeOnly(fullPath.toString())
+                    && endsWithoutSeparator(fullPath)
+                    && containsNonSeparator(file)) {
+                fullPath.append(firstSeparatorOrDefault(fullPath, '\\'));
             }
+
+            fullPath.append(file);
+            return new RuntimeScalar(fullPath.toString()).getList();
         }
 
-        // Add file
-        fullPath.append(file);
+        if (!directory.isEmpty()
+                && !file.isEmpty()
+                && directory.charAt(directory.length() - 1) != '/'
+                && file.charAt(0) != '/') {
+            directory += "/" + file;
+        } else {
+            directory += file;
+        }
 
-        // Clean up the path
-        String result = canonpath(new RuntimeArray(
-                new RuntimeScalar("dummy"),
-                new RuntimeScalar(fullPath.toString())
-        ), 0).elements.get(0).toString();
+        return new RuntimeScalar(directory).getList();
+    }
 
-        return new RuntimeScalar(result).getList();
+    private static boolean isUncVolume(String volume) {
+        return volume.matches("^[\\\\/][\\\\/][^\\\\/]+[\\\\/][^\\\\/]+$");
+    }
+
+    private static boolean startsWithoutSeparator(String value) {
+        return !value.isEmpty() && !isSeparator(value.charAt(0));
+    }
+
+    private static boolean endsWithoutSeparator(CharSequence value) {
+        return value.length() > 0 && !isSeparator(value.charAt(value.length() - 1));
+    }
+
+    private static boolean containsNonSeparator(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (!isSeparator(value.charAt(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static char firstSeparatorOrDefault(CharSequence value, char defaultSeparator) {
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (isSeparator(ch)) {
+                return ch;
+            }
+        }
+        return defaultSeparator;
+    }
+
+    private static boolean isDriveVolumeOnly(String value) {
+        return value.length() == 2
+                && Character.isLetter(value.charAt(0))
+                && value.charAt(1) == ':';
+    }
+
+    private static boolean isSeparator(char ch) {
+        return ch == '/' || ch == '\\';
     }
 
     /**

--- a/src/test/resources/unit/filespec_catpath.t
+++ b/src/test/resources/unit/filespec_catpath.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Spec ();
+
+if ($^O eq 'MSWin32') {
+    is(
+        File::Spec->catpath('C:', 'foo', 'bar'),
+        'C:foo\\bar',
+        'Win32 catpath inserts separator between directory and file',
+    );
+
+    is(
+        File::Spec->catpath('C:', 'foo', ''),
+        'C:foo',
+        'Win32 catpath accepts an empty file component',
+    );
+
+    is(
+        File::Spec->catpath('\\\\server\\share', 'dir', 'file'),
+        '\\\\server\\share\\dir\\file',
+        'Win32 catpath joins UNC volume and relative directory',
+    );
+
+    is(
+        File::Spec->catpath('', 'dir', 'file'),
+        'dir\\file',
+        'Win32 catpath uses backslash without a volume',
+    );
+} else {
+    is(
+        File::Spec->catpath('', '/tmp/'),
+        '/tmp/',
+        'catpath accepts a missing file component',
+    );
+
+    is(
+        File::Spec->catpath('', '/tmp/', ''),
+        '/tmp/',
+        'catpath preserves a trailing directory separator with an empty file',
+    );
+
+    is(
+        File::Spec->catpath('', '/tmp', 'file'),
+        '/tmp/file',
+        'catpath inserts a separator between directory and file',
+    );
+
+    is(
+        File::Spec->catpath('ignored', '/tmp/', 'file'),
+        '/tmp/file',
+        'catpath ignores the volume on Unix',
+    );
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

- Update `File::Spec->catpath` to accept omitted path components and preserve empty-file directory paths
- Match Unix `File::Spec` behavior while retaining explicit Win32 handling for drive and UNC paths
- Add focused regression coverage for the `catpath` cases used by `File::Which`

## Verification

- `make`
- `timeout 60 ./jperl src/test/resources/unit/filespec_catpath.t`
- `timeout 600 ./jcpan -t File::Which`

## Notes

- A focused forced-Windows probe matched system Perl's `File::Spec::Win32` output for drive, UNC, directory, and missing-file cases.
