### PR TITLE
Fix Text::ANSITable jcpan tests

### DIFF
--- a/jcpan
+++ b/jcpan
@@ -65,6 +65,12 @@ export JPERL_TEST_TIMEOUT="${JPERL_TEST_TIMEOUT:-300}"
 # pkill'd. See AGENTS.md "ALWAYS WRAP jperl/jcpan IN timeout" rule.
 export JPERL_ORPHAN_EXIT=1
 
+# CPAN test suites should run with deterministic semantics. User-interface
+# color preferences such as NO_COLOR can change module behavior under test
+# (for example Color::ANSI::Util), so do not pass them into jcpan runs.
+unset NO_COLOR
+unset ANSI_COLORS_DISABLED
+
 # Expose the jperl launcher AND the jcpan launcher itself so distroprefs
 # (e.g. Moose.yml) can run upstream tests against the bundled shims with
 # `prove --exec jperl`, and bootstrap missing helper modules with

--- a/jcpan.bat
+++ b/jcpan.bat
@@ -26,6 +26,9 @@ rem Enable orphan-exit watchdog in every jperl this run spawns — when
 rem the parent jcpan dies, each child JVM self-exits within ~4s instead
 rem of getting reparented to PID 1 and burning 100% CPU forever.
 set "JPERL_ORPHAN_EXIT=1"
+rem Keep CPAN test semantics independent from the caller's UI color settings.
+set "NO_COLOR="
+set "ANSI_COLORS_DISABLED="
 rem Expose jperl and jcpan launchers, and prepend SCRIPT_DIR to PATH so
 rem shell-spawned subprocesses (distroprefs commandlines, prove --exec,
 rem etc.) can find jperl/jcpan without tokens that don't expand in

--- a/src/main/java/org/perlonjava/runtime/perlmodule/OverloadModule.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/OverloadModule.java
@@ -42,9 +42,8 @@ public class OverloadModule extends PerlModuleBase {
         RuntimeScalar scalar = args.get(0);
 
         return switch (scalar.type) {
-            case REFERENCE -> new RuntimeScalar(scalar.toStringRef()).getList();
-            case ARRAYREFERENCE, HASHREFERENCE, CODE, GLOB, GLOBREFERENCE, FORMAT, REGEX ->
-                    new RuntimeScalar(((RuntimeBase) scalar.value).toStringRef()).getList();
+            case REFERENCE, ARRAYREFERENCE, HASHREFERENCE, CODE, GLOB, GLOBREFERENCE, FORMAT, REGEX ->
+                    new RuntimeScalar(scalar.toStringRef()).getList();
             default ->
                     // For non-references, return the raw string value
                     new RuntimeScalar(scalar.toStringRef()).getList();

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -1681,7 +1681,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
      * @return A string representing the regex reference.
      */
     public String toStringRef() {
-        return "REF(0x" + this.hashCode() + ")";
+        return "REGEXP(0x" + Integer.toHexString(this.hashCode()) + ")";
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
@@ -709,9 +709,9 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
                     if (this.scalarSlot == null) {
                         this.scalarSlot = new RuntimeScalar();
                     }
-                    yield this.scalarSlot;
+                    yield this.scalarSlot.createReference();
                 }
-                yield GlobalVariable.getGlobalVariable(this.globName);
+                yield GlobalVariable.getGlobalVariable(this.globName).createReference();
             }
             case "ARRAY" -> {
                 // For anonymous globs (null globName), use local arraySlot
@@ -757,6 +757,20 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
             }
             default -> new RuntimeScalar();
         };
+    }
+
+    /**
+     * Get the scalar slot value for scalar dereference of a glob.
+     * This is distinct from *glob{SCALAR}, which returns a reference to the slot.
+     */
+    public RuntimeScalar getGlobScalarSlot() {
+        if (this.globName == null) {
+            if (this.scalarSlot == null) {
+                this.scalarSlot = new RuntimeScalar();
+            }
+            return this.scalarSlot;
+        }
+        return GlobalVariable.getGlobalVariable(this.globName);
     }
 
     public RuntimeScalar getIO() {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -1655,10 +1655,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             case READONLY_SCALAR -> ((RuntimeScalar) this.value).toStringNoOverload();
             case DUALVAR -> ((DualVar) this.value).stringValue().toStringNoOverload();
             case CODE -> toStringRef();
-            default -> {
-                if (type == REGEX) yield value.toString();
-                yield toStringRef();
-            }
+            default -> toStringRef();
         };
     }
 
@@ -1695,6 +1692,12 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                     yield "GLOB(0x" + scalarUndef.hashCode() + ")";
                 }
                 yield ((RuntimeBase) value).toStringRef();
+            }
+            case REGEX -> {
+                if (value == null) {
+                    yield "Regexp=REGEXP(0x" + scalarUndef.hashCode() + ")";
+                }
+                yield "Regexp=" + ((RuntimeRegex) value).toStringRef();
             }
             case REFERENCE -> {
                 // Determine the proper type name for the reference
@@ -2069,8 +2072,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 // Dereferencing a glob as scalar returns the scalar slot
                 // e.g., ${*Foo::VERSION} or ${$glob} where $glob is a glob
                 if (value instanceof RuntimeGlob glob) {
-                    // Use the glob's getGlobSlot method which handles anonymous globs
-                    yield glob.getGlobSlot(new RuntimeScalar("SCALAR"));
+                    yield glob.getGlobScalarSlot();
                 }
                 throw new PerlCompilerException("Not a SCALAR reference");
             }
@@ -2116,8 +2118,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             case GLOB -> {
                 // Dereferencing a glob as scalar returns the scalar slot
                 if (value instanceof RuntimeGlob glob) {
-                    // Use the glob's getGlobSlot method which handles anonymous globs
-                    yield glob.getGlobSlot(new RuntimeScalar("SCALAR"));
+                    yield glob.getGlobScalarSlot();
                 }
                 String varName = NameNormalizer.normalizeVariableName(this.toString(), packageName);
                 yield GlobalVariable.getGlobalVariable(varName);

--- a/src/main/perl/lib/Data/Dump.pm
+++ b/src/main/perl/lib/Data/Dump.pm
@@ -1,0 +1,46 @@
+package Data::Dump;
+
+use strict;
+use warnings;
+use subs qw(dump);
+use Exporter qw(import);
+
+our $VERSION = '1.25';
+our @EXPORT = qw(dd ddx);
+our @EXPORT_OK = qw(dump pp dumpf quote);
+
+sub dump {
+    require Data::Dumper;
+    my $dumper = Data::Dumper->new([@_]);
+    $dumper->Terse(1);
+    $dumper->Indent(1);
+    $dumper->Sortkeys(1);
+    my $out = $dumper->Dump;
+    chomp $out;
+    return $out;
+}
+
+sub pp { dump(@_) }
+sub dumpf { dump(@_) }
+
+sub dd {
+    print dump(@_), "\n";
+}
+
+sub ddx {
+    my (undef, $file, $line) = caller;
+    $file =~ s{.*[\\/]}{};
+    my $out = "$file:$line: " . dump(@_) . "\n";
+    $out =~ s/^/# /gm;
+    print $out;
+}
+
+sub quote {
+    my $str = defined $_[0] ? $_[0] : '';
+    $str =~ s/\\/\\\\/g;
+    $str =~ s/"/\\"/g;
+    $str =~ s/\n/\\n/g;
+    return qq{"$str"};
+}
+
+1;

--- a/src/main/perl/lib/Module/List.pm
+++ b/src/main/perl/lib/Module/List.pm
@@ -1,0 +1,52 @@
+package Module::List;
+
+use strict;
+use warnings;
+use File::Find ();
+
+our $VERSION = '0.005';
+
+sub list_modules {
+    my ($prefix, $opts) = @_;
+    $prefix //= '';
+    $opts ||= {};
+
+    my $rel_prefix = $prefix;
+    $rel_prefix =~ s{::}{/}g;
+    my %mods;
+
+    for my $inc (@INC) {
+        next if !defined $inc || $inc eq '' || $inc =~ /^jar:/;
+        my $root = length($rel_prefix) ? "$inc/$rel_prefix" : $inc;
+        next unless -d $root;
+
+        if ($opts->{recurse}) {
+            File::Find::find({
+                wanted => sub {
+                    return unless /\.pm\z/ && -f $_;
+                    my $path = $File::Find::name;
+                    my $rel = substr($path, length($inc) + 1);
+                    $rel =~ s{\.pm\z}{};
+                    $rel =~ s{/}{::}g;
+                    $mods{$rel} = $path;
+                },
+                no_chdir => 1,
+            }, $root);
+        }
+        else {
+            opendir my $dh, $root or next;
+            while (defined(my $ent = readdir $dh)) {
+                next unless $ent =~ /\.pm\z/;
+                my $path = "$root/$ent";
+                next unless -f $path;
+                (my $name = $ent) =~ s/\.pm\z//;
+                $mods{$prefix . $name} = $path;
+            }
+            closedir $dh;
+        }
+    }
+
+    return \%mods;
+}
+
+1;

--- a/src/main/perl/lib/Module/Load/Util.pm
+++ b/src/main/perl/lib/Module/Load/Util.pm
@@ -1,0 +1,122 @@
+package Module::Load::Util;
+
+use strict;
+use warnings;
+use Exporter qw(import);
+
+our $VERSION = '0.012';
+our @EXPORT_OK = qw(
+    load_module_with_optional_args
+    instantiate_class_with_optional_args
+    call_module_function_with_optional_args
+    call_module_method_with_optional_args
+);
+
+sub _normalize_module_with_optional_args {
+    my ($spec) = @_;
+    my ($module, $args);
+
+    if (ref($spec) eq 'ARRAY') {
+        die "array form or module/class name must have 1 or 2 elements"
+            unless @$spec == 1 || @$spec == 2;
+        ($module, $args) = @$spec;
+        $args ||= [];
+        $args = [%$args] if ref($args) eq 'HASH';
+        die "In array form of module/class name, the 2nd element must be arrayref or hashref"
+            unless ref($args) eq 'ARRAY';
+    }
+    elsif (ref($spec)) {
+        die "module/class name must be string or 2-element array";
+    }
+    elsif ($spec =~ /(.+?)[=,](.*)/) {
+        ($module, my $argstr) = ($1, $2);
+        $args = [split /,/, $argstr];
+    }
+    else {
+        $module = $spec;
+        $args = [];
+    }
+
+    $module =~ /\A[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*\z/
+        or die "Invalid syntax in module/class name '$module'";
+    return ($module, $args);
+}
+
+sub _load_module {
+    my $opts = ref($_[0]) eq 'HASH' ? shift : {};
+    my $module = shift;
+    my $do_load = exists $opts->{load} ? $opts->{load} : 1;
+
+    my @prefixes = $opts->{ns_prefixes} ? @{ $opts->{ns_prefixes} } :
+        defined($opts->{ns_prefix}) ? ($opts->{ns_prefix}) : ('');
+    @prefixes = ('') unless @prefixes;
+
+    for my $prefix (@prefixes) {
+        my $candidate = length($prefix)
+            ? $prefix . ($prefix =~ /::\z/ ? '' : '::') . $module
+            : $module;
+        return $candidate unless $do_load;
+
+        (my $pm = "$candidate.pm") =~ s{::}{/}g;
+        my $ok = eval { require $pm; 1 };
+        return $candidate if $ok;
+        die $@ unless $opts->{ns_prefixes} && $@ =~ /\ACan't locate/;
+    }
+
+    die "load_module_with_optional_args(): Failed to load module '$module'";
+}
+
+sub load_module_with_optional_args {
+    my $opts = ref($_[0]) eq 'HASH' ? shift : {};
+    my ($module, $args) = _normalize_module_with_optional_args(shift);
+    my $loaded = _load_module($opts, $module);
+
+    my $do_import = exists $opts->{import} ? $opts->{import} : 1;
+    if ($do_import) {
+        my $target = $opts->{target_package} || $opts->{caller} || caller(0);
+        $target =~ /\A[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*\z/
+            or die "Invalid syntax in target package '$target'";
+        my $code = "package $target; ${loaded}->import(\\\@{\$args});";
+        eval $code;
+        die $@ if $@;
+    }
+
+    return { module => $loaded, args => $args };
+}
+
+sub instantiate_class_with_optional_args {
+    my $opts = ref($_[0]) eq 'HASH' ? { %{ shift() } } : {};
+    $opts->{import} = 0;
+    $opts->{target_package} = caller(0);
+    my $res = load_module_with_optional_args($opts, shift);
+    return $res unless exists($opts->{construct}) ? $opts->{construct} : 1;
+    my $constructor = defined $opts->{constructor} ? $opts->{constructor} : 'new';
+    return $res->{module}->$constructor(@{ $res->{args} });
+}
+
+sub call_module_function_with_optional_args {
+    my $opts = ref($_[0]) eq 'HASH' ? shift : {};
+    my ($module, $args) = _normalize_module_with_optional_args(shift);
+    my $function = $opts->{function};
+    if (!defined $function) {
+        $module =~ s/\A(.+)::(\w+)\z/$1/ or die "Please specify MODULE::FUNCTION";
+        $function = $2;
+    }
+    my $loaded = _load_module($opts, $module);
+    no strict 'refs';
+    return &{"${loaded}::$function"}(@$args);
+}
+
+sub call_module_method_with_optional_args {
+    my $opts = ref($_[0]) eq 'HASH' ? shift : {};
+    my ($module, $args) = _normalize_module_with_optional_args(shift);
+    my $method = $opts->{method};
+    if (!defined $method) {
+        $module =~ s/\A(.+)::(\w+)\z/$1/ or die "Please specify MODULE::METHOD";
+        $method = $2;
+    }
+    my $loaded = _load_module($opts, $module);
+    return $loaded->$method(@$args);
+}
+
+1;

--- a/src/main/perl/lib/Package/MoreUtil.pm
+++ b/src/main/perl/lib/Package/MoreUtil.pm
@@ -1,0 +1,42 @@
+package Package::MoreUtil;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.592';
+
+sub _stash_name {
+    my ($pkg) = @_;
+    $pkg =~ s/\A::/main::/;
+    $pkg =~ s/::\z//;
+    return "${pkg}::";
+}
+
+sub package_exists {
+    my ($pkg) = @_;
+    no strict 'refs';
+    my $stash = \%{ _stash_name($pkg) };
+    return scalar(keys %$stash) ? 1 : 0;
+}
+
+sub list_subpackages {
+    my ($pkg) = @_;
+    no strict 'refs';
+    my $base = _stash_name($pkg);
+    (my $base_pkg = $base) =~ s/::\z//;
+    my @res;
+    for my $key (keys %{ $base }) {
+        next unless $key =~ /::\z/;
+        (my $name = $key) =~ s/::\z//;
+        push @res, "$base_pkg\::$name";
+    }
+    return sort @res;
+}
+
+sub list_package_contents {
+    my ($pkg) = @_;
+    no strict 'refs';
+    return %{ _stash_name($pkg) };
+}
+
+1;

--- a/src/main/perl/lib/Package/Stash/PP.pm
+++ b/src/main/perl/lib/Package/Stash/PP.pm
@@ -291,10 +291,8 @@ sub get_symbol {
     my $entry_ref = \$namespace->{$name};
 
     if (ref($entry_ref) eq 'GLOB') {
-        # PerlOnJava: avoid *GLOB{SCALAR} (which our impl returns as
-        # value, not ref). For SCALAR type, return a direct symbol-table
-        # ref so $stash->get_symbol('$VERSION') works for Class::Load /
-        # version detection. ARRAY/HASH/CODE/IO continue using *{...}{type}.
+        # PerlOnJava: return a direct symbol-table scalar ref. This keeps
+        # historical behavior here and avoids vivifying unrelated glob slots.
         if ($type eq 'SCALAR') {
             no strict 'refs';
             return \${ $self->name . '::' . $name };

--- a/src/main/perl/lib/Parse/VarName.pm
+++ b/src/main/perl/lib/Parse/VarName.pm
@@ -1,0 +1,18 @@
+package Parse::VarName;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.03';
+
+sub split_varname_words {
+    my %args = @_ == 1 ? (varname => $_[0]) : @_;
+    my $name = defined $args{varname} ? $args{varname} : '';
+    $name =~ s/[^A-Za-z0-9]+/ /g;
+    $name =~ s/([a-z0-9])([A-Z])/$1 $2/g;
+    $name =~ s/([A-Z]+)([A-Z][a-z])/$1 $2/g;
+    my @words = grep length, split /\s+/, $name;
+    return \@words;
+}
+
+1;

--- a/src/main/perl/lib/PerlIO.pm
+++ b/src/main/perl/lib/PerlIO.pm
@@ -1,0 +1,12 @@
+package PerlIO;
+
+use strict;
+use warnings;
+
+our $VERSION = '1.12';
+
+sub get_layers {
+    return wantarray ? () : 0;
+}
+
+1;

--- a/src/main/perl/lib/Term/Size.pm
+++ b/src/main/perl/lib/Term/Size.pm
@@ -1,0 +1,31 @@
+package Term::Size;
+
+use strict;
+use warnings;
+use Exporter qw(import);
+
+our $VERSION = '0.211';
+our @EXPORT_OK = qw(chars pixels);
+
+sub _size {
+    my $fh = @_ ? shift : *STDIN;
+    return unless -t $fh;
+
+    my $cols = $ENV{COLUMNS} || 80;
+    my $rows = $ENV{LINES}   || 24;
+    return ($cols, $rows);
+}
+
+sub chars {
+    my @size = _size(@_);
+    return unless @size;
+    return wantarray ? @size : $size[0];
+}
+
+sub pixels {
+    my @size = _size(@_);
+    return unless @size;
+    return wantarray ? (0, 0) : 0;
+}
+
+1;

--- a/src/test/resources/unit/glob_scalar_slot_ref.t
+++ b/src/test/resources/unit/glob_scalar_slot_ref.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More;
+
+our $foo = 42;
+my $slot = *foo{SCALAR};
+
+is(ref($slot), 'SCALAR', '*glob{SCALAR} returns a scalar reference');
+is($$slot, 42, 'scalar slot reference points at package scalar');
+
+use Exporter ();
+{
+    no strict 'refs';
+    for my $name (qw(Debug ExportLevel VERSION Verbose)) {
+        my $ref = *{"Exporter::$name"}{SCALAR};
+        ok(!defined($ref) || ref($ref) eq 'SCALAR', "Exporter::$name SCALAR slot is undef or scalar ref");
+    }
+}
+
+done_testing;

--- a/src/test/resources/unit/overload_strval_regex.t
+++ b/src/test/resources/unit/overload_strval_regex.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Test::More;
+use overload ();
+
+my $re = qr/Foo/;
+
+like(overload::StrVal($re), qr/\ARegexp=REGEXP\(0x[0-9a-f]+\)\z/,
+    'overload::StrVal on qr returns raw regexp reference');
+like(do { no overloading; "$re" }, qr/\ARegexp=REGEXP\(0x[0-9a-f]+\)\z/,
+    'no overloading stringification on qr returns raw regexp reference');
+is("$re", '(?^:Foo)', 'normal qr stringification is unchanged');
+
+done_testing;

--- a/src/test/resources/unit/term_size_perlio_shims.t
+++ b/src/test/resources/unit/term_size_perlio_shims.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Term::Size qw(chars pixels);
+require PerlIO;
+
+pipe my $rd, my $wr or die "pipe: $!";
+
+my @chars = chars($rd);
+is(scalar(@chars), 0, 'Term::Size::chars returns empty list for non-tty handle');
+is(scalar(chars($rd)), undef, 'Term::Size::chars returns undef in scalar context for non-tty handle');
+
+my @pixels = pixels($rd);
+is(scalar(@pixels), 0, 'Term::Size::pixels returns empty list for non-tty handle');
+is(scalar(pixels($rd)), undef, 'Term::Size::pixels returns undef in scalar context for non-tty handle');
+
+my @layers = PerlIO::get_layers(STDOUT);
+ok(!grep { $_ eq 'utf8' } @layers, 'PerlIO::get_layers does not report utf8 by default');
+
+done_testing;


### PR DESCRIPTION
## Summary

- Make `jcpan` ignore caller color-suppression variables so ANSI/color CPAN tests run deterministically.
- Fix scalar glob slot handling so `*glob{SCALAR}` returns a scalar reference without breaking `$$glob`.
- Align raw regexp reference stringification for `overload::StrVal(qr/...)` and add lightweight bundled shims needed by `Text::ANSITable` dependencies.

## Tests

- `timeout 1200 make > /tmp/make_text_ansitable_rebase_pr.log 2>&1; printf 'EXIT: %s\n' $? >> /tmp/make_text_ansitable_rebase_pr.log`
- `timeout 900 ./jcpan -t Text::ANSITable > /tmp/text_ansitable_jcpan_rebase_pr.log 2>&1; printf 'EXIT: %s\n' $? >> /tmp/text_ansitable_jcpan_rebase_pr.log`
