### PR TITLE
Fix CPAN random tester regressions

### DIFF
--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -3325,7 +3325,12 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             }
         } else if (frame >= stackTraceSize) {
             RuntimeCode activeCode = hasExplicitExpr ? getActiveCodeAt(originalFrame) : null;
-            if (activeCode != null && !calledFromDB) {
+            String activeSubName = activeCode != null
+                    ? applyAnonNameOverride(callerSubNameForCode(activeCode))
+                    : null;
+            if (activeCode != null && !calledFromDB
+                    && hasExplicitlyRenamedActiveCode()
+                    && activeSubName != null && !activeSubName.isEmpty()) {
                 String pkg = normalizeCallerPackage(activeCode.packageName);
                 if (ctx == RuntimeContextType.SCALAR) {
                     res.add(new RuntimeScalar(pkg));
@@ -3333,13 +3338,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     res.add(new RuntimeScalar(pkg));
                     res.add(new RuntimeScalar(activeCode.cvStartFile != null ? activeCode.cvStartFile : ""));
                     res.add(new RuntimeScalar(activeCode.cvStartLine));
-                    String subName = applyAnonNameOverride(callerSubNameForCode(activeCode));
-                    if (subName == null || subName.isEmpty()) {
-                        subName = pkg + "::__ANON__";
-                    }
-                    res.add(subName != null && !subName.isEmpty()
-                            ? new RuntimeScalar(subName)
-                            : RuntimeScalarCache.scalarUndef);
+                    res.add(new RuntimeScalar(activeSubName));
                     Boolean hasArgsFromStack = getHasArgsAt(originalFrame);
                     res.add(hasArgsFromStack != null && hasArgsFromStack
                             ? RuntimeScalarCache.scalarTrue
@@ -3395,6 +3394,15 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         }
         String pkg = normalizeCallerPackage(code.packageName);
         return pkg + "::" + code.subName;
+    }
+
+    private static boolean hasExplicitlyRenamedActiveCode() {
+        for (RuntimeCode active : activeCodeStack.get()) {
+            if (active.explicitlyRenamed) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String applyAnonNameOverride(String subName) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -3325,7 +3325,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             }
         } else if (frame >= stackTraceSize) {
             RuntimeCode activeCode = hasExplicitExpr ? getActiveCodeAt(originalFrame) : null;
-            if (activeCode != null && activeCode.explicitlyRenamed) {
+            if (activeCode != null && !calledFromDB) {
                 String pkg = normalizeCallerPackage(activeCode.packageName);
                 if (ctx == RuntimeContextType.SCALAR) {
                     res.add(new RuntimeScalar(pkg));
@@ -3334,6 +3334,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     res.add(new RuntimeScalar(activeCode.cvStartFile != null ? activeCode.cvStartFile : ""));
                     res.add(new RuntimeScalar(activeCode.cvStartLine));
                     String subName = applyAnonNameOverride(callerSubNameForCode(activeCode));
+                    if (subName == null || subName.isEmpty()) {
+                        subName = pkg + "::__ANON__";
+                    }
                     res.add(subName != null && !subName.isEmpty()
                             ? new RuntimeScalar(subName)
                             : RuntimeScalarCache.scalarUndef);

--- a/src/main/perl/lib/CPAN/Config.pm
+++ b/src/main/perl/lib/CPAN/Config.pm
@@ -70,6 +70,7 @@ sub _bootstrap_prefs {
         'Test-File-ShareDir.yml'     => 'PerlOnJava/CpanDistroprefs/Test-File-ShareDir.yml',
         'DateTime-Locale.yml'        => 'PerlOnJava/CpanDistroprefs/DateTime-Locale.yml',
         'Test-File.yml'              => 'PerlOnJava/CpanDistroprefs/Test-File.yml',
+        'Test-SharedFork.yml'        => 'PerlOnJava/CpanDistroprefs/Test-SharedFork.yml',
         'UNIVERSAL-can.yml'          => 'PerlOnJava/CpanDistroprefs/UNIVERSAL-can.yml',
         'UNIVERSAL-isa.yml'          => 'PerlOnJava/CpanDistroprefs/UNIVERSAL-isa.yml',
         'Test-MockObject.yml'        => 'PerlOnJava/CpanDistroprefs/Test-MockObject.yml',

--- a/src/main/perl/lib/PerlOnJava/CpanDistroprefs/Test-SharedFork.yml
+++ b/src/main/perl/lib/PerlOnJava/CpanDistroprefs/Test-SharedFork.yml
@@ -1,0 +1,14 @@
+---
+comment: |
+  PerlOnJava distroprefs for Test::SharedFork.
+
+  PerlOnJava does not implement fork, and Test::SharedFork's own test suite
+  intentionally exercises fork coordination. Some downstream pure-Perl
+  distributions, such as Module::Build::Pluggable, load Test::SharedFork as a
+  test harness helper while their useful behavior remains independently covered
+  by their own tests. Build the module but skip its fork-only upstream tests so
+  CPAN can stage it for those downstream test phases.
+match:
+  distribution: "^EXODIST/Test-SharedFork-"
+test:
+  commandline: "PERLONJAVA_SKIP"

--- a/src/test/resources/unit/caller_line_number.t
+++ b/src/test/resources/unit/caller_line_number.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
-use Test::More tests => 13;
+use Test::More tests => 14;
 use Eval::Closure qw(eval_closure);
 use Sub::Util qw(set_subname);
 
@@ -137,5 +137,29 @@ is( $renamed_eval_closure->(),
 is( CallerLineNumber::GeneratedAccessor::generated(),
     'CallerLineNumber::GeneratedAccessor::generated',
     'caller(1)[3] uses explicit set_subname for generated accessors' );
+
+{
+    package CallerLineNumber::TiedHash;
+    require Tie::Hash;
+    our @ISA = qw(Tie::StdHash);
+    sub FETCH {
+        main::is('x', 'x', 'Test::More context survives set_subname accessor tied FETCH');
+        return 42;
+    }
+
+    package CallerLineNumber::SetSubnameAccessor;
+    sub new {
+        my %store;
+        tie %store, 'CallerLineNumber::TiedHash';
+        return bless \%store, shift;
+    }
+
+    my $accessor = sub { return $_[0]{value} };
+    Sub::Util::set_subname('CallerLineNumber::SetSubnameAccessor::value', $accessor);
+    no strict 'refs';
+    *{'CallerLineNumber::SetSubnameAccessor::value'} = $accessor;
+}
+
+my $tied_fetch_value = CallerLineNumber::SetSubnameAccessor->new->value();
 
 # End of tests


### PR DESCRIPTION
## Summary

- Fix `caller` stack reporting for generated accessors when a tied hash callback runs after the Java stack frame has disappeared.
- Add a regression covering `Sub::Util::set_subname` accessors with tied hash `FETCH` and `Test::More` context depth.
- Add a PerlOnJava distropref for `Test::SharedFork` so downstream pure-Perl tests can stage it while skipping its fork-only upstream tests.

## Verification

- `prove src/test/resources/unit/caller_line_number.t`
- `timeout 1200 make`
- Full CPAN retest with `timeout 900 ./jcpan -t ...` for:
  - `IO::Scalar`
  - `ExtUtils::CBuilder`
  - `Test::Differences`
  - `Test::Most`
  - `DateTime::Calendar::TauStation`
  - `DateTime::Format::RFC3501`
  - `LWP::Protocol::https`
  - `HTTP::Cookies`
  - `Class::Accessor::Fast`
  - `Module::Build::Pluggable`

Final CPAN summary: `/tmp/cpan-regressions-final-summary.txt`
