### PR TITLE
Fix imported log shadowing for Complete::Path

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/ParserTables.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParserTables.java
@@ -34,6 +34,7 @@ public class ParserTables {
             "gethostbyname", "getpwuid", "glob",
             "hex",
             "kill",
+            "log",
             "oct", "open",
             "readline", "readpipe", "rename", "require",
             "send",

--- a/src/test/resources/unit/core_operator_import_shadow.t
+++ b/src/test/resources/unit/core_operator_import_shadow.t
@@ -13,4 +13,14 @@ is(atan2(1, 2), 'shadow:1:2', 'use subs can shadow CORE atan2');
 my $core = CORE::atan2(1, 1);
 ok(abs($core - 0.785398163397448) < 0.0001, 'CORE::atan2 still calls the builtin');
 
+{
+    use subs 'log';
+    sub log {
+        return join ":", "shadow", @_;
+    }
+
+    is(log(30, "warnmsg"), 'shadow:30:warnmsg', 'use subs can shadow CORE log');
+    ok(abs(CORE::log(exp(1)) - 1) < 0.0001, 'CORE::log still calls the builtin');
+}
+
 done_testing();


### PR DESCRIPTION
## Summary

- Allow imported/use-subs `log` to shadow CORE `log` during parser override checks
- Add a regression test covering `use subs 'log'` while preserving `CORE::log`

## Testing

- `make`
- `timeout 60 ./jperl src/test/resources/unit/core_operator_import_shadow.t`
- `timeout 60 ./jperl -I/Users/fglock/.perlonjava/cpan/build/Log-ger-0.042-21/lib /Users/fglock/.perlonjava/cpan/build/Log-ger-0.042-21/t/plugin-multilevellog.t`
- `timeout 600 ./jcpan -t Complete::Path`
