### PR TITLE
Fix Sub::Identify CPAN tests

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -1026,6 +1026,17 @@ public class SubroutineParser {
         return handleNamedSubWithFilter(parser, subName, prototype, attributes, block, false, declaration);
     }
 
+    private static boolean isConstantCvBody(String prototype, BlockNode block) {
+        if (prototype == null || !prototype.isEmpty() || block == null || block.elements.size() != 1) {
+            return false;
+        }
+        Node node = block.elements.get(0);
+        while (node instanceof ListNode list && list.handle == null && list.elements.size() == 1) {
+            node = list.elements.get(0);
+        }
+        return node instanceof NumberNode || node instanceof StringNode;
+    }
+
     public static ListNode handleNamedSubWithFilter(Parser parser, String subName, String prototype, List<String> attributes, BlockNode block, boolean filterLexicalMethods, String declaration) {
         // `sub BEGIN { ... }` / `sub END { ... }` / etc.: phaser-named subs
         // are treated like the corresponding `BEGIN { ... }` block — the body
@@ -1233,6 +1244,13 @@ public class SubroutineParser {
         // from fullName so caller()/set_subname see a consistent pair.
         int lastSep = fullName.lastIndexOf("::");
         placeholder.subName = lastSep >= 0 ? fullName.substring(lastSep + 2) : subName;
+        // For `sub X::foo { }` in package main, packageName should be "X",
+        // not "main". Set this before MODIFY_CODE_ATTRIBUTES so attribute
+        // callbacks that introspect the half-compiled CV see the real CvSTASH.
+        placeholder.packageName = lastSep >= 0
+                ? fullName.substring(0, lastSep)
+                : parser.ctx.symbolTable.getCurrentPackage();
+        placeholder.isConstantCv = isConstantCvBody(prototype, block);
 
         // Call MODIFY_CODE_ATTRIBUTES if attributes are present
         // In Perl, this is called at compile time after the sub is defined.
@@ -1245,12 +1263,6 @@ public class SubroutineParser {
                     : packageToUse;
             callModifyCodeAttributes(attrPackage, codeRef, attributes, parser, block.tokenIndex);
         }
-
-        // Set packageName from the sub's fully-qualified name (CvSTASH equivalent).
-        // For `sub X::foo { }` in package main, packageName should be "X", not "main".
-        placeholder.packageName = lastSep >= 0
-                ? fullName.substring(0, lastSep)
-                : parser.ctx.symbolTable.getCurrentPackage();
 
         // B::CV->START line must be available before lazy compilation instantiates
         // the JVM/interpreted body — e.g. Fennec::Lite calls B::svref_2object($cr)

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Internals.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Internals.java
@@ -60,6 +60,7 @@ public class Internals extends PerlModuleBase {
             // such as Pod::Coverage can skip imported helpers.
             internals.registerMethod("jperl_is_imported_sub", "jperl_is_imported_sub", "$");
             internals.registerMethod("jperl_cv_start_location", "jperlCvStartLocation", "$");
+            internals.registerMethod("jperl_cv_is_constant", "jperlCvIsConstant", "$");
             internals.registerMethod("jperl_end_av_ref", "jperlEndAvRef", "");
         } catch (NoSuchMethodException e) {
             System.err.println("Warning: Missing Internals method: " + e.getMessage());
@@ -662,5 +663,21 @@ public class Internals extends PerlModuleBase {
             file = defFile;
         }
         return new RuntimeList(new RuntimeScalar(file), new RuntimeScalar(line));
+    }
+
+    /**
+     * Returns true when a CODE reference represents a compile-time constant CV.
+     * Used by the bundled {@code B} shim for {@code B::CV->CvFLAGS}.
+     */
+    public static RuntimeList jperlCvIsConstant(RuntimeArray args, int ctx) {
+        if (args.size() == 0) return new RuntimeScalar(0).getList();
+        RuntimeScalar s = args.get(0);
+        if (s == null) return new RuntimeScalar(0).getList();
+        s = s.scalar();
+        if (s.type != RuntimeScalarType.CODE || !(s.value instanceof RuntimeCode code)) {
+            return new RuntimeScalar(0).getList();
+        }
+        boolean isConst = code.constantValue != null || code.isConstantCv;
+        return new RuntimeScalar(isConst ? 1 : 0).getList();
     }
 }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/SubIdentify.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/SubIdentify.java
@@ -1,0 +1,106 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.backend.bytecode.InterpretedCode;
+import org.perlonjava.runtime.runtimetypes.GlobalVariable;
+import org.perlonjava.runtime.runtimetypes.NameNormalizer;
+import org.perlonjava.runtime.runtimetypes.RuntimeArray;
+import org.perlonjava.runtime.runtimetypes.RuntimeCode;
+import org.perlonjava.runtime.runtimetypes.RuntimeList;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalarType;
+
+/**
+ * Java-backed XS shim for Sub::Identify.
+ */
+public class SubIdentify extends PerlModuleBase {
+    public static final String XS_VERSION = "0.14";
+
+    public SubIdentify() {
+        super("Sub::Identify", false);
+    }
+
+    public static void initialize() {
+        SubIdentify module = new SubIdentify();
+        try {
+            module.registerMethod("get_code_info", "getCodeInfo", "$");
+            module.registerMethod("get_code_location", "getCodeLocation", "$");
+            module.registerMethod("is_sub_constant", "isSubConstant", "$");
+        } catch (NoSuchMethodException e) {
+            System.err.println("Warning: Missing Sub::Identify method: " + e.getMessage());
+        }
+    }
+
+    private static RuntimeCode codeArg(RuntimeArray args) {
+        if (args.size() == 0) return null;
+        RuntimeScalar scalar = args.get(0);
+        if (scalar == null) return null;
+        scalar = scalar.scalar();
+        if (scalar.type != RuntimeScalarType.CODE || !(scalar.value instanceof RuntimeCode code)) {
+            return null;
+        }
+        return code;
+    }
+
+    private static boolean visibleCodeSlotMatches(RuntimeCode code, String fullName) {
+        RuntimeScalar slot = GlobalVariable.globalCodeRefs.get(fullName);
+        return slot != null
+                && slot.type == RuntimeScalarType.CODE
+                && slot.value == code
+                && (code.defined() || code.isDeclared);
+    }
+
+    private static String[] codeInfo(RuntimeCode code) {
+        String pkg = code.packageName;
+        String name = code.subName;
+
+        if (code.explicitlyRenamed) {
+            if (pkg == null || pkg.isEmpty()) pkg = "main";
+            if (name == null) name = "";
+            return new String[] { pkg, name };
+        }
+
+        if (pkg == null || pkg.isEmpty()) pkg = "main";
+        if (name == null || name.isEmpty()) {
+            return new String[] { pkg, "__ANON__" };
+        }
+
+        String fullName = NameNormalizer.normalizeVariableName(name, pkg);
+        if (!visibleCodeSlotMatches(code, fullName)) {
+            return new String[] { pkg, "__ANON__" };
+        }
+
+        return new String[] { pkg, name };
+    }
+
+    public static RuntimeList getCodeInfo(RuntimeArray args, int ctx) {
+        RuntimeCode code = codeArg(args);
+        if (code == null) return new RuntimeList();
+
+        String[] info = codeInfo(code);
+        return new RuntimeList(new RuntimeScalar(info[0]), new RuntimeScalar(info[1]));
+    }
+
+    public static RuntimeList getCodeLocation(RuntimeArray args, int ctx) {
+        RuntimeCode code = codeArg(args);
+        if (code == null) return new RuntimeList();
+
+        String file = code.cvStartFile;
+        int line = code.cvStartLine;
+        if ((line <= 0 || file == null || file.isEmpty()) && code instanceof InterpretedCode interpreted) {
+            file = interpreted.sourceName;
+            line = interpreted.sourceLine;
+        }
+        if (line <= 0) return new RuntimeList();
+        if (file == null || file.isEmpty()) file = "-e";
+        return new RuntimeList(new RuntimeScalar(file), new RuntimeScalar(line));
+    }
+
+    public static RuntimeList isSubConstant(RuntimeArray args, int ctx) {
+        RuntimeCode code = codeArg(args);
+        if (code == null) return new RuntimeScalar(0).getList();
+
+        boolean hasEmptyPrototype = code.prototype != null && code.prototype.isEmpty();
+        boolean isConstant = hasEmptyPrototype && (code.constantValue != null || code.isConstantCv);
+        return new RuntimeScalar(isConstant ? 1 : 0).getList();
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -579,6 +579,12 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      */
     public String cvStartFile;
     public int cvStartLine;
+    /**
+     * True when the parser recognized this CV as a compile-time constant sub
+     * (for example {@code sub foo () { 1 }}). {@link #constantValue} covers
+     * constants installed through {@code use constant} and stash assignment.
+     */
+    public boolean isConstantCv;
 
     /**
      * When a coderef is installed with {@code *Package::name = $cr}, records the
@@ -832,6 +838,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         clone.stashInstallPackage = this.stashInstallPackage;
         clone.stashInstallSub = this.stashInstallSub;
         clone.installedViaAnonGlobAssign = this.installedViaAnonGlobAssign;
+        clone.cvStartFile = this.cvStartFile;
+        clone.cvStartLine = this.cvStartLine;
+        clone.isConstantCv = this.isConstantCv;
         clone.isStatic = this.isStatic;
         clone.isDeclared = this.isDeclared;
         clone.constantValue = this.constantValue;

--- a/src/main/perl/lib/B.pm
+++ b/src/main/perl/lib/B.pm
@@ -20,7 +20,7 @@ our $VERSION = '1.88';
 
 # Export functionality
 use Exporter 'import';
-our @EXPORT_OK = qw(svref_2object class perlstring CVf_ANON SVf_IOK SVf_NOK SVf_POK SVp_IOK SVp_NOK SVp_POK);
+our @EXPORT_OK = qw(svref_2object class perlstring CVf_ANON CVf_CONST SVf_IOK SVf_NOK SVf_POK SVp_IOK SVp_NOK SVp_POK);
 our %EXPORT_TAGS = (
     all => \@EXPORT_OK,
 );
@@ -40,10 +40,11 @@ use constant {
 
 # CV flags
 use constant {
-    CVf_ANON      => 0x0004,
-    CVf_UNIQUE    => 0x0008,
-    CVf_METHOD    => 0x0040,
-    CVf_ISXSUB    => 0x0080,
+    CVf_METHOD    => 0x0001,
+    CVf_CONST     => 0x0004,
+    CVf_ISXSUB    => 0x0008,
+    CVf_ANON      => 0x0080,
+    CVf_UNIQUE    => 0x0100,
 };
 
 # Stub classes for B objects
@@ -181,7 +182,19 @@ package B::CV {
                     # (or Sub::Util::set_subname) carry a private flag; in
                     # real Perl their CvGV points to a free-floating GV with
                     # the assigned name, and NAME should always reflect that.
-                    if ($renamed || defined &{"$fqn"}) {
+                    my $slot_matches = 0;
+                    if (!$renamed) {
+                        no strict 'refs';
+                        my $slot = *{$fqn}{CODE};
+                        if (defined $slot) {
+                            local $@;
+                            $slot_matches = eval {
+                                require Scalar::Util;
+                                Scalar::Util::refaddr($slot) == Scalar::Util::refaddr($self->{ref});
+                            } ? 1 : 0;
+                        }
+                    }
+                    if ($renamed || $slot_matches) {
                         $self->{_pkg_name} = $pkg;
                         $self->{_sub_name} = $name;
                         $self->{_is_anon}  = ($name eq '__ANON__') ? 1 : 0;
@@ -224,7 +237,7 @@ package B::CV {
         my $ref = $self->{ref};
         if ($ref && ref($ref) eq 'CODE') {
             local $@;
-            eval { require Internals; 1 } or return B::COP->new("-e", 0);
+            eval { require Internals; 1 } or return B::NULL->new();
             my @loc = Internals::jperl_cv_start_location($ref);
             if (@loc >= 2) {
                 my ($file, $line) = @loc;
@@ -235,7 +248,7 @@ package B::CV {
                 }
             }
         }
-        return B::COP->new("-e", 0);
+        return B::NULL->new();
     }
     
     sub ROOT {
@@ -256,7 +269,12 @@ package B::CV {
     sub CvFLAGS {
         my $self = shift;
         $self->_introspect;
-        return $self->{_is_anon} ? 0x0004 : 0;  # CVf_ANON for anonymous subs
+        my $flags = $self->{_is_anon} ? B::CVf_ANON() : 0;
+        local $@;
+        if (eval { require Internals; Internals::jperl_cv_is_constant($self->{ref}) }) {
+            $flags |= B::CVf_CONST();
+        }
+        return $flags;
     }
 
     sub XSUB {
@@ -401,15 +419,13 @@ package B::OP {
 }
 
 package B::NULL {
-    our @ISA = ('B::OP');
     sub new {
         my $class = shift;
         return bless {}, $class;
     }
 
     sub next {
-        # NULL is terminal -- return self to prevent infinite loops
-        return $_[0];
+        return undef;
     }
 }
 
@@ -495,8 +511,9 @@ sub end_av {
     return B::AV->new(Internals::jperl_end_av_ref());
 }
 
-# Export CVf_ANON as a function
-sub CVf_ANON() { return 0x0004; }
+# Export CV flags as functions
+sub CVf_CONST() { return 0x0004; }
+sub CVf_ANON() { return 0x0080; }
 
 # GV flag for "this CV was imported". Real Perl uses 0x80 in older perls and
 # 0x4000 in newer ones; Pod::Coverage falls back to 0x80 when this is missing.

--- a/src/test/resources/unit/b_cv_subidentify_metadata.t
+++ b/src/test/resources/unit/b_cv_subidentify_metadata.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More;
+use B ();
+use Test2::Util::Sub qw(sub_info);
+
+sub xander;
+my $decl = B::svref_2object(\&xander);
+is($decl->GV->STASH->NAME, 'main', 'forward declaration keeps stash');
+is($decl->GV->NAME, 'xander', 'forward declaration keeps GV name');
+ok(!$decl->START->isa('B::COP'), 'forward declaration has no start COP');
+
+sub deux ();
+sub quatre () { 4 }
+
+my $const = B::CVf_CONST();
+ok(!(B::svref_2object(\&deux)->CvFLAGS & $const), 'prototype-only declaration is not constant');
+is(B::svref_2object(\&quatre)->CvFLAGS & $const, $const, 'empty-prototype literal sub is constant');
+
+my $info = sub_info(\&quatre);
+is($info->{name}, 'quatre', 'B op walk terminates for Test2::Util::Sub');
+
+done_testing;


### PR DESCRIPTION
## Summary

- add a Java-backed Sub::Identify XS shim for get_code_info, get_code_location, and is_sub_constant
- tighten B.pm CV metadata for forward declarations, constant CV flags, no-body START handling, and optree traversal termination
- record named-sub package metadata before attribute callbacks and add focused B metadata regression coverage

## Tests

- `make`
- `./jcpan -t Sub::Identify`
