### PR TITLE
fix: resolve CPAN regression modules

### DIFF
--- a/dev/tools/cpan_random_tester.pl
+++ b/dev/tools/cpan_random_tester.pl
@@ -78,8 +78,8 @@ my $packages_gz  = glob('~/.cpan/sources/modules/02packages.details.txt.gz');
 # CLI options
 # ──────────────────────────────────────────────────────────────────────
 my $count       = 10;
-my $timeout     = 1200;   # soft wall-clock timeout; progress can extend it
-my $activity_grace = 300; # after soft timeout, allow this many idle seconds
+my $timeout     = 2400;   # soft wall-clock timeout; progress can extend it
+my $activity_grace = 600; # after soft timeout, allow this many idle seconds
 my $max_runtime = 0;      # 0 = no hard cap beyond activity timeout
 my $progress_interval = 60;
 my $jcpan_jobs  = 1;      # passed through as `jcpan --jobs N`
@@ -1148,13 +1148,13 @@ Options:
                    Can be:
                      - Comma-separated: --modules Foo::Bar,Baz::Qux
                      - File path: --modules modules.txt (one per line, # for comments)
-  --timeout N      Default timeout per target module in seconds (default: 1200).
+  --timeout N      Default timeout per target module in seconds (default: 2400).
                    This is a soft wall clock: after this time, runs continue
                    while they keep producing output.
                    Known-slow distributions use a larger timeout wired in this script.
   --activity-grace N
                    After --timeout has elapsed, kill the target if it produces
-                   no output for this many seconds (default: 300).
+                   no output for this many seconds (default: 600).
   --max-runtime N  Optional hard cap per target module in seconds (default: 0,
                    disabled). Useful for chatty tests that never finish.
   --progress-interval N

--- a/jcpan
+++ b/jcpan
@@ -51,10 +51,10 @@ else
     exit 1
 fi
 
-# Set default per-test timeout (300s) to kill hanging tests
+# Set default per-test timeout (900s) to kill hanging tests
 # Tests that produce no output for this duration will be killed
-# Override: JPERL_TEST_TIMEOUT=0 (disable) or JPERL_TEST_TIMEOUT=600 (10 min)
-export JPERL_TEST_TIMEOUT="${JPERL_TEST_TIMEOUT:-300}"
+# Override: JPERL_TEST_TIMEOUT=0 (disable) or JPERL_TEST_TIMEOUT=900 (15 min)
+export JPERL_TEST_TIMEOUT="${JPERL_TEST_TIMEOUT:-900}"
 
 # Enable the orphan-exit watchdog in every jperl this run spawns. If the
 # parent jcpan / test_harness process is killed (e.g. SIGKILL'd by the

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -370,47 +370,7 @@ public class BytecodeCompiler implements Visitor {
         if (!scopeIndices.isEmpty()) {
             int scopeIdx = scopeIndices.pop();
 
-            // Gather variable indices to determine if cleanup is needed.
-            java.util.List<Integer> scalarIndices = symbolTable.getMyScalarIndicesInScope(scopeIdx);
-            java.util.List<Integer> hashIndices = symbolTable.getMyHashIndicesInScope(scopeIdx);
-            java.util.List<Integer> arrayIndices = symbolTable.getMyArrayIndicesInScope(scopeIdx);
-
-            // Only emit pushMark/popAndFlush when there are variables that need cleanup.
-            // Scopes with no my-variables skip this entirely.
-            boolean needsCleanup = flush
-                    && (!scalarIndices.isEmpty() || !hashIndices.isEmpty() || !arrayIndices.isEmpty());
-
-            // Push mark so popAndFlush only drains entries added by
-            // scopeExitCleanup. Entries from method returns within the block
-            // that are below the mark will be processed by the next setLarge()
-            // or undefine() flush, or by the enclosing scope's exit.
-            if (needsCleanup) {
-                emit(Opcodes.MORTAL_PUSH_MARK);
-            }
-
-            // Emit SCOPE_EXIT_CLEANUP for each my-scalar register in the exiting scope.
-            // This calls RuntimeScalar.scopeExitCleanup() which handles:
-            // 1. IO fd recycling for anonymous filehandle globs
-            // 2. refCount decrement for blessed references with DESTROY
-            for (int reg : scalarIndices) {
-                emit(Opcodes.SCOPE_EXIT_CLEANUP);
-                emitReg(reg);
-            }
-
-            // Walk hash/array variables for nested blessed references.
-            for (int reg : hashIndices) {
-                emit(Opcodes.SCOPE_EXIT_CLEANUP_HASH);
-                emitReg(reg);
-            }
-            for (int reg : arrayIndices) {
-                emit(Opcodes.SCOPE_EXIT_CLEANUP_ARRAY);
-                emitReg(reg);
-            }
-
-            // Pop mark and flush only entries added since the mark
-            if (needsCleanup) {
-                emit(Opcodes.MORTAL_POP_FLUSH);
-            }
+            emitScopeCleanup(scopeIdx, flush);
 
             symbolTable.exitScope(scopeIdx);
             if (!savedNextRegister.isEmpty()) {
@@ -427,6 +387,130 @@ public class BytecodeCompiler implements Visitor {
                 st.warningFatalStack.pop();
                 st.warningDisabledStack.pop();
             }
+        }
+    }
+
+    private void emitScopeCleanup(int scopeIdx, boolean flush) {
+        // Gather variable indices to determine if cleanup is needed.
+        java.util.List<Integer> scalarIndices = symbolTable.getMyScalarIndicesInScope(scopeIdx);
+        java.util.List<Integer> hashIndices = symbolTable.getMyHashIndicesInScope(scopeIdx);
+        java.util.List<Integer> arrayIndices = symbolTable.getMyArrayIndicesInScope(scopeIdx);
+
+        // Only emit pushMark/popAndFlush when there are variables that need cleanup.
+        // Scopes with no my-variables skip this entirely.
+        boolean needsCleanup = flush
+                && (!scalarIndices.isEmpty() || !hashIndices.isEmpty() || !arrayIndices.isEmpty());
+
+        // Push mark so popAndFlush only drains entries added by
+        // scopeExitCleanup. Entries from method returns within the block
+        // that are below the mark will be processed by the next setLarge()
+        // or undefine() flush, or by the enclosing scope's exit.
+        if (needsCleanup) {
+            emit(Opcodes.MORTAL_PUSH_MARK);
+        }
+
+        // Emit SCOPE_EXIT_CLEANUP for each my-scalar register in the exiting scope.
+        // This calls RuntimeScalar.scopeExitCleanup() which handles:
+        // 1. IO fd recycling for anonymous filehandle globs
+        // 2. refCount decrement for blessed references with DESTROY
+        for (int reg : scalarIndices) {
+            emit(Opcodes.SCOPE_EXIT_CLEANUP);
+            emitReg(reg);
+        }
+
+        // Walk hash/array variables for nested blessed references.
+        for (int reg : hashIndices) {
+            emit(Opcodes.SCOPE_EXIT_CLEANUP_HASH);
+            emitReg(reg);
+        }
+        for (int reg : arrayIndices) {
+            emit(Opcodes.SCOPE_EXIT_CLEANUP_ARRAY);
+            emitReg(reg);
+        }
+
+        // Pop mark and flush only entries added since the mark.
+        if (needsCleanup) {
+            emit(Opcodes.MORTAL_POP_FLUSH);
+        }
+    }
+
+    private void emitLoopControlScopeCleanup(LoopInfo loopInfo) {
+        if (loopInfo.cleanupScopeIndex < 0) {
+            return;
+        }
+        emitScopeCleanup(loopInfo.cleanupScopeIndex, true);
+    }
+
+    private Set<Integer> myVariableIndexSet() {
+        return new HashSet<>(symbolTable.getMyVariableIndicesInScope(0));
+    }
+
+    private List<Integer> indicesAddedSince(List<Integer> indices, Set<Integer> before) {
+        if (indices.isEmpty()) {
+            return indices;
+        }
+        List<Integer> added = new ArrayList<>();
+        for (int idx : indices) {
+            if (!before.contains(idx)) {
+                added.add(idx);
+            }
+        }
+        return added;
+    }
+
+    private MyVarCleanupRegisters myVariablesAddedSince(Set<Integer> before) {
+        return new MyVarCleanupRegisters(
+                indicesAddedSince(symbolTable.getMyScalarIndicesInScope(0), before),
+                indicesAddedSince(symbolTable.getMyHashIndicesInScope(0), before),
+                indicesAddedSince(symbolTable.getMyArrayIndicesInScope(0), before),
+                indicesAddedSince(symbolTable.getMyVariableIndicesInScope(0), before));
+    }
+
+    private void emitMyVarCleanup(MyVarCleanupRegisters cleanup, boolean flush) {
+        if (cleanup.isEmpty()) {
+            return;
+        }
+
+        for (int reg : cleanup.scalarRegs) {
+            emit(Opcodes.SCOPE_EXIT_CLEANUP);
+            emitReg(reg);
+        }
+        for (int reg : cleanup.hashRegs) {
+            emit(Opcodes.SCOPE_EXIT_CLEANUP_HASH);
+            emitReg(reg);
+        }
+        for (int reg : cleanup.arrayRegs) {
+            emit(Opcodes.SCOPE_EXIT_CLEANUP_ARRAY);
+            emitReg(reg);
+        }
+        if (flush) {
+            emit(Opcodes.MORTAL_FLUSH);
+        }
+    }
+
+    private static final class MyVarCleanupRegisters {
+        private static final MyVarCleanupRegisters EMPTY = new MyVarCleanupRegisters(
+                List.of(), List.of(), List.of(), List.of());
+
+        final List<Integer> scalarRegs;
+        final List<Integer> hashRegs;
+        final List<Integer> arrayRegs;
+        final List<Integer> allRegs;
+
+        MyVarCleanupRegisters(List<Integer> scalarRegs, List<Integer> hashRegs,
+                              List<Integer> arrayRegs, List<Integer> allRegs) {
+            this.scalarRegs = scalarRegs;
+            this.hashRegs = hashRegs;
+            this.arrayRegs = arrayRegs;
+            this.allRegs = allRegs;
+        }
+
+        static MyVarCleanupRegisters empty() {
+            return EMPTY;
+        }
+
+        boolean isEmpty() {
+            return allRegs.isEmpty();
         }
     }
 
@@ -1958,9 +2042,6 @@ public class BytecodeCompiler implements Visitor {
             throwCompilerException("Hash slice requires HashLiteralNode");
         }
         HashLiteralNode keysNode = (HashLiteralNode) node.right;
-        if (keysNode.elements.isEmpty()) {
-            throwCompilerException("Hash slice requires at least one key");
-        }
 
         // Compile all keys into a list
         List<Integer> keyRegs = new ArrayList<>();
@@ -1997,7 +2078,21 @@ public class BytecodeCompiler implements Visitor {
         emitReg(hashReg);
         emitReg(keysListReg);
 
-        lastResultReg = rdSlice;
+        if (currentCallContext == RuntimeContextType.SCALAR) {
+            int lastIndexReg = allocateRegister();
+            emit(Opcodes.LOAD_INT);
+            emitReg(lastIndexReg);
+            emit(-1);
+
+            int scalarReg = allocateOutputRegister();
+            emit(Opcodes.ARRAY_GET);
+            emitReg(scalarReg);
+            emitReg(rdSlice);
+            emitReg(lastIndexReg);
+            lastResultReg = scalarReg;
+        } else {
+            lastResultReg = rdSlice;
+        }
     }
 
     void handleHashKeyValueSlice(BinaryOperatorNode node, OperatorNode leftOp) {
@@ -2113,6 +2208,30 @@ public class BytecodeCompiler implements Visitor {
             return;
         }
 
+        if (op.equals("x=") && node.left instanceof OperatorNode leftOp && leftOp.operator.equals("%")) {
+            throwCompilerException("Can't modify hash dereference in repeat (x)", node.getIndex());
+            return;
+        }
+
+        if (op.equals("^^=")) {
+            compileNode(node.right, -1, RuntimeContextType.SCALAR);
+            int valueReg = lastResultReg;
+            int targetReg = compileLhsForCompoundAssignment(node);
+            int resultReg = allocateRegister();
+
+            emit(Opcodes.XOR_LOGICAL);
+            emitReg(resultReg);
+            emitReg(targetReg);
+            emitReg(valueReg);
+
+            emit(Opcodes.SET_SCALAR);
+            emitReg(targetReg);
+            emitReg(resultReg);
+
+            lastResultReg = targetReg;
+            return;
+        }
+
         // Compile the right operand first (the value to add/subtract/etc.)
         compileNode(node.right, -1, RuntimeContextType.SCALAR);
         int valueReg = lastResultReg;
@@ -2160,6 +2279,11 @@ public class BytecodeCompiler implements Visitor {
     private int compileLhsForCompoundAssignment(BinaryOperatorNode node) {
         int targetReg;
 
+        if (node.left instanceof ListNode listNode && listNode.elements.size() == 1) {
+            compileNode(listNode.elements.get(0), -1, RuntimeContextType.LVALUE);
+            return lastResultReg;
+        }
+
         // Check if left side is a simple variable reference
         if (node.left instanceof OperatorNode leftOp) {
             if (leftOp.operator.equals("$") && leftOp.operand instanceof IdentifierNode) {
@@ -2181,14 +2305,14 @@ public class BytecodeCompiler implements Visitor {
                     emit(nameIdx);
                 }
             } else {
-                // Other operator (not simple variable) - compile as expression in SCALAR context
-                compileNode(node.left, -1, RuntimeContextType.SCALAR);
+                // Other operator (not simple variable) - compile as lvalue expression
+                compileNode(node.left, -1, RuntimeContextType.LVALUE);
                 targetReg = lastResultReg;
             }
         } else {
             // Not an OperatorNode (could be BinaryOperatorNode like ($x &= $y))
-            // Compile the left side as an expression in SCALAR context
-            compileNode(node.left, -1, RuntimeContextType.SCALAR);
+            // Compile the left side as an lvalue expression
+            compileNode(node.left, -1, RuntimeContextType.LVALUE);
             targetReg = lastResultReg;
         }
 
@@ -4668,10 +4792,15 @@ public class BytecodeCompiler implements Visitor {
                     return;
                 }
 
-                // Compile operand in LIST context to get the actual value
+                // Compile most operands in LIST context to get the actual value.
                 // Example: \@array should get a reference to the array itself,
-                // not its size (which would happen in SCALAR context)
-                compileNode(node.operand, -1, RuntimeContextType.LIST);
+                // not its size (which would happen in SCALAR context). Assignment
+                // expressions are the exception: \(my @a = ...) references the
+                // scalar assignment result, matching Perl's prototype refgen path.
+                int refContext = node.operand instanceof BinaryOperatorNode binOp && binOp.operator.equals("=")
+                        ? RuntimeContextType.SCALAR
+                        : RuntimeContextType.LIST;
+                compileNode(node.operand, -1, refContext);
                 int valueReg = lastResultReg;
 
                 // Allocate register for reference
@@ -5641,6 +5770,7 @@ public class BytecodeCompiler implements Visitor {
         int bodyStartPc = bytecode.size();
         LoopInfo loopInfo = new LoopInfo(node.labelName, bodyStartPc, true);
         loopStack.push(loopInfo);
+        loopInfo.cleanupScopeIndex = symbolTable.currentScopeIndex() + 1;
 
         // Step 8: Execute body
         if (node.body != null) {
@@ -5840,6 +5970,7 @@ public class BytecodeCompiler implements Visitor {
         loopStack.push(loopInfo);
 
         int loopEndJumpPc = -1;
+        MyVarCleanupRegisters conditionMyCleanup = MyVarCleanupRegisters.empty();
 
         if (node.isDoWhile) {
             // do-while loop: body executes at least once, condition checked at end
@@ -5876,8 +6007,10 @@ public class BytecodeCompiler implements Visitor {
             } else {
                 int condReg = allocateRegister();
                 if (node.condition != null) {
+                    Set<Integer> conditionMyBefore = myVariableIndexSet();
                     // Evaluate condition in SCALAR context (need boolean result)
                     compileNode(node.condition, -1, RuntimeContextType.SCALAR);
+                    conditionMyCleanup = myVariablesAddedSince(conditionMyBefore);
                     condReg = lastResultReg;
                 } else {
                     // No condition means infinite loop - load true
@@ -5897,8 +6030,10 @@ public class BytecodeCompiler implements Visitor {
             // Step 3: Check condition (redo jumps here)
             int condReg = allocateRegister();
             if (node.condition != null) {
+                Set<Integer> conditionMyBefore = myVariableIndexSet();
                 // Evaluate condition in SCALAR context (need boolean result)
                 compileNode(node.condition, -1, RuntimeContextType.SCALAR);
+                conditionMyCleanup = myVariablesAddedSince(conditionMyBefore);
                 condReg = lastResultReg;
             } else {
                 // No condition means infinite loop - load true
@@ -5915,6 +6050,7 @@ public class BytecodeCompiler implements Visitor {
 
             // Step 5: Execute body
             if (node.body != null) {
+                loopInfo.cleanupScopeIndex = symbolTable.currentScopeIndex() + 1;
                 node.body.accept(this);
             }
 
@@ -5932,6 +6068,7 @@ public class BytecodeCompiler implements Visitor {
             }
 
             // Step 9: Jump back to loop start
+            emitMyVarCleanup(conditionMyCleanup, true);
             emit(Opcodes.GOTO);
             emitInt(loopStartPc);
         }
@@ -5940,6 +6077,7 @@ public class BytecodeCompiler implements Visitor {
         // POP_LOCAL_LEVEL must be at loopEndPc so `last` runs it.
         // On normal exit (condition false) this is a no-op since the body already cleaned up.
         int loopEndPc = bytecode.size();
+        emitMyVarCleanup(conditionMyCleanup, true);
         if (for3LocalLevelReg >= 0) {
             emit(Opcodes.POP_LOCAL_LEVEL);
             emitReg(for3LocalLevelReg);
@@ -6373,6 +6511,7 @@ public class BytecodeCompiler implements Visitor {
                 LoopInfo targetLoop = localMatchLoops.get(i);
                 patchJump(matchPatchPos, bytecode.size());
 
+                emitLoopControlScopeCleanup(targetLoop);
                 emit(Opcodes.MORTAL_FLUSH);
                 emitWithToken(localOpcode, node.getIndex());
                 int patchPc = bytecode.size();
@@ -6438,6 +6577,7 @@ public class BytecodeCompiler implements Visitor {
                 : op.equals("next") ? Opcodes.NEXT
                 : Opcodes.REDO;
 
+        emitLoopControlScopeCleanup(targetLoop);
         emit(Opcodes.MORTAL_FLUSH);
         emitWithToken(opcode, node.getIndex());
 
@@ -6464,12 +6604,14 @@ public class BytecodeCompiler implements Visitor {
         final List<Integer> redoPcs;  // PCs to patch for redo
         final boolean isTrueLoop;    // True for for/while/foreach; false for do-while/bare blocks
         int continuePc;              // PC for next (continue block or increment)
+        int cleanupScopeIndex;       // Lower bound for scopes bypassed by local loop control
 
         LoopInfo(String label, int startPc, boolean isTrueLoop) {
             this.label = label;
             this.startPc = startPc;
             this.isTrueLoop = isTrueLoop;
             this.continuePc = -1;  // Will be set later
+            this.cleanupScopeIndex = -1;
             this.breakPcs = new ArrayList<>();
             this.nextPcs = new ArrayList<>();
             this.redoPcs = new ArrayList<>();

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -1256,7 +1256,7 @@ public class BytecodeInterpreter {
                                     // bypassing RuntimeCode.apply() indirection chain
                                     if (codeRef.type == RuntimeScalarType.CODE && codeRef.value instanceof InterpretedCode interpCode) {
                                         RuntimeCode.requireLvalueCallable(interpCode, context, null);
-                                        int effectiveContext = RuntimeCode.effectiveCallContext(context);
+                                        int effectiveContext = RuntimeCode.effectiveCallContext(interpCode, context);
                                         // Direct call to interpreter - skip RuntimeCode.apply overhead
                                         // Push args to argsStack for getCallerArgs() support (used by List::Util::any/all/etc.)
                                         RuntimeCode.pushArgs(callArgs);
@@ -1286,7 +1286,7 @@ public class BytecodeInterpreter {
                                             // Use fast path for InterpretedCode
                                             if (codeRef.type == RuntimeScalarType.CODE && codeRef.value instanceof InterpretedCode interpCode) {
                                                 RuntimeCode.requireLvalueCallable(interpCode, context, "tailcall");
-                                                int effectiveContext = RuntimeCode.effectiveCallContext(context);
+                                                int effectiveContext = RuntimeCode.effectiveCallContext(interpCode, context);
                                                 // Push args for tail call too
                                                 RuntimeCode.pushArgs(callArgs);
                                                 try {

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
@@ -498,6 +498,14 @@ public class CompileAssignment {
                                 bytecodeCompiler.compileNode(node.right, -1, rhsContext);
                                 int listReg = bytecodeCompiler.lastResultReg;
 
+                                int countReg = -1;
+                                if (outerContext == RuntimeContextType.SCALAR) {
+                                    countReg = bytecodeCompiler.allocateRegister();
+                                    bytecodeCompiler.emit(Opcodes.LIST_TO_COUNT);
+                                    bytecodeCompiler.emitReg(countReg);
+                                    bytecodeCompiler.emitReg(listReg);
+                                }
+
                                 // Populate array from list
                                 bytecodeCompiler.emit(Opcodes.ARRAY_SET_FROM_LIST);
                                 bytecodeCompiler.emitReg(arrayReg);
@@ -507,11 +515,7 @@ public class CompileAssignment {
 
                                 bytecodeCompiler.emitVarAttrsIfNeeded(leftOp, arrayReg, "@");
 
-                                if (rhsContext == RuntimeContextType.SCALAR) {
-                                    int countReg = bytecodeCompiler.allocateRegister();
-                                    bytecodeCompiler.emit(Opcodes.ARRAY_SIZE);
-                                    bytecodeCompiler.emitReg(countReg);
-                                    bytecodeCompiler.emitReg(listReg);
+                                if (outerContext == RuntimeContextType.SCALAR) {
                                     bytecodeCompiler.lastResultReg = countReg;
                                 } else {
                                     bytecodeCompiler.lastResultReg = arrayReg;
@@ -524,6 +528,14 @@ public class CompileAssignment {
                             bytecodeCompiler.compileNode(node.right, -1, rhsContext);
                             int listReg = bytecodeCompiler.lastResultReg;
 
+                            int countReg = -1;
+                            if (outerContext == RuntimeContextType.SCALAR) {
+                                countReg = bytecodeCompiler.allocateRegister();
+                                bytecodeCompiler.emit(Opcodes.LIST_TO_COUNT);
+                                bytecodeCompiler.emitReg(countReg);
+                                bytecodeCompiler.emitReg(listReg);
+                            }
+
                             bytecodeCompiler.registerVariable(varName, arrayReg);
                             bytecodeCompiler.emit(Opcodes.NEW_ARRAY);
                             bytecodeCompiler.emitReg(arrayReg);
@@ -535,11 +547,7 @@ public class CompileAssignment {
                             // Runtime attribute dispatch for my variables with attributes
                             bytecodeCompiler.emitVarAttrsIfNeeded(leftOp, arrayReg, "@");
 
-                            if (rhsContext == RuntimeContextType.SCALAR) {
-                                int countReg = bytecodeCompiler.allocateRegister();
-                                bytecodeCompiler.emit(Opcodes.ARRAY_SIZE);
-                                bytecodeCompiler.emitReg(countReg);
-                                bytecodeCompiler.emitReg(listReg);
+                            if (outerContext == RuntimeContextType.SCALAR) {
                                 bytecodeCompiler.lastResultReg = countReg;
                             } else {
                                 bytecodeCompiler.lastResultReg = arrayReg;
@@ -564,6 +572,14 @@ public class CompileAssignment {
                                 bytecodeCompiler.compileNode(node.right, -1, rhsContext);
                                 int listReg = bytecodeCompiler.lastResultReg;
 
+                                int countReg = -1;
+                                if (outerContext == RuntimeContextType.SCALAR) {
+                                    countReg = bytecodeCompiler.allocateRegister();
+                                    bytecodeCompiler.emit(Opcodes.LIST_TO_COUNT);
+                                    bytecodeCompiler.emitReg(countReg);
+                                    bytecodeCompiler.emitReg(listReg);
+                                }
+
                                 // Populate hash from list
                                 bytecodeCompiler.emit(Opcodes.HASH_SET_FROM_LIST);
                                 bytecodeCompiler.emitReg(hashReg);
@@ -573,7 +589,7 @@ public class CompileAssignment {
 
                                 bytecodeCompiler.emitVarAttrsIfNeeded(leftOp, hashReg, "%");
 
-                                bytecodeCompiler.lastResultReg = hashReg;
+                                bytecodeCompiler.lastResultReg = outerContext == RuntimeContextType.SCALAR ? countReg : hashReg;
                                 return;
                             }
 
@@ -591,6 +607,14 @@ public class CompileAssignment {
                             bytecodeCompiler.emit(Opcodes.NEW_HASH);
                             bytecodeCompiler.emitReg(hashReg);
 
+                            int countReg = -1;
+                            if (outerContext == RuntimeContextType.SCALAR) {
+                                countReg = bytecodeCompiler.allocateRegister();
+                                bytecodeCompiler.emit(Opcodes.LIST_TO_COUNT);
+                                bytecodeCompiler.emitReg(countReg);
+                                bytecodeCompiler.emitReg(listReg);
+                            }
+
                             // Populate hash from list
                             bytecodeCompiler.emit(Opcodes.HASH_SET_FROM_LIST);
                             bytecodeCompiler.emitReg(hashReg);
@@ -599,7 +623,7 @@ public class CompileAssignment {
                             // Runtime attribute dispatch for my variables with attributes
                             bytecodeCompiler.emitVarAttrsIfNeeded(leftOp, hashReg, "%");
 
-                            bytecodeCompiler.lastResultReg = hashReg;
+                            bytecodeCompiler.lastResultReg = outerContext == RuntimeContextType.SCALAR ? countReg : hashReg;
                             return;
                         }
                     }
@@ -908,6 +932,14 @@ public class CompileAssignment {
                         bytecodeCompiler.emit(nameIdx);
                     }
 
+                    int countReg = -1;
+                    if (outerContext == RuntimeContextType.SCALAR) {
+                        countReg = bytecodeCompiler.allocateRegister();
+                        bytecodeCompiler.emit(Opcodes.LIST_TO_COUNT);
+                        bytecodeCompiler.emitReg(countReg);
+                        bytecodeCompiler.emitReg(valueReg);
+                    }
+
                     // Populate array from list using setFromList
                     bytecodeCompiler.emit(Opcodes.ARRAY_SET_FROM_LIST);
                     bytecodeCompiler.emitReg(arrayReg);
@@ -915,12 +947,7 @@ public class CompileAssignment {
 
                     // In scalar context, return the array size; in list context, return the array
                     if (outerContext == RuntimeContextType.SCALAR) {
-                        // Convert array to scalar (returns size)
-                        int sizeReg = bytecodeCompiler.allocateRegister();
-                        bytecodeCompiler.emit(Opcodes.ARRAY_SIZE);
-                        bytecodeCompiler.emitReg(sizeReg);
-                        bytecodeCompiler.emitReg(arrayReg);
-                        bytecodeCompiler.lastResultReg = sizeReg;
+                        bytecodeCompiler.lastResultReg = countReg;
                     } else {
                         bytecodeCompiler.lastResultReg = arrayReg;
                     }
@@ -1159,6 +1186,14 @@ public class CompileAssignment {
                             bytecodeCompiler.emit(pkgIdx);
                         }
 
+                        int countReg = -1;
+                        if (outerContext == RuntimeContextType.SCALAR) {
+                            countReg = bytecodeCompiler.allocateRegister();
+                            bytecodeCompiler.emit(Opcodes.LIST_TO_COUNT);
+                            bytecodeCompiler.emitReg(countReg);
+                            bytecodeCompiler.emitReg(valueReg);
+                        }
+
                         // Assign the value to the dereferenced array
                         bytecodeCompiler.emit(Opcodes.ARRAY_SET_FROM_LIST);
                         bytecodeCompiler.emitReg(arrayReg);
@@ -1166,11 +1201,7 @@ public class CompileAssignment {
 
                         // In scalar context, return array size; in list context, return the array
                         if (outerContext == RuntimeContextType.SCALAR) {
-                            int sizeReg = bytecodeCompiler.allocateRegister();
-                            bytecodeCompiler.emit(Opcodes.ARRAY_SIZE);
-                            bytecodeCompiler.emitReg(sizeReg);
-                            bytecodeCompiler.emitReg(arrayReg);
-                            bytecodeCompiler.lastResultReg = sizeReg;
+                            bytecodeCompiler.lastResultReg = countReg;
                         } else {
                             bytecodeCompiler.lastResultReg = arrayReg;
                         }
@@ -1872,6 +1903,14 @@ public class CompileAssignment {
                 bytecodeCompiler.compileNode(listNode, -1, RuntimeContextType.LVALUE_LIST);
                 int lhsListReg = bytecodeCompiler.lastResultReg;
 
+                int countReg = -1;
+                if (outerContext == RuntimeContextType.SCALAR) {
+                    countReg = bytecodeCompiler.allocateRegister();
+                    bytecodeCompiler.emit(Opcodes.LIST_TO_COUNT);
+                    bytecodeCompiler.emitReg(countReg);
+                    bytecodeCompiler.emitReg(rhsListReg);
+                }
+
                 // Call SET_FROM_LIST to assign RHS values to LHS lvalues
                 // setFromList() returns a RuntimeArray with scalarContextSize set to the
                 // original RHS element count, and elements containing the assigned values.
@@ -1884,12 +1923,6 @@ public class CompileAssignment {
 
                 if (outerContext == RuntimeContextType.SCALAR) {
                     // In scalar context, return the RHS element count.
-                    // resultReg is a RuntimeArray with scalarContextSize set;
-                    // ARRAY_SIZE on it calls scalar() which returns scalarContextSize.
-                    int countReg = bytecodeCompiler.allocateRegister();
-                    bytecodeCompiler.emit(Opcodes.ARRAY_SIZE);
-                    bytecodeCompiler.emitReg(countReg);
-                    bytecodeCompiler.emitReg(resultReg);
                     bytecodeCompiler.lastResultReg = countReg;
                 } else {
                     // In list context, return the assigned values (after hash dedup etc.)

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
@@ -101,7 +101,7 @@ public class CompileBinaryOperator {
                 break;
         }
 
-        // Handle compound assignment operators (+=, -=, *=, /=, %=, .=, &=, |=, ^=, &.=, |.=, ^.=, binary&=, binary|=, binary^=, x=, **=, <<=, >>=, &&=, ||=)
+        // Handle compound assignment operators (+=, -=, *=, /=, %=, .=, &=, |=, ^=, &.=, |.=, ^.=, binary&=, binary|=, binary^=, x=, **=, <<=, >>=, &&=, ||=, ^^=)
         if (node.operator.equals("+=") || node.operator.equals("-=") ||
                 node.operator.equals("*=") || node.operator.equals("/=") ||
                 node.operator.equals("%=") || node.operator.equals(".=") ||
@@ -110,7 +110,7 @@ public class CompileBinaryOperator {
                 node.operator.equals("x=") || node.operator.equals("**=") ||
                 node.operator.equals("<<=") || node.operator.equals(">>=") ||
                 node.operator.equals("&&=") || node.operator.equals("||=") ||
-                node.operator.equals("//=") ||
+                node.operator.equals("//=") || node.operator.equals("^^=") ||
                 node.operator.equals("binary&=") ||
                 node.operator.equals("binary|=") ||
                 node.operator.equals("binary^=")) {

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -1175,7 +1175,8 @@ public class CompileOperator {
                     bytecodeCompiler.evalSiteRegistries.add(bytecodeCompiler.symbolTable.getVisibleVariableRegistry());
                     bytecodeCompiler.evalSitePragmaFlags.add(new int[]{
                             bytecodeCompiler.symbolTable.strictOptionsStack.peek(),
-                            bytecodeCompiler.symbolTable.featureFlagsStack.peek()
+                            bytecodeCompiler.symbolTable.featureFlagsStack.peek(),
+                            op.equals("evalbytes") ? 1 : 0
                     });
                     bytecodeCompiler.emitWithToken(Opcodes.EVAL_STRING, node.getIndex());
                     bytecodeCompiler.emitReg(rd);

--- a/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
@@ -104,8 +104,22 @@ public class EvalStringHandler {
                                              Map<String, Integer> siteRegistry,
                                              int siteStrictOptions,
                                              int siteFeatureFlags) {
+        return evalStringList(perlCode, currentCode, registers, sourceName, sourceLine,
+                callContext, siteRegistry, siteStrictOptions, siteFeatureFlags, false);
+    }
+
+    public static RuntimeList evalStringList(String perlCode,
+                                             InterpretedCode currentCode,
+                                             RuntimeBase[] registers,
+                                             String sourceName,
+                                             int sourceLine,
+                                             int callContext,
+                                             Map<String, Integer> siteRegistry,
+                                             int siteStrictOptions,
+                                             int siteFeatureFlags,
+                                             boolean isEvalbytes) {
         return evalStringList(perlCode, RuntimeScalarType.STRING, currentCode, registers,
-                sourceName, sourceLine, callContext, siteRegistry, siteStrictOptions, siteFeatureFlags);
+                sourceName, sourceLine, callContext, siteRegistry, siteStrictOptions, siteFeatureFlags, isEvalbytes);
     }
 
     public static RuntimeList evalStringList(RuntimeScalar codeScalar,
@@ -117,8 +131,22 @@ public class EvalStringHandler {
                                              Map<String, Integer> siteRegistry,
                                              int siteStrictOptions,
                                              int siteFeatureFlags) {
+        return evalStringList(codeScalar, currentCode, registers, sourceName, sourceLine,
+                callContext, siteRegistry, siteStrictOptions, siteFeatureFlags, false);
+    }
+
+    public static RuntimeList evalStringList(RuntimeScalar codeScalar,
+                                             InterpretedCode currentCode,
+                                             RuntimeBase[] registers,
+                                             String sourceName,
+                                             int sourceLine,
+                                             int callContext,
+                                             Map<String, Integer> siteRegistry,
+                                             int siteStrictOptions,
+                                             int siteFeatureFlags,
+                                             boolean isEvalbytes) {
         return evalStringList(codeScalar.toString(), codeScalar.type, currentCode, registers,
-                sourceName, sourceLine, callContext, siteRegistry, siteStrictOptions, siteFeatureFlags);
+                sourceName, sourceLine, callContext, siteRegistry, siteStrictOptions, siteFeatureFlags, isEvalbytes);
     }
 
     private static RuntimeList evalStringList(String perlCode,
@@ -130,13 +158,18 @@ public class EvalStringHandler {
                                              int callContext,
                                              Map<String, Integer> siteRegistry,
                                              int siteStrictOptions,
-                                             int siteFeatureFlags) {
+                                             int siteFeatureFlags,
+                                             boolean isEvalbytes) {
         try {
             evalTrace("EvalStringHandler enter ctx=" + callContext + " srcName=" + sourceName +
                     " srcLine=" + sourceLine + " codeLen=" + (perlCode != null ? perlCode.length() : -1) +
                     " sourceType=" + sourceType);
             // Step 1: Clear $@ at start of eval
             GlobalVariable.getGlobalVariable("main::@").set("");
+
+            if (isEvalbytes && RuntimeCode.shouldDecodeEvalbytesUtf8Source(perlCode)) {
+                perlCode = RuntimeCode.decodeEvalbytesUtf8Source(perlCode);
+            }
 
             // Step 2: Parse the string to AST
             Lexer lexer = new Lexer(perlCode);
@@ -152,7 +185,7 @@ public class EvalStringHandler {
 
             CompilerOptions opts = new CompilerOptions();
             opts.fileName = evalFileName;
-            configureEvalSourceOptions(opts, perlCode, sourceType);
+            configureEvalSourceOptions(opts, perlCode, sourceType, isEvalbytes);
             ScopedSymbolTable symbolTable = new ScopedSymbolTable();
 
             // Add standard variables that are always available in eval context.
@@ -398,7 +431,16 @@ public class EvalStringHandler {
 
     private static void configureEvalSourceOptions(CompilerOptions opts,
                                                    String perlCode,
-                                                   int sourceType) {
+                                                   int sourceType,
+                                                   boolean isEvalbytes) {
+        if (isEvalbytes) {
+            if (RuntimeCode.shouldDecodeEvalbytesUtf8Source(perlCode)) {
+                opts.isUnicodeSource = true;
+            } else {
+                opts.isEvalbytes = true;
+            }
+            return;
+        }
         if (sourceType == RuntimeScalarType.BYTE_STRING) {
             opts.isByteStringSource = true;
             return;
@@ -442,7 +484,7 @@ public class EvalStringHandler {
 
             CompilerOptions opts = new CompilerOptions();
             opts.fileName = evalFileName;
-            configureEvalSourceOptions(opts, perlCode, RuntimeScalarType.STRING);
+            configureEvalSourceOptions(opts, perlCode, RuntimeScalarType.STRING, false);
             ScopedSymbolTable symbolTable = new ScopedSymbolTable();
 
             // Add standard variables that are always available in eval context.

--- a/src/main/java/org/perlonjava/backend/bytecode/InterpretedCode.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InterpretedCode.java
@@ -283,7 +283,7 @@ public class InterpretedCode extends RuntimeCode implements PerlSubroutine {
             return new RuntimeList(constantValue);
         }
         RuntimeCode.requireLvalueCallable(this, callContext, null);
-        int effectiveContext = RuntimeCode.effectiveCallContext(callContext);
+        int effectiveContext = RuntimeCode.effectiveCallContext(this, callContext);
         // Push args for getCallerArgs() support (used by List::Util::any/all/etc.)
         // This matches what RuntimeCode.apply() does for JVM-compiled subs
         RuntimeCode.pushArgs(args);
@@ -295,7 +295,7 @@ public class InterpretedCode extends RuntimeCode implements PerlSubroutine {
         }
         try {
             return RuntimeCode.coerceScalarCallResult(
-                    BytecodeInterpreter.execute(this, args, effectiveContext), effectiveContext);
+                    BytecodeInterpreter.execute(this, args, effectiveContext), effectiveContext, callContext);
         } finally {
             if (warningBitsString != null) {
                 WarningBitsRegistry.popCurrent();
@@ -313,7 +313,7 @@ public class InterpretedCode extends RuntimeCode implements PerlSubroutine {
             return new RuntimeList(constantValue);
         }
         RuntimeCode.requireLvalueCallable(this, callContext, subroutineName);
-        int effectiveContext = RuntimeCode.effectiveCallContext(callContext);
+        int effectiveContext = RuntimeCode.effectiveCallContext(this, callContext);
         // Push args for getCallerArgs() support (used by List::Util::any/all/etc.)
         RuntimeCode.pushArgs(args);
         RuntimeCode.pushActiveCode(this);
@@ -324,7 +324,7 @@ public class InterpretedCode extends RuntimeCode implements PerlSubroutine {
         try {
             return RuntimeCode.coerceScalarCallResult(
                     BytecodeInterpreter.execute(this, args, effectiveContext, subroutineName),
-                    effectiveContext);
+                    effectiveContext, callContext);
         } finally {
             if (warningBitsString != null) {
                 WarningBitsRegistry.popCurrent();

--- a/src/main/java/org/perlonjava/backend/bytecode/SlowOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/SlowOpcodeHandler.java
@@ -292,11 +292,13 @@ public class SlowOpcodeHandler {
         // Look up per-eval-site pragma flags (strict/feature at compile time of eval site)
         int siteStrictOptions = -1;
         int siteFeatureFlags = -1;
+        boolean siteIsEvalbytes = false;
         if (evalSiteIndex >= 0 && code.evalSitePragmaFlags != null
                 && evalSiteIndex < code.evalSitePragmaFlags.size()) {
             int[] pragmaFlags = code.evalSitePragmaFlags.get(evalSiteIndex);
             siteStrictOptions = pragmaFlags[0];
             siteFeatureFlags = pragmaFlags[1];
+            siteIsEvalbytes = pragmaFlags.length > 2 && pragmaFlags[2] != 0;
         }
 
         RuntimeBase codeValue = registers[stringReg];
@@ -310,6 +312,11 @@ public class SlowOpcodeHandler {
                 " ctx=" + evalCallContext + " evalSite=" + evalSiteIndex +
                 " codeType=" + codeScalar.type + " codeLen=" + codeScalar.toString().length() +
                 " src=" + (code != null ? code.sourceName : "null"));
+
+        if (siteIsEvalbytes) {
+            GlobalVariable.getGlobalVariable("main::@").set("");
+            ScalarUtils.assertBytes(codeScalar);
+        }
 
         int callContext = evalCallContext;
         if (registers[2] instanceof RuntimeScalar rs) {
@@ -328,7 +335,8 @@ public class SlowOpcodeHandler {
                     callContext,
                     siteRegistry,
                     siteStrictOptions,
-                    siteFeatureFlags
+                    siteFeatureFlags,
+                    siteIsEvalbytes
             );
             registers[rd] = result;
             evalTrace("EVAL_STRING opcode exit LIST stored=" + (registers[rd] != null ? registers[rd].getClass().getSimpleName() : "null") +
@@ -343,7 +351,8 @@ public class SlowOpcodeHandler {
                     callContext,
                     siteRegistry,
                     siteStrictOptions,
-                    siteFeatureFlags
+                    siteFeatureFlags,
+                    siteIsEvalbytes
             ).scalar();
             registers[rd] = result;
             evalTrace("EVAL_STRING opcode exit SCALAR/VOID stored=" + (registers[rd] != null ? registers[rd].getClass().getSimpleName() : "null") +

--- a/src/main/java/org/perlonjava/backend/jvm/EmitBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitBinaryOperator.java
@@ -229,11 +229,13 @@ public class EmitBinaryOperator {
             // Use the new *Assign methods which check for compound overloads first
             EmitterVisitor scalarVisitor =
                     emitterVisitor.with(RuntimeContextType.SCALAR);
+            EmitterVisitor lvalueVisitor =
+                    emitterVisitor.with(RuntimeContextType.LVALUE);
             MethodVisitor mv = emitterVisitor.ctx.mv;
 
             // We need to properly handle the lvalue by using spill slots
             // This ensures the same object is both read and written
-            node.left.accept(scalarVisitor); // target - left parameter
+            node.left.accept(lvalueVisitor); // target - left parameter
             int leftSlot = emitterVisitor.ctx.javaClassInfo.acquireSpillSlot();
             boolean pooledLeft = leftSlot >= 0;
             if (!pooledLeft) {
@@ -265,8 +267,10 @@ public class EmitBinaryOperator {
             // Use the old approach: strip = and call base operator, then assign
             EmitterVisitor scalarVisitor =
                     emitterVisitor.with(RuntimeContextType.SCALAR); // execute operands in scalar context
+            EmitterVisitor lvalueVisitor =
+                    emitterVisitor.with(RuntimeContextType.LVALUE);
             MethodVisitor mv = emitterVisitor.ctx.mv;
-            node.left.accept(scalarVisitor); // target - left parameter
+            node.left.accept(lvalueVisitor); // target - left parameter
             int leftSlot = emitterVisitor.ctx.javaClassInfo.acquireSpillSlot();
             boolean pooledLeft = leftSlot >= 0;
             if (!pooledLeft) {

--- a/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
@@ -467,7 +467,15 @@ public class EmitBlock {
                 || hasBlockResultRegister;
         boolean flushAtScopeExit = !isSubBody
                 && (isDoBlock ? doBlockFreshResult : !blockMayNeedResultAfterScopeExit);
-        EmitStatement.emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex, flushAtScopeExit);
+        int returnedLvalueSlot = -1;
+        if (isSubBody && emitterVisitor.ctx.javaClassInfo.isLvalueSubroutine) {
+            returnedLvalueSlot = emitterVisitor.ctx.symbolTable.allocateLocalVariable();
+            mv.visitVarInsn(Opcodes.ASTORE, returnedLvalueSlot);
+        }
+        EmitStatement.emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex, flushAtScopeExit, returnedLvalueSlot);
+        if (returnedLvalueSlot >= 0) {
+            mv.visitVarInsn(Opcodes.ALOAD, returnedLvalueSlot);
+        }
         emitterVisitor.ctx.symbolTable.exitScope(scopeIndex);
         emitPostBlockStrictOptions(mv, node);
         if (CompilerOptions.DEBUG_ENABLED) emitterVisitor.ctx.logDebug("generateCodeBlock end");

--- a/src/main/java/org/perlonjava/backend/jvm/EmitControlFlow.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitControlFlow.java
@@ -152,8 +152,16 @@ public class EmitControlFlow {
         Label label = operator.equals("next") ? loopLabels.nextLabel
                 : operator.equals("last") ? loopLabels.lastLabel
                 : loopLabels.redoLabel;
+        emitLoopControlScopeCleanup(ctx, loopLabels);
         emitMortalFlushAboveMark(ctx);
         ctx.mv.visitJumpInsn(Opcodes.GOTO, label);
+    }
+
+    private static void emitLoopControlScopeCleanup(EmitterContext ctx, LoopLabels loopLabels) {
+        if (loopLabels.cleanupScopeIndex < 0) {
+            return;
+        }
+        EmitStatement.emitScopeExitNullStores(ctx, loopLabels.cleanupScopeIndex, true);
     }
 
     private static void emitMortalFlushAboveMark(EmitterContext ctx) {

--- a/src/main/java/org/perlonjava/backend/jvm/EmitForeach.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitForeach.java
@@ -586,6 +586,7 @@ public class EmitForeach {
         EmitterVisitor voidVisitor = emitterVisitor.with(RuntimeContextType.VOID);
         if (node.body instanceof BlockNode blockNode) {
             int bodyScopeIndex = emitterVisitor.ctx.symbolTable.enterScope();
+            currentLoopLabels.cleanupScopeIndex = bodyScopeIndex;
             Local.localRecord bodyLocalRecord = Local.localSetup(emitterVisitor.ctx, blockNode, mv, true);
 
             pushGotoLabelsForBlock(emitterVisitor, blockNode);

--- a/src/main/java/org/perlonjava/backend/jvm/EmitLogicalOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitLogicalOperator.java
@@ -105,7 +105,7 @@ public class EmitLogicalOperator {
         // Evaluate the left side once and spill it to keep the operand stack clean.
         // This is critical when the right side may perform non-local control flow (return/last/next/redo)
         // and jump away during evaluation.
-        node.left.accept(emitterVisitor.with(RuntimeContextType.SCALAR)); // target - left parameter
+        node.left.accept(emitterVisitor.with(RuntimeContextType.LVALUE)); // target - left parameter
 
         // Vivify the LHS proxy so hash/array entries exist before the condition check.
         // This matches Perl 5's behavior where $h{key} ||= expr creates the hash entry

--- a/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
@@ -1771,6 +1771,8 @@ public class EmitOperator {
                     // *{EXPR} — EXPR is evaluated in scalar context (e.g. Symbol::qualify_to_ref's
                     // \*{ qualify $_[0], ... }). LIST context breaks the comma/ternary inside braces.
                     contextType = RuntimeContextType.SCALAR;
+                } else if (node.operand instanceof BinaryOperatorNode binOp && binOp.operator.equals("=")) {
+                    contextType = RuntimeContextType.SCALAR;
                 }
 
                 if (node.operand instanceof StringNode strNode) {

--- a/src/main/java/org/perlonjava/backend/jvm/EmitStatement.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitStatement.java
@@ -12,7 +12,9 @@ import org.perlonjava.frontend.astnode.*;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * The EmitStatement class is responsible for handling various control flow statements
@@ -88,6 +90,10 @@ public class EmitStatement {
      * @param flush      If true, emit scoped MortalList flush around null stores
      */
     static void emitScopeExitNullStores(EmitterContext ctx, int scopeIndex, boolean flush) {
+        emitScopeExitNullStores(ctx, scopeIndex, flush, -1);
+    }
+
+    static void emitScopeExitNullStores(EmitterContext ctx, int scopeIndex, boolean flush, int returnedLvalueSlot) {
         // Gather variable indices for this scope first, to determine if cleanup is needed.
         java.util.List<Integer> scalarIndices = withoutCaptured(ctx, ctx.symbolTable.getMyScalarIndicesInScope(scopeIndex));
         java.util.List<Integer> hashIndices = withoutCaptured(ctx, ctx.symbolTable.getMyHashIndicesInScope(scopeIndex));
@@ -144,11 +150,20 @@ public class EmitStatement {
         // and handles IO fd recycling for anonymous filehandle globs.
         for (int idx : scalarIndices) {
             ctx.mv.visitVarInsn(Opcodes.ALOAD, idx);
-            ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
-                    "org/perlonjava/runtime/runtimetypes/RuntimeScalar",
-                    "scopeExitCleanup",
-                    "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)V",
-                    false);
+            if (returnedLvalueSlot >= 0) {
+                ctx.mv.visitVarInsn(Opcodes.ALOAD, returnedLvalueSlot);
+                ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                        "org/perlonjava/runtime/runtimetypes/RuntimeScalar",
+                        "scopeExitCleanupPreservingReturnedLvalue",
+                        "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)V",
+                        false);
+            } else {
+                ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                        "org/perlonjava/runtime/runtimetypes/RuntimeScalar",
+                        "scopeExitCleanup",
+                        "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)V",
+                        false);
+            }
         }
         // Phase 1b: Walk hash/array variables for nested blessed references.
         // When a hash/array goes out of scope, any blessed refs stored inside
@@ -224,6 +239,117 @@ public class EmitStatement {
                     "flush",
                     "()V",
                     false);
+        }
+    }
+
+    private static Set<Integer> myVariableIndexSet(EmitterContext ctx, int scopeIndex) {
+        return new HashSet<>(ctx.symbolTable.getMyVariableIndicesInScope(scopeIndex));
+    }
+
+    private static List<Integer> indicesAddedSince(List<Integer> indices, Set<Integer> before) {
+        if (indices.isEmpty()) {
+            return indices;
+        }
+        List<Integer> added = new ArrayList<>();
+        for (int idx : indices) {
+            if (!before.contains(idx)) {
+                added.add(idx);
+            }
+        }
+        return added;
+    }
+
+    private static ConditionMyCleanup conditionMyCleanupSince(EmitterContext ctx, int scopeIndex, Set<Integer> before) {
+        if (scopeIndex < 0) {
+            return ConditionMyCleanup.empty();
+        }
+
+        List<Integer> scalarIndices = indicesAddedSince(
+                withoutCaptured(ctx, ctx.symbolTable.getMyScalarIndicesInScope(scopeIndex)), before);
+        List<Integer> hashIndices = indicesAddedSince(
+                withoutCaptured(ctx, ctx.symbolTable.getMyHashIndicesInScope(scopeIndex)), before);
+        List<Integer> arrayIndices = indicesAddedSince(
+                withoutCaptured(ctx, ctx.symbolTable.getMyArrayIndicesInScope(scopeIndex)), before);
+        List<Integer> allIndices = indicesAddedSince(
+                withoutCaptured(ctx, ctx.symbolTable.getMyVariableIndicesInScope(scopeIndex)), before);
+
+        return new ConditionMyCleanup(scalarIndices, hashIndices, arrayIndices, allIndices);
+    }
+
+    private static void emitConditionMyCleanup(EmitterContext ctx, ConditionMyCleanup cleanup) {
+        if (cleanup.isEmpty()) {
+            return;
+        }
+
+        for (int idx : cleanup.scalarIndices) {
+            ctx.mv.visitVarInsn(Opcodes.ALOAD, idx);
+            ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                    "org/perlonjava/runtime/runtimetypes/RuntimeScalar",
+                    "scopeExitCleanup",
+                    "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)V",
+                    false);
+        }
+        for (int idx : cleanup.hashIndices) {
+            ctx.mv.visitVarInsn(Opcodes.ALOAD, idx);
+            ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                    "org/perlonjava/runtime/runtimetypes/MortalList",
+                    "scopeExitCleanupHash",
+                    "(Lorg/perlonjava/runtime/runtimetypes/RuntimeHash;)V",
+                    false);
+        }
+        for (int idx : cleanup.arrayIndices) {
+            ctx.mv.visitVarInsn(Opcodes.ALOAD, idx);
+            ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                    "org/perlonjava/runtime/runtimetypes/MortalList",
+                    "scopeExitCleanupArray",
+                    "(Lorg/perlonjava/runtime/runtimetypes/RuntimeArray;)V",
+                    false);
+        }
+
+        if (ctx.javaClassInfo.cleanupNeeded) {
+            for (int idx : cleanup.allIndices) {
+                ctx.mv.visitVarInsn(Opcodes.ALOAD, idx);
+                ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                        "org/perlonjava/runtime/runtimetypes/MyVarCleanupStack",
+                        "unregister",
+                        "(Ljava/lang/Object;)V",
+                        false);
+            }
+        }
+        for (int idx : cleanup.allIndices) {
+            ctx.mv.visitInsn(Opcodes.ACONST_NULL);
+            ctx.mv.visitVarInsn(Opcodes.ASTORE, idx);
+        }
+        ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                "org/perlonjava/runtime/runtimetypes/MortalList",
+                "flush",
+                "()V",
+                false);
+    }
+
+    private static final class ConditionMyCleanup {
+        private static final ConditionMyCleanup EMPTY = new ConditionMyCleanup(
+                List.of(), List.of(), List.of(), List.of());
+
+        final List<Integer> scalarIndices;
+        final List<Integer> hashIndices;
+        final List<Integer> arrayIndices;
+        final List<Integer> allIndices;
+
+        ConditionMyCleanup(List<Integer> scalarIndices, List<Integer> hashIndices,
+                           List<Integer> arrayIndices, List<Integer> allIndices) {
+            this.scalarIndices = scalarIndices;
+            this.hashIndices = hashIndices;
+            this.arrayIndices = arrayIndices;
+            this.allIndices = allIndices;
+        }
+
+        static ConditionMyCleanup empty() {
+            return EMPTY;
+        }
+
+        boolean isEmpty() {
+            return allIndices.isEmpty();
         }
     }
 
@@ -458,9 +584,17 @@ public class EmitStatement {
             // Check for pending signals (alarm, etc.) at loop entry
             emitSignalCheck(mv);
 
+            ConditionMyCleanup conditionMyCleanup = ConditionMyCleanup.empty();
+
             // Visit the condition node in scalar context
             if (node.condition != null) {
+                Set<Integer> conditionMyBefore = node.useNewScope
+                        ? myVariableIndexSet(emitterVisitor.ctx, scopeIndex)
+                        : Set.of();
                 node.condition.accept(emitterVisitor.with(RuntimeContextType.SCALAR));
+                if (node.useNewScope) {
+                    conditionMyCleanup = conditionMyCleanupSince(emitterVisitor.ctx, scopeIndex, conditionMyBefore);
+                }
 
                 if (needWhileConditionResult) {
                     mv.visitInsn(Opcodes.DUP);
@@ -514,6 +648,7 @@ public class EmitStatement {
                         RuntimeContextType.VOID,
                         true,
                         true);
+                emitterVisitor.ctx.javaClassInfo.getInnermostLoopLabels().cleanupScopeIndex = scopeIndex + 1;
 
                 // Visit the loop body
                 if (needsReturnValue) {
@@ -558,6 +693,7 @@ public class EmitStatement {
             }
 
             if (!node.isSimpleBlock) {
+                emitConditionMyCleanup(emitterVisitor.ctx, conditionMyCleanup);
                 // Jump back to the start label to continue the loop
                 mv.visitJumpInsn(Opcodes.GOTO, startLabel);
             }

--- a/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
@@ -1231,7 +1231,12 @@ public class EmitVariable {
         new BinaryOperatorNode("||", testStateVariable, initStateVariable, tokenIndex)
                 .accept(emitterVisitor.with(RuntimeContextType.VOID));
 
-        varNode.accept(emitterVisitor.with(RuntimeContextType.SCALAR));
+        int resultContext = switch (ctx.contextType) {
+            case RuntimeContextType.RUNTIME -> RuntimeContextType.RUNTIME;
+            case RuntimeContextType.LIST, RuntimeContextType.LVALUE_LIST -> RuntimeContextType.LIST;
+            default -> RuntimeContextType.SCALAR;
+        };
+        varNode.accept(emitterVisitor.with(resultContext));
     }
 
     static void handleMyOperator(EmitterVisitor emitterVisitor, OperatorNode node) {

--- a/src/main/java/org/perlonjava/backend/jvm/LoopLabels.java
+++ b/src/main/java/org/perlonjava/backend/jvm/LoopLabels.java
@@ -36,6 +36,13 @@ public class LoopLabels {
     public Label controlFlowHandler;
 
     /**
+     * Lexical scope lower bound that must be cleaned before a local
+     * last/next/redo jump. Normal loop-end labels clean the loop's outer
+     * scope; this covers body/nested scopes that the jump bypasses.
+     */
+    public int cleanupScopeIndex = -1;
+
+    /**
      * The context type in which this loop operates
      */
     public int context;

--- a/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
+++ b/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
@@ -32,6 +32,21 @@ import static org.perlonjava.frontend.parser.ParserNodeUtils.scalarUnderscore;
  * ; - separates required from optional arguments
  */
 public class PrototypeArgs {
+    private static boolean isListUtilCallback(String subName) {
+        if (subName == null || subName.isEmpty()) {
+            return false;
+        }
+        String baseName = subName;
+        int idx = baseName.lastIndexOf("::");
+        if (idx >= 0) {
+            baseName = baseName.substring(idx + 2);
+        }
+        return switch (baseName) {
+            case "reduce", "reductions", "any", "all", "none", "notall",
+                    "first", "pairmap", "pairgrep", "pairfirst" -> true;
+            default -> false;
+        };
+    }
 
     private static boolean isOpenDupMode(Node modeNode) {
         if (modeNode instanceof StringNode stringNode) {
@@ -403,16 +418,16 @@ public class PrototypeArgs {
             char c = prototype.charAt(i);
 
             if (inBackslash) {
-                if (c == '[') {
+                if (inGroup) {
+                    if (c == ']') {
+                        count++;
+                        inGroup = false;
+                        inBackslash = false;
+                    }
+                } else if (c == '[') {
                     inGroup = true;
                 } else if (!inGroup) {
                     count++;
-                    inBackslash = false;
-                }
-            } else if (inGroup) {
-                if (c == ']') {
-                    count++;
-                    inGroup = false;
                     inBackslash = false;
                 }
             } else {
@@ -429,6 +444,34 @@ public class PrototypeArgs {
         }
 
         return count;
+    }
+
+    private static boolean hasSlurpyPrototypeSlot(String prototype) {
+        boolean inBackslash = false;
+        boolean inGroup = false;
+
+        for (int i = 0; i < prototype.length(); i++) {
+            char c = prototype.charAt(i);
+
+            if (inBackslash) {
+                if (inGroup) {
+                    if (c == ']') {
+                        inGroup = false;
+                        inBackslash = false;
+                    }
+                } else if (c == '[') {
+                    inGroup = true;
+                } else if (!inGroup) {
+                    inBackslash = false;
+                }
+            } else if (c == '\\') {
+                inBackslash = true;
+            } else if (c == '@' || c == '%') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -882,6 +925,9 @@ public class PrototypeArgs {
             
             try {
                 Node block = new SubroutineNode(null, null, null, ParseBlock.parseBlock(parser), false, parser.tokenIndex);
+                if (isListUtilCallback(parser.ctx.symbolTable.getCurrentSubroutine())) {
+                    block.setAnnotation("isMapGrepBlock", true);
+                }
                 TokenUtils.consume(parser, LexerTokenType.OPERATOR, "}");
                 // Code references/blocks are evaluated in SCALAR context
                 block.setAnnotation("context", "SCALAR");
@@ -1085,7 +1131,9 @@ public class PrototypeArgs {
         //     so assignment and other operators ARE consumed. Example:
         //     sreftest my $a = 'val', $i++  →  sreftest(\(my $a = 'val'), $i++)
         Node referenceArg;
-        boolean useNamedUnary = !hasParentheses && countPrototypeArgs(prototype) <= 1;
+        boolean useNamedUnary = !hasParentheses
+                && countPrototypeArgs(prototype) <= 1
+                && !hasSlurpyPrototypeSlot(prototype);
         if (useNamedUnary) {
             referenceArg = parseBackslashArgWithComma(parser, isOptional, needComma, expectedType);
         } else {

--- a/src/main/java/org/perlonjava/frontend/semantic/ScopedSymbolTable.java
+++ b/src/main/java/org/perlonjava/frontend/semantic/ScopedSymbolTable.java
@@ -172,6 +172,13 @@ public class ScopedSymbolTable {
     }
 
     /**
+     * Returns the current top lexical scope index.
+     */
+    public int currentScopeIndex() {
+        return symbolTableStack.size() - 1;
+    }
+
+    /**
      * Exits the current scope by popping the top SymbolTable from the stack.
      * Also removes the top state of warnings, features, and strict options.
      * <p>

--- a/src/main/java/org/perlonjava/runtime/operators/ListOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ListOperators.java
@@ -20,7 +20,7 @@ public class ListOperators {
      * Only releases captures for closures flagged as isMapGrepBlock (set by the
      * compiler for BLOCK syntax). Named subs and user closures are not affected.
      */
-    private static void releaseEphemeralCaptures(RuntimeScalar closure) {
+    public static void releaseEphemeralCaptures(RuntimeScalar closure) {
         if (closure.type == RuntimeScalarType.CODE
                 && closure.value instanceof RuntimeCode code
                 && code.isMapGrepBlock) {

--- a/src/main/java/org/perlonjava/runtime/operators/ReferenceOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ReferenceOperators.java
@@ -72,8 +72,8 @@ public class ReferenceOperators {
             // which specific increment/decrement site causes the
             // metaclass refCount underflow during CMOP bootstrap.
             if (RuntimeBase.refCountTraceEnabled()
-                    && org.perlonjava.runtime.runtimetypes.DestroyDispatch
-                            .classNeedsWalkerGate(newBlessId)) {
+                    && (org.perlonjava.runtime.runtimetypes.DestroyDispatch
+                            .classNeedsWalkerGate(newBlessId))) {
                 referent.refCountTrace = true;
                 System.err.println("[REFCOUNT] *** ARMED *** base="
                     + System.identityHashCode(referent)

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Encode.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Encode.java
@@ -1132,9 +1132,19 @@ public class Encode extends PerlModuleBase {
         RuntimeScalar arg = args.get(0);
         boolean wasUtf8 = (arg.type == STRING);
         if (!wasUtf8) {
-            boolean fromBytes = (arg.type == BYTE_STRING);
+            String s = arg.toString();
+            byte[] bytes = s.getBytes(StandardCharsets.ISO_8859_1);
             arg.type = STRING;
-            arg.utf8UncheckedOctets = fromBytes;
+            try {
+                CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
+                        .onMalformedInput(CodingErrorAction.REPORT)
+                        .onUnmappableCharacter(CodingErrorAction.REPORT);
+                arg.value = decoder.decode(ByteBuffer.wrap(bytes)).toString();
+                arg.utf8UncheckedOctets = false;
+            } catch (CharacterCodingException e) {
+                arg.value = s;
+                arg.utf8UncheckedOctets = true;
+            }
         }
         return new RuntimeScalar(wasUtf8).getList();
     }
@@ -1150,9 +1160,11 @@ public class Encode extends PerlModuleBase {
         RuntimeScalar arg = args.get(0);
         boolean wasUtf8 = (arg.type == STRING);
         if (wasUtf8) {
-            String s = arg.toString();
-            byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
-            arg.set(new String(bytes, StandardCharsets.ISO_8859_1));
+            if (!arg.utf8UncheckedOctets) {
+                String s = arg.toString();
+                byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+                arg.set(new String(bytes, StandardCharsets.ISO_8859_1));
+            }
         }
         arg.type = BYTE_STRING;
         arg.utf8UncheckedOctets = false;

--- a/src/main/java/org/perlonjava/runtime/perlmodule/ListUtil.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/ListUtil.java
@@ -157,6 +157,10 @@ public class ListUtil extends PerlModuleBase {
         }
     }
 
+    private static void releaseEphemeralCaptures(RuntimeScalar codeRef) {
+        ListOperators.releaseEphemeralCaptures(codeRef);
+    }
+
     /**
      * Gets the package name from a code ref for $a/$b variable resolution.
      * In Perl 5, reduce/pairmap/etc. use $a and $b in the caller's package,
@@ -192,9 +196,11 @@ public class ListUtil extends PerlModuleBase {
         RuntimeList values = createSubList(args, 1);
 
         if (values.size() == 0) {
+            releaseEphemeralCaptures(codeRef);
             return scalarUndef.getList();
         }
         if (values.size() == 1) {
+            releaseEphemeralCaptures(codeRef);
             return values.elements.get(0).scalar().getList();
         }
 
@@ -228,6 +234,7 @@ public class ListUtil extends PerlModuleBase {
         } finally {
             varA.set(saveA);
             varB.set(saveB);
+            releaseEphemeralCaptures(codeRef);
         }
     }
 
@@ -244,6 +251,7 @@ public class ListUtil extends PerlModuleBase {
         RuntimeArray results = new RuntimeArray();
 
         if (values.size() == 0) {
+            releaseEphemeralCaptures(codeRef);
             return results.getList();
         }
 
@@ -274,6 +282,7 @@ public class ListUtil extends PerlModuleBase {
         } finally {
             varA.set(saveA);
             varB.set(saveB);
+            releaseEphemeralCaptures(codeRef);
         }
     }
 
@@ -390,6 +399,7 @@ public class ListUtil extends PerlModuleBase {
             return scalarUndef.getList();
         } finally {
             GlobalVariable.aliasGlobalVariable("main::_", saveValue);
+            releaseEphemeralCaptures(codeRef);
         }
     }
 
@@ -816,6 +826,7 @@ public class ListUtil extends PerlModuleBase {
         } finally {
             GlobalVariable.aliasGlobalVariable(aName, saveA);
             GlobalVariable.aliasGlobalVariable(bName, saveB);
+            releaseEphemeralCaptures(codeRef);
         }
 
         return ctx == RuntimeContextType.SCALAR ?
@@ -870,6 +881,7 @@ public class ListUtil extends PerlModuleBase {
         } finally {
             GlobalVariable.aliasGlobalVariable(aName, saveA);
             GlobalVariable.aliasGlobalVariable(bName, saveB);
+            releaseEphemeralCaptures(codeRef);
         }
 
         return ctx == RuntimeContextType.SCALAR ?
@@ -920,6 +932,7 @@ public class ListUtil extends PerlModuleBase {
         } finally {
             GlobalVariable.aliasGlobalVariable(aName, saveA);
             GlobalVariable.aliasGlobalVariable(bName, saveB);
+            releaseEphemeralCaptures(codeRef);
         }
 
         return ctx == RuntimeContextType.SCALAR ? scalarFalse.getList() : new RuntimeList();

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Storable.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Storable.java
@@ -40,7 +40,7 @@ public class Storable extends PerlModuleBase {
             storable.registerMethod("store", null);
             storable.registerMethod("retrieve", null);
             storable.registerMethod("nstore", null);
-            storable.registerMethod("dclone", null);
+            storable.registerMethod("dclone", "$");
             storable.registerMethod("last_op_in_netorder", null);
 
             storable.defineExport("EXPORT", "store", "retrieve", "nstore", "freeze", "thaw", "nfreeze", "dclone");
@@ -453,12 +453,13 @@ public class Storable extends PerlModuleBase {
                     // Create new TieHash with cloned handler
                     newHash.type = RuntimeHash.TIED_HASH;
                     newHash.elements = new TieHash(tieHash.getTiedPackage(), previousValue, clonedSelf);
-                    // Copy the data through the tied interface (STORE calls)
-                    // Iterate original hash via FIRSTKEY/NEXTKEY and FETCH each value
+                    // Initialize the backing value directly. Replaying through STORE
+                    // breaks read-only tie classes during dclone; the cloned handler
+                    // already carries the tie object's state.
                     RuntimeScalar firstKey = TieHash.tiedFirstKey(origHash);
                     while (firstKey.type != RuntimeScalarType.UNDEF) {
                         RuntimeScalar val = TieHash.tiedFetch(origHash, firstKey);
-                        TieHash.tiedStore(newHash, firstKey, deepClone(val, cloned));
+                        previousValue.put(firstKey.toString(), deepClone(val, cloned));
                         firstKey = TieHash.tiedNextKey(origHash, firstKey);
                     }
                 } else {
@@ -489,16 +490,18 @@ public class Storable extends PerlModuleBase {
                     RuntimeArray previousValue = new RuntimeArray();
                     newArray.type = RuntimeArray.TIED_ARRAY;
                     newArray.elements = new TieArray(tieArray.getTiedPackage(), previousValue, clonedSelf, newArray);
-                    // Copy the data through the tied interface (STORE calls)
+                    // Initialize the backing value directly. Replaying through STORE
+                    // breaks read-only tie classes during dclone; the cloned handler
+                    // already carries the tie object's state.
                     int size = TieArray.tiedFetchSize(origArray).getInt();
                     for (int i = 0; i < size; i++) {
                         RuntimeScalar val = TieArray.tiedFetch(origArray, new RuntimeScalar(i));
-                        TieArray.tiedStore(newArray, new RuntimeScalar(i), deepClone(val, cloned));
+                        previousValue.add(deepClone(val, cloned));
                     }
                 } else {
                     // Regular (untied) array: deep-clone each element
                     for (RuntimeScalar element : origArray.elements) {
-                        newArray.elements.add(deepClone(element, cloned));
+                        newArray.add(deepClone(element, cloned));
                     }
                 }
                 yield newRef;

--- a/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessor.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessor.java
@@ -69,6 +69,7 @@ public class RegexPreprocessor {
      * `%+` / `%-`.
      */
     static java.util.Set<String> seenNamedCaptures = new java.util.HashSet<>();
+    static java.util.Map<String, java.util.List<String>> emittedNamedCaptures = new java.util.LinkedHashMap<>();
     static int duplicateNameCounter;
 
     static void markDeferredUnicodePropertyEncountered() {
@@ -115,6 +116,7 @@ public class RegexPreprocessor {
         branchResetEncountered = false;
         backslashKEncountered = false;
         seenNamedCaptures.clear();
+        emittedNamedCaptures.clear();
         duplicateNameCounter = 0;
 
         // First, escape invalid quantifier braces (Perl compatibility)
@@ -1585,7 +1587,7 @@ public class RegexPreprocessor {
             } else if (c3 == '[') {
                 // Handle extended bracketed character class (?[...])
                 return ExtendedCharClass.handleExtendedCharacterClass(s, offset, sb, regexFlags);
-            } else if ((c3 >= 'a' && c3 <= 'z') || c3 == '-' || c3 == '^' || c3 == ':') {
+            } else if ((c3 >= 'a' && c3 <= 'z') || c3 == '-' || c3 == '^' || c3 == ':' || c3 == ')') {
                 // Handle (?modifiers: ... ) construct and non-capturing groups
                 return RegexPreprocessorHelper.handleFlagModifiers(s, offset, sb, regexFlags);
             } else if (c3 == ':') {
@@ -1671,6 +1673,7 @@ public class RegexPreprocessor {
         String name = s.substring(start, end);
         // Encode underscores for Java regex compatibility
         String encodedName = CaptureNameEncoder.encodeGroupName(name);
+        String originalEncodedName = encodedName;
         // Perl allows the same capture group name to appear in multiple
         // alternation branches (e.g. `(?<y>\d+)|(?<y>foo)`). Java's regex
         // engine rejects duplicates outright, so we suffix subsequent
@@ -1679,9 +1682,19 @@ public class RegexPreprocessor {
         if (!seenNamedCaptures.add(encodedName)) {
             encodedName = encodedName + CaptureNameEncoder.DUPLICATE_MARKER + (duplicateNameCounter++);
         }
+        emittedNamedCaptures.computeIfAbsent(originalEncodedName, k -> new java.util.ArrayList<>()).add(encodedName);
         sb.append("(?<").append(encodedName).append(">");
         captureGroupCount++; // Increment counter for capturing groups
         return handleRegex(s, end + 1, sb, regexFlags, true); // Process content inside the group
+    }
+
+    static java.util.List<String> namedBackreferenceTargets(String perlName) {
+        String encodedName = CaptureNameEncoder.encodeGroupName(perlName);
+        java.util.List<String> emitted = emittedNamedCaptures.get(encodedName);
+        if (emitted == null || emitted.isEmpty()) {
+            return java.util.Collections.singletonList(encodedName);
+        }
+        return emitted;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessorHelper.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessorHelper.java
@@ -86,11 +86,8 @@ public class RegexPreprocessorHelper {
             int endQuote = s.indexOf('\'', offset);
             if (endQuote != -1) {
                 String name = s.substring(offset, endQuote);
-                // Encode underscores for Java regex compatibility
-                String encodedName = CaptureNameEncoder.encodeGroupName(name);
                 // Convert to Java syntax \k<name>
-                sb.setLength(sb.length() - 1); // Remove the backslash
-                sb.append("\\k<").append(encodedName).append(">");
+                appendNamedBackreference(sb, name);
                 return endQuote; // Return position at closing quote
             } else {
                 RegexPreprocessor.regexError(s, offset - 2, "Unterminated \\k'...' backreference");
@@ -102,10 +99,7 @@ public class RegexPreprocessorHelper {
             int endAngle = s.indexOf('>', offset);
             if (endAngle != -1) {
                 String name = s.substring(offset, endAngle);
-                // Encode underscores for Java regex compatibility
-                String encodedName = CaptureNameEncoder.encodeGroupName(name);
-                sb.setLength(sb.length() - 1); // Remove the backslash
-                sb.append("\\k<").append(encodedName).append(">");
+                appendNamedBackreference(sb, name);
                 return endAngle; // Return position at closing >
             } else {
                 RegexPreprocessor.regexError(s, offset - 2, "Unterminated \\k<...> backreference");
@@ -144,10 +138,8 @@ public class RegexPreprocessorHelper {
                             sb.append("\\").append(groupNum);
                         }
                     } catch (NumberFormatException e) {
-                        // It's a named reference - encode underscores for Java regex
-                        String encodedRef = CaptureNameEncoder.encodeGroupName(ref);
-                        sb.setLength(sb.length() - 1); // Remove the backslash
-                        sb.append("\\k<").append(encodedRef).append(">");
+                        // It's a named reference.
+                        appendNamedBackreference(sb, ref);
                     }
                     offset = endBrace;
                 }
@@ -545,6 +537,24 @@ public class RegexPreprocessorHelper {
             }
         }
         return offset;
+    }
+
+    private static void appendNamedBackreference(StringBuilder sb, String perlName) {
+        java.util.List<String> targets = RegexPreprocessor.namedBackreferenceTargets(perlName);
+        sb.setLength(sb.length() - 1); // Remove the already-appended backslash
+        if (targets.size() == 1) {
+            sb.append("\\k<").append(targets.get(0)).append(">");
+            return;
+        }
+
+        sb.append("(?:");
+        for (int i = 0; i < targets.size(); i++) {
+            if (i > 0) {
+                sb.append('|');
+            }
+            sb.append("\\k<").append(targets.get(i)).append(">");
+        }
+        sb.append(')');
     }
 
     /**
@@ -1056,8 +1066,6 @@ public class RegexPreprocessorHelper {
             RegexPreprocessor.regexError(s, start + 2, "Sequence (?^d...) not recognized");
         }
 
-        sb.append("(?");
-
         // Split into positive and negative parts
         String[] parts = flags.split("-", 2);
         String positiveFlags = parts[0];
@@ -1129,6 +1137,16 @@ public class RegexPreprocessorHelper {
             RegexPreprocessor.inlinePFlagEncountered = true;
         }
 
+        if (positiveFlags.isEmpty()
+                && negativeFlags.isEmpty()
+                && (colonPos == -1 || closeParen < colonPos)) {
+            offset = RegexPreprocessor.handleRegex(s, closeParen + 1, sb, newFlags, true);
+            if (offset < s.length()) {
+                offset--;
+            }
+            return offset;
+        }
+
         // Handle `n` flags
         if (positiveFlags.indexOf('n') >= 0) {
             positiveFlags = positiveFlags.replace("n", "");
@@ -1142,6 +1160,7 @@ public class RegexPreprocessorHelper {
         negativeFlags = filterSupportedFlags(negativeFlags);
 
         // Build the new flag string
+        sb.append("(?");
         sb.append(positiveFlags);
         if (!negativeFlags.isEmpty()) {
             sb.append('-').append(negativeFlags);

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -6,6 +6,7 @@ import org.perlonjava.runtime.perlmodule.Utf8;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import java.util.Iterator;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +66,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
     // Capture groups from the last successful match that had captures.
     // In Perl 5, $1/$2/etc persist across non-capturing matches.
     public static String[] lastCaptureGroups = null;
+    public static Map<String, List<String>> lastNamedCaptureGroups = null;
     // Track whether the last successful match was on a BYTE_STRING input,
     // so that captures ($1, $2, $&, etc.) preserve BYTE_STRING type.
     public static boolean lastMatchWasByteString = false;
@@ -947,6 +949,37 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         }
     }
 
+    private static void updateLastNamedCaptureGroups(Matcher matcher) {
+        Map<String, Integer> namedGroups = matcher.pattern().namedGroups();
+        Map<String, List<String>> byPerlName = new LinkedHashMap<>();
+        if (namedGroups == null || namedGroups.isEmpty()) {
+            lastNamedCaptureGroups = byPerlName;
+            return;
+        }
+
+        Map<String, List<String>> javaNamesByPerlName = new LinkedHashMap<>();
+        for (String javaName : namedGroups.keySet()) {
+            if (CaptureNameEncoder.isInternalCapture(javaName)) {
+                continue;
+            }
+            String perlName = CaptureNameEncoder.decodeGroupName(javaName);
+            javaNamesByPerlName.computeIfAbsent(perlName, k -> new ArrayList<>()).add(javaName);
+        }
+
+        for (List<String> javaNames : javaNamesByPerlName.values()) {
+            javaNames.sort(java.util.Comparator.comparingInt(namedGroups::get));
+        }
+
+        for (Map.Entry<String, List<String>> entry : javaNamesByPerlName.entrySet()) {
+            List<String> values = new ArrayList<>();
+            for (String javaName : entry.getValue()) {
+                values.add(matcher.group(javaName));
+            }
+            byPerlName.put(entry.getKey(), values);
+        }
+        lastNamedCaptureGroups = byPerlName;
+    }
+
     /**
      * Direct regex matching without timeout wrapper (fast path).
      */
@@ -1172,6 +1205,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 globalMatcher = matcher;
                 globalMatchString = inputStr;
                 lastMatchUsedBackslashK = regex.hasBackslashK;
+                updateLastNamedCaptureGroups(matcher);
                 if (captureCount > 0) {
                     if (regex.hasBackslashK) {
                         // Skip the internal perlK capture group
@@ -1563,6 +1597,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 globalMatcher = matcher;
                 globalMatchString = inputStr;
                 lastMatchUsedBackslashK = regex.hasBackslashK;
+                updateLastNamedCaptureGroups(matcher);
                 if (matcher.groupCount() > 0) {
                     if (regex.hasBackslashK) {
                         // Skip the internal perlK capture group when populating $1, $2, etc.
@@ -1685,8 +1720,9 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 // /r modifier with no matches: return the original string
                 return string;
             } else {
-                // Return `undef`
-                return scalarUndef;
+                // Perl returns a defined false value for a destructive s/// that
+                // does not match.
+                return RuntimeScalarCache.scalarEmptyString;
             }
         }
     }
@@ -1732,6 +1768,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         lastSuccessfulMatchString = null;
         lastMatchUsedPFlag = false;
         lastCaptureGroups = null;
+        lastNamedCaptureGroups = null;
 
         // Reset regex cache matched flags
         reset();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/HashSpecialVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/HashSpecialVariable.java
@@ -1,14 +1,13 @@
 package org.perlonjava.runtime.runtimetypes;
 
 import org.perlonjava.runtime.mro.InheritanceResolver;
-import org.perlonjava.runtime.regex.CaptureNameEncoder;
 import org.perlonjava.runtime.regex.RuntimeRegex;
 
 import java.util.AbstractMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
 
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarUndef;
 
@@ -74,47 +73,15 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
     public Set<Entry<String, RuntimeScalar>> entrySet() {
         Set<Entry<String, RuntimeScalar>> entries = new HashSet<>();
         if (this.mode == Id.CAPTURE_ALL || this.mode == Id.CAPTURE) {
-            Matcher matcher = RuntimeRegex.globalMatcher;
-            if (matcher != null) {
-                Map<String, Integer> namedGroups = matcher.pattern().namedGroups();
-                // Collect entries by decoded Perl name so that duplicate-name
-                // captures (e.g. `(?<y>a)|(?<y>b)`) merge into a single key.
-                // Note: Java's Pattern.namedGroups() returns an unordered map
-                // (ImmutableCollections.MapN), so we must explicitly sort each
-                // bucket by group number so that the *leftmost* alternative
-                // wins (Perl semantics for $+{name}).
-                java.util.Map<String, java.util.List<String>> byPerlName = new java.util.LinkedHashMap<>();
-                for (String name : namedGroups.keySet()) {
-                    if (CaptureNameEncoder.isInternalCapture(name)) {
-                        continue;
-                    }
-                    String perlName = CaptureNameEncoder.decodeGroupName(name);
-                    byPerlName.computeIfAbsent(perlName, k -> new java.util.ArrayList<>()).add(name);
-                }
-                for (java.util.List<String> jns : byPerlName.values()) {
-                    jns.sort(java.util.Comparator.comparingInt(namedGroups::get));
-                }
-                for (Map.Entry<String, java.util.List<String>> e : byPerlName.entrySet()) {
-                    String perlName = e.getKey();
-                    java.util.List<String> javaNames = e.getValue();
+            Map<String, List<String>> namedCaptures = RuntimeRegex.lastNamedCaptureGroups;
+            if (namedCaptures != null) {
+                for (Map.Entry<String, List<String>> e : namedCaptures.entrySet()) {
                     if (this.mode == Id.CAPTURE_ALL) {
-                        // For %-, value is an arrayref containing every alternative
-                        // (matched ones get the captured value, unmatched get undef).
-                        RuntimeArray arr = new RuntimeArray();
-                        for (String jn : javaNames) {
-                            String v = matcher.group(jn);
-                            arr.push(v != null ? new RuntimeScalar(v) : new RuntimeScalar());
-                        }
-                        entries.add(new SimpleEntry<>(perlName, arr.createReference()));
+                        entries.add(new SimpleEntry<>(e.getKey(), captureAllArrayRef(e.getValue())));
                     } else {
-                        // For %+, only include the alternative that actually matched.
-                        // For duplicate names at most one branch will have matched.
-                        for (String jn : javaNames) {
-                            String v = matcher.group(jn);
-                            if (v != null) {
-                                entries.add(new SimpleEntry<>(perlName, new RuntimeScalar(v)));
-                                break;
-                            }
+                        RuntimeScalar matched = firstDefinedCapture(e.getValue());
+                        if (matched.getDefinedBoolean()) {
+                            entries.add(new SimpleEntry<>(e.getKey(), matched));
                         }
                     }
                 }
@@ -199,34 +166,14 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
     @Override
     public RuntimeScalar get(Object key) {
         if (this.mode == Id.CAPTURE_ALL || this.mode == Id.CAPTURE) {
-            Matcher matcher = RuntimeRegex.globalMatcher;
-            if (matcher != null && key instanceof String name) {
-                // Encode the Perl name to Java regex name (underscore encoding)
-                String encodedName = CaptureNameEncoder.encodeGroupName(name);
-                Map<String, Integer> namedGroups = matcher.pattern().namedGroups();
-                // Collect every Java group whose decoded Perl name matches the
-                // requested key. For non-duplicated names this is just the
-                // single direct match; for duplicated names we may have several.
-                java.util.List<String> javaNames = collectJavaNamesFor(namedGroups, encodedName);
-                if (javaNames.isEmpty()) {
-                    return scalarUndef;
-                }
+            Map<String, List<String>> namedCaptures = RuntimeRegex.lastNamedCaptureGroups;
+            if (namedCaptures != null && key instanceof String name) {
+                List<String> captures = namedCaptures.get(name);
+                if (captures == null) return scalarUndef;
                 if (this.mode == Id.CAPTURE_ALL) {
-                    // For %-, always return array ref containing one slot per alternative.
-                    RuntimeArray arr = new RuntimeArray();
-                    for (String jn : javaNames) {
-                        String v = matcher.group(jn);
-                        arr.push(v != null ? new RuntimeScalar(v) : new RuntimeScalar());
-                    }
-                    return arr.createReference();
+                    return captureAllArrayRef(captures);
                 } else {
-                    // For %+, return the matched value (or undef if no branch matched).
-                    for (String jn : javaNames) {
-                        String v = matcher.group(jn);
-                        if (v != null) {
-                            return new RuntimeScalar(v);
-                        }
-                    }
+                    return firstDefinedCapture(captures);
                 }
             }
         } else if (this.mode == Id.STASH) {
@@ -249,23 +196,15 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
     public boolean containsKey(Object key) {
         if (this.mode == Id.CAPTURE_ALL) {
             // For %-, all named groups exist (even non-participating ones)
-            Matcher matcher = RuntimeRegex.globalMatcher;
-            if (matcher != null && key instanceof String name) {
-                String encodedName = CaptureNameEncoder.encodeGroupName(name);
-                return !collectJavaNamesFor(matcher.pattern().namedGroups(), encodedName).isEmpty();
-            }
-            return false;
+            Map<String, List<String>> namedCaptures = RuntimeRegex.lastNamedCaptureGroups;
+            return namedCaptures != null && key instanceof String name && namedCaptures.containsKey(name);
         }
         if (this.mode == Id.CAPTURE) {
             // For %+, only groups that actually captured
-            Matcher matcher = RuntimeRegex.globalMatcher;
-            if (matcher != null && key instanceof String name) {
-                String encodedName = CaptureNameEncoder.encodeGroupName(name);
-                for (String jn : collectJavaNamesFor(matcher.pattern().namedGroups(), encodedName)) {
-                    if (matcher.group(jn) != null) {
-                        return true;
-                    }
-                }
+            Map<String, List<String>> namedCaptures = RuntimeRegex.lastNamedCaptureGroups;
+            if (namedCaptures != null && key instanceof String name) {
+                List<String> captures = namedCaptures.get(name);
+                return captures != null && captures.stream().anyMatch(v -> v != null);
             }
             return false;
         }
@@ -320,34 +259,21 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
         return keys;
     }
 
-    /**
-     * Returns every Java capture-group name in the matcher's pattern whose
-     * decoded Perl name equals {@code encodedPerlName}. For typical patterns
-     * this is at most one entry; for duplicate-name patterns like
-     * {@code (?<y>a)|(?<y>b)} the preprocessor renames the second occurrence
-     * to {@code yZpjdupZ0}, etc., and this helper collects all of them.
-     */
-    private static java.util.List<String> collectJavaNamesFor(Map<String, Integer> namedGroups, String encodedPerlName) {
-        java.util.List<String> out = new java.util.ArrayList<>();
-        if (namedGroups == null) {
-            return out;
+    private static RuntimeScalar captureAllArrayRef(List<String> captures) {
+        RuntimeArray arr = new RuntimeArray();
+        for (String v : captures) {
+            arr.push(v != null ? new RuntimeScalar(v) : new RuntimeScalar());
         }
-        if (namedGroups.containsKey(encodedPerlName)) {
-            out.add(encodedPerlName);
-        }
-        // Also pick up duplicate-marker variants (e.g. nameZpjdupZ0, ZpjdupZ1, ...).
-        for (String jn : namedGroups.keySet()) {
-            if (!jn.equals(encodedPerlName)
-                    && CaptureNameEncoder.isDuplicateMarkerName(jn)
-                    && CaptureNameEncoder.stripDuplicateMarker(jn).equals(encodedPerlName)) {
-                out.add(jn);
+        return arr.createReference();
+    }
+
+    private static RuntimeScalar firstDefinedCapture(List<String> captures) {
+        for (String v : captures) {
+            if (v != null) {
+                return new RuntimeScalar(v);
             }
         }
-        // Java's Pattern.namedGroups() doesn't preserve insertion order, so sort
-        // by group number to match Perl's source order. This makes `$+{name}`
-        // return the *leftmost* alternative for duplicate-named captures.
-        out.sort(java.util.Comparator.comparingInt(namedGroups::get));
-        return out;
+        return scalarUndef;
     }
 
     @Override

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
@@ -31,6 +31,11 @@ public class MortalList {
     // Drained at statement boundaries (FREETMPS equivalent).
     private static final ArrayList<RuntimeBase> pending = new ArrayList<>();
 
+    // Tied scalar wrappers whose handler release must happen at the next
+    // statement boundary. Used when a :lvalue sub returns a tied lexical: the
+    // callee's scope exits before the caller performs STORE.
+    private static final ArrayList<TiedVariableBase> pendingTiedReleases = new ArrayList<>();
+
     // Scalars whose scope has exited while captureCount > 0.
     // These variables hold blessed references that could not be decremented
     // at scope exit because closures still reference the RuntimeScalar.
@@ -89,6 +94,11 @@ public class MortalList {
             base.traceRefCount(0, "MortalList.deferDecrement (queued)");
         }
         pending.add(base);
+    }
+
+    public static void deferTiedObjectRelease(TiedVariableBase tiedVariable) {
+        if (!active || tiedVariable == null) return;
+        pendingTiedReleases.add(tiedVariable);
     }
 
     /**
@@ -643,6 +653,20 @@ public class MortalList {
     // Each mark records the pending list size at scope entry, so that
     // popAndFlush() only processes entries added within that scope.
     private static final ArrayList<Integer> marks = new ArrayList<>();
+    private static final ArrayList<Integer> tiedReleaseMarks = new ArrayList<>();
+
+    private static void processDeferredEntriesFrom(int pendingStartIdx, int tiedReleaseStartIdx) {
+        int pendingIdx = pendingStartIdx;
+        int tiedReleaseIdx = tiedReleaseStartIdx;
+        while (pendingIdx < pending.size() || tiedReleaseIdx < pendingTiedReleases.size()) {
+            while (tiedReleaseIdx < pendingTiedReleases.size()) {
+                pendingTiedReleases.get(tiedReleaseIdx++).releaseTiedObject();
+            }
+            while (pendingIdx < pending.size()) {
+                processDeferredBase(pending.get(pendingIdx++), false);
+            }
+        }
+    }
 
     /**
      * Process all pending decrements. Called at statement boundaries.
@@ -862,7 +886,7 @@ public class MortalList {
     public static void flush() {
         if (!active) return;
         if (flushing) return;
-        if (pending.isEmpty()) {
+        if (pending.isEmpty() && pendingTiedReleases.isEmpty()) {
             processReadyDeferredCaptures();
             maybeAutoSweepAfterFlush();
             return;
@@ -870,12 +894,11 @@ public class MortalList {
         invalidateDrainReachabilityCaches();
         flushing = true;
         try {
-            // Process list — DESTROY may add new entries, so use index-based loop
-            for (int i = 0; i < pending.size(); i++) {
-                processDeferredBase(pending.get(i), false);
-            }
+            processDeferredEntriesFrom(0, 0);
             pending.clear();
+            pendingTiedReleases.clear();
             marks.clear(); // All entries drained; marks are meaningless now
+            tiedReleaseMarks.clear();
         } finally {
             flushing = false;
             invalidateDrainReachabilityCaches();
@@ -985,6 +1008,7 @@ public class MortalList {
     public static void pushMark() {
         if (!active) return;
         marks.add(pending.size());
+        tiedReleaseMarks.add(pendingTiedReleases.size());
     }
 
     /**
@@ -997,6 +1021,9 @@ public class MortalList {
     public static void popMark() {
         if (!active || marks.isEmpty()) return;
         marks.removeLast();
+        if (!tiedReleaseMarks.isEmpty()) {
+            tiedReleaseMarks.removeLast();
+        }
     }
 
     /**
@@ -1014,7 +1041,7 @@ public class MortalList {
         if (!active) return;
         if (flushing) return;
         boolean topLevel = marks.isEmpty();
-        if (pending.isEmpty()) {
+        if (pending.isEmpty() && pendingTiedReleases.isEmpty()) {
             processReadyDeferredCaptures();
             if (topLevel) {
                 maybeAutoSweep();
@@ -1022,7 +1049,8 @@ public class MortalList {
             return;
         }
         int mark = marks.isEmpty() ? 0 : marks.getLast();
-        if (pending.size() <= mark) {
+        int tiedMark = tiedReleaseMarks.isEmpty() ? 0 : tiedReleaseMarks.getLast();
+        if (pending.size() <= mark && pendingTiedReleases.size() <= tiedMark) {
             processReadyDeferredCaptures();
             if (topLevel) {
                 maybeAutoSweep();
@@ -1032,12 +1060,13 @@ public class MortalList {
         invalidateDrainReachabilityCaches();
         flushing = true;
         try {
-            for (int i = mark; i < pending.size(); i++) {
-                processDeferredBase(pending.get(i), false);
-            }
+            processDeferredEntriesFrom(mark, tiedMark);
             // Remove only entries above the mark
             while (pending.size() > mark) {
                 pending.removeLast();
+            }
+            while (pendingTiedReleases.size() > tiedMark) {
+                pendingTiedReleases.removeLast();
             }
         } finally {
             flushing = false;
@@ -1058,7 +1087,8 @@ public class MortalList {
     public static void popAndFlush() {
         if (!active || marks.isEmpty()) return;
         int mark = marks.removeLast();
-        if (pending.size() <= mark) {
+        int tiedMark = tiedReleaseMarks.isEmpty() ? 0 : tiedReleaseMarks.removeLast();
+        if (pending.size() <= mark && pendingTiedReleases.size() <= tiedMark) {
             // Even if no mortal entries to process, check deferred captures
             // that may have become ready (captureCount reached 0) during
             // scope cleanup.
@@ -1068,12 +1098,13 @@ public class MortalList {
         }
         invalidateDrainReachabilityCaches();
         // Process entries from mark onwards (DESTROY may add new entries)
-        for (int i = mark; i < pending.size(); i++) {
-            processDeferredBase(pending.get(i), false);
-        }
+        processDeferredEntriesFrom(mark, tiedMark);
         // Remove only the entries we processed (keep entries before mark)
         while (pending.size() > mark) {
             pending.removeLast();
+        }
+        while (pendingTiedReleases.size() > tiedMark) {
+            pendingTiedReleases.removeLast();
         }
         invalidateDrainReachabilityCaches();
         // After processing mortals (which may have triggered releaseCaptures

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RegexState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RegexState.java
@@ -2,6 +2,8 @@ package org.perlonjava.runtime.runtimetypes;
 
 import org.perlonjava.runtime.regex.RuntimeRegex;
 
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 
 /**
@@ -25,6 +27,7 @@ public class RegexState implements DynamicState {
     private final RuntimeRegex lastSuccessfulPattern;
     private final boolean lastMatchUsedPFlag;
     private final String[] lastCaptureGroups;
+    private final Map<String, List<String>> lastNamedCaptureGroups;
     private final boolean lastMatchWasByteString;
 
     public RegexState() {
@@ -40,6 +43,7 @@ public class RegexState implements DynamicState {
         this.lastSuccessfulPattern = RuntimeRegex.lastSuccessfulPattern;
         this.lastMatchUsedPFlag = RuntimeRegex.lastMatchUsedPFlag;
         this.lastCaptureGroups = RuntimeRegex.lastCaptureGroups;
+        this.lastNamedCaptureGroups = RuntimeRegex.lastNamedCaptureGroups;
         this.lastMatchWasByteString = RuntimeRegex.lastMatchWasByteString;
     }
 
@@ -69,6 +73,7 @@ public class RegexState implements DynamicState {
         RuntimeRegex.lastSuccessfulPattern = this.lastSuccessfulPattern;
         RuntimeRegex.lastMatchUsedPFlag = this.lastMatchUsedPFlag;
         RuntimeRegex.lastCaptureGroups = this.lastCaptureGroups;
+        RuntimeRegex.lastNamedCaptureGroups = this.lastNamedCaptureGroups;
         RuntimeRegex.lastMatchWasByteString = this.lastMatchWasByteString;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -32,6 +32,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Supplier;
 
@@ -391,6 +392,15 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 : callContext;
     }
 
+    public static int effectiveCallContext(RuntimeCode code, int callContext) {
+        if (isLvalueCode(code)
+                && (callContext == RuntimeContextType.LVALUE
+                || callContext == RuntimeContextType.LVALUE_LIST)) {
+            return callContext;
+        }
+        return effectiveCallContext(callContext);
+    }
+
     public static RuntimeList returnList(RuntimeBase retVal, int callContext) {
         return returnList(retVal, callContext, true);
     }
@@ -446,7 +456,10 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             }
             if (effectiveContext == RuntimeContextType.SCALAR && result.elements.size() == 1) {
                 RuntimeBase value = result.elements.getFirst();
-                if (value instanceof RuntimeScalar scalar && scalar.type == RuntimeScalarType.TIED_SCALAR) {
+                if (originalContext != RuntimeContextType.LVALUE
+                        && originalContext != RuntimeContextType.LVALUE_LIST
+                        && value instanceof RuntimeScalar scalar
+                        && scalar.type == RuntimeScalarType.TIED_SCALAR) {
                     return copyReturnedReferenceScalars(new RuntimeList(scalar.tiedFetch()), originalContext, copyCapturedScalars);
                 }
             }
@@ -1421,6 +1434,38 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         return evalStringHelper(code, evalTag, new Object[0]);
     }
 
+    public static boolean shouldDecodeEvalbytesUtf8Source(String source) {
+        if (source == null) {
+            return false;
+        }
+        int pos = source.indexOf("use utf8");
+        while (pos >= 0) {
+            boolean startsAtWordBoundary = pos == 0 || !Character.isJavaIdentifierPart(source.charAt(pos - 1));
+            int after = pos + "use utf8".length();
+            boolean endsAtWordBoundary = after >= source.length()
+                    || Character.isWhitespace(source.charAt(after))
+                    || source.charAt(after) == ';';
+            if (startsAtWordBoundary && endsAtWordBoundary) {
+                for (int i = 0; i < pos; i++) {
+                    if (source.charAt(i) > 127) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            pos = source.indexOf("use utf8", pos + 1);
+        }
+        return false;
+    }
+
+    public static String decodeEvalbytesUtf8Source(String source) {
+        byte[] bytes = new byte[source.length()];
+        for (int i = 0; i < source.length(); i++) {
+            bytes[i] = (byte) (source.charAt(i) & 0xFF);
+        }
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
     /**
      * Compiles the text of an eval string into a Class that represents an anonymous subroutine.
      * After the Class is returned to the caller, an instance of the Class will be populated
@@ -1491,8 +1536,14 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             // If so, treat it as Unicode source to preserve Unicode characters during parsing
             // EXCEPT for evalbytes, which must treat everything as bytes
             String evalString = code.toString();
+            boolean evalbytesUtf8Source = ctx.isEvalbytes && shouldDecodeEvalbytesUtf8Source(evalString);
+            if (evalbytesUtf8Source) {
+                evalString = decodeEvalbytesUtf8Source(evalString);
+            }
             boolean hasUnicode = false;
-            if (!ctx.isEvalbytes && code.type != RuntimeScalarType.BYTE_STRING) {
+            if (evalbytesUtf8Source) {
+                hasUnicode = true;
+            } else if (!ctx.isEvalbytes && code.type != RuntimeScalarType.BYTE_STRING) {
                 for (int i = 0; i < evalString.length(); i++) {
                     if (evalString.charAt(i) > 127) {
                         hasUnicode = true;
@@ -1512,7 +1563,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             if (hasUnicode) {
                 evalCompilerOptions.isUnicodeSource = true;
             }
-            if (ctx.isEvalbytes) {
+            if (ctx.isEvalbytes && !evalbytesUtf8Source) {
                 evalCompilerOptions.isEvalbytes = true;
             }
             if (isByteStringSource) {
@@ -1537,7 +1588,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             // Include package name in cache key to ensure source location info is correct per-package
             int featureFlags = ctx.symbolTable.featureFlagsStack.peek();
             String currentPackage = ctx.symbolTable.getCurrentPackage();
-            String cacheKey = code.toString() + '\0' + evalTag + '\0' + hasUnicode + '\0' + ctx.isEvalbytes + '\0' + isByteStringSource + '\0' + featureFlags + '\0' + currentPackage;
+            String cacheKey = evalString + '\0' + evalTag + '\0' + hasUnicode + '\0' + ctx.isEvalbytes + '\0' + evalbytesUtf8Source + '\0' + isByteStringSource + '\0' + featureFlags + '\0' + currentPackage;
             Class<?> cachedClass = null;
             if (!isDebugging) {
                 synchronized (evalCache) {
@@ -1986,11 +2037,17 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
 
         try {
             String evalString = code.toString();
+            boolean evalbytesUtf8Source = ctx.isEvalbytes && shouldDecodeEvalbytesUtf8Source(evalString);
+            if (evalbytesUtf8Source) {
+                evalString = decodeEvalbytesUtf8Source(evalString);
+            }
             evalTrace("evalStringWithInterpreter parse start tag=" + evalTag + " ctx=" + callContext +
                     " fileName=" + ctx.compilerOptions.fileName);
             // Handle Unicode source detection (same logic as evalStringHelper)
             boolean hasUnicode = false;
-            if (!ctx.isEvalbytes && code.type != RuntimeScalarType.BYTE_STRING) {
+            if (evalbytesUtf8Source) {
+                hasUnicode = true;
+            } else if (!ctx.isEvalbytes && code.type != RuntimeScalarType.BYTE_STRING) {
                 for (int i = 0; i < evalString.length(); i++) {
                     if (evalString.charAt(i) > 127) {
                         hasUnicode = true;
@@ -2006,7 +2063,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             if (hasUnicode) {
                 evalCompilerOptions.isUnicodeSource = true;
             }
-            if (ctx.isEvalbytes) {
+            if (ctx.isEvalbytes && !evalbytesUtf8Source) {
                 evalCompilerOptions.isEvalbytes = true;
             }
             if (isByteStringSource) {
@@ -3461,7 +3518,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     ? code.packageName + "::" + code.subName
                     : null;
             requireLvalueCallable(code, callContext, resolvedSubroutineName);
-            int effectiveContext = effectiveCallContext(callContext);
+            int effectiveContext = effectiveCallContext(code, callContext);
             // Look up warning bits for the code's class and push to context stack
             // This enables FATAL warnings to work even at top-level (no caller frame)
             String warningBits = getWarningBitsForCode(code);
@@ -3776,7 +3833,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
 
             if (code.defined()) {
                 requireLvalueCallable(code, callContext, subroutineName);
-                int effectiveContext = effectiveCallContext(callContext);
+                int effectiveContext = effectiveCallContext(code, callContext);
                 // Look up warning bits for the code's class and push to context stack
                 String warningBits = getWarningBitsForCode(code);
                 if (warningBits != null) {
@@ -4030,7 +4087,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
 
             if (code.defined()) {
                 requireLvalueCallable(code, callContext, subroutineName);
-                int effectiveContext = effectiveCallContext(callContext);
+                int effectiveContext = effectiveCallContext(code, callContext);
                 // Look up warning bits for the code's class and push to context stack
                 String warningBits = getWarningBitsForCode(code);
                 if (warningBits != null) {
@@ -4480,7 +4537,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             }
 
             requireLvalueCallable(this, callContext, null);
-            int effectiveContext = effectiveCallContext(callContext);
+            int effectiveContext = effectiveCallContext(this, callContext);
 
             // Debug mode: push args and track subroutine entry
             if (DebugState.debugMode) {
@@ -4599,7 +4656,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             }
 
             requireLvalueCallable(this, callContext, subroutineName);
-            int effectiveContext = effectiveCallContext(callContext);
+            int effectiveContext = effectiveCallContext(this, callContext);
 
             // Debug mode: push args and track subroutine entry
             if (DebugState.debugMode) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
@@ -869,7 +869,12 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
      * @return A RuntimeList containing the elements of the hash.
      */
     public RuntimeList getList() {
-        return new RuntimeList(this);
+        RuntimeList result = new RuntimeList();
+        Iterator<RuntimeScalar> iterator = iterator();
+        while (iterator.hasNext()) {
+            result.elements.add(new RuntimeScalar(iterator.next()));
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -3551,6 +3551,17 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         }
     }
 
+    public static void scopeExitCleanupPreservingReturnedLvalue(RuntimeScalar scalar, RuntimeBase returnedLvalue) {
+        if (scalar != null
+                && scalar == returnedLvalue
+                && scalar.type == RuntimeScalarType.TIED_SCALAR
+                && scalar.value instanceof TiedVariableBase tiedVariable) {
+            MortalList.deferTiedObjectRelease(tiedVariable);
+            return;
+        }
+        scopeExitCleanup(scalar);
+    }
+
     private static class RuntimeScalarIterator implements Iterator<RuntimeScalar> {
         private final RuntimeScalar scalar;
         private boolean hasNext = true;

--- a/src/test/resources/unit/compound_assignment.t
+++ b/src/test/resources/unit/compound_assignment.t
@@ -96,9 +96,19 @@ $a = 0;
 $a ||= 1;
 ok(!($a != 1), '0 ||= 1 equals 1');
 
+# Logical XOR Assignment
+$a = 0;
+$a ^^= 1;
+is($a, 1, '0 ^^= 1 equals 1');
+
 # Defined-or Assignment
 my $undefined;
 $undefined //= "default";
 ok(!($undefined ne "default"), 'undefined //= \'default\' equals \'default\'');
+
+# Parenthesized compound assignment should stay an lvalue
+my ($x, $y) = (0x7a, 0x3e);
+($x &= $y) .= "x";
+is($x, "58x", 'parenthesized bitwise assignment remains assignable');
 
 done_testing();

--- a/src/test/resources/unit/encode_utf8_on_off.t
+++ b/src/test/resources/unit/encode_utf8_on_off.t
@@ -1,0 +1,23 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 8;
+use Encode qw(_utf8_on _utf8_off is_utf8);
+
+sub ords {
+    return [ map { ord($_) } split //, $_[0] ];
+}
+
+my $s = "s\xC3\xA1";
+ok(!is_utf8($s), 'raw UTF-8 octets start with UTF-8 flag off');
+is_deeply(ords($s), [0x73, 0xC3, 0xA1], 'raw UTF-8 octets before _utf8_on');
+
+my $was = _utf8_on($s);
+ok(!$was, '_utf8_on returns previous false flag state');
+ok(is_utf8($s), '_utf8_on turns UTF-8 flag on');
+is_deeply(ords($s), [0x73, 0xE1], '_utf8_on decodes valid UTF-8 octets');
+
+$was = _utf8_off($s);
+is($was, 1, '_utf8_off returns previous true flag state');
+ok(!is_utf8($s), '_utf8_off turns UTF-8 flag off');
+is_deeply(ords($s), [0x73, 0xC3, 0xA1], '_utf8_off restores raw UTF-8 octets');

--- a/src/test/resources/unit/evalbytes.t
+++ b/src/test/resources/unit/evalbytes.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+use feature qw(evalbytes unicode_eval);
+
+my $u100_utf8 = "\xc4\x80";
+is(evalbytes("no strict 'subs'; use utf8; $u100_utf8"), chr 256, 'evalbytes decodes source after use utf8');
+
+my $upcode = "no strict 'subs'; use utf8; $u100_utf8" . chr 256;
+chop $upcode;
+is(evalbytes($upcode), chr 256, 'evalbytes decodes upgraded byte source after use utf8');
+
+eval { evalbytes chr 256 };
+like($@, qr/Wide character/, 'evalbytes rejects non-byte characters');

--- a/src/test/resources/unit/hash.t
+++ b/src/test/resources/unit/hash.t
@@ -45,6 +45,14 @@ is($iterated_count, scalar(keys %hash), 'Iteration count matches key count');
     is_deeply(\@slice, ['value2', 'value3'], 'Hashref slice retrieval');
 }
 
+{
+    my @slice = @hash{()};
+    is_deeply(\@slice, [], 'Empty hash slice returns an empty list');
+    my $empty_scalar = scalar @hash{()};
+    ok(!defined($empty_scalar), 'Empty hash slice is undef in scalar context');
+    is(join(':', 30, scalar @hash{()}), '30:', 'Empty hash slice composes in list context');
+}
+
 # Slice delete
 delete @hash{'key2', 'key3'};
 ok(!exists $hash{key2} && !exists $hash{key3}, 'Slice delete successful');

--- a/src/test/resources/unit/parser_syntax_error.t
+++ b/src/test/resources/unit/parser_syntax_error.t
@@ -5,4 +5,7 @@ use Test::More;
 eval q{sub parser_syntax_error_probe { if }};
 like($@, qr/\Asyntax error at /, 'unexpected token reports Perl syntax error');
 
+eval q{%@x=0};
+like($@, qr/Can't modify hash dereference in repeat \(x\)/, 'hash dereference repeat assignment reports Perl error');
+
 done_testing();

--- a/src/test/resources/unit/prototype_backslash_typecheck.t
+++ b/src/test/resources/unit/prototype_backslash_typecheck.t
@@ -18,4 +18,23 @@ my @array = (1, 2, 3);
 is(wants_hash_ref(%hash), 2, 'hash prototype still accepts hash variables');
 is(wants_array_ref(@array), 3, 'array prototype still accepts array variables');
 
+sub readonly_style(\[$@%]@) {
+    return (ref($_[0]), ${$_[0]}, scalar @_);
+}
+
+my ($ref_type, $value, $argc) = readonly_style my $scalar = 42;
+is($ref_type, 'SCALAR', 'slurpy backslash group prototype references declared scalar');
+is($value, 42, 'assignment stays inside slurpy backslash group argument');
+is($argc, 1, 'slurpy backslash group prototype does not invent extra arguments');
+
+($ref_type, $value, $argc) = readonly_style my @assigned_array = (3, 5);
+is($ref_type, 'SCALAR', 'slurpy backslash group prototype references array assignment result');
+is($value, 2, 'array assignment result count stays inside slurpy backslash group argument');
+is($argc, 1, 'array assignment through slurpy backslash group remains one argument');
+
+($ref_type, $value, $argc) = readonly_style my %assigned_hash = (key => 42);
+is($ref_type, 'SCALAR', 'slurpy backslash group prototype references hash assignment result');
+is($value, 2, 'hash assignment result count stays inside slurpy backslash group argument');
+is($argc, 1, 'hash assignment through slurpy backslash group remains one argument');
+
 done_testing();

--- a/src/test/resources/unit/refcount/list_util_block_capture_cleanup.t
+++ b/src/test/resources/unit/refcount/list_util_block_capture_cleanup.t
@@ -1,0 +1,66 @@
+use strict;
+use warnings;
+use Test::More;
+use List::Util ();
+use Scalar::Util qw(refaddr weaken);
+
+{
+    package ListUtilCleanup::Element;
+    sub DESTROY {
+        delete $main::PARENT{Scalar::Util::refaddr($_[0])};
+        $main::DESTROYED++;
+    }
+}
+
+{
+    package ListUtilCleanup::Node;
+    our @ISA = ('ListUtilCleanup::Element');
+
+    sub tokens {
+        @{ $_[0]->{children} };
+    }
+
+    sub serialize {
+        my $self = shift;
+        my @tokens = $self->tokens;
+        my $out = '';
+
+        foreach my $i (0 .. $#tokens) {
+            my $token = $tokens[$i];
+            $out .= $token->{content};
+            if ($token->{damaged}) {
+                my $last_index = $#tokens;
+                my $last_line = List::Util::none {
+                    $tokens[$_] and $tokens[$_]->{content} =~ /\n/
+                } (($i + 1) .. $last_index);
+                my $any_after = List::Util::any {
+                    $tokens[$_]->{damaged}
+                } (($i + 1) .. $#tokens);
+                $out .= ($last_line ? 'L' : '') . ($any_after ? 'A' : '');
+            }
+        }
+
+        $out;
+    }
+}
+
+our (%PARENT, $DESTROYED);
+
+{
+    my $node = bless { children => [] }, 'ListUtilCleanup::Node';
+    for my $i (1 .. 3) {
+        my $token = bless {
+            content => ($i == 2 ? "\n" : 'x'),
+            damaged => ($i == 1),
+        }, 'ListUtilCleanup::Element';
+        push @{ $node->{children} }, $token;
+        weaken($PARENT{refaddr($token)} = $node);
+    }
+
+    is($node->serialize, "x\nx", 'List::Util block can capture and inspect token array');
+}
+
+is(scalar(keys %PARENT), 0, 'List::Util block captures are released after call');
+is($DESTROYED, 4, 'parent and children are destroyed after scope exit');
+
+done_testing;

--- a/src/test/resources/unit/refcount/loop_control_scope_cleanup.t
+++ b/src/test/resources/unit/refcount/loop_control_scope_cleanup.t
@@ -1,0 +1,49 @@
+use strict;
+use warnings;
+use Test::More tests => 6;
+use Scalar::Util qw(refaddr weaken);
+
+our (%WEAK, $DESTROYED);
+
+{
+    package LoopControlCleanupProbe;
+    sub DESTROY {
+        delete $main::WEAK{Scalar::Util::refaddr($_[0])};
+        $main::DESTROYED++;
+    }
+}
+
+for (1 .. 5) {
+    my $obj = bless {}, 'LoopControlCleanupProbe';
+    weaken($WEAK{refaddr($obj)} = $obj);
+    next;
+}
+
+is scalar(keys %WEAK), 0, 'next cleans lexicals before continuing';
+is $DESTROYED, 5, 'next fires DESTROY for each skipped scope';
+
+%WEAK = ();
+$DESTROYED = 0;
+
+while (1) {
+    my $obj = bless {}, 'LoopControlCleanupProbe';
+    weaken($WEAK{refaddr($obj)} = $obj);
+    last;
+}
+
+is scalar(keys %WEAK), 0, 'last cleans lexicals before leaving loop';
+is $DESTROYED, 1, 'last fires DESTROY for skipped scope';
+
+%WEAK = ();
+$DESTROYED = 0;
+
+my $i = 0;
+while ($i < 3) {
+    $i++;
+    my $obj = bless {}, 'LoopControlCleanupProbe';
+    weaken($WEAK{refaddr($obj)} = $obj);
+    redo if $i < 3;
+}
+
+is scalar(keys %WEAK), 0, 'redo cleans lexicals before restarting block';
+is $DESTROYED, 3, 'redo fires DESTROY for each restarted scope';

--- a/src/test/resources/unit/refcount/while_condition_my_weak_hash.t
+++ b/src/test/resources/unit/refcount/while_condition_my_weak_hash.t
@@ -1,0 +1,39 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 2;
+use Scalar::Util qw(weaken refaddr);
+use Internals;
+
+our %PARENT;
+
+{
+    package WhileConditionMyWeakHashObject;
+    sub DESTROY {}
+}
+
+sub top_like {
+    my $cursor = shift;
+    while (my $parent = $PARENT{refaddr($cursor)}) {
+        $cursor = $parent;
+    }
+    $cursor;
+}
+
+my $root  = bless {}, 'WhileConditionMyWeakHashObject';
+my $child = bless {}, 'WhileConditionMyWeakHashObject';
+weaken($PARENT{refaddr($child)} = $root);
+
+is(
+    Internals::jperl_refstate_str($root),
+    'HASH:WhileConditionMyWeakHashObject:0:W',
+    'weak parent starts without counted strong refs',
+);
+
+top_like($child) for 1 .. 20;
+
+is(
+    Internals::jperl_refstate_str($root),
+    'HASH:WhileConditionMyWeakHashObject:0:W',
+    'while condition my weak hash lookup does not leak parent refs',
+);

--- a/src/test/resources/unit/regex/regex_duplicate_named_backreference.t
+++ b/src/test/resources/unit/regex/regex_duplicate_named_backreference.t
@@ -1,0 +1,43 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 13;
+
+my @branch_cases = (
+    ['a/a', 1, 'a'],
+    ['b/b', 1, 'b'],
+    ['a/b', 0, undef],
+    ['b/a', 0, undef],
+);
+
+for my $case (@branch_cases) {
+    my ($s, $match, $capture) = @$case;
+    if ($s =~ /(?:(?<x>a)\/\k<x>|(?<x>b)\/\k<x>)/) {
+        ok($match, "duplicate named backref branch match $s");
+        is($+{x}, $capture, "duplicate named backref branch capture $s");
+    } else {
+        ok(!$match, "duplicate named backref branch reject $s");
+    }
+}
+
+my @post_cases = (
+    ['aa', 1, 'a'],
+    ['bb', 1, 'b'],
+    ['ab', 0, undef],
+    ['ba', 0, undef],
+);
+
+for my $case (@post_cases) {
+    my ($s, $match, $capture) = @$case;
+    if ($s =~ /(?:(?<x>a)|(?<x>b))\k<x>/) {
+        ok($match, "duplicate named backref after alternation match $s");
+        is($+{x}, $capture, "duplicate named backref after alternation capture $s");
+    } else {
+        ok(!$match, "duplicate named backref after alternation reject $s");
+    }
+}
+
+'3/5/09' =~ /^\s*(?:(?<m>\d\d?)(?<sep>[\s\.\/\-])(?<d>\d\d?)\k<sep>(?<y>\d\d\d\d)|(?<m>\d\d?)(?<sep>[\s\.\/\-])(?<d>\d\d?)\k<sep>(?<y>\d\d)|(?<m>\d\d?)(?<sep>[\s\.\/\-])(?<d>\d\d?))\s*$/;
+is_deeply({ y => $+{y}, m => $+{m}, d => $+{d}, sep => $+{sep} },
+          { y => '09', m => '3', d => '5', sep => '/' },
+          'Date::Manip-style duplicate named separator backref matches two-digit year');

--- a/src/test/resources/unit/regex/regex_empty_inline_modifier.t
+++ b/src/test/resources/unit/regex/regex_empty_inline_modifier.t
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+ok('Big Market' =~ qr/(?)Market/, 'empty inline modifier group is a no-op');
+
+my $modifiers = '';
+my $regex = 'Market';
+ok('Big Market' =~ qr/(?$modifiers)$regex/, 'interpolated empty inline modifier group is a no-op');
+
+ok('Big Market' =~ qr/(?i)market/, 'non-empty inline modifier group still applies');
+ok('Big Market' =~ qr/(?:Big)\s+(?)Market/x, 'empty inline modifier works inside extended regex');

--- a/src/test/resources/unit/regex/regex_named_capture_subst_state.t
+++ b/src/test/resources/unit/regex/regex_named_capture_subst_state.t
@@ -1,0 +1,24 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 9;
+
+my $s = 'aa';
+is($s =~ s/(?<of>a)//g, 2, 'global substitution with named capture matches twice');
+is($+{of}, 'a', 'global substitution leaves the last named capture in %+');
+is_deeply($-{of}, ['a'], 'global substitution leaves named capture alternatives in %-');
+
+$s = 'bc';
+$s =~ s/(?<of>b)//g;
+$s =~ s/(?<of>x)//g;
+is($+{of}, 'b', 'failed substitution preserves previous named capture in %+');
+is_deeply($-{of}, ['b'], 'failed substitution preserves previous named capture in %-');
+
+'z' =~ /z/;
+ok(!exists $+{of}, 'successful match without named captures clears %+');
+ok(!exists $-{of}, 'successful match without named captures clears %-');
+
+my $dup = 'ab';
+$dup =~ s/(?<x>a)|(?<x>b)//g;
+is($+{x}, 'b', 'duplicate named capture reports last global substitution branch in %+');
+is_deeply($-{x}, [undef, 'b'], 'duplicate named capture alternatives survive exhausted matcher');

--- a/src/test/resources/unit/regex/regexreplace.t
+++ b/src/test/resources/unit/regex/regexreplace.t
@@ -19,6 +19,11 @@ $replacement = "Galaxy";
 $substituted = $string =~ s/$pattern/$replacement/r;
 ok(!($substituted ne "Hello World"), '\'Hello World\' remains \'Hello World\'');
 
+my $replace_count = $string =~ s/$pattern/$replacement/;
+ok(defined $replace_count, 'failed destructive s/// returns a defined false value');
+ok(!$replace_count, 'failed destructive s/// result is false');
+is($replace_count, '', 'failed destructive s/// stringifies to empty string');
+
 # Global substitution
 $string = "Hello World World";
 $pattern = qr/World/;

--- a/src/test/resources/unit/state.t
+++ b/src/test/resources/unit/state.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 13;
+use Test::More tests => 17;
 use feature 'state';
 
 # Function using a state variable
@@ -66,5 +66,21 @@ sub state_hash {
 # Test the state hash
 is_deeply({state_hash()}, {a => 1, b => 2, c => 3}, 'First call to state_hash should return {a => 1, b => 2, c => 3}');
 is_deeply({state_hash()}, {a => 1, b => 2, c => 4}, 'Second call to state_hash should return {a => 1, b => 2, c => 4}');
+
+sub state_hash_return {
+    state %h = (a => 1);
+}
+
+my $hash_result = join '', state_hash_return(), state_hash_return();
+is($hash_result, 'a1a1', 'state hash implicit return expands in list context');
+is(scalar state_hash_return(), 1, 'state hash implicit return counts in scalar context');
+
+sub state_array_return {
+    state @a = qw(b 2);
+}
+
+my $array_result = join '', state_array_return(), state_array_return();
+is($array_result, 'b2b2', 'state array implicit return expands in list context');
+is(scalar state_array_return(), 2, 'state array implicit return counts in scalar context');
 
 done_testing();

--- a/src/test/resources/unit/storable.t
+++ b/src/test/resources/unit/storable.t
@@ -7,7 +7,7 @@ use File::Temp qw(tempfile);
 use Storable qw(store retrieve nstore freeze thaw nfreeze dclone);
 
 # Test plan
-plan tests => 13;
+plan tests => 15;
 
 subtest 'Basic scalar serialization' => sub {
     plan tests => 6;
@@ -241,6 +241,24 @@ subtest 'Deep cloning' => sub {
     isa_ok($blessed_clone, 'CloneTest', 'Cloned blessed object preserves class');
 };
 
+subtest 'dclone has unary prototype' => sub {
+    plan tests => 3;
+
+    is(prototype('dclone'), '$', 'imported dclone has scalar prototype');
+    is(prototype('Storable::dclone'), '$', 'qualified dclone has scalar prototype');
+
+    sub _storable_proto_receiver {
+        return scalar(@_) . ':' . ref($_[1]) . ':' . $_[2];
+    }
+
+    my $source = [ 'x' ];
+    is(
+        _storable_proto_receiver('head', dclone $source, 'tail'),
+        '3:ARRAY:tail',
+        'bare dclone consumes one argument inside a larger argument list'
+    );
+};
+
 subtest 'Deep cloning preserves hash-wrapper independence' => sub {
     plan tests => 2;
 
@@ -263,6 +281,59 @@ subtest 'Deep cloning preserves hash-wrapper independence' => sub {
         $clone->{attrs}{order_by}[0] != $clone->{shared},
         'order_by chunk hash and shared wrapper hash are distinct refs in clone'
     );
+};
+
+subtest 'dclone array elements keep destructor-owned nested state' => sub {
+    plan tests => 3;
+
+    package _StDcloneClearingElement;
+
+    sub DESTROY {
+        %{ $_[0] } = ();
+        $main::_st_dclone_destroyed++;
+    }
+
+    package _StDcloneDocument;
+
+    sub STORABLE_freeze {
+        my ($self, $cloning) = @_;
+        my $class = ref $self;
+        my %hash = %$self;
+        return ($class, \%hash);
+    }
+
+    sub STORABLE_thaw {
+        my ($self, undef, $class, $hash) = @_;
+        bless $self, $class;
+        foreach (keys %$hash) {
+            $self->{$_} = delete $hash->{$_};
+        }
+    }
+
+    package _StDcloneNode;
+    our @ISA = ('_StDcloneClearingElement');
+
+    package _StDcloneToken;
+    our @ISA = ('_StDcloneClearingElement');
+
+    package main;
+
+    local $_st_dclone_destroyed = 0;
+    my $original = bless {
+        children => [
+            bless({
+                children => [
+                    bless({ content => 'x' }, '_StDcloneToken'),
+                ],
+            }, '_StDcloneNode'),
+        ],
+    }, '_StDcloneDocument';
+
+    my $clone = dclone($original);
+
+    is(scalar(@{ $clone->{children} }), 1, 'top-level array child survives dclone');
+    is(scalar(@{ $clone->{children}[0]{children} }), 1, 'nested array child survives dclone');
+    is($clone->{children}[0]{children}[0]{content}, 'x', 'nested token content survives dclone');
 };
 
 # Regression test: STORABLE_freeze hook cookie must survive nfreeze/thaw.

--- a/src/test/resources/unit/tied_lvalue_sub_return.t
+++ b/src/test/resources/unit/tied_lvalue_sub_return.t
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 13;
+
+{
+    package TiedLvalueSubReturnTie;
+
+    sub TIESCALAR {
+        my ($class, $get, $set) = @_;
+        bless [$get, $set], $class;
+    }
+
+    sub FETCH {
+        my ($self) = @_;
+        return $self->[0]->();
+    }
+
+    sub STORE {
+        my ($self, $value) = @_;
+        return $self->[1]->($value);
+    }
+}
+
+my $stored;
+
+sub tied_lvalue :lvalue {
+    tie(my $value, 'TiedLvalueSubReturnTie',
+        sub { $stored },
+        sub { $stored = $_[0] });
+    $value;
+}
+
+tied_lvalue() = 10;
+is($stored, 10, 'assignment to tied lvalue sub result calls STORE');
+is(tied_lvalue(), 10, 'ordinary read from tied lvalue sub result calls FETCH');
+
+tied_lvalue() *= 2;
+is($stored, 20, 'compound multiplication stores through tied lvalue sub result');
+
+tied_lvalue() += 3;
+is($stored, 23, 'compound addition stores through tied lvalue sub result');
+
+tied_lvalue() .= 'ski';
+is($stored, '23ski', 'compound concatenation stores through tied lvalue sub result');
+
+is(tied_lvalue() .= 'doo', '23skidoo', 'compound assignment returns stored value');
+is($stored, '23skidoo', 'compound assignment result remains stored');
+
+$stored = undef;
+tied_lvalue() ||= 'beta';
+is($stored, 'beta', 'logical ||= stores through tied lvalue sub result when false');
+
+tied_lvalue() ||= 'gamma';
+is($stored, 'beta', 'logical ||= skips STORE when tied lvalue sub result is true');
+
+$stored = '';
+tied_lvalue() &&= 'delta';
+is($stored, '', 'logical &&= skips STORE when tied lvalue sub result is false');
+
+$stored = 'true';
+tied_lvalue() &&= 'delta';
+is($stored, 'delta', 'logical &&= stores through tied lvalue sub result when true');
+
+$stored = undef;
+tied_lvalue() //= 'defined';
+is($stored, 'defined', 'defined-or //= stores through tied lvalue sub result when undef');
+
+tied_lvalue() //= 'again';
+is($stored, 'defined', 'defined-or //= skips STORE when tied lvalue sub result is defined');


### PR DESCRIPTION
Fix CPAN regressions for DateTime::Format::DateManip, ExtUtils::MakeMaker::CPANfile, LV, Readonly, JSON::Hyper, and Pistachio.

Add focused regression coverage for regex capture state, duplicate named captures, Encode utf8 flag helpers, tied lvalue returns, prototype parsing, Storable clone ownership, List::Util block capture cleanup, and loop scope cleanup.

Increase CPAN random tester and jcpan timeout defaults for dependency-heavy test runs.

Generated with Codex (https://openai.com/codex)

Co-Authored-By: Codex <codex@openai.com>
