### PR TITLE
Track Sub::MultiMethod jcpan blocker

### DIFF
--- a/dev/modules/README.md
+++ b/dev/modules/README.md
@@ -10,6 +10,7 @@ This directory contains design documents and guides related to porting CPAN modu
 | [cpanel_json_xs.md](cpanel_json_xs.md) | **Cpanel::JSON::XS** — plan for full upstream `t/` parity (Java XS port, phased) |
 | [moose_support.md](moose_support.md) | Path to Moose/Class::MOP support (blocked by B module) |
 | [moo_support.md](moo_support.md) | Moo support status (96% working) |
+| [sub_multimethod.md](sub_multimethod.md) | **Sub::MultiMethod** — currently blocked only by pending `builtin::export_lexically`; module suite passes after no-test dependency install |
 | [xs_fallback.md](xs_fallback.md) | XS fallback mechanism for pure Perl modules |
 | [xsloader.md](xsloader.md) | XSLoader architecture |
 | [makemaker_perlonjava.md](makemaker_perlonjava.md) | ExtUtils::MakeMaker implementation |

--- a/dev/modules/sub_multimethod.md
+++ b/dev/modules/sub_multimethod.md
@@ -1,0 +1,67 @@
+# Sub::MultiMethod Support for PerlOnJava
+
+## Overview
+
+`Sub::MultiMethod` 1.003 is a pure-Perl multimethod dispatcher that depends on
+`Exporter::Tiny`, `Role::Hooks`, and `Type::Tiny`. This document tracks the
+remaining work needed for a clean:
+
+```bash
+./jcpan -t Sub::MultiMethod
+```
+
+## Current Status
+
+**Branch:** `fix/sub-multimethod-jcpan`  
+**Module version:** Sub::MultiMethod 1.003  
+**Status:** Blocked on `builtin::export_lexically` support in a separate PR  
+**Last checked:** 2026-05-26
+
+## Findings
+
+### Clean `jcpan -t` failure
+
+The first failing dependency is `Exporter::Tiny` 1.006003:
+
+```text
+Undefined subroutine &builtin::export_lexically called at .../Exporter/Tiny.pm line 138.
+t/14lexical.t ............ Dubious, test returned 255
+Result: FAIL
+```
+
+Because `Exporter::Tiny` is not installed after that failure, `Type::Tiny` cannot
+compile, and `Sub::MultiMethod` later fails with missing dependency errors such as
+`Eval/TypeTiny.pm`, `Types/Standard.pm`, and `Type/Library.pm`.
+
+### Exploratory run past the blocker
+
+To check for independent `Sub::MultiMethod` failures, the blocked dependencies
+were installed locally without running their tests:
+
+```bash
+timeout 600 ./jcpan -Ti Exporter::Tiny Type::Tiny
+timeout 900 ./jcpan -t Sub::MultiMethod
+```
+
+With `Exporter::Tiny` and `Type::Tiny` present, `Role::Hooks` passes its test
+suite and `Sub::MultiMethod` itself passes:
+
+```text
+Role::Hooks: All tests successful. Files=13, Tests=12
+Sub::MultiMethod: All tests successful. Files=23, Tests=135
+```
+
+## Next Steps
+
+1. Merge the separate `builtin::export_lexically` implementation.
+2. Re-test from a clean local CPAN state:
+   ```bash
+   timeout 900 ./jcpan -t Sub::MultiMethod > /tmp/sub_multimethod_after_builtin.log 2>&1
+   ```
+3. If `Exporter::Tiny` and `Type::Tiny` install cleanly, no additional
+   `Sub::MultiMethod` fix is expected based on the exploratory run.
+
+## Related
+
+- `dev/modules/type_tiny.md`
+- `dev/modules/pure-perl-exporter.md`


### PR DESCRIPTION
## Summary

Track the current `./jcpan -t Sub::MultiMethod` status in `dev/modules/sub_multimethod.md`.

Findings:
- Clean `./jcpan -t Sub::MultiMethod` is blocked first by `Exporter::Tiny` failing `t/14lexical.t` because `builtin::export_lexically` is not yet implemented on this branch.
- The later `Type::Tiny` and `Sub::MultiMethod` failures are dependency fallout because `Exporter::Tiny` is not installed after its test failure.
- After installing the blocked dependencies locally with `-T`, `Sub::MultiMethod` itself passes its upstream suite.

## Test Evidence

Baseline:

```text
timeout 900 ./jcpan -t Sub::MultiMethod > /tmp/sub_multimethod_before.log 2>&1
Exporter::Tiny t/14lexical.t: Undefined subroutine &builtin::export_lexically
Sub::MultiMethod: failed because Exporter::Shiny, Type::Params, and Types::Standard were missing
```

Exploratory run past the pending builtin blocker:

```text
timeout 600 ./jcpan -Ti Exporter::Tiny Type::Tiny > /tmp/sub_multimethod_notest_deps.log 2>&1
timeout 900 ./jcpan -t Sub::MultiMethod > /tmp/sub_multimethod_after_notest_deps.log 2>&1
Role::Hooks: PASS, Files=13, Tests=12
Sub::MultiMethod: PASS, Files=23, Tests=135
```

Repo verification:

```text
timeout 1200 make > /tmp/make_sub_multimethod_tracking.log 2>&1
BUILD SUCCESSFUL in 1m 12s
```

## Blocker

This PR intentionally does not implement `builtin::export_lexically`; that work is being handled separately. Once it merges, re-run from a clean local CPAN state:

```bash
timeout 900 ./jcpan -t Sub::MultiMethod > /tmp/sub_multimethod_after_builtin.log 2>&1
```
