### PR TITLE
Fix XML::Parser parsefile handle dispatch

### DIFF
--- a/src/main/perl/lib/XML/Parser.pm
+++ b/src/main/perl/lib/XML/Parser.pm
@@ -221,11 +221,13 @@ sub parsefile {
     my $old_base = $self->{Base};
     $self->{Base} = $file;
 
+    # Pass the opened handle as an old-style typeglob so subclass parse()
+    # wrappers that probe handles with *{$arg}{IO} see a real handle.
     if (wantarray) {
-        eval { @ret = $self->parse( $fh, @_ ); };
+        eval { @ret = $self->parse( *{$fh}, @_ ); };
     }
     else {
-        eval { $ret = $self->parse( $fh, @_ ); };
+        eval { $ret = $self->parse( *{$fh}, @_ ); };
     }
     my $err = $@;
     $self->{Base} = $old_base;

--- a/src/main/perl/lib/XML/Parser/Expat.pm
+++ b/src/main/perl/lib/XML/Parser/Expat.pm
@@ -537,7 +537,9 @@ sub parsefile {
 
     open( my $fh, '<', $_[0] ) or croak "Couldn't open $_[0]:\n$!";
     binmode($fh);
-    my $ret = $self->parse($fh);
+    # Pass an old-style typeglob for compatibility with subclasses that
+    # identify filehandles by probing *{$arg}{IO}.
+    my $ret = $self->parse(*{$fh});
     close($fh);
     $ret;
 }

--- a/src/test/resources/unit/xml_parser_parsefile_typeglob.t
+++ b/src/test/resources/unit/xml_parser_parsefile_typeglob.t
@@ -1,0 +1,45 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw(tempfile);
+use XML::Parser;
+
+{
+    package Local::Parser::ParsefileProbe;
+    our @ISA = ('XML::Parser');
+
+    sub _is_typeglob_handle {
+        my ($source) = @_;
+        return 0 if ref($source);
+        no strict 'refs';
+        return eval { *{$source}{IO} } ? 1 : 0;
+    }
+
+    sub parse {
+        my ($self, $source) = @_;
+        push @{ $self->{seen_typeglob_handles} }, _is_typeglob_handle($source);
+        return wantarray ? ('parsed', 'list') : 'parsed';
+    }
+}
+
+my ($fh, $filename) = tempfile();
+print {$fh} "<root/>\n";
+close $fh or die "close $filename: $!";
+
+my $parser = bless {}, 'Local::Parser::ParsefileProbe';
+
+is($parser->parsefile($filename), 'parsed', 'scalar parsefile result is forwarded');
+my @result = $parser->parsefile($filename);
+is_deeply(\@result, ['parsed', 'list'], 'list parsefile result is forwarded');
+
+is_deeply(
+    $parser->{seen_typeglob_handles},
+    [1, 1],
+    'parsefile passes a typeglob handle to subclass parse wrappers'
+);
+is($parser->{Base}, undef, 'parsefile restores Base after parsing');
+
+unlink $filename or die "unlink $filename: $!";
+
+done_testing();


### PR DESCRIPTION
## Summary

- pass XML::Parser parsefile handles to parse() as old-style typeglobs
- apply the same compatibility path in XML::Parser::Expat::parsefile
- add a regression test for subclass parse() wrappers that identify handles via *{$arg}{IO}

## Verification

- `make`
- `timeout 600 ./jcpan -t SVG::Parser`
- `timeout 300 /Users/fglock/projects/PerlOnJava4/jperl -MTest::Harness -e 'runtests @ARGV' t/file.t t/parsefile_base_restore.t t/bare_glob_filehandle.t t/extern_ent_lexical_glob.t`

Note: I also started `make test-bundled-modules`, but stopped it after it was already red on unrelated Data-UUID failures and had stalled in another module. The XML::Parser-focused module tests above passed separately.
