### PR TITLE
Fix LWP jcpan result classification

### DIFF
--- a/dev/tools/cpan_random_tester.pl
+++ b/dev/tools/cpan_random_tester.pl
@@ -524,6 +524,13 @@ sub parse_all_module_results {
             next;
         }
 
+        if (is_perlonjava_distropref_skip_output($text)) {
+            $r{status} = 'SKIP';
+            $r{reason} = 'distroprefs';
+            push @results, \%r;
+            next;
+        }
+
         if ($text =~ /Result: FAIL/ || $text =~ /(?:make|Build) test -- NOT OK/) {
             $r{status} = 'FAIL';
             if ($total_tests > 0) {
@@ -556,7 +563,7 @@ sub parse_all_module_results {
 
     # --- Pass 3: catch modules that never reached the test phase ---
     # (configure failures, build failures, etc.)
-    my %pending_bundled_skip;
+    my %pending_skip;
     for my $line (split /\n/, $output) {
         if ($line =~ /Running (?:test|install) for module '([^']+)'/) {
             $last_mod = $1;
@@ -590,16 +597,19 @@ sub parse_all_module_results {
         # output shapes may omit the standard make-test block, so keep this
         # fallback too. Defer recording until after the scan so a later
         # configure/build failure still wins.
-        $pending_bundled_skip{$last_mod} = 1
+        $pending_skip{$last_mod} = 'bundled'
             if $last_mod && !$seen{$last_mod} && is_bundled_skip_output($line);
+
+        $pending_skip{$last_mod} ||= 'distroprefs'
+            if $last_mod && !$seen{$last_mod} && is_perlonjava_distropref_skip_output($line);
     }
 
-    for my $mod (sort keys %pending_bundled_skip) {
+    for my $mod (sort keys %pending_skip) {
         next if $seen{$mod}++;
         my %r = (
             module => $mod, status => 'SKIP',
             tests => undef, pass_count => undef,
-            error => '', reason => 'bundled',
+            error => '', reason => $pending_skip{$mod},
         );
         push @results, \%r;
     }
@@ -612,6 +622,11 @@ sub is_bundled_skip_output {
     return 1 if $text =~ /PerlOnJava:\s+.+?\s+is bundled in the JAR;\s+skipping upstream test suite/i;
     return 1 if $text =~ /NOTE:\s+\S+\.pm\s+is bundled;\s+upstream test suite will be skipped/i;
     return 0;
+}
+
+sub is_perlonjava_distropref_skip_output {
+    my ($text) = @_;
+    return $text =~ /PERLONJAVA_SKIP -- (?:configure|make|test|install) phase skipped/ ? 1 : 0;
 }
 
 

--- a/docs/guides/cpan-distroprefs.md
+++ b/docs/guides/cpan-distroprefs.md
@@ -81,6 +81,18 @@ Skipping the target distribution's test phase is a last resort. If you do it,
 document the supported subset and keep a separate smoke test or downstream test
 that proves the behavior PerlOnJava claims to support.
 
+The `jcpan` launchers export `PERLONJAVA_JCPAN_ARGS` with the CPAN arguments
+after wrapper-only options such as `--jobs`. Dependency-only skips can use an
+`env` `not_PERLONJAVA_JCPAN_ARGS` match to stay out of direct target runs.
+For example:
+
+```yaml
+match:
+  distribution: "^AUTHOR/Example-Module-"
+  env:
+    not_PERLONJAVA_JCPAN_ARGS: "(^|[[:space:]])Example::Module($|[[:space:]])"
+```
+
 ## Basic YAML Shape
 
 A distropref should include a detailed `comment`, a narrow `match`, and only the

--- a/jcpan
+++ b/jcpan
@@ -84,6 +84,7 @@ case "$JCPAN_BIN" in
     /*) ;;                       # already absolute
     *)  JCPAN_BIN="$SCRIPT_DIR/jcpan" ;;
 esac
+export PERLONJAVA_JCPAN_ARGS="${ARGS[*]}"
 export PATH="$SCRIPT_DIR:$PATH"
 
 exec "$SCRIPT_DIR/jperl" "$CPAN_SCRIPT" "${ARGS[@]}"

--- a/jcpan.bat
+++ b/jcpan.bat
@@ -35,5 +35,6 @@ rem etc.) can find jperl/jcpan without tokens that don't expand in
 rem POSIX sh. See src/main/perl/lib/CPAN/Config.pm (Moose.yml).
 set "JPERL_BIN=%SCRIPT_DIR%jperl.bat"
 set "JCPAN_BIN=%SCRIPT_DIR%jcpan.bat"
+set "PERLONJAVA_JCPAN_ARGS=%JCPAN_ARGS%"
 set "PATH=%SCRIPT_DIR%;%PATH%"
 "%SCRIPT_DIR%jperl.bat" "%SCRIPT_DIR%src\main\perl\bin\cpan" %JCPAN_ARGS%

--- a/src/main/perl/lib/PerlOnJava/CpanDistroprefs/libwww-perl.yml
+++ b/src/main/perl/lib/PerlOnJava/CpanDistroprefs/libwww-perl.yml
@@ -7,7 +7,12 @@ comment: |
   that are not stable prerequisites for testing LWP::Online here. Skip the
   dependency test phase so CPAN can stage LWP::Simple; the LWP::Online
   suite still runs normally.
+
+  Do not apply this dependency-only skip when libwww-perl itself is the
+  requested jcpan target. The LWP suite is expected to run in that case.
 match:
   distribution: "^OALDERS/libwww-perl-"
+  env:
+    not_PERLONJAVA_JCPAN_ARGS: "(^|[[:space:]])(?:LWP|LWP::UserAgent)($|[[:space:]])"
 test:
   commandline: "PERLONJAVA_SKIP"

--- a/src/test/resources/unit/cpan_distroprefs_jcpan_args.t
+++ b/src/test/resources/unit/cpan_distroprefs_jcpan_args.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+use Test::More;
+use CPAN::Distroprefs;
+
+my $pref = CPAN::Distroprefs::Pref->new({
+    data => {
+        match => {
+            distribution => '^OALDERS/libwww-perl-',
+            env => {
+                not_PERLONJAVA_JCPAN_ARGS =>
+                    '(^|[[:space:]])(?:LWP|LWP::UserAgent)($|[[:space:]])',
+            },
+        },
+        test => {
+            commandline => 'PERLONJAVA_SKIP',
+        },
+    },
+});
+
+my %match_info = (
+    distribution => 'OALDERS/libwww-perl-6.83.tar.gz',
+    module       => [],
+    perl         => $^X,
+    perlconfig   => {},
+    env          => {},
+);
+
+ok(
+    $pref->matches(\%match_info),
+    'libwww-perl dependency skip matches when no direct jcpan args are exposed',
+);
+
+$match_info{env}{PERLONJAVA_JCPAN_ARGS} = '-t LWP::Online';
+ok(
+    $pref->matches(\%match_info),
+    'libwww-perl dependency skip still matches for a downstream target',
+);
+
+$match_info{env}{PERLONJAVA_JCPAN_ARGS} = '-t LWP';
+ok(
+    !$pref->matches(\%match_info),
+    'libwww-perl dependency skip does not match direct LWP tests',
+);
+
+$match_info{env}{PERLONJAVA_JCPAN_ARGS} = '-t LWP::UserAgent';
+ok(
+    !$pref->matches(\%match_info),
+    'libwww-perl dependency skip does not match direct LWP::UserAgent tests',
+);
+
+done_testing;


### PR DESCRIPTION
## Summary

- expose requested `jcpan` arguments to CPAN distroprefs via `PERLONJAVA_JCPAN_ARGS`
- keep the `libwww-perl` dependency-only test skip out of direct `LWP` and `LWP::UserAgent` runs
- classify `PERLONJAVA_SKIP -- ... phase skipped` in `cpan_random_tester.pl` as `SKIP distroprefs` instead of `FAIL Unknown test outcome`
- add a focused unit test for the libwww-perl distropref match behavior

## Verification

- `timeout 60 ./jperl src/test/resources/unit/cpan_distroprefs_jcpan_args.t`
- `perl -c dev/tools/cpan_random_tester.pl`
- `timeout 1200 make`
- `timeout 1200 ./jcpan -t LWP::UserAgent`
- `timeout 1200 ./jcpan -t LWP`

Both direct CPAN targets now run the libwww-perl test phase and parse as `PASS 157/157`.

## Notes

`MooseX::Types::Moose` can still hit `Unknown test outcome` in older random-tester logs for a separate truncated/incomplete `Build test` output shape. This PR fixes the LWP false regressions and the explicit distroprefs skip parser case.
