### PR TITLE
Bundle pure-Perl Class::XSAccessor

### DIFF
--- a/docs/reference/bundled-modules.md
+++ b/docs/reference/bundled-modules.md
@@ -351,6 +351,7 @@ These are loaded automatically or via `use`:
 | `Attribute::Handlers` | Perl | |
 | `Devel::Cycle` | Perl | |
 | `Devel::Peek` | Perl | |
+| `Class::XSAccessor` / `Class::XSAccessor::Array` | Perl | Pure-Perl replacement for the CPAN XS accessors; no entersub optimizer |
 | `Class::MOP` | Perl | Upstream 2.4000 source |
 | `Moose` | Perl | Upstream 2.4000 source; ~99% of upstream tests pass (no threads). See note below. |
 | `B` | Perl | `svref_2object`, `B::CV`/`GV`/`STASH`, `CVf_ANON`, etc. — enough for `Class::MOP::get_code_info` and `B::Deparse`. |

--- a/docs/reference/xs-compatibility.md
+++ b/docs/reference/xs-compatibility.md
@@ -24,9 +24,10 @@ These modules have optimized Java implementations built into PerlOnJava:
 | Time::HiRes | TimeHiRes.java | - | Uses System.nanoTime() |
 | DBI | Dbi.java | - | JDBC backend |
 
-## Modules with Built-in PP Fallbacks
+## Modules with PP Fallbacks or Shims
 
-These CPAN modules automatically fall back to pure Perl when XS is unavailable:
+These modules either fall back to pure Perl when XS is unavailable, or are
+replaced by a bundled PerlOnJava shim:
 
 | Module | Fallback Module | Detection Pattern | Notes |
 |--------|-----------------|-------------------|-------|
@@ -35,7 +36,7 @@ These CPAN modules automatically fall back to pure Perl when XS is unavailable:
 | Cpanel::JSON::XS | JSON::PP | `/loadable object/` | Bundled shim inherits `JSON::PP` (same stack as `JSON`) |
 | List::Util | List::Util::PP | varies | Some functions only |
 | Params::Util | Params::Util::PP | varies | Separate distribution |
-| Class::XSAccessor | fallback in .pm | `/loadable object/` | Pure Perl accessors |
+| Class::XSAccessor | bundled Perl shim | n/a | Pure-Perl hash/array accessors; XS entersub optimizer disabled |
 
 ## Modules Requiring Java XS Implementation
 

--- a/src/main/perl/lib/Class/XSAccessor.pm
+++ b/src/main/perl/lib/Class/XSAccessor.pm
@@ -1,0 +1,226 @@
+package Class::XSAccessor;
+
+use 5.008;
+use strict;
+use warnings;
+use Carp qw(croak);
+use Scalar::Util qw(reftype);
+use Class::XSAccessor::Heavy;
+
+our $VERSION = '1.19';
+
+sub _make_hash {
+    my $ref = shift;
+
+    if (ref($ref)) {
+        if (ref($ref) eq 'ARRAY') {
+            $ref = { map { $_ => $_ } @$ref };
+        }
+    }
+    else {
+        $ref = { $ref, $ref };
+    }
+
+    return $ref;
+}
+
+sub import {
+    my $own_class = shift;
+    my ($caller_pkg) = caller();
+
+    my %opts = ref($_[0]) eq 'HASH' ? %{ $_[0] } : @_;
+    $caller_pkg = $opts{class} if defined $opts{class};
+
+    my $read_subs      = _make_hash($opts{getters} || {});
+    my $set_subs       = _make_hash($opts{setters} || {});
+    my $acc_subs       = _make_hash($opts{accessors} || {});
+    my $lvacc_subs     = _make_hash($opts{lvalue_accessors} || {});
+    my $pred_subs      = _make_hash($opts{predicates} || {});
+    my $ex_pred_subs   = _make_hash($opts{exists_predicates} || {});
+    my $def_pred_subs  = _make_hash($opts{defined_predicates} || {});
+    my $test_subs      = _make_hash($opts{__tests__} || {});
+    my $construct_subs = $opts{constructors}
+        || [ defined($opts{constructor}) ? $opts{constructor} : () ];
+    my $true_subs      = $opts{true} || [];
+    my $false_subs     = $opts{false} || [];
+
+    for my $subtype (
+        [ getter          => $read_subs ],
+        [ setter          => $set_subs ],
+        [ accessor        => $acc_subs ],
+        [ lvalue_accessor => $lvacc_subs ],
+        [ test            => $test_subs ],
+        [ ex_predicate    => $ex_pred_subs ],
+        [ def_predicate   => $def_pred_subs ],
+        [ def_predicate   => $pred_subs ],
+    ) {
+        my ($type, $subs) = @$subtype;
+        for my $subname (keys %$subs) {
+            _generate_method($caller_pkg, $subname, $subs->{$subname}, \%opts, $type);
+        }
+    }
+
+    for my $subtype (
+        [ constructor => $construct_subs ],
+        [ true        => $true_subs ],
+        [ false       => $false_subs ],
+    ) {
+        my ($type, $subs) = @$subtype;
+        for my $subname (@$subs) {
+            _generate_method($caller_pkg, $subname, q{}, \%opts, $type);
+        }
+    }
+}
+
+sub _generate_method {
+    my ($caller_pkg, $subname, $hashkey, $opts, $type) = @_;
+
+    croak("Cannot use undef as a hash key for generating an XS $type accessor. (Sub: $subname)")
+        if not defined $hashkey;
+
+    $subname = "${caller_pkg}::$subname" if $subname !~ /::/;
+
+    Class::XSAccessor::Heavy::check_sub_existence($subname) if not $opts->{replace};
+    no warnings 'redefine';
+
+    if ($type eq 'getter') {
+        newxs_getter($subname, $hashkey);
+    }
+    elsif ($type eq 'lvalue_accessor') {
+        newxs_lvalue_accessor($subname, $hashkey);
+    }
+    elsif ($type eq 'setter') {
+        newxs_setter($subname, $hashkey, $opts->{chained} || 0);
+    }
+    elsif ($type eq 'def_predicate') {
+        newxs_defined_predicate($subname, $hashkey);
+    }
+    elsif ($type eq 'ex_predicate') {
+        newxs_exists_predicate($subname, $hashkey);
+    }
+    elsif ($type eq 'constructor') {
+        newxs_constructor($subname);
+    }
+    elsif ($type eq 'true') {
+        newxs_boolean($subname, 1);
+    }
+    elsif ($type eq 'false') {
+        newxs_boolean($subname, 0);
+    }
+    elsif ($type eq 'test') {
+        newxs_test($subname, $hashkey);
+    }
+    else {
+        newxs_accessor($subname, $hashkey, $opts->{chained} || 0);
+    }
+}
+
+sub _usage {
+    my ($name, $args) = @_;
+    $name =~ s/^.*:://;
+    croak("Usage: $name($args)");
+}
+
+sub _check_hash_invocant {
+    my ($self) = @_;
+    croak('Class::XSAccessor: invalid instance method invocant: no hash ref supplied')
+        if !ref($self) || (reftype($self) || q{}) ne 'HASH';
+}
+
+sub _install {
+    my ($name, $code) = @_;
+    no strict 'refs';
+    no warnings 'redefine';
+    *{$name} = $code;
+}
+
+sub newxs_getter {
+    my ($name, $key) = @_;
+    _install($name, sub {
+        @_ == 1 or _usage($name, 'self');
+        _check_hash_invocant($_[0]);
+        return $_[0]->{$key};
+    });
+}
+
+sub newxs_lvalue_accessor {
+    my ($name, $key) = @_;
+    _install($name, sub : lvalue {
+        @_ == 1 or _usage($name, 'self');
+        _check_hash_invocant($_[0]);
+        $_[0]->{$key};
+    });
+}
+
+sub newxs_setter {
+    my ($name, $key, $chained) = @_;
+    _install($name, sub {
+        @_ == 2 or _usage($name, 'self, newvalue');
+        _check_hash_invocant($_[0]);
+        $_[0]->{$key} = $_[1];
+        return $chained ? $_[0] : $_[1];
+    });
+}
+
+sub newxs_accessor {
+    my ($name, $key, $chained) = @_;
+    _install($name, sub {
+        @_ >= 1 or _usage($name, 'self, ...');
+        _check_hash_invocant($_[0]);
+        if (@_ > 1) {
+            $_[0]->{$key} = $_[1];
+            return $chained ? $_[0] : $_[1];
+        }
+        return $_[0]->{$key};
+    });
+}
+
+sub newxs_predicate {
+    goto &newxs_defined_predicate;
+}
+
+sub newxs_defined_predicate {
+    my ($name, $key) = @_;
+    _install($name, sub {
+        @_ == 1 or _usage($name, 'self');
+        _check_hash_invocant($_[0]);
+        return defined $_[0]->{$key} ? 1 : q{};
+    });
+}
+
+sub newxs_exists_predicate {
+    my ($name, $key) = @_;
+    _install($name, sub {
+        @_ == 1 or _usage($name, 'self');
+        _check_hash_invocant($_[0]);
+        return exists $_[0]->{$key} ? 1 : q{};
+    });
+}
+
+sub newxs_constructor {
+    my ($name) = @_;
+    _install($name, sub {
+        my $class = shift;
+        croak('Uneven number of arguments to constructor.') if @_ % 2;
+        return bless { @_ }, ref($class) || $class;
+    });
+}
+
+sub newxs_boolean {
+    my ($name, $truth) = @_;
+    _install($name, sub {
+        @_ == 1 or _usage($name, 'self');
+        return $truth ? 1 : q{};
+    });
+}
+
+sub newxs_test {
+    my ($name, $key) = @_;
+    newxs_accessor($name, $key, 0);
+}
+
+sub __entersub_optimized__ {
+    return 0;
+}
+
+1;

--- a/src/main/perl/lib/Class/XSAccessor/Array.pm
+++ b/src/main/perl/lib/Class/XSAccessor/Array.pm
@@ -1,0 +1,168 @@
+package Class::XSAccessor::Array;
+
+use 5.008;
+use strict;
+use warnings;
+use Carp qw(croak);
+use Scalar::Util qw(reftype);
+use Class::XSAccessor ();
+use Class::XSAccessor::Heavy;
+
+our $VERSION = '1.19';
+
+sub import {
+    my $own_class = shift;
+    my ($caller_pkg) = caller();
+
+    my %opts = ref($_[0]) eq 'HASH' ? %{ $_[0] } : @_;
+    $caller_pkg = $opts{class} if defined $opts{class};
+
+    my $read_subs      = $opts{getters} || {};
+    my $set_subs       = $opts{setters} || {};
+    my $acc_subs       = $opts{accessors} || {};
+    my $lvacc_subs     = $opts{lvalue_accessors} || {};
+    my $pred_subs      = $opts{predicates} || {};
+    my $construct_subs = $opts{constructors}
+        || [ defined($opts{constructor}) ? $opts{constructor} : () ];
+    my $true_subs      = $opts{true} || [];
+    my $false_subs     = $opts{false} || [];
+
+    for my $subtype (
+        [ getter          => $read_subs ],
+        [ setter          => $set_subs ],
+        [ accessor        => $acc_subs ],
+        [ lvalue_accessor => $lvacc_subs ],
+        [ predicate       => $pred_subs ],
+    ) {
+        my ($type, $subs) = @$subtype;
+        $subs = Class::XSAccessor::_make_hash($subs);
+        for my $subname (keys %$subs) {
+            _generate_method($caller_pkg, $subname, $subs->{$subname}, \%opts, $type);
+        }
+    }
+
+    for my $subtype (
+        [ constructor => $construct_subs ],
+        [ true        => $true_subs ],
+        [ false       => $false_subs ],
+    ) {
+        my ($type, $subs) = @$subtype;
+        for my $subname (@$subs) {
+            _generate_method($caller_pkg, $subname, q{}, \%opts, $type);
+        }
+    }
+}
+
+sub _generate_method {
+    my ($caller_pkg, $subname, $array_index, $opts, $type) = @_;
+
+    croak("Cannot use undef as a array index for generating an XS $type accessor. (Sub: $subname)")
+        if not defined $array_index;
+
+    $subname = "${caller_pkg}::$subname" if $subname !~ /::/;
+
+    Class::XSAccessor::Heavy::check_sub_existence($subname) if not $opts->{replace};
+    no warnings 'redefine';
+
+    if ($type eq 'getter') {
+        newxs_getter($subname, $array_index);
+    }
+    elsif ($type eq 'lvalue_accessor') {
+        newxs_lvalue_accessor($subname, $array_index);
+    }
+    elsif ($type eq 'setter') {
+        newxs_setter($subname, $array_index, $opts->{chained} || 0);
+    }
+    elsif ($type eq 'predicate') {
+        newxs_predicate($subname, $array_index);
+    }
+    elsif ($type eq 'constructor') {
+        newxs_constructor($subname);
+    }
+    elsif ($type eq 'true') {
+        Class::XSAccessor::newxs_boolean($subname, 1);
+    }
+    elsif ($type eq 'false') {
+        Class::XSAccessor::newxs_boolean($subname, 0);
+    }
+    else {
+        newxs_accessor($subname, $array_index, $opts->{chained} || 0);
+    }
+}
+
+sub _check_array_invocant {
+    my ($self) = @_;
+    croak('Class::XSAccessor: invalid instance method invocant: no array ref supplied')
+        if !ref($self) || (reftype($self) || q{}) ne 'ARRAY';
+}
+
+sub _usage {
+    goto &Class::XSAccessor::_usage;
+}
+
+sub _install {
+    my ($name, $code) = @_;
+    no strict 'refs';
+    no warnings 'redefine';
+    *{$name} = $code;
+}
+
+sub newxs_getter {
+    my ($name, $index) = @_;
+    _install($name, sub {
+        @_ == 1 or _usage($name, 'self');
+        _check_array_invocant($_[0]);
+        return $_[0]->[$index];
+    });
+}
+
+sub newxs_lvalue_accessor {
+    my ($name, $index) = @_;
+    _install($name, sub : lvalue {
+        @_ == 1 or _usage($name, 'self');
+        _check_array_invocant($_[0]);
+        $_[0]->[$index];
+    });
+}
+
+sub newxs_setter {
+    my ($name, $index, $chained) = @_;
+    _install($name, sub {
+        @_ == 2 or _usage($name, 'self, newvalue');
+        _check_array_invocant($_[0]);
+        $_[0]->[$index] = $_[1];
+        return $chained ? $_[0] : $_[1];
+    });
+}
+
+sub newxs_accessor {
+    my ($name, $index, $chained) = @_;
+    _install($name, sub {
+        @_ >= 1 or _usage($name, 'self, ...');
+        _check_array_invocant($_[0]);
+        if (@_ > 1) {
+            $_[0]->[$index] = $_[1];
+            return $chained ? $_[0] : $_[1];
+        }
+        return $_[0]->[$index];
+    });
+}
+
+sub newxs_predicate {
+    my ($name, $index) = @_;
+    _install($name, sub {
+        @_ == 1 or _usage($name, 'self');
+        _check_array_invocant($_[0]);
+        return defined $_[0]->[$index] ? 1 : q{};
+    });
+}
+
+sub newxs_constructor {
+    my ($name) = @_;
+    _install($name, sub {
+        my $class = shift;
+        return bless [], ref($class) || $class;
+    });
+}
+
+1;

--- a/src/main/perl/lib/Class/XSAccessor/Heavy.pm
+++ b/src/main/perl/lib/Class/XSAccessor/Heavy.pm
@@ -1,0 +1,39 @@
+package Class::XSAccessor::Heavy;
+
+use 5.008;
+use strict;
+use warnings;
+use Carp ();
+
+our $VERSION = '1.19';
+our @CARP_NOT = qw(
+    Class::XSAccessor
+    Class::XSAccessor::Array
+);
+
+sub check_sub_existence {
+    my $subname = shift;
+
+    my $sub_package = $subname;
+    $sub_package =~ s/([^:]+)$// or die;
+    my $bare_subname = $1;
+
+    my $sym;
+    {
+        no strict 'refs';
+        $sym = \%{"$sub_package"};
+    }
+    no warnings;
+    local *s = $sym->{$bare_subname};
+    my $coderef = *s{CODE};
+    if ($coderef) {
+        $sub_package =~ s/::$//;
+        Carp::croak(
+            "Cannot replace existing subroutine '$bare_subname' in package '$sub_package' "
+            . "with an XS implementation. If you wish to force a replacement, add the "
+            . "'replace => 1' parameter to the arguments of 'use " . (caller())[0] . "'."
+        );
+    }
+}
+
+1;

--- a/src/test/resources/unit/class_xsaccessor_pp.t
+++ b/src/test/resources/unit/class_xsaccessor_pp.t
@@ -1,0 +1,78 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Class::XSAccessor ();
+use Class::XSAccessor::Array ();
+
+is(Class::XSAccessor->VERSION, '1.19', 'bundled Class::XSAccessor version');
+ok(!Class::XSAccessor::__entersub_optimized__(), 'XS entersub optimizer is disabled');
+
+package XSAHash;
+use Class::XSAccessor
+    constructor        => 'new',
+    accessors          => { foo => 'foo' },
+    getters            => { get_bar => 'bar' },
+    setters            => { set_bar => 'bar' },
+    predicates         => { has_bar => 'bar' },
+    exists_predicates  => { has_baz => 'baz' },
+    lvalue_accessors   => { lv => 'lv' },
+    true               => [ 'always_true' ],
+    false              => [ 'always_false' ];
+
+package XSAArray;
+use Class::XSAccessor::Array
+    constructor      => 'new',
+    accessors        => { foo => 0 },
+    getters          => { get_bar => 1 },
+    setters          => { set_bar => 1 },
+    predicates       => { has_bar => 1 },
+    lvalue_accessors => { lv => 2 };
+
+package main;
+
+my $hash = XSAHash->new(foo => 'a', bar => undef);
+isa_ok($hash, 'XSAHash');
+is($hash->foo, 'a', 'hash accessor reads');
+is($hash->foo('b'), 'b', 'hash accessor writes');
+is($hash->foo, 'b', 'hash accessor returns new value');
+is($hash->set_bar('c'), 'c', 'hash setter writes');
+is($hash->get_bar, 'c', 'hash getter reads');
+ok($hash->has_bar, 'defined predicate sees defined value');
+$hash->set_bar(undef);
+ok(!$hash->has_bar, 'defined predicate rejects undef');
+ok(!$hash->has_baz, 'exists predicate rejects missing key');
+$hash->{baz} = undef;
+ok($hash->has_baz, 'exists predicate accepts undef value');
+$hash->lv = 42;
+is($hash->lv, 42, 'hash lvalue accessor writes');
+ok($hash->always_true, 'true constant accessor');
+ok(!$hash->always_false, 'false constant accessor');
+
+my $array = XSAArray->new(foo => 'ignored');
+isa_ok($array, 'XSAArray');
+ok(!defined $array->foo, 'array constructor ignores arguments');
+is($array->foo('x'), 'x', 'array accessor writes');
+is($array->foo, 'x', 'array accessor reads');
+ok(!$array->has_bar, 'array predicate rejects undef');
+is($array->set_bar('y'), 'y', 'array setter writes');
+is($array->get_bar, 'y', 'array getter reads');
+ok($array->has_bar, 'array predicate sees defined value');
+$array->lv = 84;
+is($array->lv, 84, 'array lvalue accessor writes');
+
+my $ok = eval { XSAHash->foo; 1 };
+ok(!$ok, 'hash accessor rejects class invocant');
+like($@, qr/Class::XSAccessor: invalid instance method invocant: no hash ref supplied/,
+    'hash bad invocant error');
+
+$ok = eval { XSAArray->foo; 1 };
+ok(!$ok, 'array accessor rejects class invocant');
+like($@, qr/Class::XSAccessor: invalid instance method invocant: no array ref supplied/,
+    'array bad invocant error');
+
+$ok = eval { XSAHash::foo(); 1 };
+ok(!$ok, 'hash accessor rejects missing invocant');
+like($@, qr/Usage: foo\(self, \.\.\.\)/, 'hash missing invocant usage');
+
+done_testing();


### PR DESCRIPTION
## Summary

- Bundle pure-Perl `Class::XSAccessor`, `Class::XSAccessor::Array`, and `Class::XSAccessor::Heavy` shims.
- Cover hash/array accessors, constructors, predicates, lvalue accessors, and bad-invocant errors with a focused unit test.
- Update bundled-module and XS compatibility documentation.

## Verification

- `make`
- `./jcpan -t Class::XSAccessor`
- `JCPAN_RUN_BUNDLED_TESTS=1 ./jcpan -t Class::XSAccessor`
