### PR TITLE
Fix Template object die payload preservation

### DIFF
--- a/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
+++ b/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
@@ -407,13 +407,18 @@ public class WarnDie {
     public static RuntimeBase die(RuntimeBase message, RuntimeScalar where, String fileName, int lineNumber) {
         var errVariable = getGlobalVariable("main::@");
         var oldErr = new RuntimeScalar(errVariable);
+        RuntimeScalar first = message.getFirst();
+        boolean objectMessage = RuntimeScalarType.isReference(first)
+                && first.type != RuntimeScalarType.REGEX;
 
-        if (message.toString().isEmpty()) {
+        if (!objectMessage && message.toString().isEmpty()) {
             // Empty message
             message = dieEmptyMessage(oldErr, fileName, lineNumber);
+            first = message.getFirst();
+            objectMessage = RuntimeScalarType.isReference(first)
+                    && first.type != RuntimeScalarType.REGEX;
         }
-        if (!RuntimeScalarType.isReference(message.getFirst())
-                || message.getFirst().type == RuntimeScalarType.REGEX) {
+        if (!objectMessage) {
             // Error message
             String out = message.toString();
             if (!out.endsWith("\n")) {
@@ -432,7 +437,7 @@ public class WarnDie {
             errVariable.set(out);
         } else {
             // Error object
-            errVariable.set(message.getFirst());
+            errVariable.set(first);
         }
 
         // System.out.println("die :" + errVariable);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlDieException.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlDieException.java
@@ -15,11 +15,22 @@ public class PerlDieException extends RuntimeException {
     private final RuntimeBase payload;
 
     public PerlDieException(RuntimeBase payload) {
-        super(payload == null ? null : payload.toString());
+        super(safeMessage(payload));
         this.payload = payload;
     }
 
     public RuntimeBase getPayload() {
         return payload;
+    }
+
+    private static String safeMessage(RuntimeBase payload) {
+        if (payload == null) return null;
+
+        RuntimeScalar first = payload.getFirst();
+        if (first != null && RuntimeScalarType.isReference(first)) {
+            return first.toStringNoOverload();
+        }
+
+        return payload.toString();
     }
 }

--- a/src/test/resources/unit/die_object_eval.t
+++ b/src/test/resources/unit/die_object_eval.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+{
+    package LocalAtStringException;
+
+    use overload
+        bool => sub { 1 },
+        q{""} => sub {
+            my $self = shift;
+            my $deparse = do {
+                local $@;
+                require B::Deparse;
+                B::Deparse->new;
+            };
+            my $code = $deparse->coderef2text(sub { });
+            return $self->{message};
+        };
+
+    sub new {
+        bless { message => "object failure" }, shift;
+    }
+}
+
+my $ok = eval {
+    die LocalAtStringException->new;
+    1;
+};
+
+my $error = $@;
+
+ok(!$ok, 'eval catches object die');
+isa_ok($error, 'LocalAtStringException');
+is("$error", 'object failure', 'object die payload survives overload stringification with local $@');


### PR DESCRIPTION
## Summary

- Preserve object payloads passed to `die` without invoking overloaded stringification
- Avoid stringifying object die payloads in `PerlDieException`
- Add a regression test for eval `$@` preservation when string overload uses `local $@`

## Verification

- `make`
- `./jcpan -t Template`

`./jcpan -t Template` now passes with `t/zz-error-exception-gh-373.t .. ok`.
