### PR TITLE
Fix Parse::RecDescent interpreter scalar refs

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -57,6 +57,7 @@ public class BytecodeInterpreter {
         return scalar instanceof ReadOnlyAlias
                 || scalar.captureCount > 0
                 || scalar.captureRefCountOwned > 0
+                || scalar.referencedByScalarReference
                 || scalar.type == RuntimeScalarType.TIED_SCALAR
                 || scalar.type == RuntimeScalarType.READONLY_SCALAR;
     }
@@ -513,9 +514,6 @@ public class BytecodeInterpreter {
                                 int dest = bytecode[pc++];
                                 int src = bytecode[pc++];
                                 RuntimeBase srcVal = registers[src];
-                                if (dest == 51 && srcVal instanceof RuntimeList) {
-                                    new RuntimeException("TRACE ALIAS dest=51 src=" + src + " putting list in reg 51, srcVal=" + srcVal).printStackTrace();
-                                }
                                 registers[dest] = isImmutableProxy(srcVal) ? ensureMutableScalar(srcVal) : srcVal;
                             }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -217,6 +217,14 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
      */
     public boolean ownsScalarReferenceContents;
 
+    /**
+     * True once a scalar reference has been created to this scalar, e.g.
+     * {@code \$x}. Interpreter lexical assignment must preserve the scalar
+     * object's identity after that point so existing references continue to
+     * observe later assignments to the lexical.
+     */
+    public boolean referencedByScalarReference;
+
     // Constructors
     public RuntimeScalar() {
         this.type = UNDEF;
@@ -2624,6 +2632,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     // store the RuntimeGlob directly, losing the reference to this container.
     // Internals::SvREADONLY needs the container to set/get readonly status.
     public RuntimeScalar createReference() {
+        referencedByScalarReference = true;
         RuntimeScalar result = new RuntimeScalar();
         result.type = RuntimeScalarType.REFERENCE;
         result.value = this;
@@ -3488,6 +3497,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         currentState.value = this.value;
         currentState.blessId = this.blessId;
         currentState.ownsScalarReferenceContents = this.ownsScalarReferenceContents;
+        currentState.referencedByScalarReference = this.referencedByScalarReference;
         currentState.tainted = this.tainted;
         // Push the current state onto the stack
         dynamicStateStack.push(currentState);
@@ -3510,6 +3520,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         if (!dynamicStateStack.isEmpty()) {
             // Pop the most recent saved state from the stack
             RuntimeScalar previousState = dynamicStateStack.pop();
+            boolean referencedDuringLocal = this.referencedByScalarReference;
 
             RuntimeBase displacedBase = null;
             if ((this.type & RuntimeScalarType.REFERENCE_BIT) != 0
@@ -3523,6 +3534,8 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             this.value = previousState.value;
             this.blessId = previousState.blessId;
             this.ownsScalarReferenceContents = previousState.ownsScalarReferenceContents;
+            this.referencedByScalarReference =
+                    previousState.referencedByScalarReference || referencedDuringLocal;
             this.tainted = previousState.tainted;
 
             releaseScalarReferenceContents(scalarReferenceContents);

--- a/src/test/resources/unit/interpreter_scalar_ref_assignment.t
+++ b/src/test/resources/unit/interpreter_scalar_ref_assignment.t
@@ -1,0 +1,43 @@
+use Test::More tests => 2;
+
+my $pad = ('$dummy = $dummy + 1;' . "\n") x 3500;
+
+my $code = <<'PERL';
+package TieOffset;
+sub TIESCALAR {
+    bless { text => $_[1], full_length => $_[2], prev => $_[3] ? -1 : 0 }, $_[0]
+}
+sub FETCH {
+    my $self = $_[0];
+    return $self->{full_length} - length(${ $self->{text} }) + $self->{prev};
+}
+sub STORE { die "store" }
+
+package main;
+sub fallback_scalar_ref_assignment {
+    my $dummy = 0;
+__PAD__
+    my $direct;
+    my $direct_ref = \$direct;
+    $direct = "updated";
+
+    my $text;
+    tie my $offset, "TieOffset", \$text, 8;
+    tie my $previous_offset, "TieOffset", \$text, 8, 1;
+    $text = "a  b   c";
+    my $before = $offset;
+    substr($text, 0, 1) = "";
+    my $after = $offset;
+    my $previous = $previous_offset;
+
+    return ($$direct_ref, "$before:$after:$previous");
+}
+PERL
+
+$code =~ s/__PAD__/$pad/;
+eval $code;
+die $@ if $@;
+
+my ($direct, $offsets) = fallback_scalar_ref_assignment();
+is($direct, "updated", 'interpreter fallback preserves direct scalar refs across lexical assignment');
+is($offsets, "0:1:0", 'interpreter fallback preserves tied counter refs across lexical assignment');


### PR DESCRIPTION
## Summary
- Preserve interpreter lexical scalar slots after scalar references are created.
- Fix Parse::RecDescent item position counters tied to `\$text` before later `$text = $_[1]` assignment.
- Remove leftover interpreter TRACE ALIAS stack trace and add a focused regression test.

## Tests
- `make`
- `timeout 900 ./jcpan -t Parse::RecDescent`
