### PR TITLE
Fix LWP::Online CPAN deps and speed streamed tests

### DIFF
--- a/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
@@ -43,6 +43,7 @@ public class MortalList {
     // deferredCaptures for final cleanup — they are effectively dead
     // from Perl's view, only held Java-alive by this static list.
     private static final java.util.IdentityHashMap<RuntimeScalar, Integer> deferredCapturesSet = new java.util.IdentityHashMap<>();
+    private static boolean deferredCapturesMayBeReady = false;
 
     private static final ThreadLocal<ArrayDeque<RuntimeBase>> temporaryRoots =
             ThreadLocal.withInitial(ArrayDeque::new);
@@ -100,6 +101,15 @@ public class MortalList {
     public static void addDeferredCapture(RuntimeScalar scalar) {
         deferredCaptures.add(scalar);
         deferredCapturesSet.merge(scalar, 1, Integer::sum);
+        if (scalar.captureCount == 0 && scalar.scopeExited) {
+            deferredCapturesMayBeReady = true;
+        }
+    }
+
+    static void noteDeferredCaptureMayBeReady() {
+        if (!deferredCaptures.isEmpty()) {
+            deferredCapturesMayBeReady = true;
+        }
     }
 
     /**
@@ -120,6 +130,8 @@ public class MortalList {
      */
     private static void processReadyDeferredCaptures() {
         if (deferredCaptures.isEmpty()) return;
+        if (!deferredCapturesMayBeReady) return;
+        deferredCapturesMayBeReady = false;
         boolean found = false;
         for (int i = deferredCaptures.size() - 1; i >= 0; i--) {
             RuntimeScalar scalar = deferredCaptures.get(i);
@@ -165,6 +177,7 @@ public class MortalList {
         }
         deferredCaptures.clear();
         deferredCapturesSet.clear();
+        deferredCapturesMayBeReady = false;
         flush();
 
         // After flushing deferred captures, clear weak refs for objects that
@@ -375,7 +388,9 @@ public class MortalList {
         // source_registrations hash is assigned into the live schema while the
         // original hash later exits; walking it here would destroy ResultSources
         // still reachable through the schema.
-        if (hadLocalBinding && isReachableFromExternalRootCached(hash)) return;
+        if (hadLocalBinding
+                && hash.refCount >= 0
+                && ReachabilityWalker.isReachableFromExternalRootExcludingDirectLexical(hash)) return;
         for (RuntimeScalar val : hash.elements.values()) {
             deferDecrementRecursive(val);
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ReachabilityWalker.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ReachabilityWalker.java
@@ -851,6 +851,83 @@ public class ReachabilityWalker {
     }
 
     /**
+     * Target-specific reachability query for scope-exit cleanup of a named
+     * lexical container. The container's own my-variable slot is still present
+     * in {@link MyVarCleanupStack} while cleanup runs, so this deliberately
+     * skips that direct root and only returns true for another root path.
+     */
+    public static boolean isReachableFromExternalRootExcludingDirectLexical(RuntimeBase target) {
+        if (target == null) return false;
+        final int MAX_VISITS = 50_000;
+
+        Set<RuntimeBase> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+        java.util.ArrayDeque<RuntimeBase> todo = new java.util.ArrayDeque<>();
+
+        for (RuntimeScalar sc : GlobalVariable.globalCodeRefs.values()) {
+            seedTarget(sc, target, seen, todo);
+            if (seen.contains(target)) return true;
+            if (sc != null && sc.value instanceof RuntimeCode code
+                    && followGlobalCodeCaptures(code, target, seen, todo)) {
+                return true;
+            }
+        }
+        for (RuntimeScalar sc : GlobalVariable.globalVariables.values()) {
+            seedTarget(sc, target, seen, todo);
+            if (seen.contains(target)) return true;
+        }
+        for (RuntimeArray array : GlobalVariable.globalArrays.values()) {
+            if (array == target) return true;
+            if (seen.add(array)) todo.addLast(array);
+        }
+        for (RuntimeHash hash : GlobalVariable.globalHashes.values()) {
+            if (hash == target) return true;
+            if (seen.add(hash)) todo.addLast(hash);
+        }
+        for (RuntimeBase rescued : DestroyDispatch.snapshotRescuedForWalk()) {
+            if (rescued == target) return true;
+            if (seen.add(rescued)) todo.addLast(rescued);
+        }
+        for (RuntimeScalar sc : ScalarRefRegistry.snapshot()) {
+            if (sc == null) continue;
+            if (sc.captureCount > 0) continue;
+            if (WeakRefRegistry.isweak(sc)) continue;
+            if (sc.scopeExited) continue;
+            if (!MyVarCleanupStack.isLive(sc) && !sc.refCountOwned) continue;
+            if (followScalar(sc, target, seen, todo)) return true;
+        }
+        for (Object liveVar : MyVarCleanupStack.snapshotLiveVars()) {
+            if (liveVar == target) continue;
+            if (liveVar instanceof RuntimeScalar sc) {
+                if (WeakRefRegistry.isweak(sc)) continue;
+                if (followScalar(sc, target, seen, todo)) return true;
+            } else if (liveVar instanceof RuntimeBase rb) {
+                if (seen.add(rb)) todo.addLast(rb);
+            }
+        }
+
+        int visits = 0;
+        while (!todo.isEmpty() && visits < MAX_VISITS) {
+            RuntimeBase cur = todo.removeFirst();
+            visits++;
+            if (cur == target) return true;
+            if (cur instanceof RuntimeStash) continue;
+            if (cur instanceof RuntimeHash h) {
+                if (h.elements instanceof HashSpecialVariable) continue;
+                for (RuntimeScalar v : h.elements.values()) {
+                    if (followScalar(v, target, seen, todo)) return true;
+                }
+            } else if (cur instanceof RuntimeArray a) {
+                for (RuntimeScalar v : a.elements) {
+                    if (followScalar(v, target, seen, todo)) return true;
+                }
+            } else if (cur instanceof RuntimeScalar sc) {
+                if (followScalar(sc, target, seen, todo)) return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Cached equivalent of {@link #isReachableFromExternalRoot(RuntimeBase)}.
      * <p>
      * The package/rescued root graph is snapshotted separately from live

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArray.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArray.java
@@ -92,21 +92,21 @@ public class RuntimeArray extends RuntimeBase implements RuntimeScalarReference,
 
         @Override
         public boolean add(RuntimeScalar value) {
-            owner.notePackageRootMutation();
+            owner.notePackageRootMutation(null, value);
             owner.markPackageRootedValue(value);
             return super.add(value);
         }
 
         @Override
         public void add(int index, RuntimeScalar element) {
-            owner.notePackageRootMutation();
+            owner.notePackageRootMutation(null, element);
             owner.markPackageRootedValue(element);
             super.add(index, element);
         }
 
         @Override
         public boolean addAll(java.util.Collection<? extends RuntimeScalar> c) {
-            owner.notePackageRootMutation();
+            owner.notePackageRootMutationIf(owner.hasRootEdge(c));
             for (RuntimeScalar value : c) {
                 owner.markPackageRootedValue(value);
             }
@@ -115,7 +115,7 @@ public class RuntimeArray extends RuntimeBase implements RuntimeScalarReference,
 
         @Override
         public boolean addAll(int index, java.util.Collection<? extends RuntimeScalar> c) {
-            owner.notePackageRootMutation();
+            owner.notePackageRootMutationIf(owner.hasRootEdge(c));
             for (RuntimeScalar value : c) {
                 owner.markPackageRootedValue(value);
             }
@@ -124,7 +124,8 @@ public class RuntimeArray extends RuntimeBase implements RuntimeScalarReference,
 
         @Override
         public RuntimeScalar set(int index, RuntimeScalar element) {
-            owner.notePackageRootMutation();
+            RuntimeScalar previous = super.get(index);
+            owner.notePackageRootMutation(previous, element);
             owner.markPackageRootedValue(element);
             return super.set(index, element);
         }
@@ -132,21 +133,55 @@ public class RuntimeArray extends RuntimeBase implements RuntimeScalarReference,
         @Override
         public RuntimeScalar remove(int index) {
             RuntimeScalar previous = super.remove(index);
-            owner.notePackageRootMutation();
+            owner.notePackageRootMutation(previous, null);
             return previous;
         }
 
         @Override
         public boolean remove(Object o) {
             boolean removed = super.remove(o);
-            if (removed) owner.notePackageRootMutation();
+            if (removed && o instanceof RuntimeScalar scalar) {
+                owner.notePackageRootMutation(scalar, null);
+            }
             return removed;
         }
 
         @Override
         public void clear() {
-            if (!isEmpty()) owner.notePackageRootMutation();
+            if (!isEmpty()) owner.notePackageRootClear(this);
             super.clear();
+        }
+    }
+
+    private static boolean rootEdge(RuntimeScalar value) {
+        return value != null
+                && (value.type & RuntimeScalarType.REFERENCE_BIT) != 0
+                && value.value instanceof RuntimeBase;
+    }
+
+    private boolean hasRootEdge(java.util.Collection<? extends RuntimeScalar> values) {
+        if (!isPackageGlobalRoot) return false;
+        for (RuntimeScalar value : values) {
+            if (rootEdge(value)) return true;
+        }
+        return false;
+    }
+
+    private void notePackageRootMutation(RuntimeScalar oldValue, RuntimeScalar newValue) {
+        if (isPackageGlobalRoot && (rootEdge(oldValue) || rootEdge(newValue))) {
+            MortalList.invalidateExternalRootSnapshot();
+        }
+    }
+
+    private void notePackageRootMutationIf(boolean invalidates) {
+        if (invalidates) {
+            MortalList.invalidateExternalRootSnapshot();
+        }
+    }
+
+    private void notePackageRootClear(java.util.Collection<? extends RuntimeScalar> values) {
+        if (hasRootEdge(values)) {
+            MortalList.invalidateExternalRootSnapshot();
         }
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -774,6 +774,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                         if (s.type == RuntimeScalarType.TIED_SCALAR
                                 && s.value instanceof TiedVariableBase tiedVariable) {
                             tiedVariable.releaseTiedObject();
+                            MortalList.noteDeferredCaptureMayBeReady();
                             continue;
                         }
                         if ((s.type & RuntimeScalarType.REFERENCE_BIT) != 0
@@ -781,6 +782,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                                 && rb.blessId != 0) {
                             MortalList.releaseCapturedDecrement(s);
                         }
+                        MortalList.noteDeferredCaptureMayBeReady();
                     }
                 }
             }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
@@ -79,14 +79,24 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
 
         @Override
         public RuntimeScalar put(String key, RuntimeScalar value) {
-            owner.notePackageRootMutation();
+            RuntimeScalar previous = super.get(key);
+            owner.notePackageRootMutation(previous, value);
             owner.markPackageRootedValue(value);
             return super.put(key, value);
         }
 
         @Override
         public void putAll(Map<? extends String, ? extends RuntimeScalar> m) {
-            owner.notePackageRootMutation();
+            boolean invalidates = false;
+            if (owner.isPackageRootedHash()) {
+                for (Map.Entry<? extends String, ? extends RuntimeScalar> e : m.entrySet()) {
+                    if (rootEdge(super.get(e.getKey())) || rootEdge(e.getValue())) {
+                        invalidates = true;
+                        break;
+                    }
+                }
+            }
+            owner.notePackageRootMutationIf(invalidates);
             for (RuntimeScalar value : m.values()) {
                 owner.markPackageRootedValue(value);
             }
@@ -97,7 +107,7 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
         public RuntimeScalar remove(Object key) {
             RuntimeScalar previous = super.remove(key);
             if (previous != null) {
-                owner.notePackageRootMutation();
+                owner.notePackageRootMutation(previous, null);
             }
             return previous;
         }
@@ -105,7 +115,7 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
         @Override
         public void clear() {
             if (!isEmpty()) {
-                owner.notePackageRootMutation();
+                owner.notePackageRootClear(values());
             }
             super.clear();
         }
@@ -113,6 +123,34 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
 
     private boolean isPackageRootedHash() {
         return isPackageGlobalRoot || isGlobalPackageHash;
+    }
+
+    private static boolean rootEdge(RuntimeScalar value) {
+        return value != null
+                && (value.type & REFERENCE_BIT) != 0
+                && value.value instanceof RuntimeBase;
+    }
+
+    private void notePackageRootMutation(RuntimeScalar oldValue, RuntimeScalar newValue) {
+        if (isPackageRootedHash() && (rootEdge(oldValue) || rootEdge(newValue))) {
+            MortalList.invalidateExternalRootSnapshot();
+        }
+    }
+
+    private void notePackageRootMutationIf(boolean invalidates) {
+        if (invalidates) {
+            MortalList.invalidateExternalRootSnapshot();
+        }
+    }
+
+    private void notePackageRootClear(Collection<RuntimeScalar> values) {
+        if (!isPackageRootedHash()) return;
+        for (RuntimeScalar value : values) {
+            if (rootEdge(value)) {
+                MortalList.invalidateExternalRootSnapshot();
+                return;
+            }
+        }
     }
 
     void notePackageRootMutation() {
@@ -321,7 +359,6 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
                             RuntimeScalarCache.scalarEmptyString);
                 }
 
-                notePackageRootMutation();
                 // Clear existing elements but keep the same Map instance to preserve capacity
                 MortalList.deferDestroyForContainerClear(this.elements.values());
                 this.elements.clear();
@@ -396,8 +433,6 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
      * @param value The value for the hash entry.
      */
     public void put(String key, RuntimeScalar value) {
-        notePackageRootMutation();
-        markPackageRootedValue(value);
         switch (type) {
             case PLAIN_HASH -> {
                 elements.put(key, value);
@@ -407,6 +442,8 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
                 elements.put(key, value);
             }
             case TIED_HASH -> {
+                notePackageRootMutation(null, value);
+                markPackageRootedValue(value);
                 TieHash.tiedStore(this, new RuntimeScalar(key), value);
             }
             case READONLY_HASH -> throw new PerlCompilerException("Modification of a read-only value attempted");
@@ -1198,7 +1235,7 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
      * @return The current RuntimeHash instance after undefining its elements.
      */
     public RuntimeHash undefine() {
-        notePackageRootMutation();
+        notePackageRootClear(this.elements.values());
         // Fast path: if no value could possibly fire a DESTROY, use the
         // old one-shot path (one flush total instead of N flushes). The
         // slow progressive path below is only required when at least one
@@ -1235,7 +1272,7 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
             String key = entry.getKey();
             RuntimeScalar value = entry.getValue();
             it.remove();
-            notePackageRootMutation();
+            notePackageRootMutation(value, null);
             if (this.byteKeys != null) this.byteKeys.remove(key);
             // Defer DESTROY for this one value, then flush so it runs now.
             MortalList.deferDestroyForContainerClear(java.util.Collections.singletonList(value));
@@ -1318,7 +1355,6 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
         currentState.type = this.type;
         dynamicStateStack.push(currentState);
         // Clear the hash
-        notePackageRootMutation();
         this.elements.clear();
         this.byteKeys = null;
         this.blessId = 0;
@@ -1355,8 +1391,9 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
                 this.refCount = savedRefCount;
                 this.blessId = savedBlessId;
             }
-            notePackageRootMutation();
+            notePackageRootClear(this.elements.values());
             this.elements = previousState.elements;
+            notePackageRootClear(this.elements.values());
             if (isPackageRootedHash()) {
                 for (RuntimeScalar value : this.elements.values()) {
                     markPackageRootedValue(value);

--- a/src/main/perl/lib/CPAN/Config.pm
+++ b/src/main/perl/lib/CPAN/Config.pm
@@ -72,6 +72,9 @@ sub _bootstrap_prefs {
         'Type-Tiny.yml'              => 'PerlOnJava/CpanDistroprefs/Type-Tiny.yml',
         'HTML-Parser.yml'            => 'PerlOnJava/CpanDistroprefs/HTML-Parser.yml',
         'HTTP-Message.yml'           => 'PerlOnJava/CpanDistroprefs/HTTP-Message.yml',
+        'HTTP-Daemon.yml'            => 'PerlOnJava/CpanDistroprefs/HTTP-Daemon.yml',
+        'WWW-RobotRules.yml'         => 'PerlOnJava/CpanDistroprefs/WWW-RobotRules.yml',
+        'libwww-perl.yml'            => 'PerlOnJava/CpanDistroprefs/libwww-perl.yml',
     );
     $pref_install{'OpenAI-API.yml'} = $ENV{PERLONJAVA_OPENAI_LIVE_TESTING}
         ? 'PerlOnJava/CpanDistroprefs/OpenAI-API.live.yml'

--- a/src/main/perl/lib/CPAN/Distribution.pm
+++ b/src/main/perl/lib/CPAN/Distribution.pm
@@ -2193,49 +2193,212 @@ STUB
     }
 }
 
-#-> sub CPAN::Distribution::_try_perlonjava_fallback_pl
-# PerlOnJava: When Makefile.PL exits cleanly but creates no Makefile,
-# generate a minimal fallback Makefile.PL from META.yml/META.json
-# and re-run it so PerlOnJava's WriteMakefile can install .pm files.
-sub _try_perlonjava_fallback_pl {
-    my ($self, $system) = @_;
+#-> sub CPAN::Distribution::_perlonjava_clean_meta_scalar
+sub _perlonjava_clean_meta_scalar {
+    my ($value) = @_;
+    return unless defined $value;
+    $value =~ s/^\s+//;
+    $value =~ s/\s+$//;
+    $value =~ s/^['"]//;
+    $value =~ s/['"]$//;
+    return $value;
+}
 
-    # Try to extract NAME and VERSION from META files
-    my ($name, $version);
-    for my $meta_file ('META.yml', 'META.json') {
+#-> sub CPAN::Distribution::_perlonjava_perl_string
+sub _perlonjava_perl_string {
+    my ($value) = @_;
+    $value = '' unless defined $value;
+    $value =~ s/\\/\\\\/g;
+    $value =~ s/'/\\'/g;
+    return "'$value'";
+}
+
+#-> sub CPAN::Distribution::_perlonjava_add_fallback_prereqs
+sub _perlonjava_add_fallback_prereqs {
+    my ($args, $arg_key, $requires) = @_;
+    return unless ref $requires eq 'HASH';
+
+    for my $module (sort keys %$requires) {
+        next if $module eq 'perl';
+        my $version = $requires->{$module};
+        $version = 0 unless defined $version && length $version;
+        $args->{$arg_key}{$module} = "$version";
+    }
+
+    delete $args->{$arg_key}
+        if ref $args->{$arg_key} eq 'HASH' && !%{ $args->{$arg_key} };
+}
+
+#-> sub CPAN::Distribution::_perlonjava_fallback_pl_args_from_meta_struct
+sub _perlonjava_fallback_pl_args_from_meta_struct {
+    my ($self, $struct) = @_;
+    return unless ref $struct eq 'HASH';
+
+    my $module_name = $struct->{module_name}
+                   || $struct->{x_module_name}
+                   || $struct->{name};
+    return unless defined $module_name && length $module_name;
+    $module_name = _perlonjava_clean_meta_scalar($module_name);
+    $module_name =~ s/-/::/g;
+
+    my %args = (
+        NAME    => $module_name,
+        VERSION => _perlonjava_clean_meta_scalar($struct->{version}) || '0',
+    );
+
+    _perlonjava_add_fallback_prereqs(\%args, 'PREREQ_PM',          $struct->{requires});
+    _perlonjava_add_fallback_prereqs(\%args, 'BUILD_REQUIRES',     $struct->{build_requires});
+    _perlonjava_add_fallback_prereqs(\%args, 'CONFIGURE_REQUIRES', $struct->{configure_requires});
+
+    if (ref $struct->{prereqs} eq 'HASH') {
+        _perlonjava_add_fallback_prereqs(
+            \%args,
+            'PREREQ_PM',
+            $struct->{prereqs}{runtime}{requires},
+        );
+        _perlonjava_add_fallback_prereqs(
+            \%args,
+            'BUILD_REQUIRES',
+            $struct->{prereqs}{build}{requires},
+        );
+        _perlonjava_add_fallback_prereqs(
+            \%args,
+            'TEST_REQUIRES',
+            $struct->{prereqs}{test}{requires},
+        );
+        _perlonjava_add_fallback_prereqs(
+            \%args,
+            'CONFIGURE_REQUIRES',
+            $struct->{prereqs}{configure}{requires},
+        );
+    }
+
+    return \%args;
+}
+
+#-> sub CPAN::Distribution::_perlonjava_fallback_pl_args_from_cpan_meta
+sub _perlonjava_fallback_pl_args_from_cpan_meta {
+    my ($self, $meta_file) = @_;
+
+    my $meta = eval {
+        require CPAN::Meta;
+        CPAN::Meta->load_file($meta_file);
+    };
+    return if !$meta;
+
+    my $struct = eval { $meta->as_struct({ version => '1.4' }) } || {};
+    my $args = $self->_perlonjava_fallback_pl_args_from_meta_struct($struct);
+    return if !$args;
+
+    my $prereqs = eval { $meta->effective_prereqs };
+    if ($prereqs) {
+        for my $spec (
+            [ 'PREREQ_PM',          runtime   => 'requires' ],
+            [ 'BUILD_REQUIRES',     build     => 'requires' ],
+            [ 'TEST_REQUIRES',      test      => 'requires' ],
+            [ 'CONFIGURE_REQUIRES', configure => 'requires' ],
+        ) {
+            my ($arg_key, $phase, $type) = @$spec;
+            my $requirements = eval {
+                $prereqs->requirements_for($phase, $type)->as_string_hash;
+            };
+            _perlonjava_add_fallback_prereqs($args, $arg_key, $requirements);
+        }
+    }
+
+    return $args;
+}
+
+#-> sub CPAN::Distribution::_perlonjava_fallback_pl_args_from_meta_files
+sub _perlonjava_fallback_pl_args_from_meta_files {
+    my ($self) = @_;
+
+    for my $meta_file (qw(META.json META.yml)) {
         next unless -f $meta_file;
+
+        my $args = $self->_perlonjava_fallback_pl_args_from_cpan_meta($meta_file);
+        return $args if $args && $args->{NAME};
+
+        my $struct;
+        if ($meta_file =~ /\.ya?ml\z/i) {
+            $struct = eval { $self->parse_meta_yml($meta_file) };
+            $args = $self->_perlonjava_fallback_pl_args_from_meta_struct($struct);
+            return $args if $args && $args->{NAME};
+        }
+
         if (open my $fh, '<', $meta_file) {
             local $/;
             my $content = <$fh>;
             close $fh;
+
+            my ($name, $version);
             if ($meta_file eq 'META.json') {
-                ($name) = $content =~ /"name"\s*:\s*"([^"]+)"/;
+                ($name) = $content =~ /"(?:x_)?module_name"\s*:\s*"([^"]+)"/;
+                ($name) = $content =~ /"name"\s*:\s*"([^"]+)"/ if !defined $name;
                 ($version) = $content =~ /"version"\s*:\s*"([^"]+)"/;
             } else {
-                ($name) = $content =~ /^name:\s*(\S+)/m;
+                ($name) = $content =~ /^(?:x_)?module_name:\s*(\S+)/m;
+                ($name) = $content =~ /^name:\s*(\S+)/m if !defined $name;
                 ($version) = $content =~ /^version:\s*['"]?(\S+?)['"]?\s*$/m;
             }
-            last if $name;
+            next unless defined $name;
+            $name = _perlonjava_clean_meta_scalar($name);
+            $name =~ s/-/::/g;
+            return {
+                NAME    => $name,
+                VERSION => _perlonjava_clean_meta_scalar($version) || '0',
+            };
         }
     }
 
-    return 0 unless $name;
-    $version ||= '0';
+    return;
+}
 
-    # Convert dist name to module name (e.g., XML-Parser -> XML::Parser)
-    (my $module_name = $name) =~ s/-/::/g;
+#-> sub CPAN::Distribution::_perlonjava_fallback_makefile_pl
+sub _perlonjava_fallback_makefile_pl {
+    my ($self, $args) = @_;
+
+    my $text = "use ExtUtils::MakeMaker;\n";
+    $text .= "WriteMakefile(\n";
+    $text .= "    NAME    => " . _perlonjava_perl_string($args->{NAME}) . ",\n";
+    $text .= "    VERSION => " . _perlonjava_perl_string($args->{VERSION} || '0') . ",\n";
+
+    for my $arg_key (qw(PREREQ_PM BUILD_REQUIRES TEST_REQUIRES CONFIGURE_REQUIRES)) {
+        next unless ref $args->{$arg_key} eq 'HASH' && %{ $args->{$arg_key} };
+        $text .= "    $arg_key => {\n";
+        for my $module (sort keys %{ $args->{$arg_key} }) {
+            $text .= "        "
+                   . _perlonjava_perl_string($module)
+                   . " => "
+                   . _perlonjava_perl_string($args->{$arg_key}{$module})
+                   . ",\n";
+        }
+        $text .= "    },\n";
+    }
+
+    $text .= ");\n";
+    return $text;
+}
+
+#-> sub CPAN::Distribution::_try_perlonjava_fallback_pl
+# PerlOnJava: When Makefile.PL exits cleanly but creates no Makefile,
+# generate a fallback Makefile.PL from META.yml/META.json and re-run it
+# so PerlOnJava's WriteMakefile can install .pm files and preserve prereqs.
+sub _try_perlonjava_fallback_pl {
+    my ($self, $system) = @_;
+
+    my $args = $self->_perlonjava_fallback_pl_args_from_meta_files;
+    return 0 unless $args && $args->{NAME};
+    $args->{VERSION} ||= '0';
+
+    my $module_name = $args->{NAME};
+    my $version = $args->{VERSION};
 
     $CPAN::Frontend->myprint("PerlOnJava: Generating fallback Makefile.PL for $module_name $version\n");
 
-    # Write minimal Makefile.PL
+    # Write fallback Makefile.PL
     if (open my $fh, '>', 'Makefile.PL') {
-        print $fh <<"FALLBACK";
-use ExtUtils::MakeMaker;
-WriteMakefile(
-    NAME         => '$module_name',
-    VERSION      => '$version',
-);
-FALLBACK
+        print $fh $self->_perlonjava_fallback_makefile_pl($args);
         close $fh;
     } else {
         return 0;

--- a/src/main/perl/lib/PerlOnJava/CpanDistroprefs/HTTP-Daemon.yml
+++ b/src/main/perl/lib/PerlOnJava/CpanDistroprefs/HTTP-Daemon.yml
@@ -1,0 +1,12 @@
+---
+comment: |
+  PerlOnJava distroprefs for HTTP::Daemon.
+
+  HTTP::Daemon is a build/test dependency of libwww-perl. Its upstream
+  suite starts local daemon/socket tests that are not a useful gate for
+  staging LWP::Simple under PerlOnJava. Skip the dependency test phase so
+  `jcpan -t LWP::Online` can continue to the target distribution.
+match:
+  distribution: "^OALDERS/HTTP-Daemon-"
+test:
+  commandline: "PERLONJAVA_SKIP"

--- a/src/main/perl/lib/PerlOnJava/CpanDistroprefs/WWW-RobotRules.yml
+++ b/src/main/perl/lib/PerlOnJava/CpanDistroprefs/WWW-RobotRules.yml
@@ -1,0 +1,12 @@
+---
+comment: |
+  PerlOnJava distroprefs for WWW::RobotRules.
+
+  WWW::RobotRules is a runtime dependency of libwww-perl. Its DBM-backed
+  tests require AnyDBM_File, which PerlOnJava does not currently provide.
+  The pure-Perl module is still needed by libwww-perl, so skip the
+  dependency test phase and stage it for downstream tests.
+match:
+  distribution: "^OALDERS/WWW-RobotRules-"
+test:
+  commandline: "PERLONJAVA_SKIP"

--- a/src/main/perl/lib/PerlOnJava/CpanDistroprefs/libwww-perl.yml
+++ b/src/main/perl/lib/PerlOnJava/CpanDistroprefs/libwww-perl.yml
@@ -1,0 +1,13 @@
+---
+comment: |
+  PerlOnJava distroprefs for libwww-perl.
+
+  LWP::Online depends on LWP::Simple from libwww-perl. libwww-perl's
+  upstream suite includes local HTTP daemon tests and live-network checks
+  that are not stable prerequisites for testing LWP::Online here. Skip the
+  dependency test phase so CPAN can stage LWP::Simple; the LWP::Online
+  suite still runs normally.
+match:
+  distribution: "^OALDERS/libwww-perl-"
+test:
+  commandline: "PERLONJAVA_SKIP"

--- a/src/main/perl/lib/Test/Builder.pm
+++ b/src/main/perl/lib/Test/Builder.pm
@@ -223,6 +223,7 @@ sub child {
     # Clear $TODO for the child.
     my $orig_TODO = $self->find_TODO(undef, 1, undef);
 
+    my $subtest_buffered = $parent->format ? 0 : 1;
     my $subevents = [];
 
     my $hub = $ctx->stack->new_hub(
@@ -238,7 +239,7 @@ sub child {
         return $e;
     }, inherit => 1) if $orig_TODO;
 
-    $hub->listen(sub { push @$subevents => $_[1] });
+    $hub->listen(sub { push @$subevents => $_[1] }) if $subtest_buffered;
 
     $hub->set_nested( $parent->nested + 1 );
 
@@ -251,7 +252,7 @@ sub child {
     $meta->{subevents} = $subevents;
     $meta->{subtest_id} = $hub->id;
     $meta->{subtest_uuid} = $hub->uuid;
-    $meta->{subtest_buffered} = $parent->format ? 0 : 1;
+    $meta->{subtest_buffered} = $subtest_buffered;
 
     $self->_add_ts_hooks;
 
@@ -942,6 +943,31 @@ my %numeric_cmps = map { ( $_, 1 ) } ( "<", "<=", ">", ">=", "==", "!=", "<=>" )
 # Bad, these are not comparison operators. Should we include more?
 my %cmp_ok_bl = map { ( $_, 1 ) } ( "=", "+=", ".=", "x=", "^=", "|=", "||=", "&&=", "...");
 
+my %cmp_ok_cacheable = map { ( $_, 1 ) }
+  qw(< <= > >= == != <=> eq ne lt le gt ge cmp =~ !~ && ||);
+my %cmp_ok_check_cache;
+my %cmp_ok_fast = map { ( $_, 1 ) }
+  qw(< <= > >= == != <=> eq ne lt le gt ge cmp);
+
+sub _cmp_ok_fast_compare {
+    my ($got, $type, $expect) = @_;
+
+    return $got <   $expect if $type eq '<';
+    return $got <=  $expect if $type eq '<=';
+    return $got >   $expect if $type eq '>';
+    return $got >=  $expect if $type eq '>=';
+    return $got ==  $expect if $type eq '==';
+    return $got !=  $expect if $type eq '!=';
+    return $got <=> $expect if $type eq '<=>';
+    return $got eq  $expect if $type eq 'eq';
+    return $got ne  $expect if $type eq 'ne';
+    return $got lt  $expect if $type eq 'lt';
+    return $got le  $expect if $type eq 'le';
+    return $got gt  $expect if $type eq 'gt';
+    return $got ge  $expect if $type eq 'ge';
+    return $got cmp $expect;
+}
+
 sub cmp_ok {
     my( $self, $got, $type, $expect, $name ) = @_;
     my $ctx = $self->ctx;
@@ -959,26 +985,51 @@ sub cmp_ok {
 
         my($pack, $file, $line) = $ctx->trace->call();
         my $warning_bits = $ctx->trace->warning_bits;
-        # convert this to a code string so the BEGIN doesn't have to close
-        # over it, which can lead to issues with Devel::Cover
-        my $bits_code = defined $warning_bits ? qq["\Q$warning_bits\E"] : 'undef';
 
-        # Make sure warnings and location matches the caller. Can't do the
-        # comparison directly in the eval, as closing over variables can
-        # capture them forever when running with Devel::Cover.
-        my $check;
-        $succ = eval qq[
+        if ($cmp_ok_fast{$type}) {
+            $succ = eval {
+                local ${^WARNING_BITS} = $warning_bits;
+                $test = _cmp_ok_fast_compare($got, $type, $expect);
+                1;
+            };
+        }
+        else {
+            # convert this to a code string so the BEGIN doesn't have to close
+            # over it, which can lead to issues with Devel::Cover
+            my $bits_code = defined $warning_bits ? qq["\Q$warning_bits\E"] : 'undef';
+
+            my $check;
+            my $cache_key;
+            if ($cmp_ok_cacheable{$type}) {
+                $cache_key = join "\0",
+                  $type,
+                  defined($warning_bits) ? length($warning_bits) . ":$warning_bits" : "undef",
+                  defined($file) ? $file : "undef",
+                  defined($line) ? $line : "undef";
+                $check = $cmp_ok_check_cache{$cache_key};
+                $succ = 1 if $check;
+            }
+
+            # Make sure warnings and location matches the caller. Can't do the
+            # comparison directly in the eval, as closing over variables can
+            # capture them forever when running with Devel::Cover.
+            unless ($check) {
+            $succ = eval qq[
 BEGIN {\${^WARNING_BITS} = $bits_code};
 #line $line "(eval in cmp_ok) $file"
 \$check = sub { \$_[0] $type \$_[1] };
 1;
 ];
+                $cmp_ok_check_cache{$cache_key} = $check
+                  if $succ && defined $cache_key && $check;
+            }
 
-        if ($succ) {
-            $succ = eval {
-                $test = $check->($got, $expect);
-                1;
-            };
+            if ($succ) {
+                $succ = eval {
+                    $test = $check->($got, $expect);
+                    1;
+                };
+            }
         }
         $error = $@;
     }

--- a/src/test/resources/unit/cpan_fallback_prereqs.t
+++ b/src/test/resources/unit/cpan_fallback_prereqs.t
@@ -1,0 +1,88 @@
+use strict;
+use warnings;
+use Test::More;
+
+use CPAN::Distribution;
+
+my $args = CPAN::Distribution->_perlonjava_fallback_pl_args_from_meta_struct({
+    name               => 'LWP-Online',
+    module_name        => 'LWP::Online',
+    version            => '1.08',
+    requires           => {
+        'LWP::Simple' => '5.805',
+        'URI'         => '1.35',
+        perl          => '5.005',
+    },
+    build_requires     => {
+        'Test::More' => '0.42',
+    },
+    configure_requires => {
+        'ExtUtils::MakeMaker' => '6.42',
+    },
+});
+
+is($args->{NAME}, 'LWP::Online', 'fallback uses module_name when present');
+is($args->{VERSION}, '1.08', 'fallback preserves version');
+is_deeply(
+    $args->{PREREQ_PM},
+    {
+        'LWP::Simple' => '5.805',
+        'URI'         => '1.35',
+    },
+    'fallback maps runtime requires to PREREQ_PM and skips perl',
+);
+is_deeply(
+    $args->{BUILD_REQUIRES},
+    { 'Test::More' => '0.42' },
+    'fallback preserves build requires',
+);
+is_deeply(
+    $args->{CONFIGURE_REQUIRES},
+    { 'ExtUtils::MakeMaker' => '6.42' },
+    'fallback preserves configure requires',
+);
+
+my $makefile_pl = CPAN::Distribution->_perlonjava_fallback_makefile_pl($args);
+
+like($makefile_pl, qr/NAME\s+=> 'LWP::Online'/, 'generated Makefile.PL names module');
+like($makefile_pl, qr/VERSION\s+=> '1\.08'/, 'generated Makefile.PL has version');
+like($makefile_pl, qr/PREREQ_PM\s+=> \{/, 'generated Makefile.PL has PREREQ_PM');
+like($makefile_pl, qr/'LWP::Simple'\s+=> '5\.805'/, 'generated Makefile.PL has LWP::Simple prereq');
+like($makefile_pl, qr/'URI'\s+=> '1\.35'/, 'generated Makefile.PL has URI prereq');
+unlike($makefile_pl, qr/'perl'\s+=>/, 'generated Makefile.PL does not emit perl as a module prereq');
+
+my $v2_args = CPAN::Distribution->_perlonjava_fallback_pl_args_from_meta_struct({
+    name          => 'Example-Dist',
+    x_module_name => 'Example::Dist',
+    version       => '2.00',
+    prereqs       => {
+        runtime => {
+            requires => {
+                'Runtime::Dep' => '1.0',
+            },
+        },
+        build => {
+            requires => {
+                'Build::Dep' => '2.0',
+            },
+        },
+        test => {
+            requires => {
+                'Test::Dep' => '3.0',
+            },
+        },
+        configure => {
+            requires => {
+                'Configure::Dep' => '4.0',
+            },
+        },
+    },
+});
+
+is($v2_args->{NAME}, 'Example::Dist', 'fallback accepts x_module_name');
+is_deeply($v2_args->{PREREQ_PM}, { 'Runtime::Dep' => '1.0' }, 'v2 runtime prereqs are mapped');
+is_deeply($v2_args->{BUILD_REQUIRES}, { 'Build::Dep' => '2.0' }, 'v2 build prereqs are mapped');
+is_deeply($v2_args->{TEST_REQUIRES}, { 'Test::Dep' => '3.0' }, 'v2 test prereqs are mapped');
+is_deeply($v2_args->{CONFIGURE_REQUIRES}, { 'Configure::Dep' => '4.0' }, 'v2 configure prereqs are mapped');
+
+done_testing();


### PR DESCRIPTION
## Summary

- add fallback prereq metadata for CPAN distributions whose test dependencies are not declared reliably
- add PerlOnJava distroprefs for LWP::Online's libwww-perl dependency path so pure-Perl modules can be staged despite local-daemon/DBM test blockers
- avoid retaining streamed subtest events in `Test::Builder`, and cache/fast-path `cmp_ok` operators used heavily by File::Listing
- reduce unnecessary runtime root-snapshot invalidation and scoped hash rescue work during large CPAN test runs

## Verification

- `make` PASS
- `timeout 7200 ./jcpan -t LWP::Online` PASS, `Files=3, Tests=8`, `real 192.35`
- `timeout 600 ./jcpan -t File::Listing` PASS, `Files=3, Tests=17074`, `real 74.97`
- `timeout 7200 ./jcpan -t Moo` PASS, `Files=71, Tests=841`, `real 267.93`
- `timeout 7200 ./jcpan -t DBIx::Class` PASS, `Files=314, Tests=13120`, `real 2112.12`
