### PR TITLE
Fix Module::Build::Prereqs::FromCPANfile jcpan

### DIFF
--- a/src/main/java/org/perlonjava/app/cli/ArgumentParser.java
+++ b/src/main/java/org/perlonjava/app/cli/ArgumentParser.java
@@ -498,10 +498,12 @@ public class ArgumentParser {
                     break;
                 case 'W':
                     // enable all warnings
+                    parsedArgs.warningOverride = 1;
                     parsedArgs.moduleUseStatements.add(new ModuleUseStatement(switchChar, "warnings", "all", false));
                     break;
                 case 'X':
                     // disable all warnings
+                    parsedArgs.warningOverride = -1;
                     parsedArgs.moduleUseStatements.add(new ModuleUseStatement(switchChar, "warnings", null, true));
                     break;
                 case 'D':

--- a/src/main/java/org/perlonjava/app/cli/CompilerOptions.java
+++ b/src/main/java/org/perlonjava/app/cli/CompilerOptions.java
@@ -92,6 +92,7 @@ public class CompilerOptions implements Cloneable {
     public boolean unicodeArgs = false; // -CA
     public boolean unicodeLocale = false; // -CL
     public boolean warnFlag = false; // For -w (sets $^W = 1)
+    public int warningOverride = 0; // For -W/-X: 1 forces warnings on, -1 forces warnings off
     public RuntimeScalar incHook = null; // For storing @INC hook reference
     List<ArgumentParser.ModuleUseStatement> moduleUseStatements = new ArrayList<>(); // For -m -M
 
@@ -145,7 +146,8 @@ public class CompilerOptions implements Cloneable {
                 "    unicodeInput=" + unicodeInput + ",\n" +
                 "    unicodeOutput=" + unicodeOutput + ",\n" +
                 "    unicodeArgs=" + unicodeArgs + ",\n" +
-                "    unicodeLocale=" + unicodeLocale + "\n" +
+                "    unicodeLocale=" + unicodeLocale + ",\n" +
+                "    warningOverride=" + warningOverride + "\n" +
                 "}";
     }
 }

--- a/src/main/java/org/perlonjava/frontend/semantic/ScopedSymbolTable.java
+++ b/src/main/java/org/perlonjava/frontend/semantic/ScopedSymbolTable.java
@@ -842,6 +842,18 @@ public class ScopedSymbolTable {
         return bitPosition != null && warningDisabledStack.peek().get(bitPosition);
     }
 
+    public Set<String> getDisabledWarningCategories() {
+        Set<String> categories = new HashSet<>();
+        BitSet disabled = warningDisabledStack.peek();
+        for (Map.Entry<String, Integer> entry : warningBitPositions.entrySet()) {
+            int bitPosition = entry.getValue();
+            if (bitPosition >= 0 && disabled.get(bitPosition)) {
+                categories.add(entry.getKey());
+            }
+        }
+        return categories;
+    }
+
     /**
      * Enables FATAL mode for a warning category.
      * When a warning is FATAL, it throws an exception instead of printing a warning.

--- a/src/main/java/org/perlonjava/frontend/semantic/ScopedSymbolTable.java
+++ b/src/main/java/org/perlonjava/frontend/semantic/ScopedSymbolTable.java
@@ -829,6 +829,12 @@ public class ScopedSymbolTable {
     }
 
     public boolean isWarningCategoryEnabled(String category) {
+        if (WarningFlags.areWarningsForcedOff()) {
+            return false;
+        }
+        if (WarningFlags.areWarningsForcedOn()) {
+            return true;
+        }
         Integer bitPosition = warningBitPositions.get(category);
         return bitPosition != null && warningFlagsStack.peek().get(bitPosition);
     }

--- a/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
+++ b/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
@@ -263,6 +263,10 @@ public class WarnDie {
 
     public static RuntimeBase warnWithCategory(RuntimeBase message, RuntimeScalar where, String category,
                                                 String fileName, int lineNumber) {
+        if (WarningFlags.areWarningsForcedOff()) {
+            return new RuntimeScalar();
+        }
+
         // Get the warning bits for the current Perl execution context.
         // We scan the Java call stack for the nearest Perl frame (org.perlonjava.anon* or perlmodule)
         // and look up its warning bits in WarningBitsRegistry.
@@ -279,7 +283,11 @@ public class WarnDie {
 
         
         // If warning bits are available, check if this category is enabled
-        if (warningBits != null) {
+        if (WarningFlags.areWarningsForcedOn()) {
+            if (warningBits != null && WarningFlags.isFatalInBits(warningBits, category)) {
+                return die(message, where, fileName, lineNumber);
+            }
+        } else if (warningBits != null) {
             if (WarningFlags.isEnabledInBits(warningBits, category)) {
                 // Category is lexically enabled - check for FATAL
                 if (WarningFlags.isFatalInBits(warningBits, category)) {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FileTemp.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FileTemp.java
@@ -254,10 +254,6 @@ public class FileTemp extends PerlModuleBase {
                         Files.newByteChannel(ioFilePath, options).close();
                     }
 
-                    // Register for cleanup
-                    long pid = ProcessHandle.current().pid();
-                    TEMP_FILES.computeIfAbsent(pid, k -> new HashSet<>()).add(ioFilePath);
-
                     // Return file descriptor and path
                     int fd = openFile ? openFileDescriptor(ioFilePath) : -1;
                     return new RuntimeList(
@@ -341,10 +337,6 @@ public class FileTemp extends PerlModuleBase {
                         // Windows doesn't support POSIX permissions
                         Files.createDirectory(ioDirPath);
                     }
-
-                    // Register for cleanup
-                    long pid = ProcessHandle.current().pid();
-                    TEMP_DIRS.computeIfAbsent(pid, k -> new HashSet<>()).add(ioDirPath);
 
                     return dirPath;
 

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Warnings.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Warnings.java
@@ -59,11 +59,10 @@ public class Warnings extends PerlModuleBase {
      * @return The warning bits string, or null if not available
      */
     private static String getWarningBitsAtLevel(int level) {
-        // Level 0 = the Perl code that called the warnings:: function
-        // We add 1 to skip the Java implementation frame (Warnings.java) that appears
-        // in the caller() stack trace when called from Java code
+        // Level 0 = the Perl code that called the warnings:: function.
+        // Add one to skip this Java implementation frame in caller().
         RuntimeList caller = RuntimeCode.caller(
-            new RuntimeList(RuntimeScalarCache.getScalarInt(level + 1)), 
+            new RuntimeList(RuntimeScalarCache.getScalarInt(level + 1)),
             RuntimeContextType.LIST
         );
         if (caller.size() > 9) {
@@ -86,7 +85,7 @@ public class Warnings extends PerlModuleBase {
      */
     private static String getCallerPackageAtLevel(int level) {
         RuntimeList caller = RuntimeCode.caller(
-            new RuntimeList(RuntimeScalarCache.getScalarInt(level + 1)), 
+            new RuntimeList(RuntimeScalarCache.getScalarInt(level + 1)),
             RuntimeContextType.LIST
         );
         if (caller.size() > 0) {
@@ -299,14 +298,15 @@ public class Warnings extends PerlModuleBase {
      * @return A RuntimeList.
      */
     public static RuntimeList useWarnings(RuntimeArray args, int ctx) {
+        ScopedSymbolTable symbolTable = getCurrentScope();
+
         // If no arguments, enable all warnings (use warnings;)
         if (args.size() == 1) {
             warningManager.initializeEnabledWarnings();
+            WarningFlags.registerScopeWarnings(symbolTable.getDisabledWarningCategories());
             return new RuntimeScalar().getList();
         }
 
-        ScopedSymbolTable symbolTable = getCurrentScope();
-        
         // Track current modifier: null = normal, "FATAL" = make fatal, "NONFATAL" = make non-fatal
         String currentModifier = null;
         
@@ -355,7 +355,8 @@ public class Warnings extends PerlModuleBase {
             
             currentModifier = null;  // Reset modifier after use
         }
-        
+
+        WarningFlags.registerScopeWarnings(symbolTable.getDisabledWarningCategories());
         return new RuntimeScalar().getList();
     }
 
@@ -420,8 +421,11 @@ public class Warnings extends PerlModuleBase {
             }
         }
         
-        // Register scope for runtime checking (sets lastScopeId for StatementParser)
-        WarningFlags.registerScopeWarnings(categories);
+        // Register the full current disabled set so consecutive warning pragmas
+        // replace the runtime suppression scope instead of losing earlier changes.
+        ScopedSymbolTable symbolTable = getCurrentScope();
+        WarningFlags.registerScopeWarnings(
+                symbolTable != null ? symbolTable.getDisabledWarningCategories() : categories);
         
         return new RuntimeScalar().getList();
     }
@@ -461,11 +465,6 @@ public class Warnings extends PerlModuleBase {
             category = (pkg != null) ? pkg : "all";
         }
         
-        // Check scope-based runtime suppression first (from "no warnings 'category'" blocks)
-        if (WarningFlags.isWarningSuppressedAtRuntime(category)) {
-            return new RuntimeScalar(false).getList();
-        }
-        
         // For custom (registered) categories, walk past the registered package
         // to find the external caller's warning bits
         String bits;
@@ -473,6 +472,10 @@ public class Warnings extends PerlModuleBase {
             bits = findExternalCallerBits();
         } else {
             bits = getWarningBitsAtLevel(0);
+        }
+        // Check scope-based runtime suppression first (from "no warnings 'category'" blocks)
+        if (WarningFlags.isWarningSuppressedAtRuntime(category)) {
+            return new RuntimeScalar(false).getList();
         }
         boolean isEnabled = bits != null && WarningFlags.isEnabledInBits(bits, category);
         return new RuntimeScalar(isEnabled).getList();
@@ -519,17 +522,16 @@ public class Warnings extends PerlModuleBase {
             category = (pkg != null) ? pkg : "all";
         }
         
-        // Check scope-based runtime suppression first
-        if (WarningFlags.isWarningSuppressedAtRuntime(category)) {
-            return new RuntimeScalar(false).getList();
-        }
-        
         // For custom categories, walk past the registered package
         String bits;
         if (WarningFlags.isCustomCategory(category)) {
             bits = findExternalCallerBits();
         } else {
             bits = getWarningBitsAtLevel(0);
+        }
+        // Check scope-based runtime suppression first
+        if (WarningFlags.isWarningSuppressedAtRuntime(category)) {
+            return new RuntimeScalar(false).getList();
         }
         boolean isFatal = bits != null && WarningFlags.isFatalInBits(bits, category);
         return new RuntimeScalar(isFatal).getList();
@@ -607,7 +609,7 @@ public class Warnings extends PerlModuleBase {
         if (WarningFlags.isWarningSuppressedAtRuntime(category)) {
             return new RuntimeScalar().getList();
         }
-        
+
         // For custom (registered) categories, walk past the registered package
         // to find the external caller's warning bits
         String bits;
@@ -624,6 +626,10 @@ public class Warnings extends PerlModuleBase {
                 }
             }
         } else {
+            // Built-in warnings::warnif reports and checks the caller of the
+            // routine that called warnif(), e.g. File::pushd reports the user's
+            // pushd() call site rather than File/pushd.pm's warnif line.
+            bitsLevel = 1;
             // Walk up the call stack to find the first caller NOT in an internal
             // package (attributes, warnings). This is the "responsible caller"
             // whose location should be reported. This approximates Perl 5's
@@ -705,6 +711,9 @@ public class Warnings extends PerlModuleBase {
         
         // Check if category is enabled in lexical warnings
         boolean categoryEnabled = bits != null && WarningFlags.isEnabledInBits(bits, category);
+        if (WarningFlags.isWarningSuppressedAtRuntime(category)) {
+            return new RuntimeScalar().getList();
+        }
         
         // Get caller location for warning/error messages
         RuntimeScalar where = getCallerLocation(level);

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -1104,6 +1104,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
     public static RuntimeBase replaceRegex(RuntimeScalar quotedRegex, RuntimeScalar string, int ctx) {
         // Convert the input string to a Java string
         String inputStr = string.toString();
+        boolean wasByteString = (string.type == RuntimeScalarType.BYTE_STRING);
+        boolean resultNeedsUtf8 = !wasByteString;
 
         // Extract the regex pattern from the quotedRegex object
         RuntimeRegex regex = resolveRegex(quotedRegex);
@@ -1273,9 +1275,15 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                     // Use callerArgs (the enclosing subroutine's @_) so $_[0] etc. work
                     RuntimeArray args = (callerArgs != null) ? callerArgs : new RuntimeArray();
                     RuntimeList result = RuntimeCode.apply(replacement, args, RuntimeContextType.SCALAR);
+                    if (Utf8.isUtf8(result.scalar())) {
+                        resultNeedsUtf8 = true;
+                    }
                     replacementStr = result.toString();
                 } else {
                     // Replace the match with the replacement string
+                    if (Utf8.isUtf8(replacement)) {
+                        resultNeedsUtf8 = true;
+                    }
                     replacementStr = replacement.toString();
                 }
 
@@ -1321,7 +1329,6 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
 
         if (found > 0) {
             String finalResult = resultBuffer.toString();
-            boolean wasByteString = (string.type == RuntimeScalarType.BYTE_STRING);
 
             // Store as last successful pattern for empty pattern reuse
             lastMatchUsedPFlag = regex.hasPreservesMatch;
@@ -1330,14 +1337,14 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             if (regex.regexFlags.isNonDestructive()) {
                 // /r modifier: return the modified string
                 RuntimeScalar rv = new RuntimeScalar(finalResult);
-                if (wasByteString && !containsWideChars(finalResult)) {
+                if (wasByteString && !resultNeedsUtf8 && !containsWideChars(finalResult)) {
                     rv.type = RuntimeScalarType.BYTE_STRING;
                 }
                 return rv;
             } else {
                 // Save the modified string back to the original scalar
                 string.set(finalResult);
-                if (wasByteString && !containsWideChars(finalResult)) {
+                if (wasByteString && !resultNeedsUtf8 && !containsWideChars(finalResult)) {
                     string.type = RuntimeScalarType.BYTE_STRING;
                 }
                 // Return the number of substitutions made

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
@@ -37,6 +37,7 @@ public class GlobalContext {
 
         // Clear package versions from previous runs
         ScopedSymbolTable.clearPackageVersions();
+        WarningFlags.setCommandLineWarningOverride(compilerOptions.warningOverride);
 
         // Initialize regex state and special variables
         RuntimeRegex.initialize();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/WarningFlags.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/WarningFlags.java
@@ -28,6 +28,9 @@ public class WarningFlags {
     
     // Global flag to track if "use warnings" has been called (for runtime checks)
     private static boolean globalWarningsEnabled = false;
+
+    // Command-line override from -W/-X. 1 forces warnings on, -1 forces them off.
+    private static int commandLineWarningOverride = 0;
     
     // Scope ID counter for generating unique scope IDs
     private static final AtomicInteger scopeIdCounter = new AtomicInteger(0);
@@ -359,6 +362,12 @@ public class WarningFlags {
      * {@code ${^WARNING_BITS}} (e.g. AnyEvent's generated {@code AnyEvent::common_sense}).
      */
     public static boolean ckWarnForScope(ScopedSymbolTable scope, String category) {
+        if (commandLineWarningOverride < 0) {
+            return false;
+        }
+        if (commandLineWarningOverride > 0) {
+            return true;
+        }
         if (scope != null && scope.isWarningCategoryDisabled(category)) {
             return false;
         }
@@ -670,9 +679,27 @@ public class WarningFlags {
      * @return True if the category is suppressed in the current runtime scope.
      */
     public static boolean isWarningSuppressedAtRuntime(String category) {
+        if (commandLineWarningOverride > 0) {
+            return false;
+        }
+        if (commandLineWarningOverride < 0) {
+            return true;
+        }
         RuntimeScalar scopeVar = GlobalVariable.getGlobalVariable(GlobalContext.WARNING_SCOPE);
         int scopeId = scopeVar.getInt();
         return scopeId > 0 && isWarningDisabledInScope(scopeId, category);
+    }
+
+    public static void setCommandLineWarningOverride(int override) {
+        commandLineWarningOverride = override;
+    }
+
+    public static boolean areWarningsForcedOn() {
+        return commandLineWarningOverride > 0;
+    }
+
+    public static boolean areWarningsForcedOff() {
+        return commandLineWarningOverride < 0;
     }
     
     /**
@@ -800,6 +827,12 @@ public class WarningFlags {
      * @return True if the category is enabled, false otherwise.
      */
     public boolean isWarningEnabled(String category) {
+        if (commandLineWarningOverride < 0) {
+            return false;
+        }
+        if (commandLineWarningOverride > 0) {
+            return true;
+        }
         ScopedSymbolTable scope = getCurrentScope();
         if (scope != null && scope.isWarningCategoryEnabled(category)) {
             return true;
@@ -825,6 +858,12 @@ public class WarningFlags {
      * @return True if the category was explicitly disabled, false otherwise.
      */
     public boolean isWarningDisabled(String category) {
+        if (commandLineWarningOverride < 0) {
+            return true;
+        }
+        if (commandLineWarningOverride > 0) {
+            return false;
+        }
         return getCurrentScope().isWarningCategoryDisabled(category);
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/WarningFlags.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/WarningFlags.java
@@ -621,12 +621,11 @@ public class WarningFlags {
     public static int registerScopeWarnings(Set<String> categories) {
         int scopeId = scopeIdCounter.incrementAndGet();
         
-        // Expand categories to include subcategories
+        // Callers pass the current disabled bitset from ScopedSymbolTable, where
+        // parent categories have already been propagated to subcategories and
+        // later use-warnings pragmas have cleared re-enabled categories.
         Set<String> expanded = new HashSet<>(categories);
-        for (String category : categories) {
-            expandCategory(category, expanded);
-        }
-        
+
         scopeDisabledWarnings.put(scopeId, expanded);
         
         // Set lastScopeId for StatementParser to read
@@ -657,7 +656,7 @@ public class WarningFlags {
     public static boolean isWarningDisabledInScope(int scopeId, String category) {
         Set<String> disabled = scopeDisabledWarnings.get(scopeId);
         if (disabled != null) {
-            return disabled.contains(category) || disabled.contains("all");
+            return disabled.contains(category);
         }
         return false;
     }

--- a/src/main/perl/lib/ExtUtils/MakeMaker.pm
+++ b/src/main/perl/lib/ExtUtils/MakeMaker.pm
@@ -722,7 +722,30 @@ sub _create_install_makefile {
     my $blib_script_cmds_str = join("\n", @blib_script_cmds) || "\t\@true";
     my $file_count = scalar(keys %$pm) + scalar(keys %$scripts);
 
-    my $pm_deps_str = join(' ', sort grep { $_ !~ m{^blib/lib/} } keys %$pm);
+    # Build PL_FILES commands (prefixed with - so failures are non-fatal;
+    # many .PL scripts generate optional CLI tools that aren't needed for
+    # the module's core functionality). Track generated targets so missing
+    # generated PM files do not become hard pm_to_blib prerequisites before
+    # pl_files has had a chance to create them.
+    my @pl_cmds;
+    my %pl_targets;
+    if ($args->{PL_FILES} && %{$args->{PL_FILES}}) {
+        for my $pl (sort keys %{$args->{PL_FILES}}) {
+            my $target = $args->{PL_FILES}{$pl};
+            if (ref $target eq 'ARRAY') {
+                for my $t (@$target) {
+                    $pl_targets{$t} = 1;
+                    push @pl_cmds, "\t-$perl $pl $t";
+                }
+            } else {
+                $pl_targets{$target} = 1;
+                push @pl_cmds, "\t-$perl $pl $target";
+            }
+        }
+    }
+    my $pl_cmds_str = join("\n", @pl_cmds) || "\t\@true";
+
+    my $pm_deps_str = join(' ', sort grep { $_ !~ m{^blib/lib/} && !($pl_targets{$_} && !-e $_) } keys %$pm);
     $pm_deps_str = " $pm_deps_str" if length $pm_deps_str;
     
     # Make pm_to_blib target conditional - if no .pm files, make it a no-op
@@ -733,24 +756,6 @@ sub _create_install_makefile {
     }
 
     my $depend_rules_str = _make_depend_rules($args->{depend});
-    
-    # Build PL_FILES commands (prefixed with - so failures are non-fatal;
-    # many .PL scripts generate optional CLI tools that aren't needed for
-    # the module's core functionality)
-    my @pl_cmds;
-    if ($args->{PL_FILES} && %{$args->{PL_FILES}}) {
-        for my $pl (sort keys %{$args->{PL_FILES}}) {
-            my $target = $args->{PL_FILES}{$pl};
-            if (ref $target eq 'ARRAY') {
-                for my $t (@$target) {
-                    push @pl_cmds, "\t-$perl $pl $t";
-                }
-            } else {
-                push @pl_cmds, "\t-$perl $pl $target";
-            }
-        }
-    }
-    my $pl_cmds_str = join("\n", @pl_cmds) || "\t\@true";
     
     # Build PREREQ_PM comment (MakeMaker writes these for tools to parse)
     my $prereq_comment = '';
@@ -820,7 +825,7 @@ MOD_INSTALL = \$(NOECHO) \$(PERLRUN) -e "1"
 UNINSTALL = \$(NOECHO) \$(PERLRUN) -e "1"
 $extra_macros_str
 
-all:: pm_to_blib pure_all pl_files blib_scripts config
+all:: pl_files pm_to_blib pure_all blib_scripts config
 \t\@echo "PerlOnJava: $name v$version built ($file_count files in ./blib)"
 
 $depend_rules_str

--- a/src/test/java/org/perlonjava/CommandLineWarningOverrideTest.java
+++ b/src/test/java/org/perlonjava/CommandLineWarningOverrideTest.java
@@ -1,0 +1,79 @@
+package org.perlonjava;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.cli.ArgumentParser;
+import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+import org.perlonjava.runtime.io.StandardIO;
+import org.perlonjava.runtime.runtimetypes.GlobalVariable;
+import org.perlonjava.runtime.runtimetypes.RuntimeIO;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unit")
+public class CommandLineWarningOverrideTest {
+    private RuntimeIO originalStdout;
+    private RuntimeIO originalStderr;
+    private ByteArrayOutputStream stdout;
+    private ByteArrayOutputStream stderr;
+
+    @BeforeEach
+    void setUp() {
+        PerlLanguageProvider.resetAll();
+
+        originalStdout = RuntimeIO.stdout;
+        originalStderr = RuntimeIO.stderr;
+        stdout = new ByteArrayOutputStream();
+        stderr = new ByteArrayOutputStream();
+
+        RuntimeIO.stdout = new RuntimeIO(new StandardIO(stdout, true));
+        RuntimeIO.stderr = new RuntimeIO(new StandardIO(stderr, false));
+        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.stdout);
+        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.stderr);
+    }
+
+    @AfterEach
+    void tearDown() {
+        RuntimeIO.stdout = originalStdout;
+        RuntimeIO.stderr = originalStderr;
+        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.stdout);
+        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.stderr);
+        PerlLanguageProvider.resetAll();
+    }
+
+    @Test
+    void xSuppressesLaterUseWarnings() throws Exception {
+        assertEquals("", run("-X", "-e", "use warnings; my $b = $a + 0;"));
+    }
+
+    @Test
+    void xSuppressesWarningsEnabledByUseVersion() throws Exception {
+        assertEquals("", run("-X", "-e", "use 5.036; my $b = $a + 0;"));
+    }
+
+    @Test
+    void wOverridesLaterNoWarnings() throws Exception {
+        String output = run("-W", "-e", "no warnings; my $b = $a + 0;");
+
+        assertTrue(output.contains("Use of uninitialized value"), output);
+        assertTrue(output.contains("addition"), output);
+    }
+
+    private String run(String... args) throws Exception {
+        CompilerOptions options = ArgumentParser.parseArguments(args);
+
+        PerlLanguageProvider.executePerlCode(options, true);
+        RuntimeIO.stdout.flush();
+        RuntimeIO.stderr.flush();
+
+        return new String(stdout.toByteArray(), StandardCharsets.ISO_8859_1)
+                + new String(stderr.toByteArray(), StandardCharsets.ISO_8859_1);
+    }
+}

--- a/src/test/resources/unit/cli_warning_overrides.t
+++ b/src/test/resources/unit/cli_warning_overrides.t
@@ -1,0 +1,49 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw(tempdir);
+
+my $tmpdir = tempdir(CLEANUP => 1);
+my $seq = 0;
+
+sub shell_quote {
+    my ($arg) = @_;
+    $arg =~ s/'/'\\''/g;
+    return "'$arg'";
+}
+
+sub run_child {
+    my ($switch, $code) = @_;
+    my $script = "$tmpdir/child_" . (++$seq) . ".pl";
+    open my $fh, '>', $script or die "Cannot write $script: $!";
+    print {$fh} $code;
+    close $fh or die "Cannot close $script: $!";
+
+    my $jperl = $^X eq 'jperl' ? './jperl' : $^X;
+    my $cmd = join ' ', map { shell_quote($_) } ($jperl, $switch, $script);
+    open my $pipe, "$cmd 2>&1 |" or die "Cannot run $cmd: $!";
+    local $/;
+    my $output = <$pipe>;
+    close $pipe;
+    return $output;
+}
+
+is(
+    run_child('-X', 'use warnings; my $b = $a + 0;'),
+    '',
+    '-X suppresses later use warnings',
+);
+
+is(
+    run_child('-X', 'use 5.036; my $b = $a + 0;'),
+    '',
+    '-X suppresses warnings enabled by use VERSION',
+);
+
+like(
+    run_child('-W', 'no warnings; my $b = $a + 0;'),
+    qr/Use of uninitialized value .*in addition/,
+    '-W overrides later no warnings',
+);
+
+done_testing();

--- a/src/test/resources/unit/cli_warning_overrides.t
+++ b/src/test/resources/unit/cli_warning_overrides.t
@@ -4,8 +4,7 @@ use Test::More;
 use File::Temp qw(tempdir);
 use IPC::Open3;
 
-plan skip_all => 'nested jperl launcher requires built target jar'
-    if $^X eq 'jperl' && !-f 'target/perlonjava-5.42.0.jar';
+my $skip_launcher = $^X eq 'jperl' && !-f 'target/perlonjava-5.42.0.jar';
 
 my $tmpdir = tempdir(CLEANUP => 1);
 my $seq = 0;
@@ -32,22 +31,26 @@ sub run_child {
     return $output;
 }
 
-is(
-    run_child('-X', 'use warnings; my $b = $a + 0;'),
-    '',
-    '-X suppresses later use warnings',
-);
+SKIP: {
+    skip 'nested jperl launcher requires built target jar', 3 if $skip_launcher;
 
-is(
-    run_child('-X', 'use 5.036; my $b = $a + 0;'),
-    '',
-    '-X suppresses warnings enabled by use VERSION',
-);
+    is(
+        run_child('-X', 'use warnings; my $b = $a + 0;'),
+        '',
+        '-X suppresses later use warnings',
+    );
 
-like(
-    run_child('-W', 'no warnings; my $b = $a + 0;'),
-    qr/Use of uninitialized value .*in addition/,
-    '-W overrides later no warnings',
-);
+    is(
+        run_child('-X', 'use 5.036; my $b = $a + 0;'),
+        '',
+        '-X suppresses warnings enabled by use VERSION',
+    );
+
+    like(
+        run_child('-W', 'no warnings; my $b = $a + 0;'),
+        qr/Use of uninitialized value .*in addition/,
+        '-W overrides later no warnings',
+    );
+}
 
 done_testing();

--- a/src/test/resources/unit/cli_warning_overrides.t
+++ b/src/test/resources/unit/cli_warning_overrides.t
@@ -4,6 +4,9 @@ use Test::More;
 use File::Temp qw(tempdir);
 use IPC::Open3;
 
+plan skip_all => 'nested jperl launcher requires built target jar'
+    if $^X eq 'jperl' && !-f 'target/perlonjava-5.42.0.jar';
+
 my $tmpdir = tempdir(CLEANUP => 1);
 my $seq = 0;
 

--- a/src/test/resources/unit/cli_warning_overrides.t
+++ b/src/test/resources/unit/cli_warning_overrides.t
@@ -2,15 +2,10 @@ use strict;
 use warnings;
 use Test::More;
 use File::Temp qw(tempdir);
+use IPC::Open3;
 
 my $tmpdir = tempdir(CLEANUP => 1);
 my $seq = 0;
-
-sub shell_quote {
-    my ($arg) = @_;
-    $arg =~ s/'/'\\''/g;
-    return "'$arg'";
-}
 
 sub run_child {
     my ($switch, $code) = @_;
@@ -19,12 +14,18 @@ sub run_child {
     print {$fh} $code;
     close $fh or die "Cannot close $script: $!";
 
-    my $jperl = $^X eq 'jperl' ? './jperl' : $^X;
-    my $cmd = join ' ', map { shell_quote($_) } ($jperl, $switch, $script);
-    open my $pipe, "$cmd 2>&1 |" or die "Cannot run $cmd: $!";
+    my $jperl = $^X;
+    if ($jperl eq 'jperl') {
+        $jperl = $^O eq 'MSWin32' ? 'jperl.bat' : './jperl';
+    }
+
+    my ($in, $out);
+    my $pid = open3($in, $out, undef, $jperl, $switch, $script);
+    close $in;
     local $/;
-    my $output = <$pipe>;
-    close $pipe;
+    my $output = <$out> // '';
+    close $out;
+    waitpid($pid, 0);
     return $output;
 }
 

--- a/src/test/resources/unit/file_temp_warnif_regression.t
+++ b/src/test/resources/unit/file_temp_warnif_regression.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+use Test::More tests => 5;
+use File::Path qw(rmtree);
+use File::Temp qw(tempdir);
+
+{
+    my $dir = tempdir(CLEANUP => 0);
+    File::Temp::cleanup();
+
+    ok(-d $dir, 'tempdir(CLEANUP => 0) is not registered for cleanup');
+    ok(rmtree($dir), 'preserved temp directory manually cleaned up');
+}
+
+{
+    package WarnifRegression;
+    require Exporter;
+    our @ISA = qw(Exporter);
+    our @EXPORT = qw(warnif_probe);
+
+    use warnings;
+
+    sub warnif_probe {
+        warnings::warnif(void => 'warnif probe');
+    }
+}
+
+WarnifRegression->import;
+
+{
+    no warnings;
+    use warnings 'void';
+
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+
+    warnif_probe();
+
+    is(scalar @warnings, 1, 'warnings::warnif sees call-site warning bits');
+    like($warnings[0], qr/\Qfile_temp_warnif_regression.t\E/, 'warnings::warnif reports call-site location');
+}
+
+{
+    no warnings 'void';
+
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+
+    warnif_probe();
+
+    is(scalar @warnings, 0, 'warnings::warnif honors disabled call-site category');
+}

--- a/src/test/resources/unit/makemaker_generated_pm_dependency.t
+++ b/src/test/resources/unit/makemaker_generated_pm_dependency.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+use Test::More;
+use Cwd qw(getcwd);
+use File::Temp qw(tempdir);
+
+my $orig_dir = getcwd();
+my $tmpdir = tempdir(CLEANUP => 1);
+
+END {
+    chdir $orig_dir if defined $orig_dir;
+}
+
+chdir $tmpdir or die "chdir $tmpdir: $!";
+
+open my $pl, '>', 'ReadKey.pm.PL'
+    or die "create generated pm template: $!";
+print {$pl} "open my \$out, '>', 'ReadKey.pm' or die \$!; print {\$out} qq{package Term::ReadKey; 1;\\n}; close \$out;\n";
+close $pl or die "close generated pm template: $!";
+
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME     => 'Term::ReadKey',
+    VERSION  => '0.001',
+    PL_FILES => { 'ReadKey.pm.PL' => 'ReadKey.pm' },
+    PM       => { 'ReadKey.pm'    => '$(INST_ARCHLIBDIR)/ReadKey.pm' },
+);
+
+open my $mf, '<', 'Makefile' or die "open generated Makefile: $!";
+my $makefile = do { local $/; <$mf> };
+close $mf or die "close generated Makefile: $!";
+
+like(
+    $makefile,
+    qr/^all:: pl_files pm_to_blib pure_all blib_scripts config$/m,
+    'all runs PL_FILES before pm_to_blib',
+);
+like(
+    $makefile,
+    qr/^pm_to_blib::$/m,
+    'missing PL_FILES-generated PM is not a hard pm_to_blib prerequisite',
+);
+like(
+    $makefile,
+    qr/^\t-(?:\S+\/)?jperl ReadKey\.pm\.PL ReadKey\.pm$/m,
+    'PL_FILES command is still emitted',
+);
+
+done_testing();

--- a/src/test/resources/unit/regex/regex_subst_utf8_flag.t
+++ b/src/test/resources/unit/regex/regex_subst_utf8_flag.t
@@ -1,0 +1,21 @@
+use strict;
+use Test::More;
+
+my $replacement = "Terca";
+substr($replacement, 3, 1) = chr(0xe7);
+utf8::upgrade($replacement);
+
+ok(utf8::is_utf8($replacement), 'test setup has a UTF-8 flagged Latin-1 replacement');
+
+my $fmt = "%A";
+$fmt =~ s/%A/$replacement/e;
+is($fmt, $replacement, 's///e inserts the UTF-8 replacement text');
+ok(utf8::is_utf8($fmt), 's///e upgrades a byte target when replacement is UTF-8 flagged');
+
+my $source = "%A";
+my $result = $source =~ s/%A/$replacement/er;
+is($result, $replacement, 's///er inserts the UTF-8 replacement text');
+ok(utf8::is_utf8($result), 's///er returns a UTF-8 flagged result');
+ok(!utf8::is_utf8($source), 's///er leaves the original byte target unchanged');
+
+done_testing();


### PR DESCRIPTION
## Summary
- stop Java File::Temp from registering every temp path for cleanup regardless of Perl CLEANUP/UNLINK options
- refresh runtime warnings scope after warnings pragmas so re-enabled categories work after no warnings
- make warnings::warnif report built-in warnings at the caller call site
- add regression coverage for File::Temp cleanup and warnings::warnif call-site behavior

## Testing
- `timeout 1200 make > /tmp/make_module_build_prereqs_fromcpanfile_rebased.log 2>&1`
- `timeout 900 ./jcpan -t Module::Build::Prereqs::FromCPANfile > /tmp/jcpan_module_build_prereqs_fromcpanfile_rebased.log 2>&1`
