### PR TITLE
Fix operator-form fork in bytecode interpreter

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -705,6 +705,7 @@ public class CompileOperator {
             case "wantarray" -> { int rd = bytecodeCompiler.allocateOutputRegister(); bytecodeCompiler.emit(Opcodes.WANTARRAY); bytecodeCompiler.emitReg(rd); bytecodeCompiler.emitReg(2); bytecodeCompiler.lastResultReg = rd; }
             case "time" -> { int rd = bytecodeCompiler.allocateOutputRegister(); bytecodeCompiler.emit(Opcodes.TIME_OP); bytecodeCompiler.emitReg(rd); bytecodeCompiler.lastResultReg = rd; }
             case "wait" -> { int rd = bytecodeCompiler.allocateOutputRegister(); bytecodeCompiler.emit(Opcodes.WAIT_OP); bytecodeCompiler.emitReg(rd); bytecodeCompiler.lastResultReg = rd; }
+            case "fork" -> { int rd = bytecodeCompiler.allocateOutputRegister(); bytecodeCompiler.emitWithToken(Opcodes.FORK, node.getIndex()); bytecodeCompiler.emitReg(rd); bytecodeCompiler.lastResultReg = rd; }
             case "getppid" -> { int rd = bytecodeCompiler.allocateOutputRegister(); bytecodeCompiler.emitWithToken(Opcodes.GETPPID, node.getIndex()); bytecodeCompiler.emitReg(rd); bytecodeCompiler.lastResultReg = rd; }
             case "open" -> visitOpen(bytecodeCompiler, node);
             case "matchRegex" -> visitMatchRegex(bytecodeCompiler, node);

--- a/src/main/java/org/perlonjava/backend/bytecode/SlowOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/SlowOpcodeHandler.java
@@ -115,10 +115,7 @@ public class SlowOpcodeHandler {
     public static int executeFork(int[] bytecode, int pc, RuntimeBase[] registers) {
         int rd = bytecode[pc++];
 
-        // fork() is not supported in Java - return -1 (error)
-        // Real implementation would need JNI or native library
-        registers[rd] = new RuntimeScalar(-1);
-        GlobalVariable.getGlobalVariable("main::!").set("fork not supported on this platform");
+        registers[rd] = SystemOperator.fork(RuntimeContextType.SCALAR);
         return pc;
     }
 

--- a/src/test/resources/unit/fork_operator_skip.t
+++ b/src/test/resources/unit/fork_operator_skip.t
@@ -1,0 +1,10 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+pass 'emitted a test before fork';
+
+my $child = fork();
+ok !defined($child), 'operator-form fork() compiles and returns undef after tests begin';


### PR DESCRIPTION
## Summary

- Compile operator-form `fork()` into the existing bytecode `FORK` opcode.
- Route that opcode through PerlOnJava's existing limited/no-fork runtime behavior instead of returning `-1`.
- Add a regression test for operator-form `fork()` after TAP output has begun.

This does not add general fork support; it lets code that already handles unsupported `fork()` at runtime skip or continue instead of failing during bytecode compilation.

## Verification

- `make`
- `timeout 600 ./jcpan -t IO::Socket::SecureSocks`

Target CPAN result:

- `IO::Socket::Socks`: PASS, 92 tests; fork-only slow tests skipped.
- `IO::Socket::SecureSocks`: PASS, 2 active tests.
