### PR TITLE
Fix DATA handling for top-level __END__

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/DataSection.java
+++ b/src/main/java/org/perlonjava/frontend/parser/DataSection.java
@@ -63,12 +63,11 @@ public class DataSection {
     /**
      * Creates or updates a DATA filehandle for a package.
      *
-     * @param parser  the parser instance
-     * @param content the content after __DATA__ or __END__
+     * @param parser     the parser instance
+     * @param handleName fully-qualified DATA handle name
+     * @param content    the content after __DATA__ or __END__
      */
-    public static void createDataHandle(Parser parser, String content) {
-        String handleName = parser.ctx.symbolTable.getCurrentPackage() + "::DATA";
-
+    public static void createDataHandle(Parser parser, String handleName, String content) {
         if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("Populating DATA handle for package: " + handleName + " with content: " + content);
 
         // Get the existing RuntimeIO (which should be the placeholder we created earlier)
@@ -88,6 +87,15 @@ public class DataSection {
             GlobalVariable.getGlobalIO(handleName).setIO(fileHandle);
             if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("Created new DATA handle");
         }
+    }
+
+    private static String dataHandleName(Parser parser, String markerText) {
+        // Perl treats top-level __END__ as main::DATA even if the marker appears
+        // after a package declaration. __DATA__ remains package-relative.
+        if (markerText.equals("__END__") && parser.isTopLevelScript) {
+            return "main::DATA";
+        }
+        return parser.ctx.symbolTable.getCurrentPackage() + "::DATA";
     }
 
     /**
@@ -172,7 +180,7 @@ public class DataSection {
     }
 
     static int parseDataSection(Parser parser, int tokenIndex, List<LexerToken> tokens, LexerToken token) {
-        String handleName = parser.ctx.symbolTable.getCurrentPackage() + "::DATA";
+        String handleName = dataHandleName(parser, token.text);
 
         // Check if this package has already processed its DATA section.
         // However, allow re-processing if the DATA handle was closed (e.g., module
@@ -220,7 +228,7 @@ public class DataSection {
                 }
 
                 if (rawContent != null) {
-                    createDataHandle(parser, rawContent);
+                    createDataHandle(parser, handleName, rawContent);
                 } else {
                     // Fallback: concatenate remaining tokens (for eval/string-based code
                     // where raw bytes are not available)
@@ -237,7 +245,7 @@ public class DataSection {
                         tokenIndex++;
                     }
 
-                    createDataHandle(parser, dataContent.toString());
+                    createDataHandle(parser, handleName, dataContent.toString());
                 }
 
                 // When `use utf8` is active, apply :utf8 layer to the DATA handle.

--- a/src/test/resources/unit/data_section.t
+++ b/src/test/resources/unit/data_section.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+
+my $line = <DATA>;
+is($line, "payload\n", '__END__ in a top-level script populates main::DATA');
+
+package DataSectionEndPackage;
+
+__END__
+payload


### PR DESCRIPTION
## Summary

- Route top-level `__END__` DATA content to `main::DATA`, matching Perl even when the marker appears after a `package` declaration.
- Keep `__DATA__` package-relative.
- Add a regression test for reading `<DATA>` after a package switch.

## Tests

- `make`
- `timeout 600 ./jcpan -t Data::Transformer`

Generated with [Codex](https://openai.com/codex)
