### PR TITLE
Fix Encode::Locale dynamic aliases

### DIFF
--- a/src/main/java/org/perlonjava/runtime/perlmodule/Encode.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Encode.java
@@ -113,13 +113,12 @@ public class Encode extends PerlModuleBase {
         } catch (Exception ignored) {
         }
 
-        // "locale" and "locale_fs" - map to JVM's default charset.
-        // Encode::Locale registers these via Encode::Alias, but the Java decode/encode
-        // methods bypass Perl-side alias resolution. The JVM default charset matches
-        // what Encode::Locale detects from the OS locale (e.g. UTF-8 on modern systems).
+        // Locale fallbacks before Encode::Locale has initialized its globals.
         Charset defaultCharset = Charset.defaultCharset();
         CHARSET_ALIASES.put("locale", defaultCharset);
         CHARSET_ALIASES.put("locale_fs", defaultCharset);
+        CHARSET_ALIASES.put("console_in", defaultCharset);
+        CHARSET_ALIASES.put("console_out", defaultCharset);
 
         // UTF-32 aliases
         try {
@@ -1224,6 +1223,8 @@ public class Encode extends PerlModuleBase {
      * Handles common aliases and Perl-style encoding names.
      */
     private static Charset getCharset(String encodingName) {
+        encodingName = resolveDynamicEncodingName(encodingName);
+
         // Check aliases first
         Charset charset = CHARSET_ALIASES.get(encodingName);
         if (charset != null) {
@@ -1236,5 +1237,33 @@ public class Encode extends PerlModuleBase {
         } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
             throw new RuntimeException("Unknown encoding: " + encodingName);
         }
+    }
+
+    /**
+     * Encode::Locale exposes dynamic aliases whose target can change at
+     * runtime via reinit(). Java-backed encode/decode bypass Perl's
+     * Encode::Alias dispatcher, so read those package globals directly.
+     */
+    private static String resolveDynamicEncodingName(String encodingName) {
+        if (encodingName == null) {
+            return null;
+        }
+
+        String globalName = switch (encodingName.toLowerCase(Locale.ROOT)) {
+            case "locale" -> "Encode::Locale::ENCODING_LOCALE";
+            case "locale_fs" -> "Encode::Locale::ENCODING_LOCALE_FS";
+            case "console_in" -> "Encode::Locale::ENCODING_CONSOLE_IN";
+            case "console_out" -> "Encode::Locale::ENCODING_CONSOLE_OUT";
+            default -> null;
+        };
+        if (globalName == null) {
+            return encodingName;
+        }
+
+        RuntimeScalar aliasTarget = GlobalVariable.globalVariables.get(globalName);
+        if (aliasTarget != null && aliasTarget.getDefinedBoolean()) {
+            return aliasTarget.toString();
+        }
+        return encodingName;
     }
 }

--- a/src/main/perl/lib/Encode.pm
+++ b/src/main/perl/lib/Encode.pm
@@ -23,31 +23,48 @@ my $_java_find_encoding = \&find_encoding;
 
 # Override find_encoding to add Encode::Alias support.
 # The Java backend only recognises hardcoded charset names.  This wrapper
-# consults Encode::Alias (loaded by modules like Encode::Locale) to resolve
-# custom aliases (coderef, regex, string) before delegating to Java.
+# consults Encode::Alias (loaded by modules like Encode::Locale) dynamically.
 {
     no warnings 'redefine';
     my %_resolving;   # per-name recursion guard
+    my %_encoding_cache;
+
+    my $_cached_java_find_encoding = sub {
+        my ($name) = @_;
+        return undef unless defined $name;
+
+        my $key = lc $name;
+        return $_encoding_cache{$key} if exists $_encoding_cache{$key};
+
+        my $enc = eval { $_java_find_encoding->($name) };
+        if (defined $enc) {
+            $_encoding_cache{$key} = $enc;
+            eval {
+                $_encoding_cache{lc $enc->name} ||= $enc;
+                $_encoding_cache{lc $enc->mime_name} ||= $enc;
+            };
+        }
+        return $enc;
+    };
+
     *find_encoding = sub {
         my ($name, $skip_external) = @_;
         return undef unless defined $name;
-
-        # Fast path: try the Java charset lookup first
-        my $enc = eval { $_java_find_encoding->($name) };
-        return $enc if defined $enc;
 
         # Guard against circular alias chains for the same name
         return undef if $_resolving{$name};
         local $_resolving{$name} = 1;
 
-        # Consult Encode::Alias if it has been loaded
+        # Consult Encode::Alias first so dynamic aliases can override names
+        # that the Java backend also knows, such as "locale".
         if (defined &Encode::Alias::find_alias) {
             my $resolved = eval { Encode::Alias::find_alias("Encode", $name) };
             return $resolved if defined $resolved;
         }
 
-        return undef;
+        return $_cached_java_find_encoding->($name);
     };
+
 }
 
 sub resolve_alias {

--- a/src/test/resources/unit/encode_dynamic_alias.t
+++ b/src/test/resources/unit/encode_dynamic_alias.t
@@ -1,0 +1,33 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 5;
+
+use Encode qw(find_encoding encode decode);
+
+is find_encoding("UTF-8"), find_encoding("UTF-8"),
+    'repeated Java encoding lookup returns the cached object';
+
+{
+    package Encode::Alias;
+    our $locale = "cp1252";
+
+    sub find_alias {
+        my ($class, $name) = @_;
+        return undef unless lc($name) eq "locale";
+        return Encode::find_encoding($locale);
+    }
+}
+
+is find_encoding("locale"), find_encoding("cp1252"),
+    'dynamic alias resolves to the cached target object';
+
+$Encode::Locale::ENCODING_LOCALE = "cp1252";
+is decode(locale => "\x80"), "\x{20ac}",
+    'decode resolves Encode::Locale dynamic aliases';
+is encode(locale => "\x{20ac}"), "\x80",
+    'encode resolves Encode::Locale dynamic aliases';
+
+$Encode::Locale::ENCODING_LOCALE = "UTF-8";
+is encode(locale => "\x{20ac}"), "\xe2\x82\xac",
+    'encode observes later Encode::Locale alias changes';


### PR DESCRIPTION
## Summary

- cache Java-backed Encode encoding objects so Encode::Alias lookups compare by object identity
- resolve Encode::Locale dynamic aliases in Java encode/decode for locale, locale_fs, console_in, and console_out
- add regression coverage for dynamic aliases and Encode::Locale reinit behavior

## Tests

- make
- timeout 600 ./jcpan -t Encode::Locale
