### PR TITLE
Fix DateTime::Event::Cron::Quartz prototype captures

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
+++ b/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
@@ -538,6 +538,9 @@ public class PrototypeArgs {
         if (slots < 2) {
             return false;
         }
+        if (!nextTokenStartsQwWordList(parser)) {
+            return false;
+        }
         int saved = parser.tokenIndex;
         List<OperatorNode> savedHeredocs = ParseHeredoc.saveHeredocState(parser);
         Node expr = parser.parseExpression(parser.getPrecedence(","));
@@ -578,6 +581,13 @@ public class PrototypeArgs {
             break;
         }
         return count;
+    }
+
+    private static boolean nextTokenStartsQwWordList(Parser parser) {
+        int i = skipHorizontalWhitespaceTokens(parser.tokens, parser.tokenIndex);
+        return i < parser.tokens.size()
+                && parser.tokens.get(i).type == LexerTokenType.IDENTIFIER
+                && parser.tokens.get(i).text.equals("qw");
     }
 
     /** True if every element is a {@link StringNode} (parenthesis-free qw word list). */

--- a/src/test/resources/unit/subroutine_prototype.t
+++ b/src/test/resources/unit/subroutine_prototype.t
@@ -34,6 +34,19 @@ is( code_ref_proto { 99 }, 99, "Code reference prototype works" );
 sub multi_proto ($$) { $_[0] + $_[1] }
 is( multi_proto( 2, 3 ), 5, "Multiple argument prototype works" );
 
+{
+    sub assign_proto_arg ($$) { $_[0] = $_[1] }
+
+    assign_proto_arg my $captured_by_named_sub => 42;
+    sub read_proto_arg_capture { $captured_by_named_sub }
+
+    is(
+        read_proto_arg_capture(),
+        42,
+        "Parenthesis-free multi-scalar prototype call preserves my lexical captured by named sub"
+    );
+}
+
 sub optional_proto (;$) { defined $_[0] ? $_[0] : "default" }
 is( optional_proto(),       "default", "Optional argument prototype works without arg" );
 is( optional_proto("test"), "test",    "Optional argument prototype works with arg" );


### PR DESCRIPTION
## Summary

- Limit the parenthesis-free qw-list prototype lookahead to actual qw() starts
- Preserve lexical declarations in normal parenthesis-free multi-scalar prototype calls
- Add a regression for a prototyped call initializing a lexical captured by a named sub

## Verification

- `make`
- `timeout 30 ./jperl -e 'use strict; use warnings; sub set_scalar ($$) { $_[0] = $_[1] } set_scalar my $x => 42; sub read_x { $x } print defined(read_x()) ? read_x() : "undef", "\n"'
- `timeout 60 ./jperl src/test/resources/unit/subroutine_prototype.t`
- `timeout 900 ./jcpan -t DateTime::Event::Cron::Quartz`
