### PR TITLE
Fix Gradle unit tests using stale jperl jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -343,6 +343,17 @@ shadowJar {
     }
 }
 
+// Some Perl unit tests spawn a child interpreter via $^X. Under Gradle those
+// children go through the repository launcher, so the target jar must be built
+// before tests run; otherwise a stale target/perlonjava-*.jar can be executed.
+tasks.withType(Test).configureEach { t ->
+    t.dependsOn shadowJar
+
+    def jperlLauncher = org.gradle.internal.os.OperatingSystem.current().isWindows()
+            ? "jperl.bat" : "jperl"
+    t.environment 'PERLONJAVA_EXECUTABLE', file(jperlLauncher).absolutePath
+}
+
 // Task to generate Perl SBOM
 tasks.register('generatePerlSbom', Exec) {
     description = 'Generate SBOM for bundled Perl modules'


### PR DESCRIPTION
## Summary
- Build the shadow jar before Gradle test tasks run.
- Set `PERLONJAVA_EXECUTABLE` for all Gradle `Test` tasks so tests that spawn `$^X` use the repo launcher consistently.

## Why
`unit/cli_warning_overrides.t` launches a nested `jperl`. During `make`, unit shards could run before `shadowJar`, so the child process could execute a stale `target/perlonjava-5.42.0.jar` while the parent JUnit test used freshly compiled classes.

## Verification
- `JPERL_TEST_FILTER=unit/cli_warning_overrides.t timeout 600 make test-unit`
- `timeout 1200 make`
