### PR TITLE
Fix IO::Compress CPAN tests

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -1230,12 +1230,13 @@ public class BytecodeCompiler implements Visitor {
         }
 
         // Exit scope restores register state.
-        // Flush mortal list for non-subroutine, non-do blocks so DESTROY fires
-        // promptly at scope exit. Subroutine body blocks and do-blocks must NOT
-        // flush — the implicit return value may still be in a register and
-        // flushing could destroy it before the caller captures it.
+        // Flush mortal list for void non-subroutine, non-do blocks so DESTROY fires
+        // promptly at scope exit. Value-producing blocks must NOT flush — their
+        // implicit result may still be in a register and flushing could destroy it
+        // before the parent expression or caller captures it.
         exitScope(!node.getBooleanAnnotation("blockIsSubroutine")
-                && !node.getBooleanAnnotation("blockIsDoBlock"));
+                && !node.getBooleanAnnotation("blockIsDoBlock")
+                && outerResultReg < 0);
 
         if (needsLocalRestore) {
             emit(Opcodes.POP_LOCAL_LEVEL);
@@ -1406,9 +1407,10 @@ public class BytecodeCompiler implements Visitor {
             opcode = Opcodes.LOAD_VSTRING;
         } else if (node.forceByteString) {
             opcode = Opcodes.LOAD_BYTE_STRING;
+        } else if (isAsciiOnly(node.value)) {
+            opcode = Opcodes.LOAD_BYTE_STRING;
         } else if (emitterContext != null && emitterContext.symbolTable != null
-                && !emitterContext.symbolTable.isStrictOptionEnabled(Strict.HINT_UTF8)
-                && !emitterContext.compilerOptions.isUnicodeSource) {
+                && !emitterContext.symbolTable.isStrictOptionEnabled(Strict.HINT_UTF8)) {
             // Under `no utf8` - use BYTE_STRING, unless it contains wide characters (> 255)
             // Wide characters (like \x{100}) force the string to be UTF-8 even without `use utf8`
             boolean hasWideChars = false;
@@ -1450,6 +1452,15 @@ public class BytecodeCompiler implements Visitor {
         emit(strIndex);
 
         lastResultReg = rd;
+    }
+
+    private static boolean isAsciiOnly(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) > 127) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override

--- a/src/main/java/org/perlonjava/backend/bytecode/InterpreterState.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InterpreterState.java
@@ -107,6 +107,31 @@ public class InterpreterState {
     }
 
     /**
+     * Push a virtual eval-frame for caller() while an interpreted eval block is
+     * active but has not created a separate Java/interpreter call frame.
+     *
+     * @return true if a frame was pushed and must be popped by the caller
+     */
+    public static boolean pushEvalFrameForCurrentInterpreter() {
+        InterpreterFrame current = current();
+        if (current == null || current.code() == null) {
+            return false;
+        }
+
+        String packageName = currentPackage.get().toString();
+        if (packageName == null || packageName.isEmpty()) {
+            packageName = current.packageName();
+        }
+
+        frameStack.get().push(new InterpreterFrame(current.code(), packageName, "(eval)", true));
+
+        ArrayList<int[]> pcs = pcStack.get();
+        int currentPc = pcs.isEmpty() ? 0 : pcs.getLast()[0];
+        pcs.add(new int[]{currentPc});
+        return true;
+    }
+
+    /**
      * Pop the current interpreter frame from the stack.
      * Called at exit from BytecodeInterpreter.execute() (in finally block).
      */
@@ -187,7 +212,13 @@ public class InterpreterState {
          * Represents a single interpreter call frame.
          * Contains minimal information needed for stack trace formatting.
          */
-        public record InterpreterFrame(InterpretedCode code, String packageName, String subroutineName) {
+        public record InterpreterFrame(InterpretedCode code,
+                                       String packageName,
+                                       String subroutineName,
+                                       boolean virtualEvalFrame) {
+            public InterpreterFrame(InterpretedCode code, String packageName, String subroutineName) {
+                this(code, packageName, subroutineName, false);
+            }
     }
 
 }

--- a/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
@@ -389,6 +389,7 @@ public class EmitBlock {
                                 "setCallSiteHintHashId",
                                 "(I)V", false);
                     }
+                    emitPostBlockStrictOptions(mv, an);
                 }
 
                 if (i < lastNonNullIndex) {
@@ -443,11 +444,12 @@ public class EmitBlock {
                     "org/perlonjava/runtime/runtimetypes/RegexState", "restore", "()V", false);
         }
 
-        // Flush mortal list for non-subroutine, non-do blocks. Subroutine body
-        // blocks and do-blocks must NOT flush here because the implicit return value
-        // may be on the JVM stack and flushing could destroy it before the caller
-        // captures it. Example: $self->{cursor} ||= do { my $x = ...; create_obj() }
-        // — the do-block's scope exit would flush pending decrements from create_obj's
+        // Flush mortal list for void non-subroutine blocks. Value-producing blocks
+        // must NOT flush here because the implicit return value may still be on the
+        // JVM stack or in the parent simple-block result register; flushing could
+        // destroy it before the caller captures it. Example:
+        //   $self->{cursor} ||= do { my $x = ...; create_obj() }
+        // The do-block's scope exit would flush pending decrements from create_obj's
         // scope exit, destroying the return value before ||= can store it.
         //
         // EXCEPTION: do-blocks whose last expression is a "fresh-result"
@@ -459,10 +461,27 @@ public class EmitBlock {
         boolean isSubBody = node.getBooleanAnnotation("blockIsSubroutine");
         boolean isDoBlock = node.getBooleanAnnotation("blockIsDoBlock");
         boolean doBlockFreshResult = isDoBlock && doBlockResultIsAlwaysFresh(node);
-        EmitStatement.emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex,
-                !isSubBody && (!isDoBlock || doBlockFreshResult));
+        Object blockResultRegObj = node.getAnnotation("resultRegister");
+        boolean hasBlockResultRegister = blockResultRegObj instanceof Integer && (Integer) blockResultRegObj >= 0;
+        boolean blockMayNeedResultAfterScopeExit = emitterVisitor.ctx.contextType != RuntimeContextType.VOID
+                || hasBlockResultRegister;
+        boolean flushAtScopeExit = !isSubBody
+                && (isDoBlock ? doBlockFreshResult : !blockMayNeedResultAfterScopeExit);
+        EmitStatement.emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex, flushAtScopeExit);
         emitterVisitor.ctx.symbolTable.exitScope(scopeIndex);
+        emitPostBlockStrictOptions(mv, node);
         if (CompilerOptions.DEBUG_ENABLED) emitterVisitor.ctx.logDebug("generateCodeBlock end");
+    }
+
+    private static void emitPostBlockStrictOptions(MethodVisitor mv, AbstractNode node) {
+        Object strictOptionsObj = node.getAnnotation("postBlockStrictOptions");
+        if (strictOptionsObj instanceof Integer strictOptions) {
+            mv.visitLdcInsn(strictOptions);
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                    "org/perlonjava/runtime/WarningBitsRegistry",
+                    "setCallSiteHints",
+                    "(I)V", false);
+        }
     }
 
 }

--- a/src/main/java/org/perlonjava/backend/jvm/EmitLiteral.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitLiteral.java
@@ -255,8 +255,15 @@ public class EmitLiteral {
             return;
         }
 
-        if (node.forceByteString
-                || (!ctx.symbolTable.isStrictOptionEnabled(HINT_UTF8) && !ctx.compilerOptions.isUnicodeSource)) {
+        boolean asciiOnly = true;
+        for (int i = 0; i < node.value.length(); i++) {
+            if (node.value.charAt(i) > 127) {
+                asciiOnly = false;
+                break;
+            }
+        }
+
+        if (node.forceByteString || asciiOnly || !ctx.symbolTable.isStrictOptionEnabled(HINT_UTF8)) {
             // Under `no utf8` - create an octet string, unless it contains wide characters (> 255)
             // Wide characters (like \x{100}) force the string to be UTF-8 even without `use utf8`
             boolean hasWideChars = false;

--- a/src/main/java/org/perlonjava/backend/jvm/EmitStatement.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitStatement.java
@@ -289,7 +289,8 @@ public class EmitStatement {
 
                 int scopeIndex = emitterVisitor.ctx.symbolTable.enterScope();
                 node.thenBranch.accept(emitterVisitor);
-                emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex, true);
+                emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex,
+                        emitterVisitor.ctx.contextType == RuntimeContextType.VOID);
                 emitterVisitor.ctx.symbolTable.exitScope(scopeIndex);
 
                 for (int i = 0; i < branchLabelsPushed; i++) {
@@ -304,7 +305,8 @@ public class EmitStatement {
 
                     int scopeIndex = emitterVisitor.ctx.symbolTable.enterScope();
                     node.elseBranch.accept(emitterVisitor);
-                    emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex, true);
+                    emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex,
+                            emitterVisitor.ctx.contextType == RuntimeContextType.VOID);
                     emitterVisitor.ctx.symbolTable.exitScope(scopeIndex);
 
                     for (int i = 0; i < branchLabelsPushed; i++) {
@@ -376,7 +378,8 @@ public class EmitStatement {
         emitterVisitor.ctx.mv.visitLabel(endLabel);
 
         // Exit the scope in the symbol table
-        emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex, true);
+        emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex,
+                emitterVisitor.ctx.contextType == RuntimeContextType.VOID);
         emitterVisitor.ctx.symbolTable.exitScope(scopeIndex);
 
         for (int i = 0; i < branchLabelsPushed; i++) {
@@ -574,7 +577,8 @@ public class EmitStatement {
 
             // Exit the scope in the symbol table
             if (node.useNewScope) {
-                emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex, true);
+                emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex,
+                        !(node.isSimpleBlock && needsReturnValue));
                 emitterVisitor.ctx.symbolTable.exitScope(scopeIndex);
             }
 

--- a/src/main/java/org/perlonjava/frontend/parser/NumberParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/NumberParser.java
@@ -234,6 +234,10 @@ public class NumberParser {
             String actualNumberPart = initialPart.substring(0, pIndex);
             exponentStr = initialPart.substring(pIndex + 1);
             numberStr.append(cleanUnderscores(actualNumberPart));
+            if (exponentStr.isEmpty()) {
+                exponentStr = parseRequiredExponentTail(parser,
+                        "Malformed hexadecimal floating-point exponent");
+            }
         } else {
             numberStr.append(cleanUnderscores(initialPart));
         }
@@ -242,6 +246,7 @@ public class NumberParser {
         if (exponentStr.isEmpty() && parser.tokenIndex < parser.tokens.size() &&
                 parser.tokens.get(parser.tokenIndex).text.equals(".")) {
 
+            int beforeFractionalPart = parser.tokenIndex;
             hasFractionalPart = true;
             TokenUtils.consume(parser); // consume '.'
 
@@ -269,6 +274,10 @@ public class NumberParser {
                         }
                         exponentStr = currentToken.substring(tokenPIndex + 1);
                         TokenUtils.consume(parser);
+                        if (exponentStr.isEmpty()) {
+                            exponentStr = parseRequiredExponentTail(parser,
+                                    "Malformed hexadecimal floating-point exponent");
+                        }
                         break;
                     } else if (format.digitValidator.test(currentToken.replaceAll("_", ""))) {
                         String digitStr = cleanUnderscores(TokenUtils.consume(parser).text);
@@ -278,12 +287,22 @@ public class NumberParser {
                     }
                 } else if (currentToken.equalsIgnoreCase("p")) {
                     TokenUtils.consume(parser);
+                    exponentStr = parseRequiredExponentTail(parser,
+                            "Malformed hexadecimal floating-point exponent");
                     break;
                 } else {
                     break;
                 }
             }
-            numberStr.append(".").append(fractionalPart);
+            if (format == HEX_FORMAT && exponentStr.isEmpty()) {
+                if (numberStr.isEmpty()) {
+                    parser.throwError("Invalid hexadecimal number");
+                }
+                parser.tokenIndex = beforeFractionalPart;
+                hasFractionalPart = false;
+            } else {
+                numberStr.append(".").append(fractionalPart);
+            }
         }
 
         // Parse exponent if not found yet
@@ -296,7 +315,7 @@ public class NumberParser {
             } else {
                 // Save token index for backtracking
                 int savedTokenIndex = parser.tokenIndex;
-                exponentStr = parseHexExponentTokens(parser);
+                exponentStr = checkHexExponent(parser);
                 if (exponentStr.isEmpty()) {
                     // No exponent found, backtrack
                     parser.tokenIndex = savedTokenIndex;
@@ -406,28 +425,6 @@ public class NumberParser {
         }
     }
 
-    private static String parseHexExponentTokens(Parser parser) {
-        if (parser.tokenIndex >= parser.tokens.size()) {
-            return "";
-        }
-
-        StringBuilder exponentStr = new StringBuilder();
-        String currentToken = parser.tokens.get(parser.tokenIndex).text;
-        if (currentToken.equals("-") || currentToken.equals("+")) {
-            exponentStr.append(TokenUtils.consume(parser).text);
-        }
-
-        if (parser.tokenIndex < parser.tokens.size() &&
-                parser.tokens.get(parser.tokenIndex).type == LexerTokenType.NUMBER) {
-            exponentStr.append(cleanUnderscores(TokenUtils.consume(parser).text));
-        } else {
-            // Not a valid exponent - return empty string
-            return "";
-        }
-
-        return exponentStr.toString();
-    }
-
     private static String checkHexExponent(Parser parser) {
         if (parser.tokenIndex >= parser.tokens.size()) {
             return "";
@@ -440,18 +437,8 @@ public class NumberParser {
             TokenUtils.consume(parser);
 
             if (exponentStr.isEmpty()) {
-                if (parser.tokenIndex < parser.tokens.size() &&
-                        (parser.tokens.get(parser.tokenIndex).text.equals("-") ||
-                                parser.tokens.get(parser.tokenIndex).text.equals("+"))) {
-                    exponentStr += TokenUtils.consume(parser).text;
-                }
-
-                if (parser.tokenIndex < parser.tokens.size() &&
-                        parser.tokens.get(parser.tokenIndex).type == LexerTokenType.NUMBER) {
-                    exponentStr += TokenUtils.consume(parser).text;
-                } else {
-                    parser.throwError("Malformed hexadecimal floating-point exponent");
-                }
+                exponentStr = parseRequiredExponentTail(parser,
+                        "Malformed hexadecimal floating-point exponent");
             }
             return cleanUnderscores(exponentStr);
         } else if (currentTokenText.toLowerCase().startsWith("p")) {
@@ -459,23 +446,31 @@ public class NumberParser {
             TokenUtils.consume(parser);
 
             if (exponentStr.isEmpty()) {
-                if (parser.tokenIndex < parser.tokens.size() &&
-                        (parser.tokens.get(parser.tokenIndex).text.equals("-") ||
-                                parser.tokens.get(parser.tokenIndex).text.equals("+"))) {
-                    exponentStr += TokenUtils.consume(parser).text;
-                }
-
-                if (parser.tokenIndex < parser.tokens.size() &&
-                        parser.tokens.get(parser.tokenIndex).type == LexerTokenType.NUMBER) {
-                    exponentStr += TokenUtils.consume(parser).text;
-                } else {
-                    parser.throwError("Malformed floating-point exponent");
-                }
+                exponentStr = parseRequiredExponentTail(parser,
+                        "Malformed floating-point exponent");
             }
             return cleanUnderscores(exponentStr);
         }
 
         return "";
+    }
+
+    private static String parseRequiredExponentTail(Parser parser, String errorMessage) {
+        StringBuilder exponentStr = new StringBuilder();
+        if (parser.tokenIndex < parser.tokens.size() &&
+                (parser.tokens.get(parser.tokenIndex).text.equals("-") ||
+                        parser.tokens.get(parser.tokenIndex).text.equals("+"))) {
+            exponentStr.append(TokenUtils.consume(parser).text);
+        }
+
+        if (parser.tokenIndex < parser.tokens.size() &&
+                parser.tokens.get(parser.tokenIndex).type == LexerTokenType.NUMBER) {
+            exponentStr.append(TokenUtils.consume(parser).text);
+        } else {
+            parser.throwError(errorMessage);
+        }
+
+        return cleanUnderscores(exponentStr.toString());
     }
 
     private static int checkBinaryExponent(Parser parser) {

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -868,12 +868,6 @@ public class OperatorParser {
                     blockNode.elements.size() == 1 &&
                     blockNode.elements.get(0) instanceof StringNode stringNode) {
 
-                // Check strict refs at parse time - but only for defined operator
-                // Standard Perl allows &{string} with strict refs for exists/delete
-                if (operator.equals("defined") && parser.ctx.symbolTable.isStrictOptionEnabled(Strict.HINT_STRICT_REFS)) {
-                    throw new PerlCompilerException("Can't use string (\"" + stringNode.value + "\") as a subroutine ref while \"strict refs\" in use");
-                }
-
                 // Don't transform &{string} patterns - handle them directly in emitter
                 // This preserves the semantic difference between &{string} and \&{string}
                 // For all operators (defined/exists/delete), keep &{string} as-is and handle in emitter

--- a/src/main/java/org/perlonjava/frontend/parser/ParseBlock.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseBlock.java
@@ -115,14 +115,20 @@ public class ParseBlock {
             statements.add(new ListNode(parser.tokenIndex));
         }
 
+        Integer postBlockStrictOptions = null;
+
         // Exit the current scope before returning (unless delayed)
         if (exitScope) {
             parser.ctx.symbolTable.exitScope(scopeIndex);
+            postBlockStrictOptions = parser.ctx.symbolTable.getStrictOptions();
         }
 
         // Create and return the block node with all parsed statements
         BlockNode blockNode = new BlockNode(statements, currentIndex, parser);
         blockNode.labels = blockLabels; // Set the collected labels in the BlockNode
+        if (postBlockStrictOptions != null) {
+            blockNode.setAnnotation("postBlockStrictOptions", postBlockStrictOptions);
+        }
         return new BlockWithScope(blockNode, scopeIndex);
     }
 

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -181,12 +181,18 @@ public class SubroutineParser {
         String prototype = null;
         List<String> attributes = null;
         RuntimeScalar parseTimeCodeRef = null;
+        String prototypeErrorName = fullName;
         if (!isNewMethod && !isMethod && GlobalVariable.existsGlobalCodeRef(fullName)) {
             RuntimeScalar codeRef = GlobalVariable.getGlobalCodeRef(fullName);
             parseTimeCodeRef = codeRef;
             if (codeRef.value instanceof RuntimeCode runtimeCode) {
                 prototype = runtimeCode.prototype;
                 attributes = runtimeCode.attributes;
+                if (runtimeCode.packageName != null && runtimeCode.subName != null
+                        && !runtimeCode.packageName.isEmpty() && !runtimeCode.subName.isEmpty()
+                        && !runtimeCode.subName.equals("__ANON__")) {
+                    prototypeErrorName = runtimeCode.packageName + "::" + runtimeCode.subName;
+                }
                 subExists = runtimeCode.subroutine != null
                         || runtimeCode.methodHandle != null
                         || runtimeCode.compilerSupplier != null
@@ -530,7 +536,7 @@ public class SubroutineParser {
 
         try {
             // Set the subroutine being called for error messages
-            parser.ctx.symbolTable.setCurrentSubroutine(fullName);
+            parser.ctx.symbolTable.setCurrentSubroutine(prototypeErrorName);
 
             // Handle the parameter list for the subroutine call
             ListNode arguments;

--- a/src/main/java/org/perlonjava/runtime/io/StandardIO.java
+++ b/src/main/java/org/perlonjava/runtime/io/StandardIO.java
@@ -119,6 +119,20 @@ public class StandardIO implements IOHandle {
     public RuntimeScalar doRead(int maxBytes, Charset charset) {
         try {
             if (inputStream != null) {
+                if (StandardCharsets.ISO_8859_1.equals(charset)) {
+                    byte[] buffer = new byte[maxBytes];
+                    int bytesRead = inputStream.read(buffer);
+
+                    if (bytesRead == -1) {
+                        isEOF = true;
+                        return new RuntimeScalar("");
+                    }
+
+                    byte[] result = new byte[bytesRead];
+                    System.arraycopy(buffer, 0, result, 0, bytesRead);
+                    return new RuntimeScalar(result);
+                }
+
                 if (decoderHelper == null) {
                     decoderHelper = new CharsetDecoderHelper();
                 }
@@ -192,13 +206,9 @@ public class StandardIO implements IOHandle {
                     return new RuntimeScalar("");
                 }
 
-                // Convert bytes to string representation
-                StringBuilder result = new StringBuilder(bytesRead);
-                for (int i = 0; i < bytesRead; i++) {
-                    result.append((char) (buffer[i] & 0xFF));
-                }
-
-                return new RuntimeScalar(result.toString());
+                byte[] result = new byte[bytesRead];
+                System.arraycopy(buffer, 0, result, 0, bytesRead);
+                return new RuntimeScalar(result);
             } catch (IOException e) {
                 getGlobalVariable("main::!").set(e.getMessage());
                 return new RuntimeScalar(); // undef

--- a/src/main/java/org/perlonjava/runtime/operators/CompareOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/CompareOperators.java
@@ -1,6 +1,10 @@
 package org.perlonjava.runtime.operators;
 
+import org.perlonjava.runtime.WarningBitsRegistry;
+import org.perlonjava.runtime.perlmodule.Strict;
 import org.perlonjava.runtime.runtimetypes.*;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.*;
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.blessedId;
@@ -10,6 +14,36 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.blessedId;
  * It includes both numeric and string comparison methods.
  */
 public class CompareOperators {
+    private static boolean bytesHintActive() {
+        return (WarningBitsRegistry.getCallSiteHints() & Strict.HINT_BYTES) != 0;
+    }
+
+    private static String bytesForStringCompare(RuntimeScalar scalar) {
+        String value = scalar.toString();
+        if (scalar.type == RuntimeScalarType.BYTE_STRING) {
+            return value;
+        }
+        if (isLatin1(value)) {
+            return value;
+        }
+        return new String(value.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
+    }
+
+    private static boolean isLatin1(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) > 0xFF) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean stringEquals(RuntimeScalar arg1, RuntimeScalar arg2) {
+        if (bytesHintActive()) {
+            return bytesForStringCompare(arg1).equals(bytesForStringCompare(arg2));
+        }
+        return arg1.toString().equals(arg2.toString());
+    }
 
     /**
      * Gets the location string for warning messages using caller().
@@ -461,7 +495,7 @@ public class CompareOperators {
             throwIfFallbackDenied(runtimeScalar, blessId, arg2, blessId2, "eq");
         }
 
-        return getScalarBoolean(runtimeScalar.toString().equals(arg2.toString()));
+        return getScalarBoolean(stringEquals(runtimeScalar, arg2));
     }
 
     /**
@@ -494,7 +528,7 @@ public class CompareOperators {
             throwIfFallbackDenied(runtimeScalar, blessId, arg2, blessId2, "ne");
         }
 
-        return getScalarBoolean(!runtimeScalar.toString().equals(arg2.toString()));
+        return getScalarBoolean(!stringEquals(runtimeScalar, arg2));
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -1081,6 +1081,9 @@ public class IOOperator {
                 }
                 return argv.eof();
             }
+            if (fileHandle.value instanceof RuntimeGlob) {
+                return scalarTrue;
+            }
             GlobalVariable.getGlobalVariable("main::!")
                     .set(new RuntimeScalar(9));
             return scalarUndef;
@@ -1109,6 +1112,9 @@ public class IOOperator {
                     return scalarTrue;
                 }
                 return argv.eof();
+            }
+            if (fileHandle.value instanceof RuntimeGlob) {
+                return scalarTrue;
             }
             GlobalVariable.getGlobalVariable("main::!")
                     .set(new RuntimeScalar(9));

--- a/src/main/java/org/perlonjava/runtime/operators/ScalarGlobOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ScalarGlobOperator.java
@@ -151,6 +151,8 @@ public class ScalarGlobOperator {
             if (results.isEmpty() && !ScalarGlobOperatorHelper.containsGlobChars(pattern)) {
                 results.add(pattern);
             }
+
+            Collections.sort(results);
         } catch (Exception e) {
             // Return empty results on error
         }
@@ -314,8 +316,6 @@ public class ScalarGlobOperator {
 
         List<String> results = ScalarGlobOperatorHelper.processPattern(this, pattern);
 
-        // Preserve match/discovery order (matches perl File::DosGlob read-dir semantics).
-        // Lexicographic sort broke DosGlob.t parity vs subroutine glob().
         this.iterator = results.iterator();
     }
 

--- a/src/main/java/org/perlonjava/runtime/operators/StringOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/StringOperators.java
@@ -4,6 +4,8 @@ import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.text.CaseMap;
 import org.perlonjava.frontend.parser.NumberParser;
+import org.perlonjava.runtime.WarningBitsRegistry;
+import org.perlonjava.runtime.perlmodule.Strict;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import java.nio.charset.StandardCharsets;
@@ -18,6 +20,9 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.BYTE_STRING;
  * A utility class that provides various string operations on {@link RuntimeScalar} objects.
  */
 public class StringOperators {
+    private static boolean bytesHintActive() {
+        return (WarningBitsRegistry.getCallSiteHints() & Strict.HINT_BYTES) != 0;
+    }
 
     /**
      * Returns the length of the string representation of the given {@link RuntimeScalar}.
@@ -432,6 +437,10 @@ public class StringOperators {
         String bStr = b.toString();
         String aStr = runtimeScalar.toString();
 
+        if (bytesHintActive()) {
+            return stringConcatBytes(aStr, bStr);
+        }
+
         // In Perl, concatenation produces a UTF-8 string only if at least one
         // operand has the UTF-8 flag on (STRING type). Non-STRING types
         // (BYTE_STRING, INTEGER, DOUBLE, UNDEF) are all byte-compatible.
@@ -485,6 +494,10 @@ public class StringOperators {
         // Get string values from resolved scalars
         String aStr = aResolved.toString();
         String bStr = bResolved.toString();
+
+        if (bytesHintActive()) {
+            return stringConcatBytes(aStr, bStr);
+        }
 
         if (aResolved.type == RuntimeScalarType.STRING || bResolved.type == RuntimeScalarType.STRING) {
             return new RuntimeScalar(aStr + bStr);
@@ -836,6 +849,10 @@ public class StringOperators {
         String aStr = runtimeScalar.toStringNoOverload();
         String bStr = b.toStringNoOverload();
 
+        if (bytesHintActive()) {
+            return stringConcatBytes(aStr, bStr);
+        }
+
         if (runtimeScalar.type == RuntimeScalarType.STRING || b.type == RuntimeScalarType.STRING) {
             return new RuntimeScalar(aStr + bStr);
         }
@@ -873,6 +890,31 @@ public class StringOperators {
         }
 
         return new RuntimeScalar(aStr + bStr);
+    }
+
+    private static RuntimeScalar stringConcatBytes(String a, String b) {
+        byte[] aBytes = stringBytesForBytesPragma(a);
+        byte[] bBytes = stringBytesForBytesPragma(b);
+        byte[] out = new byte[aBytes.length + bBytes.length];
+        System.arraycopy(aBytes, 0, out, 0, aBytes.length);
+        System.arraycopy(bBytes, 0, out, aBytes.length, bBytes.length);
+        return new RuntimeScalar(out);
+    }
+
+    private static byte[] stringBytesForBytesPragma(String value) {
+        if (isLatin1(value)) {
+            return value.getBytes(StandardCharsets.ISO_8859_1);
+        }
+        return value.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static boolean isLatin1(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) > 255) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/operators/TieOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/TieOperators.java
@@ -116,7 +116,8 @@ public class TieOperators {
                 RuntimeGlob glob = variable.globDeref();
                 RuntimeIO previousValue = (RuntimeIO) glob.IO.value;
                 glob.IO.type = TIED_SCALAR;
-                TieHandle tieHandle = new TieHandle(className, previousValue, self);
+                boolean selfIsTiedGlob = self != null && self.value == glob;
+                TieHandle tieHandle = new TieHandle(className, previousValue, self, !selfIsTiedGlob);
                 // Propagate the glob name so select() returns the correct name
                 // (e.g., "main::STDOUT") even when the handle is tied.
                 if (previousValue != null) {

--- a/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
+++ b/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
@@ -107,6 +107,7 @@ public class WarnDie {
             // by the eval catch block, but the handler should see $^S=1 since we are
             // conceptually still inside eval (Perl 5 calls the handler before unwinding).
             RuntimeCode.evalDepth++;
+            boolean pushedEvalFrame = InterpreterState.pushEvalFrameForCurrentInterpreter();
             try {
                 RuntimeCode.apply(sigHandler, args, RuntimeContextType.SCALAR);
             } catch (Throwable handlerException) {
@@ -124,6 +125,9 @@ public class WarnDie {
                     err.set(new RuntimeScalar(ErrorMessageUtil.stringifyException(handlerException)));
                 }
             } finally {
+                if (pushedEvalFrame) {
+                    InterpreterState.pop();
+                }
                 RuntimeCode.evalDepth--;
                 // Restore $SIG{__DIE__}
                 DynamicVariableManager.popToLocalLevel(level);
@@ -445,22 +449,29 @@ public class WarnDie {
             int level = DynamicVariableManager.getLocalLevel();
             DynamicVariableManager.pushLocalVariable(sig);
 
-            RuntimeList res = RuntimeCode.apply(sigHandler, message.getArrayOfAlias(), RuntimeContextType.SCALAR);
+            boolean pushedEvalFrame = RuntimeCode.evalDepth > 0
+                    && InterpreterState.pushEvalFrameForCurrentInterpreter();
+            try {
+                RuntimeList res = RuntimeCode.apply(sigHandler, message.getArrayOfAlias(), RuntimeContextType.SCALAR);
 
-            // Handle TAILCALL with trampoline loop (for goto &sub in __DIE__ handlers)
-            while (res.isNonLocalGoto()) {
-                RuntimeControlFlowList flow = (RuntimeControlFlowList) res;
-                if (flow.getControlFlowType() == ControlFlowType.TAILCALL) {
-                    RuntimeScalar codeRef = flow.getTailCallCodeRef();
-                    RuntimeArray callArgs = flow.getTailCallArgs();
-                    res = RuntimeCode.apply(codeRef, "tailcall", callArgs, RuntimeContextType.SCALAR);
-                } else {
-                    break;
+                // Handle TAILCALL with trampoline loop (for goto &sub in __DIE__ handlers)
+                while (res.isNonLocalGoto()) {
+                    RuntimeControlFlowList flow = (RuntimeControlFlowList) res;
+                    if (flow.getControlFlowType() == ControlFlowType.TAILCALL) {
+                        RuntimeScalar codeRef = flow.getTailCallCodeRef();
+                        RuntimeArray callArgs = flow.getTailCallArgs();
+                        res = RuntimeCode.apply(codeRef, "tailcall", callArgs, RuntimeContextType.SCALAR);
+                    } else {
+                        break;
+                    }
                 }
+            } finally {
+                if (pushedEvalFrame) {
+                    InterpreterState.pop();
+                }
+                // Restore $SIG{__DIE__}
+                DynamicVariableManager.popToLocalLevel(level);
             }
-
-            // Restore $SIG{__DIE__}
-            DynamicVariableManager.popToLocalLevel(level);
 
             throw new PerlDieException(errVariable);
         }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/CompressRawZlib.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/CompressRawZlib.java
@@ -32,9 +32,12 @@ public class CompressRawZlib extends PerlModuleBase {
     private static final int Z_VERSION_ERROR = -6;
 
     private static final int Z_NO_FLUSH = 0;
+    private static final int Z_PARTIAL_FLUSH = 1;
     private static final int Z_SYNC_FLUSH = 2;
     private static final int Z_FULL_FLUSH = 3;
     private static final int Z_FINISH = 4;
+    private static final int Z_BLOCK = 5;
+    private static final int Z_TREES = 6;
 
     private static final int Z_DEFAULT_COMPRESSION = -1;
 
@@ -126,6 +129,7 @@ public class CompressRawZlib extends PerlModuleBase {
             crz.registerMethod("adler32", "adler32Func", null);
             crz.registerMethod("_deflateInit", "deflateInit", null);
             crz.registerMethod("_inflateInit", "inflateInit", null);
+            crz.registerMethod("_inflateScanInit", "inflateScanInit", null);
             crz.registerMethod("zlib_version", "zlibVersion", null);
             crz.registerMethod("zlibCompileFlags", null);
             crz.registerMethod("is_zlib_native", "isZlibNative", null);
@@ -153,6 +157,15 @@ public class CompressRawZlib extends PerlModuleBase {
             "compressedBytes", "uncompressedBytes", "DESTROY"
         };
         registerStreamMethods("Compress::Raw::Zlib::inflateStream", inflateMethods, "is_");
+
+        String[] inflateScanMethods = {
+            "scan", "inflate", "inflateReset", "inflateSync", "_createDeflateStream",
+            "createDeflateStream", "getLastBlockOffset", "getEndOffset", "resetLastBlockByte",
+            "crc32", "adler32", "total_in", "total_out", "msg",
+            "dict_adler", "get_Bufsize",
+            "compressedBytes", "uncompressedBytes", "DESTROY"
+        };
+        registerStreamMethods("Compress::Raw::Zlib::inflateScanStream", inflateScanMethods, "iss_");
 
         // Set $Compress::Raw::Zlib::gzip_os_code
         GlobalVariable.getGlobalVariable("Compress::Raw::Zlib::gzip_os_code")
@@ -286,7 +299,7 @@ public class CompressRawZlib extends PerlModuleBase {
         // int memLevel = args.size() > 4 ? args.get(4).getInt() : MAX_MEM_LEVEL;
         int strategy  = args.size() > 5 ? args.get(5).getInt() : 0;
         int bufsize   = args.size() > 6 ? args.get(6).getInt() : 4096;
-        String dict   = args.size() > 7 ? args.get(7).toString() : "";
+        byte[] dictBytes = args.size() > 7 ? getInputBytes(args.get(7)) : new byte[0];
 
         try {
             boolean nowrap;
@@ -311,9 +324,10 @@ public class CompressRawZlib extends PerlModuleBase {
             if (strategy == 1) deflater.setStrategy(Deflater.FILTERED);
             else if (strategy == 2) deflater.setStrategy(Deflater.HUFFMAN_ONLY);
 
-            if (!dict.isEmpty()) {
-                byte[] dictBytes = dict.getBytes(StandardCharsets.ISO_8859_1);
+            long dictAdler = 0;
+            if (dictBytes.length > 0) {
                 deflater.setDictionary(dictBytes);
+                dictAdler = adler32WithSeed(dictBytes, 1L);
             }
 
             // Create the stream object
@@ -327,8 +341,8 @@ public class CompressRawZlib extends PerlModuleBase {
             self.put("_total_out", new RuntimeScalar(0));
             self.put("_crc32", new RuntimeScalar(0L));
             self.put("_adler32", new RuntimeScalar(1L));
-            self.put("_dict_adler", new RuntimeScalar(0));
-            self.put("_msg", new RuntimeScalar(""));
+            self.put("_dict_adler", new RuntimeScalar(dictAdler));
+            self.put("_msg", new RuntimeScalar());
 
             RuntimeScalar ref = self.createReference();
             ReferenceOperators.bless(ref, new RuntimeScalar("Compress::Raw::Zlib::deflateStream"));
@@ -366,7 +380,8 @@ public class CompressRawZlib extends PerlModuleBase {
         int flags   = args.size() > 0 ? args.get(0).getInt() : 0;
         int wbits   = args.size() > 1 ? args.get(1).getInt() : MAX_WBITS;
         int bufsize = args.size() > 2 ? args.get(2).getInt() : 4096;
-        String dict = args.size() > 3 ? args.get(3).toString() : "";
+        byte[] dictBytes = args.size() > 3 ? getInputBytes(args.get(3)) : new byte[0];
+        String dict = new String(dictBytes, StandardCharsets.ISO_8859_1);
 
         try {
             boolean nowrap;
@@ -382,11 +397,6 @@ public class CompressRawZlib extends PerlModuleBase {
 
             Inflater inflater = new Inflater(nowrap);
 
-            if (!dict.isEmpty()) {
-                byte[] dictBytes = dict.getBytes(StandardCharsets.ISO_8859_1);
-                inflater.setDictionary(dictBytes);
-            }
-
             RuntimeHash self = new RuntimeHash();
             self.put("_inflater", new RuntimeScalar(inflater));
             self.put("_flags", new RuntimeScalar(flags));
@@ -396,7 +406,11 @@ public class CompressRawZlib extends PerlModuleBase {
             self.put("_crc32", new RuntimeScalar(0L));
             self.put("_adler32", new RuntimeScalar(1L));
             self.put("_dict_adler", new RuntimeScalar(0));
-            self.put("_msg", new RuntimeScalar(""));
+            RuntimeScalar dictionaryScalar = new RuntimeScalar(dict);
+            dictionaryScalar.type = RuntimeScalarType.BYTE_STRING;
+            self.put("_dictionary", dictionaryScalar);
+            self.put("_dictionary_used", new RuntimeScalar(0));
+            self.put("_msg", new RuntimeScalar());
 
             RuntimeScalar ref = self.createReference();
             ReferenceOperators.bless(ref, new RuntimeScalar("Compress::Raw::Zlib::inflateStream"));
@@ -424,6 +438,26 @@ public class CompressRawZlib extends PerlModuleBase {
             result.add(new RuntimeScalar(Z_STREAM_ERROR));
             return result;
         }
+    }
+
+    public static RuntimeList inflateScanInit(RuntimeArray args, int ctx) {
+        RuntimeList result = inflateInit(args, ctx);
+        if (ctx == RuntimeContextType.SCALAR || result.isEmpty()) {
+            if (!result.isEmpty()) {
+                RuntimeScalar ref = result.elements.get(0).scalar();
+                if (ref.getDefinedBoolean()) {
+                    ReferenceOperators.bless(ref, new RuntimeScalar("Compress::Raw::Zlib::inflateScanStream"));
+                    initializeInflateScanState(ref.hashDeref());
+                }
+            }
+            return result;
+        }
+        RuntimeScalar ref = result.elements.get(0).scalar();
+        if (ref.getDefinedBoolean()) {
+            ReferenceOperators.bless(ref, new RuntimeScalar("Compress::Raw::Zlib::inflateScanStream"));
+            initializeInflateScanState(ref.hashDeref());
+        }
+        return result;
     }
 
     // =============================================
@@ -471,10 +505,11 @@ public class CompressRawZlib extends PerlModuleBase {
         long totalOut = self.get("_total_out").getLong() + baos.size();
         self.put("_total_in", new RuntimeScalar(totalIn));
         self.put("_total_out", new RuntimeScalar(totalOut));
+        self.put("_msg", new RuntimeScalar());
 
         // Write output
         if (outputRef != null) {
-            writeOutput(outputRef, baos, flags);
+            writeDeflateOutput(self, outputRef, baos, flags, false);
         }
 
         return new RuntimeScalar(Z_OK).getList();
@@ -490,6 +525,10 @@ public class CompressRawZlib extends PerlModuleBase {
 
         Deflater deflater = getDeflater(self);
         if (deflater == null) return new RuntimeScalar(Z_STREAM_ERROR).getList();
+        if (flushType < Z_NO_FLUSH || flushType > Z_TREES) {
+            self.put("_msg", new RuntimeScalar("stream error"));
+            return new RuntimeScalar(Z_STREAM_ERROR).getList();
+        }
 
         int flags = self.get("_flags").getInt();
 
@@ -522,13 +561,13 @@ public class CompressRawZlib extends PerlModuleBase {
 
         long totalOut = self.get("_total_out").getLong() + baos.size();
         self.put("_total_out", new RuntimeScalar(totalOut));
+        self.put("_msg", new RuntimeScalar());
 
         if (outputRef != null) {
-            writeOutput(outputRef, baos, flags);
+            writeDeflateOutput(self, outputRef, baos, flags, flushType == Z_FINISH);
         }
 
-        int status = deflater.finished() ? Z_STREAM_END : Z_OK;
-        return new RuntimeScalar(status).getList();
+        return new RuntimeScalar(Z_OK).getList();
     }
 
     public static RuntimeList ds_deflateReset(RuntimeArray args, int ctx) {
@@ -540,6 +579,7 @@ public class CompressRawZlib extends PerlModuleBase {
         self.put("_total_out", new RuntimeScalar(0));
         self.put("_crc32", new RuntimeScalar(0L));
         self.put("_adler32", new RuntimeScalar(1L));
+        self.put("_msg", new RuntimeScalar());
         return new RuntimeScalar(Z_OK).getList();
     }
 
@@ -548,20 +588,21 @@ public class CompressRawZlib extends PerlModuleBase {
         RuntimeHash self = args.get(0).hashDeref();
         Deflater deflater = getDeflater(self);
         if (deflater == null) return new RuntimeScalar(Z_STREAM_ERROR).getList();
+        int flags = args.size() > 1 ? args.get(1).getInt() : 0;
 
-        if (args.size() > 2) {
+        if ((flags & 1) != 0 && args.size() > 2) {
             int level = args.get(2).getInt();
             deflater.setLevel(level);
             self.put("_level", new RuntimeScalar(level));
         }
-        if (args.size() > 3) {
+        if ((flags & 2) != 0 && args.size() > 3) {
             int strategy = args.get(3).getInt();
             if (strategy == 1) deflater.setStrategy(Deflater.FILTERED);
             else if (strategy == 2) deflater.setStrategy(Deflater.HUFFMAN_ONLY);
             else deflater.setStrategy(Deflater.DEFAULT_STRATEGY);
             self.put("_strategy", new RuntimeScalar(strategy));
         }
-        if (args.size() > 4) {
+        if ((flags & 4) != 0 && args.size() > 4) {
             self.put("_bufsize", args.get(4));
         }
         return new RuntimeScalar(Z_OK).getList();
@@ -685,6 +726,9 @@ public class CompressRawZlib extends PerlModuleBase {
                         break;
                     }
                 } else if (inflater.needsDictionary()) {
+                    if (applyInflaterDictionary(self, inflater)) {
+                        continue;
+                    }
                     status = Z_NEED_DICT;
                     break;
                 } else {
@@ -694,6 +738,9 @@ public class CompressRawZlib extends PerlModuleBase {
 
             if (inflater.finished()) {
                 status = Z_STREAM_END;
+            }
+            if (status == Z_OK || status == Z_STREAM_END) {
+                self.put("_msg", new RuntimeScalar());
             }
         } catch (DataFormatException e) {
             self.put("_msg", new RuntimeScalar(e.getMessage() != null ? e.getMessage() : "data error"));
@@ -719,6 +766,13 @@ public class CompressRawZlib extends PerlModuleBase {
         if ((flags & FLAG_ADLER) != 0) {
             long adler = adler32WithSeed(outputBytes, self.get("_adler32").getLong() & 0xFFFFFFFFL);
             self.put("_adler32", new RuntimeScalar(adler));
+        }
+
+        if (isInflateScanStream(self)) {
+            appendScanInput(self, input, consumed);
+            if (status == Z_STREAM_END) {
+                updateInflateScanState(self);
+            }
         }
 
         // FLAG_CONSUME_INPUT: modify input to remove consumed bytes
@@ -759,11 +813,47 @@ public class CompressRawZlib extends PerlModuleBase {
         self.put("_total_out", new RuntimeScalar(0));
         self.put("_crc32", new RuntimeScalar(0L));
         self.put("_adler32", new RuntimeScalar(1L));
+        self.put("_dict_adler", new RuntimeScalar(0));
+        self.put("_dictionary_used", new RuntimeScalar(0));
+        self.put("_msg", new RuntimeScalar());
         return new RuntimeScalar(Z_OK).getList();
     }
 
     public static RuntimeList is_inflateSync(RuntimeArray args, int ctx) {
-        // Stub - not commonly used
+        RuntimeHash self = args.get(0).hashDeref();
+        Inflater inflater = getInflater(self);
+        if (inflater == null || args.size() < 2) {
+            return new RuntimeScalar(Z_STREAM_ERROR).getList();
+        }
+
+        RuntimeScalar inputScalar = args.get(1);
+        RuntimeScalar actualInput = inputScalar.type == RuntimeScalarType.REFERENCE
+            ? inputScalar.scalarDeref()
+            : inputScalar;
+
+        String previousTail = "";
+        RuntimeScalar tailScalar = self.get("_sync_tail");
+        if (tailScalar != null && tailScalar.getDefinedBoolean()) {
+            previousTail = tailScalar.toString();
+        }
+
+        String inputString = actualInput.toString();
+        byte[] combined = (previousTail + inputString).getBytes(StandardCharsets.ISO_8859_1);
+        int marker = findFullFlushMarker(combined);
+
+        if (marker < 0) {
+            int tailLength = Math.min(3, combined.length);
+            String tail = new String(combined, combined.length - tailLength, tailLength, StandardCharsets.ISO_8859_1);
+            self.put("_sync_tail", new RuntimeScalar(tail));
+            setScalarBytes(actualInput, "");
+            return new RuntimeScalar(Z_DATA_ERROR).getList();
+        }
+
+        int afterMarker = marker + 4;
+        String remaining = new String(combined, afterMarker, combined.length - afterMarker, StandardCharsets.ISO_8859_1);
+        self.put("_sync_tail", new RuntimeScalar(""));
+        self.put("_inflater", new RuntimeScalar(new Inflater(true)));
+        setScalarBytes(actualInput, remaining);
         return new RuntimeScalar(Z_OK).getList();
     }
 
@@ -819,6 +909,100 @@ public class CompressRawZlib extends PerlModuleBase {
         return new RuntimeList();
     }
 
+    public static RuntimeList iss_scan(RuntimeArray args, int ctx) {
+        return is_inflate(args, ctx);
+    }
+
+    public static RuntimeList iss_inflate(RuntimeArray args, int ctx) {
+        return is_inflate(args, ctx);
+    }
+
+    public static RuntimeList iss_inflateReset(RuntimeArray args, int ctx) {
+        return is_inflateReset(args, ctx);
+    }
+
+    public static RuntimeList iss_inflateSync(RuntimeArray args, int ctx) {
+        return is_inflateSync(args, ctx);
+    }
+
+    public static RuntimeList iss__createDeflateStream(RuntimeArray args, int ctx) {
+        return createDeflateStreamFromScan(args, sliceArgs(args, 1), ctx);
+    }
+
+    public static RuntimeList iss_createDeflateStream(RuntimeArray args, int ctx) {
+        return createDeflateStreamFromScan(args, deflateInitArgsFromScanCreate(args), ctx);
+    }
+
+    public static RuntimeList iss_getLastBlockOffset(RuntimeArray args, int ctx) {
+        RuntimeHash self = args.get(0).hashDeref();
+        RuntimeScalar offset = self.get("_scan_last_block_offset");
+        return new RuntimeScalar(offset != null ? offset.getLong() : 0).getList();
+    }
+
+    public static RuntimeList iss_getEndOffset(RuntimeArray args, int ctx) {
+        RuntimeHash self = args.get(0).hashDeref();
+        RuntimeScalar offset = self.get("_scan_end_offset");
+        if (offset != null) {
+            return offset.getList();
+        }
+        return is_total_in(args, ctx);
+    }
+
+    public static RuntimeList iss_resetLastBlockByte(RuntimeArray args, int ctx) {
+        RuntimeHash self = args.get(0).hashDeref();
+        if (args.size() > 1) {
+            RuntimeScalar byteScalar = args.get(1).scalar();
+            String value = byteScalar.toString();
+            if (!value.isEmpty()) {
+                RuntimeScalar maskScalar = self.get("_scan_last_block_mask");
+                int mask = maskScalar != null ? maskScalar.getInt() : 1;
+                int rewritten = (value.charAt(0) & 0xFF) ^ mask;
+                setScalarBytes(byteScalar, Character.toString((char) rewritten));
+            }
+        }
+        return new RuntimeScalar(Z_OK).getList();
+    }
+
+    public static RuntimeList iss_crc32(RuntimeArray args, int ctx) {
+        return is_crc32(args, ctx);
+    }
+
+    public static RuntimeList iss_adler32(RuntimeArray args, int ctx) {
+        return is_adler32(args, ctx);
+    }
+
+    public static RuntimeList iss_total_in(RuntimeArray args, int ctx) {
+        return is_total_in(args, ctx);
+    }
+
+    public static RuntimeList iss_total_out(RuntimeArray args, int ctx) {
+        return is_total_out(args, ctx);
+    }
+
+    public static RuntimeList iss_msg(RuntimeArray args, int ctx) {
+        return is_msg(args, ctx);
+    }
+
+    public static RuntimeList iss_dict_adler(RuntimeArray args, int ctx) {
+        return is_dict_adler(args, ctx);
+    }
+
+    public static RuntimeList iss_get_Bufsize(RuntimeArray args, int ctx) {
+        return is_get_Bufsize(args, ctx);
+    }
+
+    public static RuntimeList iss_compressedBytes(RuntimeArray args, int ctx) {
+        return is_compressedBytes(args, ctx);
+    }
+
+    public static RuntimeList iss_uncompressedBytes(RuntimeArray args, int ctx) {
+        return is_uncompressedBytes(args, ctx);
+    }
+
+    public static RuntimeList iss_DESTROY(RuntimeArray args, int ctx) {
+        return is_DESTROY(args, ctx);
+    }
+
     // =============================================
     // Helper methods
     // =============================================
@@ -847,9 +1031,252 @@ public class CompressRawZlib extends PerlModuleBase {
         return null;
     }
 
+    private static boolean applyInflaterDictionary(RuntimeHash self, Inflater inflater) {
+        RuntimeScalar used = self.get("_dictionary_used");
+        if (used != null && used.getBoolean()) {
+            return false;
+        }
+
+        RuntimeScalar dictionary = self.get("_dictionary");
+        if (dictionary == null || !dictionary.getDefinedBoolean()) {
+            return false;
+        }
+
+        byte[] dictBytes = getInputBytes(dictionary);
+        if (dictBytes.length == 0) {
+            return false;
+        }
+
+        try {
+            inflater.setDictionary(dictBytes);
+            self.put("_dict_adler", new RuntimeScalar(adler32WithSeed(dictBytes, 1L)));
+            self.put("_dictionary_used", new RuntimeScalar(1));
+            self.put("_msg", new RuntimeScalar());
+            return true;
+        } catch (IllegalArgumentException e) {
+            self.put("_msg", new RuntimeScalar(e.getMessage() != null ? e.getMessage() : "dictionary error"));
+            return false;
+        }
+    }
+
+    private static RuntimeArray sliceArgs(RuntimeArray args, int start) {
+        RuntimeArray sliced = new RuntimeArray(Math.max(0, args.size() - start));
+        for (int i = start; i < args.size(); i++) {
+            sliced.elements.add(args.get(i));
+        }
+        return sliced;
+    }
+
+    private static void initializeInflateScanState(RuntimeHash self) {
+        self.put("_scan_last_block_offset", new RuntimeScalar(0));
+        self.put("_scan_last_block_mask", new RuntimeScalar(1));
+        self.put("_scan_end_offset", new RuntimeScalar(0));
+        self.put("_scan_prime_bits", new RuntimeScalar(0));
+        self.put("_scan_prime_carry", new RuntimeScalar(0));
+        self.put("_scan_prime_final_emitted", new RuntimeScalar(0));
+        self.put("_scan_input", new RuntimeScalar(new ByteArrayOutputStream()));
+    }
+
+    private static boolean isInflateScanStream(RuntimeHash self) {
+        return self.get("_scan_input") != null;
+    }
+
+    private static void appendScanInput(RuntimeHash self, byte[] input, int consumed) {
+        if (consumed <= 0) {
+            return;
+        }
+        RuntimeScalar scanInput = self.get("_scan_input");
+        ByteArrayOutputStream baos;
+        if (scanInput != null && scanInput.type == RuntimeScalarType.JAVAOBJECT
+                && scanInput.value instanceof ByteArrayOutputStream existing) {
+            baos = existing;
+        } else {
+            baos = new ByteArrayOutputStream();
+            self.put("_scan_input", new RuntimeScalar(baos));
+        }
+        baos.write(input, 0, Math.min(consumed, input.length));
+    }
+
+    private static void updateInflateScanState(RuntimeHash self) {
+        RuntimeScalar scanInput = self.get("_scan_input");
+        if (scanInput == null || scanInput.type != RuntimeScalarType.JAVAOBJECT
+                || !(scanInput.value instanceof ByteArrayOutputStream baos)) {
+            return;
+        }
+
+        byte[] data = baos.toByteArray();
+        DeflateScanInfo info = DeflateScanInfo.scan(data);
+        if (info == null) {
+            self.put("_scan_end_offset", self.get("_total_in"));
+            self.put("_scan_prime_bits", new RuntimeScalar(0));
+            self.put("_scan_prime_carry", new RuntimeScalar(0));
+            return;
+        }
+
+        int endByteOffset = info.endBit / 8;
+        int primeBits = info.endBit & 7;
+        int primeCarry = 0;
+        if (primeBits != 0 && endByteOffset < data.length) {
+            primeCarry = data[endByteOffset] & ((1 << primeBits) - 1);
+        }
+
+        self.put("_scan_last_block_offset", new RuntimeScalar(info.lastBlockBit / 8));
+        self.put("_scan_last_block_mask", new RuntimeScalar(1 << (info.lastBlockBit & 7)));
+        self.put("_scan_end_offset", new RuntimeScalar(endByteOffset));
+        self.put("_scan_prime_bits", new RuntimeScalar(primeBits));
+        self.put("_scan_prime_carry", new RuntimeScalar(primeCarry));
+        self.put("_scan_prime_final_emitted", new RuntimeScalar(0));
+    }
+
+    private static RuntimeList createDeflateStreamFromScan(RuntimeArray args, RuntimeArray initArgs, int ctx) {
+        RuntimeHash scanSelf = args.get(0).hashDeref();
+        RuntimeList result = deflateInit(initArgs, ctx);
+        if (!result.isEmpty()) {
+            RuntimeScalar ref = result.elements.get(0).scalar();
+            if (ref.getDefinedBoolean()) {
+                RuntimeHash deflateSelf = ref.hashDeref();
+                copyScanScalar(scanSelf, deflateSelf, "_scan_prime_bits", "_prime_bits");
+                copyScanScalar(scanSelf, deflateSelf, "_scan_prime_carry", "_prime_carry");
+                deflateSelf.put("_prime_final_emitted", new RuntimeScalar(0));
+            }
+        }
+        return result;
+    }
+
+    private static void copyScanScalar(RuntimeHash from, RuntimeHash to, String fromKey, String toKey) {
+        RuntimeScalar value = from.get(fromKey);
+        if (value != null) {
+            to.put(toKey, new RuntimeScalar(value.getLong()));
+        }
+    }
+
+    private static RuntimeArray deflateInitArgsFromScanCreate(RuntimeArray args) {
+        if (args.size() > 1 && isIntegerLike(args.get(1))) {
+            return sliceArgs(args, 1);
+        }
+
+        int flags = 0;
+        int level = Z_DEFAULT_COMPRESSION;
+        int method = 8;
+        int windowBits = -MAX_WBITS;
+        int memLevel = MAX_MEM_LEVEL;
+        int strategy = 0;
+        int bufsize = 4096;
+
+        for (int i = 1; i < args.size() - 1; i += 2) {
+            String key = normalizeOption(args.get(i).toString());
+            RuntimeScalar value = args.get(i + 1);
+            switch (key) {
+                case "AppendOutput" -> {
+                    if (value.getBoolean()) flags |= FLAG_APPEND;
+                }
+                case "CRC32" -> {
+                    if (value.getBoolean()) flags |= FLAG_CRC;
+                }
+                case "ADLER32" -> {
+                    if (value.getBoolean()) flags |= FLAG_ADLER;
+                }
+                case "Bufsize" -> bufsize = value.getInt();
+                case "Level" -> level = value.getInt();
+                case "Method" -> method = value.getInt();
+                case "WindowBits" -> windowBits = value.getInt();
+                case "MemLevel" -> memLevel = value.getInt();
+                case "Strategy" -> strategy = value.getInt();
+                default -> throw new PerlCompilerException(
+                    "Compress::Raw::Zlib::InflateScan::createDeflateStream: unknown key value(s) " + key);
+            }
+        }
+
+        if (bufsize < 1) {
+            throw new PerlCompilerException(
+                "Compress::Raw::Zlib::InflateScan::createDeflateStream: Bufsize must be >= 1, you specified "
+                    + bufsize);
+        }
+
+        RuntimeArray initArgs = new RuntimeArray(7);
+        initArgs.elements.add(new RuntimeScalar(flags));
+        initArgs.elements.add(new RuntimeScalar(level));
+        initArgs.elements.add(new RuntimeScalar(method));
+        initArgs.elements.add(new RuntimeScalar(windowBits));
+        initArgs.elements.add(new RuntimeScalar(memLevel));
+        initArgs.elements.add(new RuntimeScalar(strategy));
+        initArgs.elements.add(new RuntimeScalar(bufsize));
+        return initArgs;
+    }
+
+    private static boolean isIntegerLike(RuntimeScalar scalar) {
+        String value = scalar.toString();
+        if (value.isEmpty()) return false;
+        int start = (value.charAt(0) == '-' || value.charAt(0) == '+') ? 1 : 0;
+        if (start == value.length()) return false;
+        for (int i = start; i < value.length(); i++) {
+            if (!Character.isDigit(value.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String normalizeOption(String key) {
+        while (key.startsWith("-")) {
+            key = key.substring(1);
+        }
+        return key;
+    }
+
+    private static int findFullFlushMarker(byte[] input) {
+        for (int i = 0; i <= input.length - 4; i++) {
+            if (input[i] == 0
+                    && input[i + 1] == 0
+                    && (input[i + 2] & 0xFF) == 0xFF
+                    && (input[i + 3] & 0xFF) == 0xFF) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static void setScalarBytes(RuntimeScalar scalar, String value) {
+        RuntimeScalar replacement = new RuntimeScalar(value);
+        replacement.type = RuntimeScalarType.BYTE_STRING;
+        scalar.set(replacement);
+    }
+
     /**
      * Write output bytes to a Perl scalar reference, respecting FLAG_APPEND.
      */
+    private static void writeDeflateOutput(RuntimeHash self, RuntimeScalar outputRef,
+                                           ByteArrayOutputStream baos, int flags, boolean finishing) {
+        RuntimeScalar bitsScalar = self.get("_prime_bits");
+        int primeBits = bitsScalar != null ? bitsScalar.getInt() : 0;
+        if (primeBits <= 0 || primeBits >= 8) {
+            writeOutput(outputRef, baos, flags);
+            return;
+        }
+
+        byte[] input = baos.toByteArray();
+        ByteArrayOutputStream shifted = new ByteArrayOutputStream(input.length + (finishing ? 1 : 0));
+        RuntimeScalar carryScalar = self.get("_prime_carry");
+        int carry = carryScalar != null ? carryScalar.getInt() : 0;
+
+        for (byte value : input) {
+            int b = value & 0xFF;
+            shifted.write((carry | ((b << primeBits) & 0xFF)) & 0xFF);
+            carry = b >>> (8 - primeBits);
+        }
+
+        RuntimeScalar finalEmittedScalar = self.get("_prime_final_emitted");
+        boolean finalEmitted = finalEmittedScalar != null && finalEmittedScalar.getBoolean();
+        if (finishing && !finalEmitted) {
+            shifted.write(carry & 0xFF);
+            carry = 0;
+            self.put("_prime_final_emitted", new RuntimeScalar(1));
+        }
+
+        self.put("_prime_carry", new RuntimeScalar(carry));
+        writeOutput(outputRef, shifted, flags);
+    }
+
     private static void writeOutput(RuntimeScalar outputRef, ByteArrayOutputStream baos, int flags) {
         String outStr = baos.toString(StandardCharsets.ISO_8859_1);
         RuntimeScalar outScalar;
@@ -888,5 +1315,271 @@ public class CompressRawZlib extends PerlModuleBase {
             s2 = (s2 + s1) % 65521;
         }
         return (s2 << 16) | s1;
+    }
+
+    private static final class DeflateScanInfo {
+        final int lastBlockBit;
+        final int endBit;
+
+        DeflateScanInfo(int lastBlockBit, int endBit) {
+            this.lastBlockBit = lastBlockBit;
+            this.endBit = endBit;
+        }
+
+        static DeflateScanInfo scan(byte[] data) {
+            try {
+                BitReader reader = new BitReader(data);
+                int lastBlockBit;
+                boolean last;
+                do {
+                    lastBlockBit = reader.bitPosition();
+                    last = reader.readBits(1) != 0;
+                    int type = reader.readBits(2);
+                    switch (type) {
+                        case 0 -> skipStored(reader);
+                        case 1 -> skipCompressed(reader, fixedLiteralLengthTree(), fixedDistanceTree());
+                        case 2 -> {
+                            HuffmanTrees trees = readDynamicTrees(reader);
+                            skipCompressed(reader, trees.literalLength, trees.distance);
+                        }
+                        default -> {
+                            return null;
+                        }
+                    }
+                } while (!last);
+                return new DeflateScanInfo(lastBlockBit, reader.bitPosition());
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+
+        private static void skipStored(BitReader reader) {
+            reader.alignToByte();
+            int len = reader.readBits(16);
+            int nlen = reader.readBits(16);
+            if (((len ^ 0xFFFF) & 0xFFFF) != nlen) {
+                throw new IllegalArgumentException("stored block length mismatch");
+            }
+            reader.skipBits(len * 8);
+        }
+
+        private static void skipCompressed(BitReader reader, HuffmanTree literalLength, HuffmanTree distance) {
+            while (true) {
+                int symbol = literalLength.decode(reader);
+                if (symbol < 256) {
+                    continue;
+                }
+                if (symbol == 256) {
+                    return;
+                }
+                if (symbol > 285) {
+                    throw new IllegalArgumentException("bad length symbol");
+                }
+
+                int lengthIndex = symbol - 257;
+                reader.skipBits(LENGTH_EXTRA_BITS[lengthIndex]);
+                int distanceSymbol = distance.decode(reader);
+                if (distanceSymbol < 0 || distanceSymbol >= DISTANCE_EXTRA_BITS.length) {
+                    throw new IllegalArgumentException("bad distance symbol");
+                }
+                reader.skipBits(DISTANCE_EXTRA_BITS[distanceSymbol]);
+            }
+        }
+
+        private static HuffmanTrees readDynamicTrees(BitReader reader) {
+            int hlit = reader.readBits(5) + 257;
+            int hdist = reader.readBits(5) + 1;
+            int hclen = reader.readBits(4) + 4;
+
+            int[] codeLengthLengths = new int[19];
+            for (int i = 0; i < hclen; i++) {
+                codeLengthLengths[CODE_LENGTH_ORDER[i]] = reader.readBits(3);
+            }
+            HuffmanTree codeLengthTree = new HuffmanTree(codeLengthLengths);
+
+            int[] lengths = new int[hlit + hdist];
+            int index = 0;
+            while (index < lengths.length) {
+                int symbol = codeLengthTree.decode(reader);
+                if (symbol <= 15) {
+                    lengths[index++] = symbol;
+                } else if (symbol == 16) {
+                    if (index == 0) {
+                        throw new IllegalArgumentException("repeat with no previous length");
+                    }
+                    int repeat = reader.readBits(2) + 3;
+                    int previous = lengths[index - 1];
+                    for (int i = 0; i < repeat && index < lengths.length; i++) {
+                        lengths[index++] = previous;
+                    }
+                } else if (symbol == 17) {
+                    int repeat = reader.readBits(3) + 3;
+                    for (int i = 0; i < repeat && index < lengths.length; i++) {
+                        lengths[index++] = 0;
+                    }
+                } else if (symbol == 18) {
+                    int repeat = reader.readBits(7) + 11;
+                    for (int i = 0; i < repeat && index < lengths.length; i++) {
+                        lengths[index++] = 0;
+                    }
+                } else {
+                    throw new IllegalArgumentException("bad code length symbol");
+                }
+            }
+
+            int[] litLen = new int[hlit];
+            System.arraycopy(lengths, 0, litLen, 0, hlit);
+            int[] dist = new int[hdist];
+            System.arraycopy(lengths, hlit, dist, 0, hdist);
+            return new HuffmanTrees(new HuffmanTree(litLen), new HuffmanTree(dist));
+        }
+
+        private static HuffmanTree fixedLiteralLengthTree() {
+            int[] lengths = new int[288];
+            for (int i = 0; i <= 143; i++) lengths[i] = 8;
+            for (int i = 144; i <= 255; i++) lengths[i] = 9;
+            for (int i = 256; i <= 279; i++) lengths[i] = 7;
+            for (int i = 280; i <= 287; i++) lengths[i] = 8;
+            return new HuffmanTree(lengths);
+        }
+
+        private static HuffmanTree fixedDistanceTree() {
+            int[] lengths = new int[32];
+            for (int i = 0; i < lengths.length; i++) {
+                lengths[i] = 5;
+            }
+            return new HuffmanTree(lengths);
+        }
+
+        private static int reverseBits(int code, int length) {
+            int reversed = 0;
+            for (int i = 0; i < length; i++) {
+                reversed = (reversed << 1) | (code & 1);
+                code >>>= 1;
+            }
+            return reversed;
+        }
+
+        private static final int[] LENGTH_EXTRA_BITS = {
+            0, 0, 0, 0, 0, 0, 0, 0,
+            1, 1, 1, 1,
+            2, 2, 2, 2,
+            3, 3, 3, 3,
+            4, 4, 4, 4,
+            5, 5, 5, 5,
+            0
+        };
+
+        private static final int[] DISTANCE_EXTRA_BITS = {
+            0, 0, 0, 0,
+            1, 1,
+            2, 2,
+            3, 3,
+            4, 4,
+            5, 5,
+            6, 6,
+            7, 7,
+            8, 8,
+            9, 9,
+            10, 10,
+            11, 11,
+            12, 12,
+            13, 13
+        };
+
+        private static final int[] CODE_LENGTH_ORDER = {
+            16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15
+        };
+
+        private record HuffmanTrees(HuffmanTree literalLength, HuffmanTree distance) {}
+
+        private static final class HuffmanTree {
+            private final Map<Integer, Integer> symbols = new HashMap<>();
+            private final int maxBits;
+
+            HuffmanTree(int[] lengths) {
+                int max = 0;
+                for (int length : lengths) {
+                    max = Math.max(max, length);
+                }
+                this.maxBits = max;
+                int[] counts = new int[max + 1];
+                for (int length : lengths) {
+                    if (length > 0) {
+                        counts[length]++;
+                    }
+                }
+
+                int[] nextCode = new int[max + 1];
+                int code = 0;
+                for (int bits = 1; bits <= max; bits++) {
+                    code = (code + counts[bits - 1]) << 1;
+                    nextCode[bits] = code;
+                }
+
+                for (int symbol = 0; symbol < lengths.length; symbol++) {
+                    int length = lengths[symbol];
+                    if (length == 0) {
+                        continue;
+                    }
+                    int canonical = nextCode[length]++;
+                    int reversed = reverseBits(canonical, length);
+                    symbols.put((length << 16) | reversed, symbol);
+                }
+            }
+
+            int decode(BitReader reader) {
+                int code = 0;
+                for (int length = 1; length <= maxBits; length++) {
+                    code |= reader.readBits(1) << (length - 1);
+                    Integer symbol = symbols.get((length << 16) | code);
+                    if (symbol != null) {
+                        return symbol;
+                    }
+                }
+                throw new IllegalArgumentException("bad huffman code");
+            }
+        }
+
+        private static final class BitReader {
+            private final byte[] data;
+            private int bitPosition;
+
+            BitReader(byte[] data) {
+                this.data = data;
+            }
+
+            int bitPosition() {
+                return bitPosition;
+            }
+
+            int readBits(int count) {
+                if (count < 0 || bitPosition + count > data.length * 8) {
+                    throw new IllegalArgumentException("deflate stream is truncated");
+                }
+                int value = 0;
+                for (int i = 0; i < count; i++) {
+                    int byteIndex = bitPosition >>> 3;
+                    int bitIndex = bitPosition & 7;
+                    value |= ((data[byteIndex] >>> bitIndex) & 1) << i;
+                    bitPosition++;
+                }
+                return value;
+            }
+
+            void skipBits(int count) {
+                if (count < 0 || bitPosition + count > data.length * 8) {
+                    throw new IllegalArgumentException("deflate stream is truncated");
+                }
+                bitPosition += count;
+            }
+
+            void alignToByte() {
+                int remainder = bitPosition & 7;
+                if (remainder != 0) {
+                    skipBits(8 - remainder);
+                }
+            }
+        }
     }
 }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/CompressZlib.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/CompressZlib.java
@@ -1,5 +1,7 @@
 package org.perlonjava.runtime.perlmodule;
 
+import org.perlonjava.frontend.parser.StringParser;
+import org.perlonjava.runtime.io.IOHandle;
 import org.perlonjava.runtime.operators.ReferenceOperators;
 import org.perlonjava.runtime.runtimetypes.*;
 
@@ -29,35 +31,78 @@ public class CompressZlib extends PerlModuleBase {
             cz.registerMethod("memGunzip", null);
             cz.registerMethod("crc32", null);
             cz.registerMethod("adler32", null);
+            cz.registerMethod("zlib_version", "zlibVersion", null);
+            cz.registerMethod("ZLIB_VERSION", null);
+            cz.registerMethod("ZLIB_VERNUM", null);
             cz.registerMethod("Z_OK", null);
             cz.registerMethod("Z_STREAM_END", null);
+            cz.registerMethod("Z_NEED_DICT", null);
+            cz.registerMethod("Z_ERRNO", null);
             cz.registerMethod("Z_STREAM_ERROR", null);
             cz.registerMethod("Z_DATA_ERROR", null);
+            cz.registerMethod("Z_MEM_ERROR", null);
             cz.registerMethod("Z_BUF_ERROR", null);
+            cz.registerMethod("Z_VERSION_ERROR", null);
+            cz.registerMethod("Z_NO_COMPRESSION", null);
             cz.registerMethod("Z_NO_FLUSH", null);
+            cz.registerMethod("Z_PARTIAL_FLUSH", null);
             cz.registerMethod("Z_SYNC_FLUSH", null);
             cz.registerMethod("Z_FULL_FLUSH", null);
             cz.registerMethod("Z_FINISH", null);
+            cz.registerMethod("Z_BLOCK", null);
+            cz.registerMethod("Z_TREES", null);
             cz.registerMethod("Z_DEFAULT_COMPRESSION", null);
             cz.registerMethod("Z_BEST_SPEED", null);
             cz.registerMethod("Z_BEST_COMPRESSION", null);
             cz.registerMethod("Z_FILTERED", null);
             cz.registerMethod("Z_HUFFMAN_ONLY", null);
+            cz.registerMethod("Z_RLE", null);
+            cz.registerMethod("Z_FIXED", null);
             cz.registerMethod("Z_DEFAULT_STRATEGY", null);
             cz.registerMethod("Z_DEFLATED", null);
+            cz.registerMethod("Z_NULL", null);
+            cz.registerMethod("Z_ASCII", null);
+            cz.registerMethod("Z_BINARY", null);
+            cz.registerMethod("Z_UNKNOWN", null);
             cz.registerMethod("WANT_GZIP", null);
             cz.registerMethod("WANT_GZIP_OR_ZLIB", null);
             cz.registerMethod("MAX_WBITS", null);
+            cz.registerMethod("MAX_MEM_LEVEL", null);
+            cz.registerMethod("DEF_WBITS", null);
+            cz.registerMethod("OS_CODE", null);
             cz.registerMethod("inflate", "inflateMethod", null);
             cz.registerMethod("deflate", "deflateMethod", null);
             cz.registerMethod("flush", null);
+            cz.registerMethod("msg", null);
+            cz.registerMethod("total_in", "totalIn", null);
+            cz.registerMethod("total_out", "totalOut", null);
+            cz.registerMethod("dict_adler", "dictAdler", null);
+            cz.registerMethod("get_Level", "getLevel", null);
+            cz.registerMethod("get_Strategy", "getStrategy", null);
+            cz.registerMethod("get_Bufsize", "getBufsize", null);
+            cz.registerMethod("deflateParams", null);
+            cz.registerMethod("inflateSync", null);
             cz.registerMethod("gzopen", null);
         } catch (NoSuchMethodException e) {
             System.err.println("Warning: Missing Compress::Zlib method: " + e.getMessage());
         }
 
+        GlobalVariable.getGlobalVariable("Compress::Zlib::gzerrno").set(new RuntimeScalar(0));
+
         // Initialize gzFile methods (gzread, gzwrite, gzreadline, gzeof, gzclose)
         CompressZlibGzFile.initialize();
+    }
+
+    public static RuntimeList zlibVersion(RuntimeArray args, int ctx) {
+        return new RuntimeScalar("1.2.13").getList();
+    }
+
+    public static RuntimeList ZLIB_VERSION(RuntimeArray args, int ctx) {
+        return new RuntimeScalar("1.2.13").getList();
+    }
+
+    public static RuntimeList ZLIB_VERNUM(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(0x12D0).getList();
     }
 
     public static RuntimeList Z_OK(RuntimeArray args, int ctx) {
@@ -68,6 +113,14 @@ public class CompressZlib extends PerlModuleBase {
         return new RuntimeScalar(1).getList();
     }
 
+    public static RuntimeList Z_NEED_DICT(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(2).getList();
+    }
+
+    public static RuntimeList Z_ERRNO(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(-1).getList();
+    }
+
     public static RuntimeList Z_STREAM_ERROR(RuntimeArray args, int ctx) {
         return new RuntimeScalar(-2).getList();
     }
@@ -76,12 +129,28 @@ public class CompressZlib extends PerlModuleBase {
         return new RuntimeScalar(-3).getList();
     }
 
+    public static RuntimeList Z_MEM_ERROR(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(-4).getList();
+    }
+
     public static RuntimeList Z_BUF_ERROR(RuntimeArray args, int ctx) {
         return new RuntimeScalar(-5).getList();
     }
 
+    public static RuntimeList Z_VERSION_ERROR(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(-6).getList();
+    }
+
+    public static RuntimeList Z_NO_COMPRESSION(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(0).getList();
+    }
+
     public static RuntimeList Z_NO_FLUSH(RuntimeArray args, int ctx) {
         return new RuntimeScalar(0).getList();
+    }
+
+    public static RuntimeList Z_PARTIAL_FLUSH(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(1).getList();
     }
 
     public static RuntimeList Z_SYNC_FLUSH(RuntimeArray args, int ctx) {
@@ -94,6 +163,14 @@ public class CompressZlib extends PerlModuleBase {
 
     public static RuntimeList Z_FINISH(RuntimeArray args, int ctx) {
         return new RuntimeScalar(4).getList();
+    }
+
+    public static RuntimeList Z_BLOCK(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(5).getList();
+    }
+
+    public static RuntimeList Z_TREES(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(6).getList();
     }
 
     public static RuntimeList Z_DEFAULT_COMPRESSION(RuntimeArray args, int ctx) {
@@ -116,12 +193,36 @@ public class CompressZlib extends PerlModuleBase {
         return new RuntimeScalar(2).getList();
     }
 
+    public static RuntimeList Z_RLE(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(3).getList();
+    }
+
+    public static RuntimeList Z_FIXED(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(4).getList();
+    }
+
     public static RuntimeList Z_DEFAULT_STRATEGY(RuntimeArray args, int ctx) {
         return new RuntimeScalar(0).getList();
     }
 
     public static RuntimeList Z_DEFLATED(RuntimeArray args, int ctx) {
         return new RuntimeScalar(8).getList();
+    }
+
+    public static RuntimeList Z_NULL(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(0).getList();
+    }
+
+    public static RuntimeList Z_ASCII(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(1).getList();
+    }
+
+    public static RuntimeList Z_BINARY(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(0).getList();
+    }
+
+    public static RuntimeList Z_UNKNOWN(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(2).getList();
     }
 
     public static RuntimeList WANT_GZIP(RuntimeArray args, int ctx) {
@@ -136,15 +237,29 @@ public class CompressZlib extends PerlModuleBase {
         return new RuntimeScalar(15).getList();
     }
 
+    public static RuntimeList MAX_MEM_LEVEL(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(9).getList();
+    }
+
+    public static RuntimeList DEF_WBITS(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(15).getList();
+    }
+
+    public static RuntimeList OS_CODE(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(3).getList();
+    }
+
     /**
      * Helper to extract byte data from a scalar or scalar reference.
      */
-    private static byte[] getInputBytes(RuntimeScalar dataScalar) {
+    private static byte[] getInputBytes(RuntimeScalar dataScalar, String operation) {
         RuntimeScalar actual = dataScalar;
         if (dataScalar.type == RuntimeScalarType.REFERENCE) {
             actual = dataScalar.scalarDeref();
         }
-        return actual.toString().getBytes(StandardCharsets.ISO_8859_1);
+        String data = actual.toString();
+        StringParser.assertNoWideCharacters(data, operation);
+        return data.getBytes(StandardCharsets.ISO_8859_1);
     }
 
     /**
@@ -158,7 +273,7 @@ public class CompressZlib extends PerlModuleBase {
         }
 
         int level = Deflater.DEFAULT_COMPRESSION;
-        byte[] input = getInputBytes(args.get(0));
+        byte[] input = getInputBytes(args.get(0), "compress");
 
         if (args.size() > 1) {
             level = args.get(1).getInt();
@@ -200,7 +315,7 @@ public class CompressZlib extends PerlModuleBase {
             return scalarUndef.getList();
         }
 
-        byte[] input = getInputBytes(args.get(0));
+        byte[] input = getInputBytes(args.get(0), "uncompress");
 
         try {
             Inflater inflater = new Inflater(false); // nowrap=false for zlib format
@@ -243,7 +358,7 @@ public class CompressZlib extends PerlModuleBase {
             return scalarUndef.getList();
         }
 
-        byte[] input = getInputBytes(args.get(0));
+        byte[] input = getInputBytes(args.get(0), "memGzip");
 
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream(input.length + 64);
@@ -269,7 +384,7 @@ public class CompressZlib extends PerlModuleBase {
             return scalarUndef.getList();
         }
 
-        byte[] input = getInputBytes(args.get(0));
+        byte[] input = getInputBytes(args.get(0), "memGunzip");
 
         try {
             ByteArrayInputStream bais = new ByteArrayInputStream(input);
@@ -301,7 +416,7 @@ public class CompressZlib extends PerlModuleBase {
             return new RuntimeScalar(0).getList();
         }
 
-        byte[] input = getInputBytes(args.get(0));
+        byte[] input = getInputBytes(args.get(0), "crc32");
         CRC32 crc = new CRC32();
 
         if (args.size() > 1 && args.get(1).getDefinedBoolean()) {
@@ -364,7 +479,7 @@ public class CompressZlib extends PerlModuleBase {
             return new RuntimeScalar(1).getList(); // Adler-32 of empty data is 1
         }
 
-        byte[] input = getInputBytes(args.get(0));
+        byte[] input = getInputBytes(args.get(0), "adler32");
         Adler32 adler = new Adler32();
 
         if (args.size() > 1 && args.get(1).getDefinedBoolean()) {
@@ -403,6 +518,8 @@ public class CompressZlib extends PerlModuleBase {
             Inflater inflater = new Inflater(nowrap);
             RuntimeHash self = new RuntimeHash();
             self.put(INFLATER_KEY, new RuntimeScalar(inflater));
+            self.put("_dict_adler", new RuntimeScalar(0));
+            self.put("_bufsize", new RuntimeScalar(4096));
             RuntimeScalar ref = self.createReference();
             ReferenceOperators.bless(ref, new RuntimeScalar("Compress::Zlib"));
             return ref.getList();
@@ -435,6 +552,10 @@ public class CompressZlib extends PerlModuleBase {
             Deflater deflater = new Deflater(level, nowrap);
             RuntimeHash self = new RuntimeHash();
             self.put(DEFLATER_KEY, new RuntimeScalar(deflater));
+            self.put("_level", new RuntimeScalar(level));
+            self.put("_strategy", new RuntimeScalar(0));
+            self.put("_dict_adler", new RuntimeScalar(0));
+            self.put("_bufsize", new RuntimeScalar(4096));
             RuntimeScalar ref = self.createReference();
             ReferenceOperators.bless(ref, new RuntimeScalar("Compress::Zlib"));
             return ref.getList();
@@ -564,40 +685,172 @@ public class CompressZlib extends PerlModuleBase {
         return outputScalar.getList();
     }
 
+    public static RuntimeList msg(RuntimeArray args, int ctx) {
+        if (args.isEmpty()) {
+            return scalarUndef.getList();
+        }
+        RuntimeHash self = args.get(0).hashDeref();
+        RuntimeScalar msg = self.get("_msg");
+        if (msg == null || !msg.getDefinedBoolean() || msg.toString().isEmpty()) {
+            return scalarUndef.getList();
+        }
+        return msg.getList();
+    }
+
+    public static RuntimeList totalIn(RuntimeArray args, int ctx) {
+        if (args.isEmpty()) {
+            return new RuntimeScalar(0).getList();
+        }
+        RuntimeHash self = args.get(0).hashDeref();
+        RuntimeScalar deflaterScalar = self.get(DEFLATER_KEY);
+        if (deflaterScalar != null && deflaterScalar.value instanceof Deflater deflater) {
+            return new RuntimeScalar(deflater.getBytesRead()).getList();
+        }
+        RuntimeScalar inflaterScalar = self.get(INFLATER_KEY);
+        if (inflaterScalar != null && inflaterScalar.value instanceof Inflater inflater) {
+            return new RuntimeScalar(inflater.getBytesRead()).getList();
+        }
+        return new RuntimeScalar(0).getList();
+    }
+
+    public static RuntimeList totalOut(RuntimeArray args, int ctx) {
+        if (args.isEmpty()) {
+            return new RuntimeScalar(0).getList();
+        }
+        RuntimeHash self = args.get(0).hashDeref();
+        RuntimeScalar deflaterScalar = self.get(DEFLATER_KEY);
+        if (deflaterScalar != null && deflaterScalar.value instanceof Deflater deflater) {
+            return new RuntimeScalar(deflater.getBytesWritten()).getList();
+        }
+        RuntimeScalar inflaterScalar = self.get(INFLATER_KEY);
+        if (inflaterScalar != null && inflaterScalar.value instanceof Inflater inflater) {
+            return new RuntimeScalar(inflater.getBytesWritten()).getList();
+        }
+        return new RuntimeScalar(0).getList();
+    }
+
+    public static RuntimeList dictAdler(RuntimeArray args, int ctx) {
+        if (args.isEmpty()) {
+            return new RuntimeScalar(0).getList();
+        }
+        RuntimeHash self = args.get(0).hashDeref();
+        RuntimeScalar dictAdler = self.get("_dict_adler");
+        return (dictAdler == null ? new RuntimeScalar(0) : dictAdler).getList();
+    }
+
+    public static RuntimeList getLevel(RuntimeArray args, int ctx) {
+        if (args.isEmpty()) {
+            return new RuntimeScalar(Deflater.DEFAULT_COMPRESSION).getList();
+        }
+        RuntimeHash self = args.get(0).hashDeref();
+        RuntimeScalar level = self.get("_level");
+        return (level == null ? new RuntimeScalar(Deflater.DEFAULT_COMPRESSION) : level).getList();
+    }
+
+    public static RuntimeList getStrategy(RuntimeArray args, int ctx) {
+        if (args.isEmpty()) {
+            return new RuntimeScalar(0).getList();
+        }
+        RuntimeHash self = args.get(0).hashDeref();
+        RuntimeScalar strategy = self.get("_strategy");
+        return (strategy == null ? new RuntimeScalar(0) : strategy).getList();
+    }
+
+    public static RuntimeList getBufsize(RuntimeArray args, int ctx) {
+        if (args.isEmpty()) {
+            return new RuntimeScalar(4096).getList();
+        }
+        RuntimeHash self = args.get(0).hashDeref();
+        RuntimeScalar bufsize = self.get("_bufsize");
+        return (bufsize == null ? new RuntimeScalar(4096) : bufsize).getList();
+    }
+
+    public static RuntimeList deflateParams(RuntimeArray args, int ctx) {
+        if (args.size() < 3 || args.size() % 2 == 0) {
+            throw new PerlCompilerException("Compress::Raw::Zlib::deflateParams needs Level and/or Strategy");
+        }
+
+        RuntimeHash self = args.get(0).hashDeref();
+        RuntimeScalar deflaterScalar = self.get(DEFLATER_KEY);
+        if (deflaterScalar == null || !(deflaterScalar.value instanceof Deflater deflater)) {
+            return new RuntimeScalar(-2).getList();
+        }
+
+        boolean sawKnown = false;
+        for (int i = 1; i < args.size() - 1; i += 2) {
+            String key = args.get(i).toString();
+            int value = args.get(i + 1).getInt();
+            if (key.equals("-Level") || key.equals("Level")) {
+                deflater.setLevel(value);
+                self.put("_level", new RuntimeScalar(value));
+                sawKnown = true;
+            } else if (key.equals("-Strategy") || key.equals("Strategy")) {
+                deflater.setStrategy(value);
+                self.put("_strategy", new RuntimeScalar(value));
+                sawKnown = true;
+            } else {
+                throw new PerlCompilerException("Compress::Raw::Zlib::deflateStream::deflateParams: unknown key value");
+            }
+        }
+        if (!sawKnown) {
+            throw new PerlCompilerException("Compress::Raw::Zlib::deflateParams needs Level and/or Strategy");
+        }
+        return new RuntimeScalar(0).getList();
+    }
+
+    public static RuntimeList inflateSync(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(0).getList();
+    }
+
     /**
      * gzopen($filename, $mode)
-     * Opens a gzip file for reading ('rb') or writing ('wb').
+     * Opens a gzip file for reading ('rb'), writing ('wb'), or appending ('ab').
      * Returns a blessed Compress::Zlib::gzFile object, or undef on error.
      */
     public static RuntimeList gzopen(RuntimeArray args, int ctx) {
         if (args.size() < 2) {
-            return scalarUndef.getList();
+            throw new PerlCompilerException("Not enough arguments for Compress::Zlib::gzopen");
         }
 
         // Skip 'self' if called as Compress::Zlib->gzopen() (class method)
         int argOffset = 0;
         String firstArg = args.get(0).toString();
-        if (firstArg.equals("Compress::Zlib") || firstArg.contains("::")) {
+        if (args.get(0).isString() && firstArg.equals("Compress::Zlib")) {
             argOffset = 1;
         }
 
         if (args.size() < argOffset + 2) {
-            return scalarUndef.getList();
+            throw new PerlCompilerException("Not enough arguments for Compress::Zlib::gzopen");
         }
 
-        String filename = args.get(argOffset).toString();
+        RuntimeScalar target = args.get(argOffset);
+        String filename = target.toString();
         String mode = args.get(argOffset + 1).toString();
 
         try {
             RuntimeHash self = new RuntimeHash();
             self.put("_mode", new RuntimeScalar(mode));
             self.put("_eof", new RuntimeScalar(0));
+            self.put("_pos", new RuntimeScalar(0));
+            GlobalVariable.getGlobalVariable("Compress::Zlib::gzerrno").set(new RuntimeScalar(0));
 
             if (mode.startsWith("r")) {
                 // Read mode. zlib's gzopen transparently reads non-gzip files
                 // in 'rb' mode, so detect the gzip magic and fall back to a
                 // plain InputStream when the file isn't actually gzip-compressed.
-                InputStream fis = new BufferedInputStream(new FileInputStream(filename));
+                InputStream fis;
+                if (filename.equals("-")) {
+                    RuntimeIO stdin = GlobalVariable.getGlobalIO("main::STDIN").getRuntimeIO();
+                    fis = new BufferedInputStream(new RuntimeIOInputStream(stdin, false));
+                } else if (!target.isString()) {
+                    RuntimeIO fh = target.getRuntimeIO();
+                    if (fh == null || fh.ioHandle == null) {
+                        return scalarUndef.getList();
+                    }
+                    fis = new BufferedInputStream(new RuntimeIOInputStream(fh, true));
+                } else {
+                    fis = new BufferedInputStream(new FileInputStream(filename));
+                }
                 fis.mark(2);
                 int b1 = fis.read();
                 int b2 = fis.read();
@@ -608,10 +861,23 @@ public class CompressZlib extends PerlModuleBase {
                 } else {
                     is = fis;
                 }
-                self.put("_stream", new RuntimeScalar(is));
-            } else if (mode.startsWith("w")) {
-                // Write mode - check for compression level
-                OutputStream fos = new FileOutputStream(filename);
+                self.put("_stream", new RuntimeScalar(new PushbackInputStream(is, 1)));
+            } else if (mode.startsWith("w") || mode.startsWith("a")) {
+                // Appending writes an additional gzip member, which gzip readers
+                // concatenate when reading the stream back.
+                OutputStream fos;
+                if (filename.equals("-")) {
+                    RuntimeIO stdout = GlobalVariable.getGlobalIO("main::STDOUT").getRuntimeIO();
+                    fos = new RuntimeIOOutputStream(stdout, false);
+                } else if (!target.isString()) {
+                    RuntimeIO fh = target.getRuntimeIO();
+                    if (fh == null || fh.ioHandle == null) {
+                        return scalarUndef.getList();
+                    }
+                    fos = new RuntimeIOOutputStream(fh, true);
+                } else {
+                    fos = new FileOutputStream(filename, mode.startsWith("a"));
+                }
                 GZIPOutputStream gos = new GZIPOutputStream(fos);
                 self.put("_stream", new RuntimeScalar(gos));
             } else {
@@ -622,7 +888,90 @@ public class CompressZlib extends PerlModuleBase {
             ReferenceOperators.bless(ref, new RuntimeScalar("Compress::Zlib::gzFile"));
             return ref.getList();
         } catch (IOException e) {
+            GlobalVariable.getGlobalVariable("Compress::Zlib::gzerrno").set(new RuntimeScalar(-1));
             return scalarUndef.getList();
+        }
+    }
+
+    private static class RuntimeIOInputStream extends InputStream {
+        private final RuntimeIO fh;
+        private final boolean closeUnderlying;
+
+        RuntimeIOInputStream(RuntimeIO fh, boolean closeUnderlying) {
+            this.fh = fh;
+            this.closeUnderlying = closeUnderlying;
+        }
+
+        @Override
+        public int read() throws IOException {
+            byte[] one = new byte[1];
+            int count = read(one, 0, 1);
+            return count < 0 ? -1 : one[0] & 0xFF;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            if (len == 0) {
+                return 0;
+            }
+            RuntimeScalar chunk = fh.ioHandle.read(len);
+            if (chunk == null || !chunk.getDefinedBoolean()) {
+                return -1;
+            }
+            String data = chunk.toString();
+            if (data.isEmpty()) {
+                return -1;
+            }
+            int count = Math.min(len, data.length());
+            for (int i = 0; i < count; i++) {
+                b[off + i] = (byte) (data.charAt(i) & 0xFF);
+            }
+            return count;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closeUnderlying) {
+                fh.ioHandle.close();
+            }
+        }
+    }
+
+    private static class RuntimeIOOutputStream extends OutputStream {
+        private final RuntimeIO fh;
+        private final boolean closeUnderlying;
+
+        RuntimeIOOutputStream(RuntimeIO fh, boolean closeUnderlying) {
+            this.fh = fh;
+            this.closeUnderlying = closeUnderlying;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            byte[] one = new byte[] { (byte) b };
+            write(one, 0, 1);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            String data = new String(b, off, len, StandardCharsets.ISO_8859_1);
+            RuntimeScalar ok = fh.ioHandle.write(data);
+            if (ok == null || !ok.getDefinedBoolean()) {
+                throw new IOException("write failed");
+            }
+        }
+
+        @Override
+        public void flush() throws IOException {
+            fh.ioHandle.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            flush();
+            if (closeUnderlying) {
+                fh.ioHandle.close();
+            }
         }
     }
 }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/CompressZlibGzFile.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/CompressZlibGzFile.java
@@ -1,5 +1,6 @@
 package org.perlonjava.runtime.perlmodule;
 
+import org.perlonjava.frontend.parser.StringParser;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import java.io.*;
@@ -20,6 +21,7 @@ public class CompressZlibGzFile extends PerlModuleBase {
     private static final String MODE_KEY = "_mode";
     private static final String EOF_KEY = "_eof";
     private static final String PUSHBACK_KEY = "_pushback";
+    private static final String POS_KEY = "_pos";
 
     public CompressZlibGzFile() {
         super("Compress::Zlib::gzFile", false);
@@ -32,6 +34,10 @@ public class CompressZlibGzFile extends PerlModuleBase {
             gzFile.registerMethod("gzwrite", null);
             gzFile.registerMethod("gzreadline", null);
             gzFile.registerMethod("gzeof", null);
+            gzFile.registerMethod("gztell", null);
+            gzFile.registerMethod("gzseek", null);
+            gzFile.registerMethod("gzflush", null);
+            gzFile.registerMethod("gzsetparams", null);
             gzFile.registerMethod("gzclose", null);
             gzFile.registerMethod("gzerror", null);
         } catch (NoSuchMethodException e) {
@@ -46,7 +52,7 @@ public class CompressZlibGzFile extends PerlModuleBase {
      */
     public static RuntimeList gzread(RuntimeArray args, int ctx) {
         if (args.size() < 2) {
-            return new RuntimeScalar(-1).getList();
+            return new RuntimeScalar(-2).getList(); // Z_STREAM_ERROR
         }
 
         RuntimeHash self = args.get(0).hashDeref();
@@ -55,7 +61,7 @@ public class CompressZlibGzFile extends PerlModuleBase {
         RuntimeScalar streamScalar = self.get(STREAM_KEY);
         if (streamScalar == null || streamScalar.type != RuntimeScalarType.JAVAOBJECT
                 || !(streamScalar.value instanceof InputStream is)) {
-            return new RuntimeScalar(-1).getList();
+            return new RuntimeScalar(-2).getList(); // Z_STREAM_ERROR
         }
 
         try {
@@ -76,9 +82,19 @@ public class CompressZlibGzFile extends PerlModuleBase {
                 return new RuntimeScalar(0).getList();
             }
 
-            String data = new String(buf, 0, totalRead, StandardCharsets.ISO_8859_1);
             // Modify the buffer argument in-place via @_ alias
-            args.get(1).set(data);
+            byte[] data = new byte[totalRead];
+            System.arraycopy(buf, 0, data, 0, totalRead);
+            args.get(1).set(new RuntimeScalar(data));
+            addPosition(self, totalRead);
+            if (totalRead == nbytes && is instanceof PushbackInputStream pushback) {
+                int next = pushback.read();
+                if (next == -1) {
+                    self.put(EOF_KEY, new RuntimeScalar(1));
+                } else {
+                    pushback.unread(next);
+                }
+            }
             return new RuntimeScalar(totalRead).getList();
         } catch (IOException e) {
             return new RuntimeScalar(-1).getList();
@@ -91,21 +107,30 @@ public class CompressZlibGzFile extends PerlModuleBase {
      */
     public static RuntimeList gzwrite(RuntimeArray args, int ctx) {
         if (args.size() < 2) {
+            if (!args.isEmpty()) {
+                RuntimeHash self = args.get(0).hashDeref();
+                RuntimeScalar mode = self.get(MODE_KEY);
+                if (mode != null && mode.toString().startsWith("r")) {
+                    return new RuntimeScalar(-2).getList(); // Z_STREAM_ERROR
+                }
+            }
             return new RuntimeScalar(0).getList();
         }
 
         RuntimeHash self = args.get(0).hashDeref();
         String data = args.get(1).toString();
+        StringParser.assertNoWideCharacters(data, "gzwrite");
 
         RuntimeScalar streamScalar = self.get(STREAM_KEY);
         if (streamScalar == null || streamScalar.type != RuntimeScalarType.JAVAOBJECT
                 || !(streamScalar.value instanceof OutputStream os)) {
-            return new RuntimeScalar(0).getList();
+            return new RuntimeScalar(-2).getList(); // Z_STREAM_ERROR
         }
 
         try {
             byte[] bytes = data.getBytes(StandardCharsets.ISO_8859_1);
             os.write(bytes);
+            addPosition(self, bytes.length);
             return new RuntimeScalar(bytes.length).getList();
         } catch (IOException e) {
             return new RuntimeScalar(0).getList();
@@ -148,7 +173,18 @@ public class CompressZlibGzFile extends PerlModuleBase {
 
             String result = line.toString();
             // Modify the line argument in-place via @_ alias
-            args.get(1).set(result);
+            args.get(1).set(new RuntimeScalar(result.getBytes(StandardCharsets.ISO_8859_1)));
+            addPosition(self, result.length());
+            if (c == -1) {
+                self.put(EOF_KEY, new RuntimeScalar(1));
+            } else if (c == '\n' && is instanceof PushbackInputStream pushback) {
+                int next = pushback.read();
+                if (next == -1) {
+                    self.put(EOF_KEY, new RuntimeScalar(1));
+                } else {
+                    pushback.unread(next);
+                }
+            }
             return new RuntimeScalar(result.length()).getList();
         } catch (IOException e) {
             return new RuntimeScalar(-1).getList();
@@ -168,6 +204,118 @@ public class CompressZlibGzFile extends PerlModuleBase {
         RuntimeScalar eofScalar = self.get(EOF_KEY);
         int eof = (eofScalar != null) ? eofScalar.getInt() : 0;
         return new RuntimeScalar(eof).getList();
+    }
+
+    public static RuntimeList gztell(RuntimeArray args, int ctx) {
+        if (args.isEmpty()) {
+            return new RuntimeScalar(-1).getList();
+        }
+        RuntimeHash self = args.get(0).hashDeref();
+        RuntimeScalar pos = self.get(POS_KEY);
+        return new RuntimeScalar(pos != null ? pos.getLong() : 0).getList();
+    }
+
+    public static RuntimeList gzseek(RuntimeArray args, int ctx) {
+        if (args.size() < 3) {
+            throw new IllegalArgumentException("gzseek: not enough arguments");
+        }
+        RuntimeHash self = args.get(0).hashDeref();
+        long offset = args.get(1).getLong();
+        int whence = args.get(2).getInt();
+        long current = self.get(POS_KEY) != null ? self.get(POS_KEY).getLong() : 0;
+        RuntimeScalar mode = self.get(MODE_KEY);
+        long target;
+        if (whence == 0) {
+            target = offset;
+        } else if (whence == 1) {
+            target = current + offset;
+        } else if (whence == 2) {
+            if (mode != null && mode.toString().startsWith("r")) {
+                throw new IllegalArgumentException("gzseek: SEEK_END not allowed");
+            }
+            throw new IllegalArgumentException("gzseek: cannot seek backwards");
+        } else {
+            throw new IllegalArgumentException("gzseek: unknown value, " + whence + ", for whence parameter");
+        }
+        if (target < current) {
+            throw new IllegalArgumentException("gzseek: cannot seek backwards");
+        }
+        long gap = target - current;
+        long newPosition = target;
+        if (gap > 0 && mode != null && mode.toString().startsWith("r")) {
+            RuntimeScalar streamScalar = self.get(STREAM_KEY);
+            if (streamScalar != null && streamScalar.type == RuntimeScalarType.JAVAOBJECT
+                    && streamScalar.value instanceof InputStream is) {
+                try {
+                    long remaining = gap;
+                    while (remaining > 0) {
+                        long skipped = is.skip(remaining);
+                        if (skipped > 0) {
+                            remaining -= skipped;
+                            continue;
+                        }
+                        int one = is.read();
+                        if (one == -1) {
+                            self.put(EOF_KEY, new RuntimeScalar(1));
+                            break;
+                        }
+                        remaining--;
+                    }
+                    gap -= remaining;
+                    newPosition = current + gap;
+                } catch (IOException e) {
+                    return new RuntimeScalar(0).getList();
+                }
+            }
+        } else if (gap > 0 && mode != null && mode.toString().startsWith("w")) {
+            RuntimeScalar streamScalar = self.get(STREAM_KEY);
+            if (streamScalar != null && streamScalar.type == RuntimeScalarType.JAVAOBJECT
+                    && streamScalar.value instanceof OutputStream os) {
+                try {
+                    byte[] zeros = new byte[(int) Math.min(gap, 8192)];
+                    while (gap > 0) {
+                        int chunk = (int) Math.min(gap, zeros.length);
+                        os.write(zeros, 0, chunk);
+                        gap -= chunk;
+                    }
+                } catch (IOException e) {
+                    return new RuntimeScalar(0).getList();
+                }
+            }
+        }
+        self.put(POS_KEY, new RuntimeScalar(newPosition));
+        return new RuntimeScalar(1).getList();
+    }
+
+    public static RuntimeList gzflush(RuntimeArray args, int ctx) {
+        if (args.isEmpty()) {
+            return new RuntimeScalar(-2).getList();
+        }
+        RuntimeHash self = args.get(0).hashDeref();
+        RuntimeScalar streamScalar = self.get(STREAM_KEY);
+        if (streamScalar == null || streamScalar.type != RuntimeScalarType.JAVAOBJECT) {
+            return new RuntimeScalar(-2).getList();
+        }
+        try {
+            if (streamScalar.value instanceof OutputStream os) {
+                os.flush();
+            }
+            return new RuntimeScalar(0).getList();
+        } catch (IOException e) {
+            return new RuntimeScalar(-2).getList();
+        }
+    }
+
+    public static RuntimeList gzsetparams(RuntimeArray args, int ctx) {
+        if (args.size() < 3) {
+            throw new IllegalArgumentException("Usage: Compress::Zlib::gzFile::gzsetparams(file, level, strategy)");
+        }
+        RuntimeHash self = args.get(0).hashDeref();
+        RuntimeScalar mode = self.get(MODE_KEY);
+        if (mode != null && mode.toString().startsWith("r")) {
+            return new RuntimeScalar(-2).getList();
+        }
+        return new RuntimeScalar(0).getList();
     }
 
     /**
@@ -215,6 +363,12 @@ public class CompressZlibGzFile extends PerlModuleBase {
             result.add(new RuntimeScalar(0)); // Z_OK
             return result;
         }
-        return new RuntimeScalar("").getList();
+        return new RuntimeScalar(0).getList();
+    }
+
+    private static void addPosition(RuntimeHash self, long amount) {
+        RuntimeScalar pos = self.get(POS_KEY);
+        long current = pos != null ? pos.getLong() : 0;
+        self.put(POS_KEY, new RuntimeScalar(current + amount));
     }
 }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Utf8.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Utf8.java
@@ -178,8 +178,17 @@ public class Utf8 extends PerlModuleBase {
                 // The string is already representable in ISO-8859-1, so the downgrade
                 // is logically successful even if we can't modify the scalar in-place.
                 if (!(scalar instanceof RuntimeScalarReadOnly)) {
-                    // Ensure the UTF-8 flag is off by using the ISO-8859-1 encoding
-                    scalar.set(new String(bytes, StandardCharsets.ISO_8859_1));
+                    // Ensure the UTF-8 flag is off by using the ISO-8859-1 encoding.
+                    // A substr lvalue of a read-only literal can throw while trying
+                    // to propagate the unchanged bytes back to its parent; Perl treats
+                    // utf8::downgrade($that, 1) as successful when the value itself
+                    // is representable, so keep the proxy's local byte-string state.
+                    String decodedBytes = new String(bytes, StandardCharsets.ISO_8859_1);
+                    try {
+                        scalar.set(decodedBytes);
+                    } catch (PerlCompilerException e) {
+                        scalar.value = decodedBytes;
+                    }
                     scalar.type = BYTE_STRING;
                 }
                 return new RuntimeScalar(true).getList();

--- a/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessor.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessor.java
@@ -1749,6 +1749,40 @@ public class RegexPreprocessor {
                 // Handle escape sequences
                 pos += 2;
                 totalLength++;
+            } else if (ch == '[') {
+                // A character class inside lookbehind has fixed width 1.
+                // Skip over its contents so literal braces like [${FOO}]
+                // are not misread as {n,m} quantifiers.
+                pos++;
+                boolean inEscape = false;
+                boolean first = true;
+                while (pos < pattern.length()) {
+                    char cc = pattern.charAt(pos);
+                    if (inEscape) {
+                        inEscape = false;
+                        pos++;
+                        first = false;
+                        continue;
+                    }
+                    if (cc == '\\') {
+                        inEscape = true;
+                        pos++;
+                        first = false;
+                        continue;
+                    }
+                    if (cc == ']' && !first) {
+                        pos++;
+                        break;
+                    }
+                    if (cc == '^' && first) {
+                        pos++;
+                        first = false;
+                        continue;
+                    }
+                    pos++;
+                    first = false;
+                }
+                totalLength++;
             } else if (ch == '.') {
                 // Check if followed by * or +
                 if (pos + 1 < pattern.length()) {
@@ -1771,7 +1805,7 @@ public class RegexPreprocessor {
             } else if (ch == '{') {
                 // Handle {n,m} quantifiers
                 int endBrace = pattern.indexOf('}', pos);
-                if (endBrace > pos) {
+                if (endBrace > pos && isValidQuantifierAt(pattern, pos)) {
                     String quantifier = pattern.substring(pos + 1, endBrace);
                     int multiplier = parseQuantifierMax(quantifier);
                     if (multiplier == -1) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ExceptionFormatter.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ExceptionFormatter.java
@@ -229,6 +229,9 @@ public class ExceptionFormatter {
                         entry.add(filename);
                         entry.add(line);
                         entry.add(subName);
+                        if (frame.virtualEvalFrame()) {
+                            entry.add("virtual-eval");
+                        }
                         // Interpreter frames from tokenIndex/PC represent the sub's OWN
                         // location (like JVM frames), so firstFrameFromInterpreter stays
                         // false and caller() will skip this frame to reach the actual caller.

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeScalar.java
@@ -76,9 +76,11 @@ public class GlobalRuntimeScalar extends RuntimeScalar {
         if (originalVariable instanceof OutputRecordSeparator) {
             OutputRecordSeparator.saveInternalORS();
             newLocal = new OutputRecordSeparator();
+            newLocal.set(RuntimeScalarCache.scalarUndef);
         } else if (originalVariable instanceof OutputFieldSeparator) {
             OutputFieldSeparator.saveInternalOFS();
             newLocal = new OutputFieldSeparator();
+            newLocal.set(RuntimeScalarCache.scalarUndef);
         } else {
             newLocal = new GlobalRuntimeScalar(fullName);
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -103,6 +103,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      */
     private static final ThreadLocal<ArrayDeque<EvalRuntimeContext>> evalRuntimeContextStack =
             ThreadLocal.withInitial(ArrayDeque::new);
+    private static final ThreadLocal<ArrayDeque<ArrayList<String>>> syntheticCallerFrames =
+            ThreadLocal.withInitial(ArrayDeque::new);
     // Cache for memoization of evalStringHelper results
     private static final int CLASS_CACHE_SIZE = 100;
     private static final Map<String, Class<?>> evalCache = new LinkedHashMap<String, Class<?>>(CLASS_CACHE_SIZE, 0.75f, true) {
@@ -1165,6 +1167,26 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         }
     }
 
+    private static void pushSyntheticEvalCallerFrame(String packageName, String filename, int line) {
+        ArrayList<String> frame = new ArrayList<>();
+        frame.add(packageName != null && !packageName.isEmpty() ? packageName : "main");
+        frame.add(filename != null ? filename : "(eval)");
+        frame.add(String.valueOf(line));
+        frame.add("(eval)");
+        frame.add("virtual-eval");
+        syntheticCallerFrames.get().addLast(frame);
+    }
+
+    private static void popSyntheticEvalCallerFrame() {
+        ArrayDeque<ArrayList<String>> stack = syntheticCallerFrames.get();
+        if (!stack.isEmpty()) {
+            stack.removeLast();
+        }
+        if (stack.isEmpty()) {
+            syntheticCallerFrames.remove();
+        }
+    }
+
     private static void registerEvalRuntimeAlias(EvalRuntimeContext context, char sigil, String fullName, RuntimeBase value) {
         context.aliases().add(new EvalRuntimeAlias(sigil, fullName, value));
     }
@@ -2043,6 +2065,16 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     int level = DynamicVariableManager.getLocalLevel();
                     DynamicVariableManager.pushLocalVariable(sig);
 
+                    evalDepth++;
+                    boolean pushedEvalFrame = InterpreterState.pushEvalFrameForCurrentInterpreter();
+                    boolean pushedSyntheticEvalFrame = false;
+                    if (!pushedEvalFrame) {
+                        pushSyntheticEvalCallerFrame(
+                                InterpreterState.currentPackage.get().toString(),
+                                evalCompilerOptions.fileName,
+                                1);
+                        pushedSyntheticEvalFrame = true;
+                    }
                     try {
                         RuntimeArray handlerArgs = new RuntimeArray();
                         RuntimeArray.push(handlerArgs, new RuntimeScalar(err));
@@ -2062,6 +2094,13 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                         }
                         // If handler throws other exceptions, ignore them (keep original error in $@)
                     } finally {
+                        if (pushedEvalFrame) {
+                            InterpreterState.pop();
+                        }
+                        if (pushedSyntheticEvalFrame) {
+                            popSyntheticEvalCallerFrame();
+                        }
+                        evalDepth--;
                         // Restore $SIG{__DIE__}
                         DynamicVariableManager.popToLocalLevel(level);
                     }
@@ -2751,6 +2790,16 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         Throwable t = new Throwable();
         ExceptionFormatter.StackTraceResult result = ExceptionFormatter.formatExceptionDetailed(t);
         ArrayList<ArrayList<String>> stackTrace = result.frames();
+        ArrayDeque<ArrayList<String>> syntheticFrames = syntheticCallerFrames.get();
+        if (!syntheticFrames.isEmpty()) {
+            int baseSkip = result.firstFrameFromInterpreter() ? 0 : 1;
+            int insertAt = Math.min(baseSkip + 1, stackTrace.size());
+            ArrayList<ArrayList<String>> framesToInsert = new ArrayList<>();
+            for (Iterator<ArrayList<String>> it = syntheticFrames.descendingIterator(); it.hasNext(); ) {
+                framesToInsert.add(new ArrayList<>(it.next()));
+            }
+            stackTrace.addAll(insertAt, framesToInsert);
+        }
         java.util.ArrayList<String> javaClassNames = extractJavaClassNames(t);
         int stackTraceSize = stackTrace.size();
 
@@ -2795,9 +2844,18 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 // The subroutine name at frame N is actually stored at frame N-1
                 // because it represents the sub that IS CALLING frame N
                 String subName = null;
+                String frameSubName = frameInfo.size() > 3 ? frameInfo.get(3) : null;
+                boolean virtualEvalFrame = frameInfo.size() > 4
+                        && "virtual-eval".equals(frameInfo.get(4));
+
+                // Synthetic frames such as eval blocks describe the frame itself,
+                // not the previous caller, so preserve their own subroutine name.
+                if (virtualEvalFrame && frameSubName != null && frameSubName.startsWith("(")) {
+                    subName = frameSubName;
+                }
 
                 RuntimeCode activeCode = getActiveCodeAt(originalFrame);
-                if (activeCode != null) {
+                if (subName == null && activeCode != null) {
                     subName = callerSubNameForCode(activeCode);
                 }
                 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
@@ -865,12 +865,29 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
             RuntimeIO oldSelected = existingIO == RuntimeIO.selectedHandle ? existingIO : null;
             existingIO.replaceStateFrom(io);
             existingIO.globName = this.globName;
+            Integer standardFd = standardFdForGlobName(this.globName);
+            if (standardFd != null) {
+                existingIO.registerExternalFd(standardFd);
+            }
             if (oldSelected != null) {
                 RuntimeIO.selectedHandle = existingIO;
             }
             return this;
         }
         return setIO(io);
+    }
+
+    private static Integer standardFdForGlobName(String globName) {
+        if ("main::STDIN".equals(globName)) {
+            return 0;
+        }
+        if ("main::STDOUT".equals(globName)) {
+            return 1;
+        }
+        if ("main::STDERR".equals(globName)) {
+            return 2;
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
@@ -328,6 +328,10 @@ public class RuntimeIO extends RuntimeScalar {
      * @param fd the file descriptor number to register at
      */
     public void registerExternalFd(int fd) {
+        Integer oldFd = ioToFileno.remove(this);
+        if (oldFd != null && oldFd != fd) {
+            filenoToIO.remove(oldFd);
+        }
         filenoToIO.put(fd, this);
         ioToFileno.put(this, fd);
         // Advance nextFileno past this fd to avoid collisions
@@ -1167,7 +1171,7 @@ public class RuntimeIO extends RuntimeScalar {
         if (fh == null) {
             // Check if object is eligible for overloading `*{}`
             int blessId = RuntimeScalarType.blessedId(runtimeScalar);
-            if (blessId < 0) {
+            if (blessId != 0) {
                 // Prepare overload context and check if object is eligible for overloading
                 OverloadContext ctx = OverloadContext.prepare(blessId);
                 if (ctx != null) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -2518,7 +2518,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         // make the still-live callback forget the variables it closed over.
         // Captures are released when the CODE object's counted references
         // truly reach zero.
-        if (type == RuntimeScalarType.CODE && value instanceof RuntimeCode code) {
+        if (type == RuntimeScalarType.CODE && value instanceof RuntimeCode code && globalCodeRefFqn != null) {
             boolean releasedCode = false;
             if (this.refCountOwned && code.refCount > 0) {
                 this.refCountOwned = false;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/TieHandle.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/TieHandle.java
@@ -34,6 +34,7 @@ public class TieHandle extends RuntimeIO {
      * The tied object (handler) that implements the tie interface methods.
      */
     private final RuntimeScalar self;
+    private final boolean holdsSelfReference;
 
     /**
      * The package name that this handle is tied to.
@@ -53,11 +54,17 @@ public class TieHandle extends RuntimeIO {
      * @param self          the blessed object returned by TIEHANDLE
      */
     public TieHandle(String tiedPackage, RuntimeIO previousValue, RuntimeScalar self) {
+        this(tiedPackage, previousValue, self, true);
+    }
+
+    public TieHandle(String tiedPackage, RuntimeIO previousValue, RuntimeScalar self, boolean holdSelfReference) {
         this.tiedPackage = tiedPackage;
         this.previousValue = previousValue;
         this.self = self;
+        this.holdsSelfReference = holdSelfReference;
         // Increment refCount: the tie wrapper holds a strong reference to the tied object.
-        if (self != null && (self.type & RuntimeScalarType.REFERENCE_BIT) != 0
+        if (holdSelfReference
+                && self != null && (self.type & RuntimeScalarType.REFERENCE_BIT) != 0
                 && self.value instanceof RuntimeBase base
                 && base.refCount >= 0) {
             base.refCount++;
@@ -238,6 +245,9 @@ public class TieHandle extends RuntimeIO {
      * Decrements refCount and triggers DESTROY if it reaches 0.
      */
     public void releaseTiedObject() {
+        if (!holdsSelfReference) {
+            return;
+        }
         if ((self.type & RuntimeScalarType.REFERENCE_BIT) != 0
                 && self.value instanceof RuntimeBase base) {
             if (base.refCount > 0 && --base.refCount == 0) {

--- a/src/main/perl/lib/Compress/Zlib.pm
+++ b/src/main/perl/lib/Compress/Zlib.pm
@@ -14,44 +14,71 @@ package Compress::Zlib;
 use strict;
 use warnings;
 
-our $VERSION = '2.219';
+our $VERSION = '2.220';
 
 use Exporter;
 our @ISA = qw(Exporter);
 
 XSLoader::load('Compress::Zlib');
 
+our $gzerrno = 0;
+
 our @EXPORT = qw(
+    $gzerrno
     compress
     uncompress
     memGzip
     memGunzip
+    zlib_version
     crc32
     adler32
     inflateInit
     deflateInit
     gzopen
+    ZLIB_VERSION
+    ZLIB_VERNUM
     Z_OK
     Z_STREAM_END
+    Z_NEED_DICT
+    Z_ERRNO
     Z_STREAM_ERROR
     Z_DATA_ERROR
+    Z_MEM_ERROR
     Z_BUF_ERROR
+    Z_VERSION_ERROR
+    Z_NO_COMPRESSION
     Z_NO_FLUSH
+    Z_PARTIAL_FLUSH
     Z_SYNC_FLUSH
     Z_FULL_FLUSH
     Z_FINISH
+    Z_BLOCK
+    Z_TREES
     Z_DEFAULT_COMPRESSION
     Z_BEST_SPEED
     Z_BEST_COMPRESSION
     Z_FILTERED
     Z_HUFFMAN_ONLY
+    Z_RLE
+    Z_FIXED
     Z_DEFAULT_STRATEGY
     Z_DEFLATED
+    Z_NULL
+    Z_ASCII
+    Z_BINARY
+    Z_UNKNOWN
     WANT_GZIP
     WANT_GZIP_OR_ZLIB
     MAX_WBITS
+    MAX_MEM_LEVEL
+    DEF_WBITS
+    OS_CODE
 );
 
 our @EXPORT_OK = @EXPORT;
+our %EXPORT_TAGS = (
+    ALL => \@EXPORT_OK,
+    all => \@EXPORT_OK,
+);
 
 1;

--- a/src/main/perl/lib/ExtUtils/MakeMaker.pm
+++ b/src/main/perl/lib/ExtUtils/MakeMaker.pm
@@ -255,10 +255,10 @@ sub _install_pure_perl {
         my $parent_dir = @parts ? join('/', @parts) : '';
         (my $full_path = ($name || '')) =~ s{::}{/}g;
         my $libdir = $parent_dir
-            ? File::Spec->catdir($INSTALL_BASE, $parent_dir)
+            ? _install_dest($INSTALL_BASE, $parent_dir)
             : $INSTALL_BASE;
         my $autodir = $full_path
-            ? File::Spec->catdir($INSTALL_BASE, 'auto', $full_path)
+            ? _install_dest($INSTALL_BASE, "auto/$full_path")
             : $INSTALL_BASE;
         for my $key (keys %pm) {
             my $val = $pm{$key};
@@ -289,7 +289,7 @@ sub _install_pure_perl {
                     return unless -f && /$installable_re/;
                     my $src = $File::Find::name;
                     (my $rel = $src) =~ s{^lib/}{};
-                    $pm{$src} = File::Spec->catfile($INSTALL_BASE, $rel);
+                    $pm{$src} = _install_dest($INSTALL_BASE, $rel);
                     $pm_rel_seen{$rel} = 1;
                 },
                 no_chdir => 1,
@@ -306,7 +306,7 @@ sub _install_pure_perl {
                     my $src = $File::Find::name;
                     (my $rel = $src) =~ s{^blib/lib/}{};
                     return if $pm_rel_seen{$rel};
-                    $pm{$src} = File::Spec->catfile($INSTALL_BASE, $rel);
+                    $pm{$src} = _install_dest($INSTALL_BASE, $rel);
                     $pm_rel_seen{$rel} = 1;
                 },
                 no_chdir => 1,
@@ -333,7 +333,7 @@ sub _install_pure_perl {
                     my $dest_rel = $parent_dir
                         ? File::Spec->catfile($parent_dir, $file)
                         : $file;
-                    $pm{$file} = File::Spec->catfile($INSTALL_BASE, $dest_rel)
+                    $pm{$file} = _install_dest($INSTALL_BASE, $dest_rel)
                         unless exists $pm{$file};
                 }
                 closedir($dh);
@@ -349,7 +349,7 @@ sub _install_pure_perl {
                         my $rel = $parent_dir
                             ? File::Spec->catfile($parent_dir, $src)
                             : $src;
-                        $pm{$src} = File::Spec->catfile($INSTALL_BASE, $rel)
+                        $pm{$src} = _install_dest($INSTALL_BASE, $rel)
                             unless exists $pm{$src};
                     },
                     no_chdir => 1,
@@ -376,6 +376,11 @@ sub _install_pure_perl {
     # allowing other files from the same distribution to be installed
     # (e.g. IO::Socket::SSL::Utils from the IO-Socket-SSL dist).
     #
+    # Secondary bundled modules still need to be staged into blib/lib for
+    # this distribution's own tests.  IO-Compress ships lib/Compress/Zlib.pm
+    # as a compatibility layer; dropping it from blib makes its tests load
+    # PerlOnJava's bundled shim instead of the source under test.
+    #
     # Also track whether the *primary* module of this distribution was
     # the one we SKIPped: if so, the upstream tarball's t/*.t suite is
     # almost certainly testing a different architecture from our JAR
@@ -385,16 +390,22 @@ sub _install_pure_perl {
     (my $primary_rel = $name) =~ s{::}{/}g;
     $primary_rel .= '.pm';
     my $primary_pm_bundled = 0;
+    my %blib_only_pm;
     for my $src (sort keys %pm) {
         my $dest = $pm{$src};
         (my $rel = $dest) =~ s{^\Q$INSTALL_BASE\E/?}{};
         if ($rel && -f "jar:PERL5LIB/$rel") {
             print "  SKIP: $rel (bundled in PerlOnJava JAR)\n";
-            $primary_pm_bundled = 1 if $rel eq $primary_rel;
+            if ($rel eq $primary_rel) {
+                $primary_pm_bundled = 1;
+            } else {
+                $blib_only_pm{$src} = $dest;
+            }
             delete $pm{$src};
         }
     }
     $args->{_primary_pm_bundled} = $primary_pm_bundled;
+    $args->{_blib_only_pm} = \%blib_only_pm;
     if ($primary_pm_bundled && !$ENV{JCPAN_RUN_BUNDLED_TESTS}) {
         print "  NOTE: $primary_rel is bundled; upstream test suite will be skipped.\n";
         print "        Set JCPAN_RUN_BUNDLED_TESTS=1 to run it anyway.\n";
@@ -486,10 +497,10 @@ sub _build_share_file_mapping {
             
             my $dest_base;
             if ($type eq 'dist') {
-                $dest_base = File::Spec->catdir($INSTALL_BASE, 'auto', 'share', 'dist', $dist_name);
+                $dest_base = _install_dest($INSTALL_BASE, "auto/share/dist/$dist_name");
             } elsif ($type eq 'module' && $def->{module}) {
                 (my $mod_path = $def->{module}) =~ s/::/\//g;
-                $dest_base = File::Spec->catdir($INSTALL_BASE, 'auto', 'share', 'module', $mod_path);
+                $dest_base = _install_dest($INSTALL_BASE, "auto/share/module/$mod_path");
             } else {
                 next;
             }
@@ -522,7 +533,7 @@ sub _build_share_file_mapping {
                     
                     my $src = $File::Find::name;
                     (my $rel = $src) =~ s{^\Q$src_dir\E/?}{};
-                    $files{$src} = File::Spec->catfile($dest_base, $rel);
+                    $files{$src} = _install_dest($dest_base, $rel);
                 },
                 no_chdir => 1,
                 preprocess => sub {
@@ -543,6 +554,13 @@ sub _build_share_file_mapping {
     }
     
     return %files;
+}
+
+sub _install_dest {
+    my ($base, $rel) = @_;
+    return $base unless defined $rel && length $rel;
+    $rel =~ s{\\}{/}g;
+    return $base =~ m{[\\/]$} ? "$base$rel" : "$base/$rel";
 }
 
 sub _extract_version {
@@ -656,6 +674,7 @@ sub _create_install_makefile {
     # Merge share files into pm hash so they're staged to blib
     # This happens before the loop that processes %$pm
     %$pm = (%$pm, %share_files);
+    my %blib_pm = (%$pm, %{ $args->{_blib_only_pm} || {} });
     
     for my $src (sort keys %$pm) {
         my $dest = $pm->{$src};
@@ -664,7 +683,11 @@ sub _create_install_makefile {
             push @install_cmds, _shell_mkdir($dir);
         }
         push @install_cmds, _shell_cp($src, $dest, "$INSTALL_BASE/auto");
-        
+    }
+
+    for my $src (sort keys %blib_pm) {
+        my $dest = $blib_pm{$src};
+
         # Build blib/lib copy command: derive relative path from source
         # Source is like "lib/Text/CSV.pm" -> blib dest is "blib/lib/Text/CSV.pm"
         my $blib_rel;
@@ -747,13 +770,13 @@ sub _create_install_makefile {
     }
     my $pl_cmds_str = join("\n", @pl_cmds) || "\t\@true";
 
-    my $pm_deps_str = join(' ', sort grep { $_ !~ m{^blib/lib/} && !($pl_targets{$_} && !-e $_) } keys %$pm);
+    my $pm_deps_str = join(' ', sort grep { $_ !~ m{^blib/lib/} && !($pl_targets{$_} && !-e $_) } keys %blib_pm);
     $pm_deps_str = " $pm_deps_str" if length $pm_deps_str;
     
     # Make pm_to_blib target conditional - if no .pm files, make it a no-op
     # This handles cases like File::ShareDir::Install tests that only have share files
     my $pm_to_blib_target = "pm_to_blib::";
-    if (%$pm) {
+    if (%blib_pm) {
         $pm_to_blib_target = "pm_to_blib::$pm_deps_str";
     }
 

--- a/src/main/perl/lib/File/Glob.pm
+++ b/src/main/perl/lib/File/Glob.pm
@@ -10,6 +10,7 @@ use Exporter 'import';
 our @EXPORT_OK = qw(
     glob
     bsd_glob
+    csh_glob
     GLOB_ERROR
     GLOB_CSH
     GLOB_NOMAGIC
@@ -28,6 +29,7 @@ our %EXPORT_TAGS = (
     'glob' => [ qw(
         glob
         bsd_glob
+        csh_glob
         GLOB_ERROR
         GLOB_CSH
         GLOB_NOMAGIC
@@ -67,7 +69,6 @@ sub bsd_glob {
 
     if ($pattern eq '~' || $pattern =~ m{^~/}) {
         my @matches = CORE::glob($pattern);
-        @matches = map { _dequote($_) } @matches;
         return wantarray ? @matches : $matches[0];
     }
 
@@ -77,13 +78,17 @@ sub bsd_glob {
     }
 
     my @matches = CORE::glob($pattern);
-    @matches = map { _dequote($_) } @matches;
+    @matches = sort @matches unless $flags & GLOB_NOSORT;
 
     if (!@matches && ($flags & GLOB_NOCHECK)) {
         @matches = (_dequote($pattern));
     }
 
     return wantarray ? @matches : $matches[0];
+}
+
+sub csh_glob {
+    return bsd_glob(@_);
 }
 
 # Regular glob - just use built-in

--- a/src/main/perl/lib/IO/File.pm
+++ b/src/main/perl/lib/IO/File.pm
@@ -195,6 +195,11 @@ sub open {
             return open($fh, IO::Handle::_open_mode_string($mode), $file);
         }
     }
+    if (!ref($file) && $file =~ /^\s*([+<>]*|>>)\s+-\s*$/) {
+        my $mode = $1 || '<';
+        return open($fh, "<&=STDIN") if $mode =~ /</;
+        return open($fh, ">&=STDOUT") if $mode =~ />/;
+    }
     open($fh, $file);
 }
 

--- a/src/main/perl/lib/IO/Handle.pm
+++ b/src/main/perl/lib/IO/Handle.pm
@@ -17,6 +17,7 @@ use 5.38.0;
 XSLoader::load( 'IO::Handle' );
 
 our $VERSION = '1.52';
+my %AUTOFLUSH;
 
 use Exporter 'import';
 our @EXPORT = qw();
@@ -40,6 +41,9 @@ our @EXPORT_OK = qw(
     _IOFBF
     _IOLBF
     _IONBF
+    SEEK_SET
+    SEEK_CUR
+    SEEK_END
 );
 
 # Constants for setvbuf
@@ -166,11 +170,9 @@ sub truncate {
 
 sub autoflush {
     my $fh = shift;
-    my $old_fh = select($fh);
-    my $old_val = $|;
-    $| = shift if @_;
-    $| = 1 if !defined $| && !@_;  # Default to turning on autoflush
-    select($old_fh);
+    my $key = defined fileno($fh) ? fileno($fh) : "$fh";
+    my $old_val = $AUTOFLUSH{$key} // 0;
+    $AUTOFLUSH{$key} = @_ ? ($_[0] ? 1 : 0) : 1;
     return $old_val;
 }
 
@@ -336,10 +338,16 @@ sub _open_mode_string {
 sub write {
     my $fh = shift;
     my $buf = shift;
-    my $len = shift || length($buf);
-    my $offset = shift || 0;
+    my $len = @_ ? shift : length($buf);
+    my $offset = @_ ? shift : 0;
 
-    my $data = substr($buf, $offset, $len);
+    my $data;
+    {
+        use bytes;
+        $data = substr($buf, $offset, $len);
+    }
+    utf8::encode($data) if utf8::is_utf8($data);
+    local $\;
     print $fh $data;
 }
 

--- a/src/main/perl/lib/bytes.pm
+++ b/src/main/perl/lib/bytes.pm
@@ -1,6 +1,13 @@
 package bytes;
 
-# placeholder
+our $hint_bits = 0x00000008;
+
+sub import {
+    $^H |= $hint_bits;
+}
+
+sub unimport {
+    $^H &= ~$hint_bits;
+}
 
 1;
-

--- a/src/test/resources/unit/io_compress_regressions.t
+++ b/src/test/resources/unit/io_compress_regressions.t
@@ -1,0 +1,201 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More tests => 31;
+use File::Spec;
+
+{
+    package BranchBlessGuard;
+
+    sub new {
+        if (0) {
+            bless [], shift;
+        }
+        else {
+            bless [], shift;
+        }
+    }
+
+    sub DESTROY {
+        $main::branch_bless_destroyed++;
+    }
+}
+
+my $guard = BranchBlessGuard->new;
+is($main::branch_bless_destroyed, undef, 'blessed value returned from branch survives caller assignment');
+undef $guard;
+is($main::branch_bless_destroyed, 1, 'branch-returned blessed value is destroyed after caller releases it');
+
+ok(!defined &{"main::missing_io_compress_regression_sub"}, 'defined &{string} is allowed under strict refs for missing subs');
+
+sub existing_io_compress_regression_sub { 1 }
+ok(defined &{"main::existing_io_compress_regression_sub"}, 'defined &{string} is true under strict refs for existing subs');
+
+{
+    package ImportedPrototypeRegression;
+    sub gzlike ($$) { 1 }
+}
+*main::gzlike_imported_regression = \&ImportedPrototypeRegression::gzlike;
+eval 'gzlike_imported_regression()';
+like($@, qr/Not enough arguments for ImportedPrototypeRegression::gzlike\b/,
+     'imported prototype errors report the original CV name');
+
+{
+    my $chars = "a\xFF\x{100}";
+    my $octets = "\x61\xC3\xBF\xC4\x80";
+    ok(!($chars eq $octets), 'plain string eq compares characters for UTF-8 scalars');
+    {
+        use bytes;
+        ok($chars eq $octets, 'use bytes makes string eq compare UTF-8 octets');
+    }
+}
+
+{
+    my $char = pack("W*", 0x100);
+    utf8::upgrade($char);
+    if (1) {
+        use bytes;
+        my $bytes = CORE::fc($char);
+        is(unpack("H*", $bytes), 'c480', 'use bytes folds non-ASCII as UTF-8 bytes inside block');
+    }
+    my $copy = "" . $char;
+    utf8::encode($copy);
+    is(unpack("H*", $copy), 'c480', 'use bytes block does not leak into later concatenation');
+}
+
+is($Compress::Zlib::VERSION || do { require Compress::Zlib; $Compress::Zlib::VERSION }, '2.220', 'bundled Compress::Zlib reports IO::Compress-compatible version');
+
+use IO::Handle qw(SEEK_SET SEEK_CUR SEEK_END);
+is_deeply([SEEK_SET, SEEK_CUR, SEEK_END], [0, 1, 2], 'IO::Handle exports seek constants on request');
+
+require IO::File;
+my $autoflush_fh = IO::File->new_tmpfile;
+is($autoflush_fh->autoflush(1), 0, 'IO::Handle autoflush returns initial false state');
+is($autoflush_fh->autoflush(1), 1, 'IO::Handle autoflush returns previous true state');
+
+{
+    my $stdin_data = "stdin regression\n";
+    open(SAVE_STDIN_REGRESSION, "<&STDIN") or die "dup STDIN failed: $!";
+    open(STDIN, "<", \$stdin_data) or die "reopen STDIN failed: $!";
+    is(fileno(STDIN), 0, 'reopening STDIN preserves file descriptor 0');
+    open(STDIN, "<&SAVE_STDIN_REGRESSION") or die "restore STDIN failed: $!";
+    close SAVE_STDIN_REGRESSION;
+}
+
+{
+    package OverloadedHandleRegression;
+    use overload '*{}' => sub { $_[0]->{fh} }, fallback => 1;
+    sub new { bless { fh => $_[1] }, $_[0] }
+}
+
+{
+    my $data = "x";
+    open(my $fh, "<", \$data) or die "scalar open failed: $!";
+    my $obj = OverloadedHandleRegression->new($fh);
+    ok(!eof($obj), 'eof resolves overloaded filehandle objects');
+    read($fh, my $buf, 1);
+    ok(eof($obj), 'eof sees EOF through overloaded filehandle object');
+}
+
+my $no_pre_esc = q{(?<![${BEGIN_DELIM}])};
+my $glob_pattern = 'foo#1';
+$glob_pattern =~ s/${no_pre_esc}#(\d)/bar/g;
+is($glob_pattern, 'foobar', 'lookbehind length validation ignores literal braces in character classes');
+
+require File::Glob;
+File::Glob->import(':glob');
+*File::GlobMapperRegression::globber = \&File::Glob::csh_glob;
+ok(defined &File::GlobMapperRegression::globber, 'File::Glob provides csh_glob for File::GlobMapper');
+{
+    my $dir = "io_compress_glob_order_$$";
+    mkdir $dir or die "mkdir $dir failed: $!";
+    for my $name (qw(a2 a3 a1)) {
+        open(my $fh, '>', "$dir/$name.tmp") or die "create glob fixture failed: $!";
+        print {$fh} $name;
+    }
+    my @expected_glob = map { File::Spec->catfile($dir, "$_.tmp") } qw(a1 a2 a3);
+    is_deeply([File::Glob::csh_glob("$dir/a*.tmp")],
+              \@expected_glob,
+              'File::Glob csh_glob sorts matches by default');
+    is_deeply([glob("$dir/a*.tmp")],
+              \@expected_glob,
+              'CORE glob sorts matches by default');
+    unlink "$dir/a1.tmp", "$dir/a2.tmp", "$dir/a3.tmp";
+    rmdir $dir;
+}
+
+{
+    my $fh = IO::File->new_tmpfile or die "tmpfile failed: $!";
+    local $\ = "\n";
+    $fh->write("hello");
+    seek($fh, 0, 0) or die "seek tmpfile failed: $!";
+    my $written = <$fh>;
+    is($written, 'hello', 'IO::Handle::write ignores output record separator');
+}
+
+{
+    my $buffer = '';
+    open(my $fh, '>', \$buffer) or die "scalar open failed: $!";
+    local $\ = "\n";
+    ok($fh->write("hello"), 'IO::Handle::write succeeds on scalar-backed filehandles');
+    is($buffer, 'hello', 'IO::Handle::write to scalar-backed filehandle ignores output record separator');
+}
+
+sub _print_with_local_output_record_separator {
+    my ($fh, $data) = @_;
+    local $\;
+    print $fh $data;
+}
+
+{
+    my $buffer = '';
+    open(my $fh, '>', \$buffer) or die "scalar open failed: $!";
+    local $\ = "\n";
+    _print_with_local_output_record_separator($fh, "hello");
+    is($buffer, 'hello', 'bare local output record separator clears print separator');
+}
+
+sub _downgrade_literal_substr {
+    my $buffer = \$_[0];
+    $buffer = \substr($$buffer, -1, 1);
+    return utf8::downgrade($$buffer, 1);
+}
+ok(_downgrade_literal_substr("xxx\n"), 'utf8::downgrade succeeds on byte-valued substr lvalue of literal argument');
+
+is(0xFFFFFFFF + 1, 4294967296, 'hex integer followed by plus is addition, not a hex exponent');
+
+{
+    local $SIG{__DIE__} = sub { die "die hook should be localized away" };
+    eval {
+        local $SIG{__DIE__};
+        die "localized die\n";
+    };
+    like($@, qr/^localized die/, 'bare local SIG die hook clears existing handler');
+}
+
+sub _io_compress_eval_proto_regression ($) { 1 }
+{
+    my $saw_eval_frame = 0;
+    local $SIG{__DIE__} = sub {
+        for (my $i = 0; my @caller = caller($i); $i++) {
+            $saw_eval_frame = 1 if ($caller[3] || '') eq '(eval)';
+        }
+    };
+    eval q{_io_compress_eval_proto_regression()};
+    ok($saw_eval_frame, 'eval-string compile errors expose an eval caller frame to SIG die handlers');
+}
+
+my $deflater = Compress::Zlib::deflateInit();
+ok(defined $deflater && !defined $deflater->msg, 'Compress::Zlib stream objects provide msg method');
+
+require Compress::Raw::Zlib;
+my ($scanner, $scan_status) = Compress::Raw::Zlib::_inflateScanInit();
+ok(defined $scanner && defined $scanner->getLastBlockOffset, 'inflateScanStream exposes block offset method');
+
+my $scan_deflater = $scanner->createDeflateStream(
+    -AppendOutput => 1,
+    -WindowBits   => -Compress::Raw::Zlib::MAX_WBITS(),
+    -CRC32        => 1,
+);
+ok(defined $scan_deflater && $scan_deflater->can('deflate'), 'inflateScanStream createDeflateStream accepts option pairs');

--- a/src/test/resources/unit/makemaker_secondary_bundled_blib.t
+++ b/src/test/resources/unit/makemaker_secondary_bundled_blib.t
@@ -1,0 +1,72 @@
+use strict;
+use warnings;
+use Test::More;
+use Cwd qw(getcwd);
+use File::Path qw(make_path);
+use File::Temp qw(tempdir);
+
+plan skip_all => 'Compress::Zlib is not bundled in this runtime'
+    unless -f 'jar:PERL5LIB/Compress/Zlib.pm';
+
+my $orig_dir = getcwd();
+my $tmpdir = tempdir(CLEANUP => 1);
+
+END {
+    chdir $orig_dir if defined $orig_dir;
+}
+
+chdir $tmpdir or die "chdir $tmpdir: $!";
+make_path('lib/Local', 'lib/Compress') or die "make_path test dirs: $!";
+
+open my $primary, '>', 'lib/Local/NeedsBundled.pm'
+    or die "create primary module: $!";
+print {$primary} "package Local::NeedsBundled;\nour \$VERSION = '0.001';\n1;\n";
+close $primary or die "close primary module: $!";
+
+open my $secondary, '>', 'lib/Compress/Zlib.pm'
+    or die "create secondary bundled module: $!";
+print {$secondary} "package Compress::Zlib;\nour \$VERSION = '0.001';\n1;\n";
+close $secondary or die "close secondary bundled module: $!";
+
+use ExtUtils::MakeMaker;
+
+my $site = "$tmpdir/site";
+{
+    local $ExtUtils::MakeMaker::INSTALL_BASE = $site;
+    WriteMakefile(
+        NAME    => 'Local::NeedsBundled',
+        VERSION => '0.001',
+    );
+}
+
+open my $mf, '<', 'Makefile' or die "open generated Makefile: $!";
+my $makefile = do { local $/; <$mf> };
+close $mf or die "close generated Makefile: $!";
+
+like(
+    $makefile,
+    qr/^pm_to_blib:: .*lib\/Compress\/Zlib\.pm.*lib\/Local\/NeedsBundled\.pm$/m,
+    'secondary bundled module remains a pm_to_blib dependency',
+);
+like(
+    $makefile,
+    qr/cp 'lib\/Compress\/Zlib\.pm' '\$\(INST_LIB\)\/Compress\/Zlib\.pm'/,
+    'secondary bundled module is staged into blib for tests',
+);
+unlike(
+    $makefile,
+    qr/cp 'lib\/Compress\/Zlib\.pm' '\Q$site\E\/Compress\/Zlib\.pm'/,
+    'secondary bundled module is not installed over the bundled shim',
+);
+like(
+    $makefile,
+    qr/cp 'lib\/Local\/NeedsBundled\.pm' '\Q$site\E\/Local\/NeedsBundled\.pm'/,
+    'primary module is still installed normally',
+);
+unlike(
+    $makefile,
+    qr/skipping upstream test suite/,
+    'secondary bundled modules do not make tests a no-op',
+);
+
+done_testing();


### PR DESCRIPTION
## Summary

- add IO::Compress/Compress::Zlib compatibility needed by the upstream IO::Compress test suite
- stage secondary bundled modules into `blib` during MakeMaker test builds
- fix supporting runtime gaps around raw IO, eval caller frames, ties, glob handling, bytes, and string comparisons

## Verification

- `timeout 1200 make`
- `timeout 1200 ./jcpan -t IO::Compress`
