### PR TITLE
Fix IPC::System::Options CPAN test support

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
@@ -1110,7 +1110,7 @@ public abstract class StringSegmentParser {
         if (token.type == LexerTokenType.OPERATOR) {
             // Only specific operators can follow @ for valid array variables
             return switch (token.text) {
-                case "{", "$", "+", "-", "_", "^" -> true;
+                case "{", "$", "+", "-", "_" -> true;
                 default -> false;
             };
         }

--- a/src/main/perl/lib/CPAN/Config.pm
+++ b/src/main/perl/lib/CPAN/Config.pm
@@ -43,6 +43,7 @@ sub _bootstrap_prefs {
         'Module-Build.yml'           => 'PerlOnJava/CpanDistroprefs/Module-Build.yml',
         'Class-Method-Modifiers.yml' => 'PerlOnJava/CpanDistroprefs/Class-Method-Modifiers.yml',
         'Sub-Quote.yml'              => 'PerlOnJava/CpanDistroprefs/Sub-Quote.yml',
+        'IPC-Run.yml'                => 'PerlOnJava/CpanDistroprefs/IPC-Run.yml',
         'IPC-Run3.yml'               => 'PerlOnJava/CpanDistroprefs/IPC-Run3.yml',
         'Exception-Class.yml'        => 'PerlOnJava/CpanDistroprefs/Exception-Class.yml',
         'Module-Pluggable.yml'       => 'PerlOnJava/CpanDistroprefs/Module-Pluggable.yml',
@@ -58,6 +59,7 @@ sub _bootstrap_prefs {
         'Test-File.yml'              => 'PerlOnJava/CpanDistroprefs/Test-File.yml',
         'Data-Dmp.yml'               => 'PerlOnJava/CpanDistroprefs/Data-Dmp.yml',
         'Capture-Tiny.yml'           => 'PerlOnJava/CpanDistroprefs/Capture-Tiny.yml',
+        'String-ShellQuote.yml'      => 'PerlOnJava/CpanDistroprefs/String-ShellQuote.yml',
         'Test-Differences.yml'       => 'PerlOnJava/CpanDistroprefs/Test-Differences.yml',
         'Type-Tiny.yml'              => 'PerlOnJava/CpanDistroprefs/Type-Tiny.yml',
     );
@@ -158,6 +160,8 @@ sub _bootstrap_patches {
           'PerlOnJava/CpanPatches/Data-Dmp-0.242/PerlOnJava.patch' ],
         [ 'Capture-Tiny-0.50/NoForkTeeCatchErrors.patch',
           'PerlOnJava/CpanPatches/Capture-Tiny-0.50/NoForkTeeCatchErrors.patch' ],
+        [ 'String-ShellQuote-1.04/SkipForkScriptTests.patch',
+          'PerlOnJava/CpanPatches/String-ShellQuote-1.04/SkipForkScriptTests.patch' ],
         [ 'Type-Tiny-2.010001/SkipRegexCallbackTests.patch',
           'PerlOnJava/CpanPatches/Type-Tiny-2.010001/SkipRegexCallbackTests.patch' ],
     );

--- a/src/main/perl/lib/ExtUtils/MakeMaker.pm
+++ b/src/main/perl/lib/ExtUtils/MakeMaker.pm
@@ -582,7 +582,7 @@ sub _create_install_makefile {
     };
     
     # Get the Perl interpreter path
-    my $perl = $^X;
+    my $perl = _current_perl_path();
     
     # Build test command - use TESTS from WriteMakefile args if provided, else default to t/*.t
     # Set PERL5LIB to include blib/lib and blib/arch so test subprocesses can find the module
@@ -697,6 +697,7 @@ sub _create_install_makefile {
                 push @script_cmds, _shell_mkdir($dir);
             }
             push @script_cmds, _shell_cp($src, $dest);
+            push @script_cmds, _shell_fixin($dest);
         }
     }
 
@@ -713,6 +714,7 @@ sub _create_install_makefile {
                 push @blib_script_cmds, _shell_mkdir($blib_dir);
             }
             push @blib_script_cmds, _shell_cp($src, $blib_dest);
+            push @blib_script_cmds, _shell_fixin($blib_dest);
         }
     }
 
@@ -913,6 +915,24 @@ sub _shell_mkdir {
     return "\t\@mkdir -p '$dir'";
 }
 
+sub _current_perl_path {
+    my $perl = $ENV{PERLONJAVA_EXECUTABLE} || $Config{perlpath} || $^X;
+    return $perl if File::Spec->file_name_is_absolute($perl);
+
+    for my $base ($ENV{PWD}, getcwd()) {
+        next unless defined $base && length $base;
+        my $candidate = File::Spec->catfile($base, $perl);
+        return abs_path($candidate) || $candidate if -x $candidate;
+    }
+
+    for my $dir (File::Spec->path()) {
+        my $candidate = File::Spec->catfile($dir, $perl);
+        return abs_path($candidate) || $candidate if -x $candidate;
+    }
+
+    return $perl;
+}
+
 # Helper: generate a shell cp command for Makefile.
 # Tolerant of missing source files: some distributions generate .pm files
 # from .pm.PL scripts that require XS bootstrap (e.g. Term::ReadKey) and
@@ -930,6 +950,21 @@ sub _shell_cp {
         $autosplit = " && if grep -q '^__END__\$\$' '$dest'; then \$(PERL) -MAutoSplit -e 'autosplit(\$\$ARGV[0], \$\$ARGV[1], 0, 1, 1)' '$dest' '$autosplit_dir'; fi";
     }
     return "\t\@if [ -f '$src' ]; then rm -f '$dest' && cp '$src' '$dest'$autosplit; else echo 'PerlOnJava: skipping missing source: $src'; fi";
+}
+
+# Helper: rewrite staged script shebangs such as "#!perl -w" to a shell wrapper
+# that execs the current jperl against a hidden copy of the original script.
+# Some CPAN tests execute blib/script/* directly; a plain "#!/path/to/jperl"
+# shebang is not portable because jperl itself is a launcher script.
+sub _shell_fixin {
+    my ($file) = @_;
+    return "\t\@true" if $^O eq 'MSWin32';
+    my $payload_name = "." . basename($file) . ".perlonjava";
+    my $payload = File::Spec->catfile(dirname($file), $payload_name);
+    for ($file, $payload, $payload_name) {
+        s/'/'\\''/g;
+    }
+    return "\t\@\$(PERL) -e 'my (\$\$f,\$\$payload,\$\$payload_name,\$\$perl)=\@ARGV; open my \$\$in,q{<},\$\$f or exit 0; my \@lines=<\$\$in>; close \$\$in; exit 0 unless \@lines && \$\$lines[0] =~ /^#!.*\\bperl(?:\\s+(.*))?\\r?\\n?\\z/; my \$\$args=defined \$\$1 ? q{ }.\$\$1 : q{}; open my \$\$payload_fh,q{>},\$\$payload or die \$\$!; print \$\$payload_fh \@lines; close \$\$payload_fh or die \$\$!; chmod 0644,\$\$payload; my \$\$d=chr 36; my \$\$at=chr 64; open my \$\$out,q{>},\$\$f or die \$\$!; print \$\$out qq{#!/bin/sh\\n}; print \$\$out q{dir=}.\$\$d.q{(dirname \"}.\$\$d.q{0\")}.qq{\\n}; print \$\$out q{exec \"}.\$\$perl.q{\"}.\$\$args.q{ \"}.\$\$d.q{dir/}.\$\$payload_name.q{\" \"}.\$\$d.\$\$at.q{\"}.qq{\\n}; close \$\$out or die \$\$!; chmod 0755,\$\$f;' '$file' '$payload' '$payload_name' '\$(PERL)'";
 }
 
 # Helper: generate postamble for File::ShareDir::Install

--- a/src/main/perl/lib/PerlOnJava/CpanDistroprefs/IPC-Run.yml
+++ b/src/main/perl/lib/PerlOnJava/CpanDistroprefs/IPC-Run.yml
@@ -1,0 +1,13 @@
+---
+comment: |
+  PerlOnJava distroprefs for IPC::Run.
+
+  IPC::Run installs as pure Perl, but its upstream test suite is centered on
+  fork, process control, PTYs, and child file descriptor behavior that
+  PerlOnJava does not implement.  Keep the test output visible for signal, but
+  allow CPAN to mark the test phase successful so modules that only need
+  IPC::Run as a prerequisite can install.
+match:
+  distribution: "^TODDR/IPC-Run-"
+test:
+  commandline: "PERLONJAVA_TEST_IGNORE_FAILURES"

--- a/src/main/perl/lib/PerlOnJava/CpanDistroprefs/String-ShellQuote.yml
+++ b/src/main/perl/lib/PerlOnJava/CpanDistroprefs/String-ShellQuote.yml
@@ -1,0 +1,12 @@
+---
+comment: |
+  PerlOnJava distroprefs for String::ShellQuote.
+
+  The module's pure quoting tests run under PerlOnJava.  Its final script
+  tests use open '-|' and exec a blib script through fork-style control flow,
+  which PerlOnJava does not implement.  Patch only those script tests to skip
+  on PerlOnJava.
+match:
+  distribution: "^ROSCH/String-ShellQuote-1\\.04"
+patches:
+  - "String-ShellQuote-1.04/SkipForkScriptTests.patch"

--- a/src/main/perl/lib/PerlOnJava/CpanPatches/String-ShellQuote-1.04/SkipForkScriptTests.patch
+++ b/src/main/perl/lib/PerlOnJava/CpanPatches/String-ShellQuote-1.04/SkipForkScriptTests.patch
@@ -1,0 +1,13 @@
+--- test.t.orig
++++ test.t
+@@ -103,8 +103,10 @@
+ }
+ 
+ if ($^O eq 'MSWin32') {
+     print "ok # skip not working on MSWin32\n" x 4;
++} elsif ($ENV{PERLONJAVA_EXECUTABLE} || $^X =~ /(?:^|[\/\\])jperl(?:\z|[.])/) {
++    print "ok # skip script tests require fork-compatible open\n" x 4;
+ } else {
+     $testsub = \&via_shell;
+     test '';
+     test qq{a\n},			'a';

--- a/src/test/resources/unit/makemaker_exe_files.t
+++ b/src/test/resources/unit/makemaker_exe_files.t
@@ -1,0 +1,73 @@
+use strict;
+use warnings;
+use Test::More;
+use Config;
+use Cwd qw(getcwd);
+use File::Path qw(make_path);
+use File::Spec;
+use File::Temp qw(tempdir);
+
+if ($^O eq 'MSWin32') {
+    pass('EXE_FILES shell-wrapper execution is Unix-only');
+}
+else {
+    my $orig_dir = getcwd();
+    my $tmpdir = tempdir(CLEANUP => 1);
+    my $expected_jperl = $^X;
+    if (!File::Spec->file_name_is_absolute($expected_jperl)) {
+        my $candidate = File::Spec->catfile($orig_dir, $expected_jperl);
+        $expected_jperl = $candidate if -x $candidate;
+    }
+
+    END {
+        chdir $orig_dir if defined $orig_dir;
+    }
+
+    chdir $tmpdir or die "chdir $tmpdir: $!";
+    make_path('script', 'lib/Foo') or die "make_path test dirs: $!";
+
+    open my $module, '>', 'lib/Foo/Script.pm'
+        or die "create lib/Foo/Script.pm: $!";
+    print {$module} "package Foo::Script;\nour \$VERSION = '0.001';\n1;\n";
+    close $module or die "close lib/Foo/Script.pm: $!";
+
+    open my $script, '>', 'script/demo'
+        or die "create script/demo: $!";
+    print {$script} "#!perl -w\nprint qq(ok\\n);\n";
+    close $script or die "close script/demo: $!";
+    chmod 0755, 'script/demo' or die "chmod script/demo: $!";
+
+    use ExtUtils::MakeMaker;
+
+    WriteMakefile(
+        NAME      => 'Foo::Script',
+        VERSION   => '0.001',
+        EXE_FILES => ['script/demo'],
+    );
+
+    my $make = $Config::Config{make} || 'make';
+    my $status = system($make, 'blib_scripts');
+    is($status, 0, 'blib_scripts target succeeds');
+
+    open my $staged, '<', 'blib/script/demo'
+        or die "open staged script: $!";
+    my $first_line = <$staged>;
+    my $second_line = <$staged>;
+    my $third_line = <$staged>;
+    close $staged or die "close staged script: $!";
+    chomp $first_line;
+    chomp $second_line;
+    chomp $third_line;
+
+    is($first_line, '#!/bin/sh', 'EXE_FILES shebang is rewritten to a shell wrapper');
+    is($second_line, 'dir=$(dirname "$0")', 'shell wrapper locates its script directory');
+    is($third_line, qq{exec "$expected_jperl" -w "\$dir/.demo.perlonjava" "\$@"}, 'shell wrapper execs jperl payload');
+
+    ok(-f 'blib/script/.demo.perlonjava', 'original Perl script is staged as hidden payload');
+
+    my $output = qx{blib/script/demo};
+    is($?, 0, 'rewritten staged script executes');
+    is($output, "ok\n", 'rewritten staged script produces expected output');
+}
+
+done_testing();

--- a/src/test/resources/unit/string_interpolation_at_caret.t
+++ b/src/test/resources/unit/string_interpolation_at_caret.t
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+use Test::More;
+
+is("@^", '@^', 'bare @^ remains literal in double-quoted strings');
+is("@^foo", '@^foo', 'bare @^name remains literal in double-quoted strings');
+
+my @array = qw(one two);
+is("@array", 'one two', 'ordinary arrays still interpolate');
+
+my $safe_char = qr|[^\w!%+,\-./:=@^]|;
+ok('x' !~ $safe_char, 'regex char class containing @^ parses under strict');
+ok('*' =~ $safe_char, 'regex char class containing @^ still matches unsafe chars');
+
+done_testing();


### PR DESCRIPTION
## Summary

- Fix `@^` interpolation so `String::ShellQuote` parses its shell-safe character class under `strict`
- Stage MakeMaker `EXE_FILES` through a shell wrapper that launches the current `jperl`
- Add PerlOnJava CPAN distroprefs for `IPC::Run` and `String::ShellQuote`, including a focused `String::ShellQuote` fork-test skip patch

## Tests

- `make`
- `./jcpan -t String::ShellQuote`
- `./jcpan -t IPC::System::Options`
