### PR TITLE
Fix Carp::Assert deparse diagnostics

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/Whitespace.java
+++ b/src/main/java/org/perlonjava/frontend/parser/Whitespace.java
@@ -148,17 +148,29 @@ public class Whitespace {
                         // Update the context (ErrorMessageUtil instance) with the new file name
                         parser.ctx.errorUtil.setFileName(filename);
                     }
-                } else if (tokenIndex < tokens.size() && tokens.get(tokenIndex).type == LexerTokenType.IDENTIFIER) {
+                } else if (tokenIndex < tokens.size() && isUnquotedLineFilenameToken(tokens.get(tokenIndex))) {
                     // Unquoted filename: #line N filename
-                    // Perl allows unquoted bareword filenames in #line directives
-                    String filename = tokens.get(tokenIndex).text;
-                    parser.ctx.errorUtil.setFileName(filename);
-                    tokenIndex++; // Skip the filename token
+                    // Perl allows unquoted filenames such as lib/Foo/Bar.pm.
+                    StringBuilder filenameBuilder = new StringBuilder();
+                    while (tokenIndex < tokens.size() && isUnquotedLineFilenameToken(tokens.get(tokenIndex))) {
+                        filenameBuilder.append(tokens.get(tokenIndex).text);
+                        tokenIndex++;
+                    }
+                    String filename = filenameBuilder.toString();
+                    if (!filename.isEmpty()) {
+                        parser.ctx.errorUtil.setFileName(filename);
+                    }
                 }
             } catch (NumberFormatException e) {
                 // Handle the error if the line number is not valid
             }
         }
         return tokenIndex;
+    }
+
+    private static boolean isUnquotedLineFilenameToken(LexerToken token) {
+        return token.type != LexerTokenType.WHITESPACE
+                && token.type != LexerTokenType.NEWLINE
+                && token.type != LexerTokenType.EOF;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ErrorMessageUtil.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ErrorMessageUtil.java
@@ -429,10 +429,18 @@ public class ErrorMessageUtil {
                                     currentFileName = directiveFile;
                                 }
                             }
-                        } else if (j < tokens.size() && tokens.get(j).type == LexerTokenType.IDENTIFIER) {
+                        } else if (j < tokens.size() && isUnquotedLineFilenameToken(tokens.get(j))) {
                             // Unquoted filename: #line N filename
-                            // Perl allows unquoted bareword filenames in #line directives
-                            currentFileName = tokens.get(j).text;
+                            // Perl allows unquoted filenames such as lib/Foo/Bar.pm.
+                            StringBuilder filenameBuilder = new StringBuilder();
+                            while (j < tokens.size() && isUnquotedLineFilenameToken(tokens.get(j))) {
+                                filenameBuilder.append(tokens.get(j).text);
+                                j++;
+                            }
+                            String directiveFile = filenameBuilder.toString();
+                            if (!directiveFile.isEmpty()) {
+                                currentFileName = directiveFile;
+                            }
                         }
 
                         if (directiveLine >= 0) {
@@ -453,6 +461,12 @@ public class ErrorMessageUtil {
         }
 
         return new SourceLocation(currentFileName, lineNumber);
+    }
+
+    private static boolean isUnquotedLineFilenameToken(LexerToken token) {
+        return token.type != LexerTokenType.WHITESPACE
+                && token.type != LexerTokenType.NEWLINE
+                && token.type != LexerTokenType.EOF;
     }
 
     public record SourceLocation(String fileName, int lineNumber) {
@@ -492,4 +506,3 @@ public class ErrorMessageUtil {
         return lines.toArray(new String[0]);
     }
 }
-

--- a/src/main/perl/lib/B/Deparse.pm
+++ b/src/main/perl/lib/B/Deparse.pm
@@ -10,8 +10,8 @@ our $VERSION = '1.00_perlonjava';
 # 
 # This stub provides minimal functionality:
 # 1. For Sub::Quote created subs, return the stored source code
-# 2. For simple anonymous subs whose source file is still available, return
-#    the source-visible body
+# 2. For simple anonymous subs and prototype blocks whose source file is
+#    still available, return the source-visible body
 # 3. For other subs, return a placeholder
 
 sub new {
@@ -78,34 +78,54 @@ sub _source_visible_anon_sub {
     my @lines = <$fh>;
     close $fh;
 
-    my $source = join '', @lines[($line - 1) .. ($line + 8 < @lines ? $line + 8 : $#lines)];
-    return unless $source =~ /\bsub\s*(?:\([^)]*\)\s*)?\{/;
+    my $source = join '', @lines;
+    return _extract_source_visible_block($source, $line);
+}
 
-    my $start = $-[0];
-    my $brace = index($source, '{', $start);
-    return if $brace < 0;
+sub _extract_source_visible_block {
+    my ($source, $target_line) = @_;
 
-    my $depth = 0;
-    my $end = -1;
-    for (my $i = $brace; $i < length($source); $i++) {
+    my @stack;
+    my @candidates;
+    my $line = 1;
+    for (my $i = 0; $i < length($source); $i++) {
         my $ch = substr($source, $i, 1);
         if ($ch eq '{') {
-            $depth++;
+            push @stack, [$i, $line, _looks_like_code_block_open($source, $i)];
         } elsif ($ch eq '}') {
-            $depth--;
-            if ($depth == 0) {
-                $end = $i;
-                last;
-            }
+            my $open = pop @stack;
+            next unless $open;
+            my ($start, $start_line, $looks_like_code) = @$open;
+            next unless $looks_like_code;
+            next unless $start_line <= $target_line && $target_line <= $line;
+            push @candidates, [$start, $i];
+        } elsif ($ch eq "\n") {
+            $line++;
         }
     }
-    return if $end < 0;
+    return unless @candidates;
+
+    @candidates = sort {
+        ($a->[1] - $a->[0]) <=> ($b->[1] - $b->[0])
+            || $b->[0] <=> $a->[0]
+    } @candidates;
+    my ($brace, $end) = @{$candidates[0]};
 
     my $body = substr($source, $brace + 1, $end - $brace - 1);
     $body =~ s/^\s+//;
     $body =~ s/\s+$//;
     $body .= ';' if length($body) && $body !~ /[;}]\z/;
     return "{ $body }";
+}
+
+sub _looks_like_code_block_open {
+    my ($source, $brace) = @_;
+    my $prefix = substr($source, 0, $brace);
+    $prefix =~ s/[ \t\r\n]+\z//;
+
+    return 1 if $prefix =~ /\bsub\s*(?:\([^)]*\)\s*)?\z/;
+    return 1 if $prefix =~ /(?:^|[^\w:\$\@\%])(?:[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*)\z/;
+    return 0;
 }
 
 # Additional methods that might be called
@@ -144,8 +164,8 @@ For subroutines created via Sub::Quote, the stored source code is returned.
 
 =item *
 
-For simple anonymous subroutines whose source file is still available, the
-source-visible body is returned.
+For simple anonymous subroutines and prototype blocks whose source file is
+still available, the source-visible body is returned.
 
 =item *
 

--- a/src/test/resources/unit/b_deparse_line_directive_path.t
+++ b/src/test/resources/unit/b_deparse_line_directive_path.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+use Test::More;
+use Cwd qw(getcwd);
+use File::Path qw(make_path);
+use File::Temp qw(tempdir);
+
+my $tmpdir = tempdir(CLEANUP => 1);
+my $logical = 'lib/Carp/Assert.pm';
+make_path("$tmpdir/lib/Carp") or die "make_path $tmpdir/lib/Carp: $!";
+
+open my $source_fh, '>', "$tmpdir/$logical" or die "open $tmpdir/$logical: $!";
+print {$source_fh} "\n" x 9;
+print {$source_fh} 'our $TEXT = eval { capture { $foo == $bar } };', "\n";
+close $source_fh or die "close $tmpdir/$logical: $!";
+
+open my $runner_fh, '>', "$tmpdir/embedded.t" or die "open $tmpdir/embedded.t: $!";
+print {$runner_fh} <<'PERL';
+use strict;
+use warnings;
+use B::Deparse;
+
+our ($TEXT, @CALLER);
+sub capture (&) {
+    @CALLER = caller(0);
+    return B::Deparse->new->coderef2text($_[0]);
+}
+
+my $foo = 1;
+my $bar = 2;
+#line 10 lib/Carp/Assert.pm
+$TEXT = eval { capture { $foo == $bar } };
+1;
+PERL
+close $runner_fh or die "close $tmpdir/embedded.t: $!";
+
+my $cwd = getcwd();
+chdir $tmpdir or die "chdir $tmpdir: $!";
+
+our ($TEXT, @CALLER);
+my $loaded = do './embedded.t';
+my $error = $@;
+
+chdir $cwd or die "chdir $cwd: $!";
+die $error if $error;
+die "do embedded.t: $!" unless defined $loaded;
+
+is($CALLER[1], $logical, 'unquoted #line path preserves slashes');
+is($CALLER[2], 10, 'unquoted #line path keeps mapped line number');
+like($TEXT, qr/\$foo == \$bar/, 'prototype block source is found through unquoted #line path');
+
+done_testing();

--- a/src/test/resources/unit/b_deparse_prototype_block.t
+++ b/src/test/resources/unit/b_deparse_prototype_block.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw(tempfile);
+
+my ($fh, $path) = tempfile('perlonjava_b_deparse_prototype_block_XXXX', SUFFIX => '.pl', TMPDIR => 1, UNLINK => 0);
+print {$fh} <<'PERL';
+use strict;
+use warnings;
+use B::Deparse;
+
+sub capture (&) {
+    return B::Deparse->new->coderef2text($_[0]);
+}
+
+my $foo = 1;
+my $bar = 2;
+our $TEXT = eval { capture { $foo == $bar } };
+1;
+PERL
+close $fh or die "close $path: $!";
+
+our $TEXT;
+my $loaded = do $path;
+die $@ if $@;
+die "do $path: $!" unless defined $loaded;
+
+like($TEXT, qr/\$foo == \$bar/, 'prototype block source is visible to B::Deparse');
+
+unlink $path;
+
+done_testing();


### PR DESCRIPTION
## Summary

- Preserve full unquoted `#line` filenames like `lib/Carp/Assert.pm` in parser state and accurate source-location lookup.
- Extend the bundled `B::Deparse` shim to recover source-visible prototype blocks, so `Carp::Assert::affirm { ... }` diagnostics include the asserted expression.
- Add unit coverage for prototype block deparse and unquoted `#line` paths.

## Testing

- `make`
- `./jcpan -t Carp::Assert`

Generated with [Codex](https://openai.com/codex)
