### PR TITLE
Fix Test::TempDir::Tiny END cleanup

### DIFF
--- a/src/main/java/org/perlonjava/runtime/perlmodule/Internals.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Internals.java
@@ -60,9 +60,17 @@ public class Internals extends PerlModuleBase {
             // such as Pod::Coverage can skip imported helpers.
             internals.registerMethod("jperl_is_imported_sub", "jperl_is_imported_sub", "$");
             internals.registerMethod("jperl_cv_start_location", "jperlCvStartLocation", "$");
+            internals.registerMethod("jperl_end_av_ref", "jperlEndAvRef", "");
         } catch (NoSuchMethodException e) {
             System.err.println("Warning: Missing Internals method: " + e.getMessage());
         }
+    }
+
+    /**
+     * Return a reference to the live END block queue for B::end_av().
+     */
+    public static RuntimeList jperlEndAvRef(RuntimeArray args, int ctx) {
+        return SpecialBlock.endBlocks.createReference().getList();
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/SpecialBlock.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/SpecialBlock.java
@@ -7,9 +7,10 @@ import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalVariab
  * that can be saved and executed in a specific order. This class provides methods to save and run
  * these blocks, ensuring they are executed based on their defined order and conditions.
  * <p>
- * The order of execution is influenced by how blocks are added:
- * - Blocks added with `push` are executed in Last-In-First-Out (LIFO) order.
- * - Blocks added with `unshift` are executed in First-In-First-Out (FIFO) order.
+ * The order of execution is influenced by how each queue is consumed:
+ * - END blocks are stored newest-first and consumed from the front.
+ * - INIT blocks are stored newest-first and consumed from the back.
+ * - CHECK blocks are stored oldest-first and consumed from the back.
  */
 public class SpecialBlock {
 
@@ -20,12 +21,15 @@ public class SpecialBlock {
 
     /**
      * Saves a code reference to the endBlocks array.
-     * Blocks are added using `push`, meaning they will be executed in LIFO order.
+     * Blocks are added using `unshift`, meaning they will be executed in LIFO order
+     * when runEndBlocks() removes from the front. This layout also matches Perl's
+     * B::end_av behavior: code that appends to the exposed END queue while END
+     * blocks are running fires after the remaining queued END blocks.
      *
      * @param codeRef the code reference to be saved
      */
     public static void saveEndBlock(RuntimeScalar codeRef) {
-        RuntimeArray.push(endBlocks, codeRef);
+        RuntimeArray.unshift(endBlocks, codeRef);
     }
 
     /**
@@ -62,7 +66,7 @@ public class SpecialBlock {
         }
         
         while (!endBlocks.isEmpty()) {
-            RuntimeScalar block = RuntimeArray.pop(endBlocks);
+            RuntimeScalar block = RuntimeArray.shift(endBlocks);
             if (block.getDefinedBoolean()) {
                 RuntimeCode.apply(block, new RuntimeArray(), RuntimeContextType.VOID);
             }

--- a/src/main/perl/lib/B.pm
+++ b/src/main/perl/lib/B.pm
@@ -357,6 +357,19 @@ package B::SPECIAL {
     }
 }
 
+package B::AV {
+    our @ISA = ('B::SV');
+
+    sub new {
+        my ($class, $ref) = @_;
+        return bless { ref => $ref }, $class;
+    }
+
+    sub object_2svref {
+        return $_[0]->{ref};
+    }
+}
+
 package B::STASH {
     sub new {
         my ($class, $pkg) = @_;
@@ -475,6 +488,11 @@ sub svref_2object {
     }
 
     return B::SV->new($_[0]);
+}
+
+sub end_av {
+    require Internals;
+    return B::AV->new(Internals::jperl_end_av_ref());
 }
 
 # Export CVf_ANON as a function

--- a/src/test/resources/unit/b_end_av.t
+++ b/src/test/resources/unit/b_end_av.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+
+print "1..1\n";
+
+our @seen;
+
+END {
+    push @seen, 'first';
+}
+
+END {
+    push @seen, 'second';
+    require B;
+    push @{ B::end_av()->object_2svref }, sub {
+        push @seen, 'pushed';
+        my $got = join ',', @seen;
+        if ($got eq 'second,first,pushed') {
+            print "ok 1 - B::end_av append runs after remaining END blocks\n";
+        }
+        else {
+            print "not ok 1 - B::end_av append runs after remaining END blocks\n";
+            print "# got: $got\n";
+        }
+    };
+}


### PR DESCRIPTION
## Summary

- expose the live END block queue through `B::end_av`
- preserve Perl-compatible append-during-END ordering for queued callbacks
- add a focused regression for `B::end_av()->object_2svref`

## Verification

- `make`
- `timeout 60 ./jperl src/test/resources/unit/b_end_av.t`
- `timeout 600 ./jcpan -t Test::TempDir::Tiny`
- `git diff --check`
