### PR TITLE
Fix Test::File::Contents caller line regression

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
@@ -3,6 +3,7 @@ package org.perlonjava.backend.bytecode;
 import org.perlonjava.frontend.analysis.ConstantFoldingVisitor;
 import org.perlonjava.frontend.astnode.*;
 import org.perlonjava.runtime.runtimetypes.NameNormalizer;
+import org.perlonjava.runtime.runtimetypes.RuntimeCode;
 import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
@@ -417,11 +418,11 @@ public class CompileBinaryOperator {
             // Check if this is a &func (no parens) call that should share caller's @_
             boolean shareCallerArgs = node.getBooleanAnnotation("shareCallerArgs");
 
-            // Emit CALL_SUB or CALL_SUB_SHARE_ARGS opcode
-            // Pass node.left.getIndex() so pcToTokenIndex maps the call to the function
-            // name / reference token index (call-site line) rather than the closing ')'.
-            int callSiteToken = (node.left != null && node.left.getIndex() > 0)
-                    ? node.left.getIndex() : node.getIndex();
+            // Emit CALL_SUB or CALL_SUB_SHARE_ARGS opcode. Ordinary named calls
+            // report the closing line, but non-& prototyped calls report the
+            // expression start; keep the interpreter mapping aligned with the
+            // JVM emitter.
+            int callSiteToken = callerLineCallSiteToken(node);
             int rd = CompileBinaryOperatorHelper.compileBinaryOperatorSwitch(
                     bytecodeCompiler, node.operator, rs1, rs2, callSiteToken,
                     shareCallerArgs);
@@ -777,6 +778,51 @@ public class CompileBinaryOperator {
         bytecodeCompiler.emitReg(listReg);
 
         bytecodeCompiler.lastResultReg = rd;
+    }
+
+    private static int callerLineCallSiteToken(BinaryOperatorNode node) {
+        if (usesExpressionStartLine(node)) {
+            return expressionStartIndex(node);
+        }
+
+        if (node.right != null && node.right.getIndex() > 0) {
+            return node.right.getIndex();
+        }
+        return expressionStartIndex(node);
+    }
+
+    private static int expressionStartIndex(BinaryOperatorNode node) {
+        if (node.getIndex() > 0) {
+            return node.getIndex();
+        }
+        return node.left != null ? node.left.getIndex() : -1;
+    }
+
+    private static boolean usesExpressionStartLine(BinaryOperatorNode node) {
+        String prototype = directCallPrototype(node);
+        if (prototype == null) {
+            return false;
+        }
+
+        for (int i = 0; i < prototype.length(); i++) {
+            char c = prototype.charAt(i);
+            if (Character.isWhitespace(c) || c == ';' || c == ',') {
+                continue;
+            }
+            return c != '&';
+        }
+
+        return true;
+    }
+
+    private static String directCallPrototype(BinaryOperatorNode node) {
+        if (!(node.left instanceof OperatorNode operatorNode)
+                || !operatorNode.operator.equals("&")
+                || !(operatorNode.getAnnotation("parseTimeCodeRef") instanceof RuntimeScalar codeRef)
+                || !(codeRef.value instanceof RuntimeCode code)) {
+            return null;
+        }
+        return code.prototype;
     }
 
     static boolean isArrayLikeNode(Node node) {

--- a/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
@@ -769,13 +769,10 @@ public class EmitSubroutine {
                 "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;Ljava/lang/String;)V",
                 false);
 
-        // Set debug line number to the call site. Perl reports the line where a
-        // multi-line call expression completes for caller(), not the line
-        // containing the function name. The argument ListNode is indexed at the
-        // closing token.
-        int callSiteIndex = node.right != null && node.right.getIndex() > 0
-                ? node.right.getIndex()
-                : (node.getIndex() > 0 ? node.getIndex() : (node.left != null ? node.left.getIndex() : -1));
+        // Set debug line number to the call site. Ordinary direct calls report
+        // the completed call expression's closing line, but prototyped calls
+        // whose first prototype slot is not `&` report the expression start.
+        int callSiteIndex = callerLineCallSiteIndex(node);
         if (callSiteIndex > 0) {
             ByteCodeSourceMapper.setDebugInfoLineNumber(emitterVisitor.ctx, callSiteIndex);
         }
@@ -897,6 +894,51 @@ public class EmitSubroutine {
         } else if (emitterVisitor.ctx.contextType == RuntimeContextType.VOID) {
             mv.visitInsn(Opcodes.POP);
         }
+    }
+
+    private static int callerLineCallSiteIndex(BinaryOperatorNode node) {
+        if (usesExpressionStartLine(node)) {
+            return expressionStartIndex(node);
+        }
+
+        if (node.right != null && node.right.getIndex() > 0) {
+            return node.right.getIndex();
+        }
+        return expressionStartIndex(node);
+    }
+
+    private static int expressionStartIndex(BinaryOperatorNode node) {
+        if (node.getIndex() > 0) {
+            return node.getIndex();
+        }
+        return node.left != null ? node.left.getIndex() : -1;
+    }
+
+    private static boolean usesExpressionStartLine(BinaryOperatorNode node) {
+        String prototype = directCallPrototype(node);
+        if (prototype == null) {
+            return false;
+        }
+
+        for (int i = 0; i < prototype.length(); i++) {
+            char c = prototype.charAt(i);
+            if (Character.isWhitespace(c) || c == ';' || c == ',') {
+                continue;
+            }
+            return c != '&';
+        }
+
+        return true;
+    }
+
+    private static String directCallPrototype(BinaryOperatorNode node) {
+        if (!(node.left instanceof OperatorNode operatorNode)
+                || !operatorNode.operator.equals("&")
+                || !(operatorNode.getAnnotation("parseTimeCodeRef") instanceof RuntimeScalar codeRef)
+                || !(codeRef.value instanceof RuntimeCode code)) {
+            return null;
+        }
+        return code.prototype;
     }
 
     /**

--- a/src/test/resources/unit/prototyped_call_caller_line.t
+++ b/src/test/resources/unit/prototyped_call_caller_line.t
@@ -1,0 +1,36 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+sub prototyped_call_site($$;$$) {
+    return (caller(0))[2];
+}
+
+my $expected_proto = __LINE__ + 1;
+my $got_proto = prototyped_call_site("a", "b", "c", {
+    k => 1,
+});
+is($got_proto, $expected_proto,
+   'caller line for multiline non-& prototyped call reports expression start');
+
+sub empty_prototype_call_site() {
+    return (caller(0))[2];
+}
+
+my $expected_empty = __LINE__ + 1;
+my $got_empty = empty_prototype_call_site(
+);
+is($got_empty, $expected_empty,
+   'caller line for multiline empty-prototype call reports expression start');
+
+sub unprototyped_call_site {
+    return (caller(0))[2];
+}
+
+my $expected_unprototyped = __LINE__ + 3;
+my $got_unprototyped = unprototyped_call_site(
+    sub { 1 }
+);
+is($got_unprototyped, $expected_unprototyped,
+   'caller line for multiline unprototyped named call remains closing line');


### PR DESCRIPTION
## Summary

- Fix caller() line reporting for multiline direct calls to non-& prototyped subs.
- Keep ordinary unprototyped multiline named calls reporting the closing call line.
- Add regression coverage for prototyped and unprototyped caller-line behavior.

## Verification

- `make`
- `timeout 60 ./jperl src/test/resources/unit/prototyped_call_caller_line.t`
- `timeout 600 ./jcpan -t Test::File::Contents`
