### PR TITLE
Fix Class::Component CPAN tests

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/InterpretedCode.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InterpretedCode.java
@@ -287,6 +287,7 @@ public class InterpretedCode extends RuntimeCode implements PerlSubroutine {
         // Push args for getCallerArgs() support (used by List::Util::any/all/etc.)
         // This matches what RuntimeCode.apply() does for JVM-compiled subs
         RuntimeCode.pushArgs(args);
+        RuntimeCode.pushActiveCode(this);
         // Push warning bits for FATAL warnings support
         // This allows runtime code to check current warning context
         if (warningBitsString != null) {
@@ -299,6 +300,7 @@ public class InterpretedCode extends RuntimeCode implements PerlSubroutine {
             if (warningBitsString != null) {
                 WarningBitsRegistry.popCurrent();
             }
+            RuntimeCode.popActiveCode(this);
             RuntimeCode.popArgs();
         }
     }
@@ -314,6 +316,7 @@ public class InterpretedCode extends RuntimeCode implements PerlSubroutine {
         int effectiveContext = RuntimeCode.effectiveCallContext(callContext);
         // Push args for getCallerArgs() support (used by List::Util::any/all/etc.)
         RuntimeCode.pushArgs(args);
+        RuntimeCode.pushActiveCode(this);
         // Push warning bits for FATAL warnings support
         if (warningBitsString != null) {
             WarningBitsRegistry.pushCurrent(warningBitsString);
@@ -326,6 +329,7 @@ public class InterpretedCode extends RuntimeCode implements PerlSubroutine {
             if (warningBitsString != null) {
                 WarningBitsRegistry.popCurrent();
             }
+            RuntimeCode.popActiveCode(this);
             RuntimeCode.popArgs();
         }
     }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/NextMethod.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/NextMethod.java
@@ -39,7 +39,9 @@ public class NextMethod {
 
                     if (!filename.contains(".java") && !pkg.isEmpty()
                             && !subroutineName.isEmpty() && !subroutineName.equals("(eval)")
-                            && !subroutineName.endsWith("::__ANON__")) {
+                            && !subroutineName.endsWith("::__ANON__")
+                            && !subroutineName.startsWith("next::")
+                            && !subroutineName.startsWith("maybe::next::")) {
                         String methodName;
                         String callerPackage;
                         int lastDoubleColon = subroutineName.lastIndexOf("::");

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -208,11 +208,11 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         return argsStack.get().size();
     }
 
-    private static void pushActiveCode(RuntimeCode code) {
+    public static void pushActiveCode(RuntimeCode code) {
         activeCodeStack.get().push(code);
     }
 
-    private static void popActiveCode(RuntimeCode code) {
+    public static void popActiveCode(RuntimeCode code) {
         Deque<RuntimeCode> stack = activeCodeStack.get();
         if (!stack.isEmpty() && stack.peek() == code) {
             stack.pop();
@@ -227,6 +227,17 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             if (active == code) return true;
         }
         return false;
+    }
+
+    public static RuntimeCode getActiveCodeAt(int depth) {
+        if (depth < 0) return null;
+        int i = 0;
+        for (RuntimeCode active : activeCodeStack.get()) {
+            if (i++ == depth) {
+                return active;
+            }
+        }
+        return null;
     }
 
     /**
@@ -408,6 +419,12 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         }
         if (effectiveContext == RuntimeContextType.SCALAR && result.elements.size() > 1) {
             return new RuntimeList(result.scalar());
+        }
+        if (effectiveContext == RuntimeContextType.SCALAR && result.elements.size() == 1) {
+            RuntimeBase value = result.elements.getFirst();
+            if (value instanceof RuntimeScalar scalar && scalar.type == RuntimeScalarType.TIED_SCALAR) {
+                return new RuntimeList(scalar.tiedFetch());
+            }
         }
         return copyReadonlyListReturns(result, effectiveContext);
     }
@@ -2778,10 +2795,15 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 // The subroutine name at frame N is actually stored at frame N-1
                 // because it represents the sub that IS CALLING frame N
                 String subName = null;
+
+                RuntimeCode activeCode = getActiveCodeAt(originalFrame);
+                if (activeCode != null) {
+                    subName = callerSubNameForCode(activeCode);
+                }
                 
                 // For the innermost frame (frame == 1 after skip), check currentSub first
                 // to honor set_subname() which modifies RuntimeCode.subName at runtime
-                if (frame == 1 && currentSub != null && currentSub.type == RuntimeScalarType.CODE) {
+                if (subName == null && frame == 1 && currentSub != null && currentSub.type == RuntimeScalarType.CODE) {
                     RuntimeCode code = (RuntimeCode) currentSub.value;
                     if (code.subName != null && !code.subName.isEmpty()) {
                         String codePkg = code.packageName != null ? code.packageName : "main";
@@ -2821,16 +2843,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 // an anon frame ends up as "Pkg::__ANON__"; if the package's
                 // *__ANON__ glob currently has a name override active, swap
                 // it in. See dev/modules/anon_sub_naming.md.
-                if (subName != null && subName.endsWith("::__ANON__")) {
-                    String anonPkg = subName.substring(0,
-                            subName.length() - "::__ANON__".length());
-                    RuntimeGlob anonGlob = GlobalVariable.peekGlobalIO(
-                            anonPkg + "::__ANON__");
-                    if (anonGlob != null && anonGlob.nameOverride != null
-                            && !anonGlob.nameOverride.isEmpty()) {
-                        subName = anonPkg + "::" + anonGlob.nameOverride;
-                    }
-                }
+                subName = applyAnonNameOverride(subName);
 
                 if (subName != null && !subName.isEmpty()) {
                     res.add(new RuntimeScalar(subName));  // subroutine
@@ -2962,6 +2975,45 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 } // end if (hasExplicitExpr)
             }
         } else if (frame >= stackTraceSize) {
+            RuntimeCode activeCode = hasExplicitExpr ? getActiveCodeAt(originalFrame) : null;
+            if (activeCode != null && activeCode.explicitlyRenamed) {
+                String pkg = normalizeCallerPackage(activeCode.packageName);
+                if (ctx == RuntimeContextType.SCALAR) {
+                    res.add(new RuntimeScalar(pkg));
+                } else {
+                    res.add(new RuntimeScalar(pkg));
+                    res.add(new RuntimeScalar(activeCode.cvStartFile != null ? activeCode.cvStartFile : ""));
+                    res.add(new RuntimeScalar(activeCode.cvStartLine));
+                    String subName = applyAnonNameOverride(callerSubNameForCode(activeCode));
+                    res.add(subName != null && !subName.isEmpty()
+                            ? new RuntimeScalar(subName)
+                            : RuntimeScalarCache.scalarUndef);
+                    Boolean hasArgsFromStack = getHasArgsAt(originalFrame);
+                    res.add(hasArgsFromStack != null && hasArgsFromStack
+                            ? RuntimeScalarCache.scalarTrue
+                            : RuntimeScalarCache.scalarUndef);
+                    res.add(RuntimeScalarCache.scalarUndef);
+                    res.add(RuntimeScalarCache.scalarUndef);
+                    res.add(RuntimeScalarCache.scalarUndef);
+                    int hints = WarningBitsRegistry.getCallerHintsAtFrame(frame - 1);
+                    res.add(new RuntimeScalar(hints >= 0 ? hints : 0));
+                    String warningBits = WarningBitsRegistry.getCallerBitsAtFrame(frame - 1);
+                    res.add(warningBits != null
+                            ? new RuntimeScalar(warningBits)
+                            : RuntimeScalarCache.scalarUndef);
+                    java.util.Map<String, String> callerHintHash = HintHashRegistry.getCallerHintHashAtFrame(frame - 1);
+                    if (callerHintHash != null) {
+                        RuntimeHash snapshot = new RuntimeHash();
+                        for (java.util.Map.Entry<String, String> entry : callerHintHash.entrySet()) {
+                            snapshot.elements.put(entry.getKey(), new RuntimeScalar(entry.getValue()));
+                        }
+                        res.add(snapshot.createReference());
+                    } else {
+                        res.add(RuntimeScalarCache.scalarUndef);
+                    }
+                }
+                return res;
+            }
             // Fallback: check CallerStack for synthetic frames pushed during compile-time
             // operations (e.g., MODIFY_*_ATTRIBUTES called from Java).
             // The excess frames beyond the Java stack trace are served from CallerStack.
@@ -2979,6 +3031,32 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             }
         }
         return res;
+    }
+
+    private static String callerSubNameForCode(RuntimeCode code) {
+        if (code == null || code.subName == null || code.subName.isEmpty()
+                || code.subName.startsWith("(")) {
+            return null;
+        }
+        if (code.subName.contains("::")) {
+            return code.subName;
+        }
+        String pkg = normalizeCallerPackage(code.packageName);
+        return pkg + "::" + code.subName;
+    }
+
+    private static String applyAnonNameOverride(String subName) {
+        if (subName != null && subName.endsWith("::__ANON__")) {
+            String anonPkg = subName.substring(0,
+                    subName.length() - "::__ANON__".length());
+            RuntimeGlob anonGlob = GlobalVariable.peekGlobalIO(
+                    anonPkg + "::__ANON__");
+            if (anonGlob != null && anonGlob.nameOverride != null
+                    && !anonGlob.nameOverride.isEmpty()) {
+                return anonPkg + "::" + anonGlob.nameOverride;
+            }
+        }
+        return subName;
     }
 
     private static String normalizeCallerPackage(String packageName) {

--- a/src/main/perl/lib/YAML.pm
+++ b/src/main/perl/lib/YAML.pm
@@ -17,6 +17,8 @@ our (
     $DumperClass, $LoaderClass
 );
 
+$LoadBlessed = 1 unless defined $LoadBlessed;
+
 use YAML::Node; # XXX This is a temp fix for Module::Build
 use Scalar::Util qw/ openhandle /;
 

--- a/src/test/resources/unit/caller_line_number.t
+++ b/src/test/resources/unit/caller_line_number.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use Test::More tests => 12;
+use Test::More tests => 13;
 use Eval::Closure qw(eval_closure);
 use Sub::Util qw(set_subname);
 
@@ -121,5 +121,21 @@ set_subname( 'Other::Renamed', $renamed_eval_closure );
 is( $renamed_eval_closure->(),
     'Other::Renamed',
     'caller(0)[3] uses explicit set_subname package for eval closures' );
+
+{
+    package CallerLineNumber::GeneratedAccessor;
+    sub get {
+        return (caller(1))[3];
+    }
+
+    my $generated = sub { get() };
+    Sub::Util::set_subname('CallerLineNumber::GeneratedAccessor::generated', $generated);
+    no strict 'refs';
+    *{'CallerLineNumber::GeneratedAccessor::generated'} = $generated;
+}
+
+is( CallerLineNumber::GeneratedAccessor::generated(),
+    'CallerLineNumber::GeneratedAccessor::generated',
+    'caller(1)[3] uses explicit set_subname for generated accessors' );
 
 # End of tests

--- a/src/test/resources/unit/tie_hash.t
+++ b/src/test/resources/unit/tie_hash.t
@@ -141,8 +141,23 @@ sub DESTROY {
     return $self->SUPER::DESTROY() if $self->can('SUPER::DESTROY');
 }
 
+package CallerTrackingTiedHash;
+our @ISA = ('TiedHash');
+our $caller_sub;
+
+sub FETCH {
+    my ($self, $key) = @_;
+    my @caller = caller(1);
+    $caller_sub = $caller[3];
+    return $self->SUPER::FETCH($key);
+}
+
 # Main test package
 package main;
+
+sub tied_hash_return_accessor {
+    return $_[0]->{key};
+}
 
 subtest 'Basic tie operations' => sub {
     my %hash;
@@ -191,6 +206,17 @@ subtest 'FETCH and STORE operations' => sub {
 
     # Fetch undefined key
     is($hash{nonexistent}, undef, 'undefined key returns undef');
+};
+
+subtest 'FETCH during scalar return keeps callee caller frame' => sub {
+    my %hash;
+    tie %hash, 'CallerTrackingTiedHash';
+    $hash{key} = 'value';
+    $CallerTrackingTiedHash::caller_sub = undef;
+
+    is(tied_hash_return_accessor(\%hash), 'value', 'tied hash value returned from accessor');
+    is($CallerTrackingTiedHash::caller_sub, 'main::tied_hash_return_accessor',
+       'FETCH sees the accessor frame before scalar return unwinds');
 };
 
 subtest 'EXISTS and DELETE operations' => sub {

--- a/src/test/resources/unit/yaml_blessed_load.t
+++ b/src/test/resources/unit/yaml_blessed_load.t
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 2;
+use Scalar::Util qw(blessed);
+use YAML ();
+
+my $yaml = "--- !!perl/hash:YamlBlessedLoad::Thing\nname: example\n";
+
+my $object = YAML::Load($yaml);
+is(blessed($object), 'YamlBlessedLoad::Thing', 'YAML loads perl/hash tags as blessed hashes by default');
+
+{
+    local $YAML::LoadBlessed = 0;
+    my $plain = YAML::Load($yaml);
+    is(blessed($plain), undef, 'YAML::LoadBlessed can disable blessed loading');
+}


### PR DESCRIPTION
## Summary
- Fix `caller()[3]` for Sub::Name-renamed generated accessors, including interpreted eval-generated subs.
- Materialize tied scalar return values while the callee frame is still active so tied `FETCH` sees the right caller.
- Load YAML `!!perl/hash:Class` tags as blessed objects by default, while preserving `local $YAML::LoadBlessed = 0` opt-out behavior.

## Verification
- `make`
- `timeout 600 ./jcpan -t Class::Accessor::Fast`
- `timeout 600 ./jcpan -t Class::Component`
