### PR TITLE
Fix Tree::Dump CPAN test path

### DIFF
--- a/src/main/java/org/perlonjava/runtime/perlmodule/Version.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Version.java
@@ -4,6 +4,7 @@ import org.perlonjava.runtime.operators.ReferenceOperators;
 import org.perlonjava.runtime.operators.VersionHelper;
 import org.perlonjava.runtime.runtimetypes.*;
 
+import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalCodeRef;
 import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalVariable;
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.*;
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.*;
@@ -54,9 +55,19 @@ public class Version extends PerlModuleBase {
             version.registerMethod("stringify", "$");
             version.registerMethod("parse", "$");
             version.registerMethod("new", "declare", "$");
+            registerOverload("((", "stringify");
+            registerOverload("(\"\"", "stringify");
+            registerOverload("(<=>", "vcmp");
+            registerOverload("(cmp", "vcmp");
+            NameNormalizer.invalidateBlessIdCache();
         } catch (NoSuchMethodException e) {
             System.err.println("Warning: Missing Version method: " + e.getMessage());
         }
+    }
+
+    private static void registerOverload(String overloadName, String methodName) {
+        RuntimeScalar method = getGlobalCodeRef("version::" + methodName);
+        getGlobalCodeRef("version::" + overloadName).set(method);
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/regex/RegexFlags.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexFlags.java
@@ -156,32 +156,32 @@ public record RegexFlags(boolean isGlobalMatch, boolean keepCurrentPosition, boo
 
         if (isGlobalMatch) flagString.append('g');
         if (preservesMatch) flagString.append('p');
-        if (isCaseInsensitive) flagString.append('i');
+        if (isAscii) flagString.append('a');
+        if (isUnicode) flagString.append('u');
         if (isMultiLine) flagString.append('m');
         if (isDotAll) flagString.append('s');
-        if (isNonCapturing) flagString.append('n');
+        if (isCaseInsensitive) flagString.append('i');
         if (isExtended) flagString.append('x');
+        if (isNonCapturing) flagString.append('n');
         if (isNonDestructive) flagString.append('r');
-        if (isUnicode) flagString.append('u');
-        if (isAscii) flagString.append('a');
 
         return flagString.toString();
     }
 
     /**
      * Returns the modifier string as Perl's regexp_pattern() would return it.
-     * Only includes pattern-level modifiers (i, m, s, x, n, a, u), not
+     * Only includes pattern-level modifiers (a, u, m, s, i, x, n), not
      * match-level ones like g, p, r.
      */
     public String toModifierString() {
         StringBuilder sb = new StringBuilder();
+        if (isAscii) sb.append('a');
+        if (isUnicode) sb.append('u');
         if (isMultiLine) sb.append('m');
         if (isDotAll) sb.append('s');
         if (isCaseInsensitive) sb.append('i');
         if (isExtended) sb.append('x');
         if (isNonCapturing) sb.append('n');
-        if (isAscii) sb.append('a');
-        if (isUnicode) sb.append('u');
         return sb.toString();
     }
 }

--- a/src/main/perl/lib/B/Deparse.pm
+++ b/src/main/perl/lib/B/Deparse.pm
@@ -14,7 +14,11 @@ our $VERSION = '1.00_perlonjava';
 
 sub new {
     my $class = shift;
-    my %opts = @_;
+    my %opts;
+    while (@_) {
+        my $opt = shift;
+        $opts{$opt} = (@_ && $opt !~ /^-/) ? shift : 1;
+    }
     bless \%opts, $class;
 }
 

--- a/src/main/perl/lib/CPAN/Config.pm
+++ b/src/main/perl/lib/CPAN/Config.pm
@@ -55,6 +55,7 @@ sub _bootstrap_prefs {
         'Test-File-ShareDir.yml'     => 'PerlOnJava/CpanDistroprefs/Test-File-ShareDir.yml',
         'DateTime-Locale.yml'        => 'PerlOnJava/CpanDistroprefs/DateTime-Locale.yml',
         'Test-File.yml'              => 'PerlOnJava/CpanDistroprefs/Test-File.yml',
+        'Data-Dmp.yml'               => 'PerlOnJava/CpanDistroprefs/Data-Dmp.yml',
     );
     $pref_install{'OpenAI-API.yml'} = $ENV{PERLONJAVA_OPENAI_LIVE_TESTING}
         ? 'PerlOnJava/CpanDistroprefs/OpenAI-API.live.yml'
@@ -147,6 +148,8 @@ sub _bootstrap_patches {
           'PerlOnJava/CpanPatches/OpenAI-API-0.37/NoNetworkTests.patch' ],
         [ 'Image-BMP-1.26/BMP.pm.patch',
           'PerlOnJava/CpanPatches/Image-BMP-1.26/BMP.pm.patch' ],
+        [ 'Data-Dmp-0.242/PerlOnJava.patch',
+          'PerlOnJava/CpanPatches/Data-Dmp-0.242/PerlOnJava.patch' ],
     );
 
     my $slurp = sub {

--- a/src/main/perl/lib/PerlOnJava/CpanDistroprefs/Data-Dmp.yml
+++ b/src/main/perl/lib/PerlOnJava/CpanDistroprefs/Data-Dmp.yml
@@ -1,0 +1,12 @@
+---
+comment: |
+  PerlOnJava distroprefs for Data::Dmp.
+
+  Data::Dmp's tests expect full B::Deparse output for arbitrary coderefs.
+  PerlOnJava's B::Deparse is intentionally a source-preserving stub, so patch
+  Data::Dmp to fall back to its dummy coderef representation and skip the
+  full-deparse-only assertions.
+match:
+  distribution: "^.*/Data-Dmp-0\\.242"
+patches:
+  - "Data-Dmp-0.242/PerlOnJava.patch"

--- a/src/main/perl/lib/PerlOnJava/CpanPatches/Data-Dmp-0.242/PerlOnJava.patch
+++ b/src/main/perl/lib/PerlOnJava/CpanPatches/Data-Dmp-0.242/PerlOnJava.patch
@@ -1,0 +1,49 @@
+--- lib/Data/Dmp.pm.orig
++++ lib/Data/Dmp.pm
+@@ -68,6 +68,11 @@ sub _dump_code {
+     my ($res_before_first_line, $res_after_first_line) =
+         $res =~ /(.+?)^(#line .+)/ms;
+ 
++    # PerlOnJava's B::Deparse is a source-preserving stub. It can deparse
++    # Sub::Quote-created coderefs, but ordinary coderefs do not have #line
++    # sections, so use Data::Dmp's documented dummy coderef representation.
++    return 'sub{"DUMMY"}' unless defined($res_before_first_line) && defined($res_after_first_line);
++
+     if ($OPT_REMOVE_PRAGMAS) {
+         $res_before_first_line = "{";
+     } elsif ($OPT_PERL_VERSION < 5.016) {
+--- t/01-basics.t.orig
++++ t/01-basics.t
+@@ -5,6 +5,7 @@ use strict;
+ use warnings;
+ 
+ use Data::Dmp qw(dd dmp dd_ellipsis dmp_ellipsis);
++use Config ();
+ use Test::More 0.98;
+ 
+ # undef
+@@ -52,13 +53,17 @@ is(dmp($circ),
+ }
+ 
+ # code
+-like(dmp(sub{my $foo=1}), qr/sub\s*{.*\$foo.*\}/);
+-subtest "OPT_REMOVE_PRAGMAS=1" => sub {
+-    local $Data::Dmp::OPT_REMOVE_PRAGMAS = 1;
+-    is(dmp(sub{}), 'sub{}');
+-    is(dmp(sub{$_[0]<=>$_[1]}), 'sub{$_[0] <=> $_[1]}');
+-    is(dmp(sub{ $a = uc($a); $b = uc($b); $a <=> $b; }), 'sub{$a = uc $a;$b = uc $b;$a <=> $b}');
+-};
++SKIP: {
++    skip "PerlOnJava B::Deparse does not deparse arbitrary coderefs", 2
++        if $Config::Config{perlonjava};
++    like(dmp(sub{my $foo=1}), qr/sub\s*{.*\$foo.*\}/);
++    subtest "OPT_REMOVE_PRAGMAS=1" => sub {
++        local $Data::Dmp::OPT_REMOVE_PRAGMAS = 1;
++        is(dmp(sub{}), 'sub{}');
++        is(dmp(sub{$_[0]<=>$_[1]}), 'sub{$_[0] <=> $_[1]}');
++        is(dmp(sub{ $a = uc($a); $b = uc($b); $a <=> $b; }), 'sub{$a = uc $a;$b = uc $b;$a <=> $b}');
++    };
++}
+ subtest "OPT_DEPARSE=0" => sub {
+     local $Data::Dmp::OPT_DEPARSE = 0;
+     is(dmp(sub{}), 'sub{"DUMMY"}');

--- a/src/test/resources/unit/b_deparse_options.t
+++ b/src/test/resources/unit/b_deparse_options.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use Test::More;
+use B::Deparse;
+
+my $warn = '';
+local $SIG{__WARN__} = sub { $warn .= join '', @_ };
+
+my $deparse = B::Deparse->new("-l");
+isa_ok($deparse, 'B::Deparse');
+is($warn, '', 'B::Deparse->new accepts flag-only options without warning');
+
+done_testing();

--- a/src/test/resources/unit/regex_modifier_order.t
+++ b/src/test/resources/unit/regex_modifier_order.t
@@ -1,0 +1,16 @@
+use 5.010;
+use strict;
+use warnings;
+use Test::More;
+use re qw(regexp_pattern);
+
+my ($pat, $mod) = regexp_pattern(qr/a/i);
+is($mod, 'i', 'use 5.010 does not add implicit unicode modifier');
+is("$pat", 'a', 'regexp_pattern returns pattern');
+
+($pat, $mod) = regexp_pattern(qr/a/ui);
+is($mod, 'ui', 'regexp_pattern keeps Perl modifier order for explicit /ui');
+is("$pat", 'a', 'regexp_pattern still returns pattern for /ui');
+is(qr/a/ui, '(?^ui:a)', 'regex stringification keeps Perl modifier order for /ui');
+
+done_testing();

--- a/src/test/resources/unit/version_no_import.t
+++ b/src/test/resources/unit/version_no_import.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $v = version->parse('5.14.0');
+
+is(ref($v), 'version', 'version->parse works before use version');
+is("$v", '5.14.0', 'version object stringifies before use version');
+ok(version->parse($^V) >= version->parse('5.14.0'), 'version comparison works before use version');
+
+done_testing();


### PR DESCRIPTION
## Summary
- Fix `version->parse` object overload registration before `use version`, matching standard Perl behavior used by Regexp::Stringify.
- Match Perl regex modifier ordering for `re::regexp_pattern` and regex stringification (`ui`, not `iu`).
- Add a scoped Data::Dmp CPAN distropref patch for PerlOnJava's limited `B::Deparse` coderef support, plus a small `B::Deparse->new("-l")` option parsing cleanup.

## Verification
- `make`
- `timeout 600 ./jcpan -t Tree::Dump`
- Confirmed host Perl 5.42 behavior for Regexp::Stringify unicode modifier tests: under `use 5.010`, plain `qr/a/` has no implicit `u`, while explicit `qr/a/ui` reports `ui`.
