### PR TITLE
Prepare bundled libraries for Perl 5.44

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 asm = "9.10.1"
-bouncycastle = "1.84"
+bouncycastle = "1.85"
 commons-compress = "1.28.0"
 commons-csv = "1.14.1"
 icu4j = "78.3"
-junit-jupiter = "6.1.1"
+junit-jupiter = "6.1.2"
 snakeyaml-engine = "3.0.1"
 sqlite-jdbc = "3.53.2.0"
 tomlj = "1.1.1"

--- a/pom.xml
+++ b/pom.xml
@@ -30,19 +30,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>6.1.1</version>
+            <version>6.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>6.1.1</version>
+            <version>6.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>6.1.1</version>
+            <version>6.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -78,12 +78,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.84</version>
+            <version>1.85</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.84</version>
+            <version>1.85</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/src/main/perl/lib/JSON/PP.pm
+++ b/src/main/perl/lib/JSON/PP.pm
@@ -15,7 +15,7 @@ use Carp ();
 use Scalar::Util qw(blessed reftype refaddr);
 #use Devel::Peek;
 
-our $VERSION = '4.16';
+our $VERSION = '4.18';
 
 our @EXPORT = qw(encode_json decode_json from_json to_json);
 
@@ -112,7 +112,7 @@ sub encode_json ($) { # encode
 }
 
 
-sub decode_json { # decode
+sub decode_json ($) { # decode
     ($JSON ||= __PACKAGE__->new->utf8)->decode(@_);
 }
 
@@ -329,50 +329,21 @@ sub allow_bigint {
 
 { # Convert
 
-    my $max_depth;
-    my $indent;
-    my $ascii;
-    my $latin1;
-    my $utf8;
-    my $space_before;
-    my $space_after;
-    my $canonical;
-    my $allow_blessed;
-    my $convert_blessed;
-
-    my $indent_length;
-    my $escape_slash;
-    my $bignum;
-    my $as_nonblessed;
-    my $allow_tags;
-
-    my $depth;
-    my $indent_count;
-    my $keysort;
-
-
     sub PP_encode_json {
         my $self = shift;
         my $obj  = shift;
 
-        $indent_count = 0;
-        $depth        = 0;
+        $self->{indent_count} = 0;
+        $self->{depth}        = 0;
 
         my $props = $self->{PROPS};
 
-        ($ascii, $latin1, $utf8, $indent, $canonical, $space_before, $space_after, $allow_blessed,
-            $convert_blessed, $escape_slash, $bignum, $as_nonblessed, $allow_tags)
-         = @{$props}[P_ASCII .. P_SPACE_AFTER, P_ALLOW_BLESSED, P_CONVERT_BLESSED,
-                    P_ESCAPE_SLASH, P_ALLOW_BIGNUM, P_AS_NONBLESSED, P_ALLOW_TAGS];
-
-        ($max_depth, $indent_length) = @{$self}{qw/max_depth indent_length/};
-
-        $keysort = $canonical ? sub { $a cmp $b } : undef;
+        $self->{keysort} = $self->{PROPS}[P_CANONICAL] ? sub { $a cmp $b } : undef;
 
         if ($self->{sort_by}) {
-            $keysort = ref($self->{sort_by}) eq 'CODE' ? $self->{sort_by}
-                     : $self->{sort_by} =~ /\D+/       ? $self->{sort_by}
-                     : sub { $a cmp $b };
+            $self->{keysort} = ref($self->{sort_by}) eq 'CODE' ? $self->{sort_by}
+                             : $self->{sort_by} =~ /\D+/       ? $self->{sort_by}
+                             : sub { $a cmp $b };
         }
 
         encode_error("hash- or arrayref expected (not a simple scalar, use allow_nonref to allow this)")
@@ -380,7 +351,7 @@ sub allow_bigint {
 
         my $str  = $self->object_to_json($obj);
 
-        $str .= "\n" if ( $indent ); # JSON::XS 2.26 compatible
+        $str .= "\n" if ( $self->{PROPS}[P_INDENT] ); # JSON::XS 2.26 compatible
 
         return $str;
     }
@@ -401,7 +372,7 @@ sub allow_bigint {
 
                 return $self->value_to_json($obj) if ( $obj->isa('JSON::PP::Boolean') );
 
-                if ( $allow_tags and $obj->can('FREEZE') ) {
+                if ( $self->{PROPS}[P_ALLOW_TAGS] and $obj->can('FREEZE') ) {
                     my $obj_class = ref $obj || $obj;
                     $obj = bless $obj, $obj_class;
                     my @results = $obj->FREEZE('JSON');
@@ -416,7 +387,7 @@ sub allow_bigint {
                     return '("'.$obj_class.'")['.join(',', @results).']';
                 }
 
-                if ( $convert_blessed and $obj->can('TO_JSON') ) {
+                if ( $self->{PROPS}[P_CONVERT_BLESSED] and $obj->can('TO_JSON') ) {
                     my $result = $obj->TO_JSON();
                     if ( defined $result and ref( $result ) ) {
                         if ( refaddr( $obj ) eq refaddr( $result ) ) {
@@ -430,10 +401,10 @@ sub allow_bigint {
                     return $self->object_to_json( $result );
                 }
 
-                return "$obj" if ( $bignum and _is_bignum($obj) );
+                return "$obj" if ( $self->{PROPS}[P_ALLOW_BIGNUM] and _is_bignum($obj) );
 
-                if ($allow_blessed) {
-                    return $self->blessed_to_json($obj) if ($as_nonblessed); # will be removed.
+                if ($self->{PROPS}[P_ALLOW_BLESSED]) {
+                    return $self->blessed_to_json($obj) if ($self->{PROPS}[P_AS_NONBLESSED]); # will be removed.
                     return 'null';
                 }
                 encode_error( sprintf("encountered object '%s', but neither allow_blessed, convert_blessed nor allow_tags settings are enabled (or TO_JSON/FREEZE method missing)", $obj)
@@ -454,19 +425,19 @@ sub allow_bigint {
         my @res;
 
         encode_error("json text or perl structure exceeds maximum nesting level (max_depth set too low?)")
-                                         if (++$depth > $max_depth);
+                                         if (++$self->{depth} > $self->{max_depth});
 
-        my ($pre, $post) = $indent ? $self->_up_indent() : ('', '');
-        my $del = ($space_before ? ' ' : '') . ':' . ($space_after ? ' ' : '');
+        my ($pre, $post) = $self->{PROPS}[P_INDENT] ? $self->_up_indent() : ('', '');
+        my $del = ($self->{PROPS}[P_SPACE_BEFORE] ? ' ' : '') . ':' . ($self->{PROPS}[P_SPACE_AFTER] ? ' ' : '');
 
-        for my $k ( _sort( $obj ) ) {
+        for my $k ( $self->__sort( $obj ) ) {
             push @res, $self->string_to_json( $k )
                           .  $del
                           . ( ref $obj->{$k} ? $self->object_to_json( $obj->{$k} ) : $self->value_to_json( $obj->{$k} ) );
         }
 
-        --$depth;
-        $self->_down_indent() if ($indent);
+        --$self->{depth};
+        $self->_down_indent() if ($self->{PROPS}[P_INDENT]);
 
         return '{}' unless @res;
         return '{' . $pre . join( ",$pre", @res ) . $post . '}';
@@ -478,19 +449,20 @@ sub allow_bigint {
         my @res;
 
         encode_error("json text or perl structure exceeds maximum nesting level (max_depth set too low?)")
-                                         if (++$depth > $max_depth);
+                                         if (++$self->{depth} > $self->{max_depth});
 
-        my ($pre, $post) = $indent ? $self->_up_indent() : ('', '');
+        my ($pre, $post) = $self->{PROPS}[P_INDENT] ? $self->_up_indent() : ('', '');
 
         for my $v (@$obj){
             push @res, ref($v) ? $self->object_to_json($v) : $self->value_to_json($v);
         }
 
-        --$depth;
-        $self->_down_indent() if ($indent);
+        --$self->{depth};
+        $self->_down_indent() if ($self->{PROPS}[P_INDENT]);
 
         return '[]' unless @res;
-        return '[' . $pre . join( ",$pre", @res ) . $post . ']';
+        my $space = $pre eq '' && $self->{PROPS}[P_SPACE_AFTER] ? ' ' : '';
+        return '[' . $pre . join( ",$space$pre", @res ) . $post . ']';
     }
 
     sub _looks_like_number {
@@ -579,20 +551,20 @@ sub allow_bigint {
         my ($self, $arg) = @_;
 
         $arg =~ s/(["\\\n\r\t\f\b])/$esc{$1}/g;
-        $arg =~ s/\//\\\//g if ($escape_slash);
+        $arg =~ s/\//\\\//g if ($self->{PROPS}[P_ESCAPE_SLASH]);
 
         # On ASCII platforms, matches [\x00-\x08\x0b\x0e-\x1f]
         $arg =~ s/([^\n\t\c?[:^cntrl:][:^ascii:]])/'\\u00' . unpack('H2', $1)/eg;
 
-        if ($ascii) {
+        if ($self->{PROPS}[P_ASCII]) {
             $arg = _encode_ascii($arg);
         }
 
-        if ($latin1) {
+        if ($self->{PROPS}[P_LATIN1]) {
             $arg = _encode_latin1($arg);
         }
 
-        if ($utf8) {
+        if ($self->{PROPS}[P_UTF8]) {
             utf8::encode($arg);
         }
 
@@ -620,36 +592,30 @@ sub allow_bigint {
     }
 
 
-    sub _sort {
+    sub __sort {
+        my $self = shift;
+        my $keysort = $self->{keysort};
         defined $keysort ? (sort $keysort (keys %{$_[0]})) : keys %{$_[0]};
     }
 
 
     sub _up_indent {
         my $self  = shift;
-        my $space = ' ' x $indent_length;
+        my $space = ' ' x $self->{indent_length};
 
         my ($pre,$post) = ('','');
 
-        $post = "\n" . $space x $indent_count;
+        $post = "\n" . $space x $self->{indent_count};
 
-        $indent_count++;
+        $self->{indent_count}++;
 
-        $pre = "\n" . $space x $indent_count;
+        $pre = "\n" . $space x $self->{indent_count};
 
         return ($pre,$post);
     }
 
 
-    sub _down_indent { $indent_count--; }
-
-
-    sub PP_encode_box {
-        {
-            depth        => $depth,
-            indent_count => $indent_count,
-        };
-    }
+    sub _down_indent { $_[0]->{indent_count}--; }
 
 } # Convert
 
@@ -724,34 +690,6 @@ BEGIN {
         '/'  => '/',
     );
 
-    my $text; # json data
-    my $at;   # offset
-    my $ch;   # first character
-    my $len;  # text length (changed according to UTF8 or NON UTF8)
-    # INTERNAL
-    my $depth;          # nest counter
-    my $encoding;       # json text encoding
-    my $is_valid_utf8;  # temp variable
-    my $utf8_len;       # utf8 byte length
-    # FLAGS
-    my $utf8;           # must be utf8
-    my $max_depth;      # max nest number of objects and arrays
-    my $max_size;
-    my $relaxed;
-    my $cb_object;
-    my $cb_sk_object;
-
-    my $F_HOOK;
-
-    my $allow_bignum;   # using Math::BigInt/BigFloat
-    my $singlequote;    # loosely quoting
-    my $loose;          # 
-    my $allow_barekey;  # bareKey
-    my $allow_tags;
-
-    my $alt_true;
-    my $alt_false;
-
     sub _detect_utf_encoding {
         my $text = shift;
         my @octets = unpack('C4', $text);
@@ -765,25 +703,18 @@ BEGIN {
     }
 
     sub PP_decode_json {
-        my ($self, $want_offset);
+        my ($self, $text, $want_offset) = @_;
 
-        ($self, $text, $want_offset) = @_;
-
-        ($at, $ch, $depth) = (0, '', 0);
+        @$self{qw/at ch depth/} = (0, '', 0);
 
         if ( !defined $text or ref $text ) {
-            decode_error("malformed JSON string, neither array, object, number, string or atom");
+            $self->_decode_error("malformed JSON string, neither array, object, number, string or atom");
         }
 
         my $props = $self->{PROPS};
 
-        ($utf8, $relaxed, $loose, $allow_bignum, $allow_barekey, $singlequote, $allow_tags)
-            = @{$props}[P_UTF8, P_RELAXED, P_LOOSE .. P_ALLOW_SINGLEQUOTE, P_ALLOW_TAGS];
-
-        ($alt_true, $alt_false) = @$self{qw/true false/};
-
-        if ( $utf8 ) {
-            $encoding = _detect_utf_encoding($text);
+        if ( $self->{PROPS}[P_UTF8] ) {
+            my $encoding = _detect_utf_encoding($text);
             if ($encoding ne 'UTF-8' and $encoding ne 'unknown') {
                 require Encode;
                 Encode::from_to($text, $encoding, 'utf-8');
@@ -795,81 +726,84 @@ BEGIN {
             utf8::encode( $text );
         }
 
-        $len = length $text;
+        $self->{len}  = length $text;
+        $self->{text} = $text;
 
-        ($max_depth, $max_size, $cb_object, $cb_sk_object, $F_HOOK)
-             = @{$self}{qw/max_depth  max_size cb_object cb_sk_object F_HOOK/};
-
-        if ($max_size > 1) {
+        if ($self->{max_size} > 1) {
             use bytes;
             my $bytes = length $text;
-            decode_error(
+            $self->_decode_error(
                 sprintf("attempted decode of JSON text of %s bytes size, but max_size is set to %s"
-                    , $bytes, $max_size), 1
-            ) if ($bytes > $max_size);
+                    , $bytes, $self->{max_size}), 1
+            ) if ($bytes > $self->{max_size});
         }
 
-        white(); # remove head white space
+        $self->_white(); # remove head white space
 
-        decode_error("malformed JSON string, neither array, object, number, string or atom") unless defined $ch; # Is there a first character for JSON structure?
+        $self->_decode_error("malformed JSON string, neither array, object, number, string or atom") unless defined $self->{ch}; # Is there a first character for JSON structure?
 
-        my $result = value();
+        my $result = $self->_value();
 
         if ( !$props->[ P_ALLOW_NONREF ] and !ref $result ) {
-                decode_error(
+                $self->_decode_error(
                 'JSON text must be an object or array (but found number, string, true, false or null,'
                        . ' use allow_nonref to allow this)', 1);
         }
 
-        Carp::croak('something wrong.') if $len < $at; # we won't arrive here.
+        Carp::croak('something wrong.') if $self->{len} < $self->{at}; # we won't arrive here.
 
-        my $consumed = defined $ch ? $at - 1 : $at; # consumed JSON text length
+        my $consumed = defined $self->{ch} ? $self->{at} - 1 : $self->{at}; # consumed JSON text length
 
-        white(); # remove tail white space
+        $self->_white(); # remove tail white space
 
         return ( $result, $consumed ) if $want_offset; # all right if decode_prefix
 
-        decode_error("garbage after JSON object") if defined $ch;
+        $self->_decode_error("garbage after JSON object") if defined $self->{ch};
 
         $result;
     }
 
 
-    sub next_chr {
-        return $ch = undef if($at >= $len);
-        $ch = substr($text, $at++, 1);
+    sub _next_chr {
+        my $self = shift;
+        return $self->{ch} = undef if($self->{at} >= $self->{len});
+        $self->{ch} = substr($self->{text}, $self->{at}++, 1);
     }
 
 
-    sub value {
-        white();
+    sub _value {
+        my $self = shift;
+        $self->_white();
+        my $ch = $self->{ch};
         return          if(!defined $ch);
-        return object() if($ch eq '{');
-        return array()  if($ch eq '[');
-        return tag()    if($ch eq '(');
-        return string() if($ch eq '"' or ($singlequote and $ch eq "'"));
-        return number() if($ch =~ /[0-9]/ or $ch eq '-');
-        return word();
+        return $self->_object() if($ch eq '{');
+        return $self->_array()  if($ch eq '[');
+        return $self->_tag()    if($ch eq '(');
+        return $self->_string() if($ch eq '"' or ($self->{PROPS}[P_ALLOW_SINGLEQUOTE] and $ch eq "'"));
+        return $self->_number() if($ch =~ /[0-9]/ or $ch eq '-');
+        return $self->_word();
     }
 
-    sub string {
+    sub _string {
+        my $self = shift;
         my $utf16;
         my $is_utf8;
 
-        ($is_valid_utf8, $utf8_len) = ('', 0);
+        my $utf8_len = 0;
 
         my $s = ''; # basically UTF8 flag on
 
-        if($ch eq '"' or ($singlequote and $ch eq "'")){
+        my $ch = $self->{ch};
+        if($ch eq '"' or ($self->{PROPS}[P_ALLOW_SINGLEQUOTE] and $ch eq "'")){
             my $boundChar = $ch;
 
-            OUTER: while( defined(next_chr()) ){
+            OUTER: while( defined($ch = $self->_next_chr()) ){
 
                 if($ch eq $boundChar){
-                    next_chr();
+                    $self->_next_chr();
 
                     if ($utf16) {
-                        decode_error("missing low surrogate character in surrogate pair");
+                        $self->_decode_error("missing low surrogate character in surrogate pair");
                     }
 
                     utf8::decode($s) if($is_utf8);
@@ -877,7 +811,7 @@ BEGIN {
                     return $s;
                 }
                 elsif($ch eq '\\'){
-                    next_chr();
+                    $ch = $self->_next_chr();
                     if(exists $escapes{$ch}){
                         $s .= $escapes{$ch};
                     }
@@ -885,7 +819,7 @@ BEGIN {
                         my $u = '';
 
                         for(1..4){
-                            $ch = next_chr();
+                            $ch = $self->_next_chr();
                             last OUTER if($ch !~ /[0-9a-fA-F]/);
                             $u .= $ch;
                         }
@@ -897,7 +831,7 @@ BEGIN {
                         # U+DC00 - U+DFFF
                         elsif ($u =~ /^[dD][c-fC-F][0-9a-fA-F]{2}/) { # UTF-16 low surrogate?
                             unless (defined $utf16) {
-                                decode_error("missing high surrogate character in surrogate pair");
+                                $self->_decode_error("missing high surrogate character in surrogate pair");
                             }
                             $is_utf8 = 1;
                             $s .= _decode_surrogates($utf16, $u) || next;
@@ -905,7 +839,7 @@ BEGIN {
                         }
                         else {
                             if (defined $utf16) {
-                                decode_error("surrogate pair expected");
+                                $self->_decode_error("surrogate pair expected");
                             }
 
                             my $hex = hex( $u );
@@ -920,9 +854,9 @@ BEGIN {
 
                     }
                     else{
-                        unless ($loose) {
-                            $at -= 2;
-                            decode_error('illegal backslash escape sequence in string');
+                        unless ($self->{PROPS}[P_LOOSE]) {
+                            $self->{at} -= 2;
+                            $self->_decode_error('illegal backslash escape sequence in string');
                         }
                         $s .= $ch;
                     }
@@ -930,22 +864,22 @@ BEGIN {
                 else{
 
                     if ( $ch =~ /[[:^ascii:]]/ ) {
-                        unless( $ch = is_valid_utf8($ch) ) {
-                            $at -= 1;
-                            decode_error("malformed UTF-8 character in JSON string");
+                        unless( $ch = $self->_is_valid_utf8($ch, \$utf8_len) ) {
+                            $self->{at} -= 1;
+                            $self->_decode_error("malformed UTF-8 character in JSON string");
                         }
                         else {
-                            $at += $utf8_len - 1;
+                            $self->{at} += $utf8_len - 1;
                         }
 
                         $is_utf8 = 1;
                     }
 
-                    if (!$loose) {
+                    if (!$self->{PROPS}[P_LOOSE]) {
                         if ($ch =~ $invalid_char_re)  { # '/' ok
-                            if (!$relaxed or $ch ne "\t") {
-                                $at--;
-                                decode_error(sprintf "invalid character 0x%X"
+                            if (!$self->{PROPS}[P_RELAXED] or $ch ne "\t") {
+                                $self->{at}--;
+                                $self->_decode_error(sprintf "invalid character 0x%X"
                                    . " encountered while parsing JSON string",
                                    ord $ch);
                             }
@@ -957,51 +891,53 @@ BEGIN {
             }
         }
 
-        decode_error("unexpected end of string while parsing JSON string");
+        $self->_decode_error("unexpected end of string while parsing JSON string");
     }
 
 
-    sub white {
+    sub _white {
+        my $self = shift;
+        my $ch = $self->{ch};
         while( defined $ch  ){
             if($ch eq '' or $ch =~ /\A[ \t\r\n]\z/){
-                next_chr();
+                $ch = $self->_next_chr();
             }
-            elsif($relaxed and $ch eq '/'){
-                next_chr();
+            elsif($self->{PROPS}[P_RELAXED] and $ch eq '/'){
+                $ch = $self->_next_chr();
                 if(defined $ch and $ch eq '/'){
-                    1 while(defined(next_chr()) and $ch ne "\n" and $ch ne "\r");
+                    1 while(defined($ch = $self->_next_chr()) and $ch ne "\n" and $ch ne "\r");
                 }
                 elsif(defined $ch and $ch eq '*'){
-                    next_chr();
+                    $ch = $self->_next_chr();
                     while(1){
                         if(defined $ch){
                             if($ch eq '*'){
-                                if(defined(next_chr()) and $ch eq '/'){
-                                    next_chr();
+                                if(defined($ch = $self->_next_chr()) and $ch eq '/'){
+                                    $ch = $self->_next_chr();
                                     last;
                                 }
                             }
                             else{
-                                next_chr();
+                                $ch = $self->_next_chr();
                             }
                         }
                         else{
-                            decode_error("Unterminated comment");
+                            $self->_decode_error("Unterminated comment");
                         }
                     }
                     next;
                 }
                 else{
-                    $at--;
-                    decode_error("malformed JSON string, neither array, object, number, string or atom");
+                    $self->{at}--;
+                    $self->_decode_error("malformed JSON string, neither array, object, number, string or atom");
                 }
             }
             else{
-                if ($relaxed and $ch eq '#') { # correctly?
-                    pos($text) = $at;
-                    $text =~ /\G([^\n]*(?:\r\n|\r|\n|$))/g;
-                    $at = pos($text);
-                    next_chr;
+                if ($self->{PROPS}[P_RELAXED] and $ch eq '#') { # correctly?
+                    pos($self->{text}) = $self->{at};
+                    $self->{text} =~ /\G([^\n]*(?:\r\n|\r|\n|$))/g;
+                    $self->{at} = pos($self->{text});
+                    $ch = $self->_next_chr;
                     next;
                 }
 
@@ -1011,33 +947,36 @@ BEGIN {
     }
 
 
-    sub array {
+    sub _array {
+        my $self = shift;
         my $a  = $_[0] || []; # you can use this code to use another array ref object.
 
-        decode_error('json text or perl structure exceeds maximum nesting level (max_depth set too low?)')
-                                                    if (++$depth > $max_depth);
+        $self->_decode_error('json text or perl structure exceeds maximum nesting level (max_depth set too low?)')
+                                                    if (++$self->{depth} > $self->{max_depth});
 
-        next_chr();
-        white();
+        $self->_next_chr();
+        $self->_white();
 
+        my $ch = $self->{ch};
         if(defined $ch and $ch eq ']'){
-            --$depth;
-            next_chr();
+            --$self->{depth};
+            $self->_next_chr();
             return $a;
         }
         else {
             while(defined($ch)){
-                push @$a, value();
+                push @$a, $self->_value();
 
-                white();
+                $self->_white();
 
+                $ch = $self->{ch};
                 if (!defined $ch) {
                     last;
                 }
 
                 if($ch eq ']'){
-                    --$depth;
-                    next_chr();
+                    --$self->{depth};
+                    $self->_next_chr();
                     return $a;
                 }
 
@@ -1045,90 +984,97 @@ BEGIN {
                     last;
                 }
 
-                next_chr();
-                white();
+                $self->_next_chr();
+                $self->_white();
 
-                if ($relaxed and $ch eq ']') {
-                    --$depth;
-                    next_chr();
+                $ch = $self->{ch};
+                if ($self->{PROPS}[P_RELAXED] and $ch eq ']') {
+                    --$self->{depth};
+                    $self->_next_chr();
                     return $a;
                 }
 
             }
         }
 
-        $at-- if defined $ch and $ch ne '';
-        decode_error(", or ] expected while parsing array");
+        $self->{at}-- if defined $ch and $ch ne '';
+        $self->_decode_error(", or ] expected while parsing array");
     }
 
-    sub tag {
-        decode_error('malformed JSON string, neither array, object, number, string or atom') unless $allow_tags;
+    sub _tag {
+        my $self = shift;
+        $self->_decode_error('malformed JSON string, neither array, object, number, string or atom') unless $self->{PROPS}[P_ALLOW_TAGS];
 
-        next_chr();
-        white();
+        $self->_next_chr();
+        $self->_white();
 
-        my $tag = value();
+        my $tag = $self->_value();
         return unless defined $tag;
-        decode_error('malformed JSON string, (tag) must be a string') if ref $tag;
+        $self->_decode_error('malformed JSON string, (tag) must be a string') if ref $tag;
 
-        white();
+        $self->_white();
 
+        my $ch = $self->{ch};
         if (!defined $ch or $ch ne ')') {
-            decode_error(') expected after tag');
+            $self->_decode_error(') expected after tag');
         }
 
-        next_chr();
-        white();
+        $self->_next_chr();
+        $self->_white();
 
-        my $val = value();
+        my $val = $self->_value();
         return unless defined $val;
-        decode_error('malformed JSON string, tag value must be an array') unless ref $val eq 'ARRAY';
+        $self->_decode_error('malformed JSON string, tag value must be an array') unless ref $val eq 'ARRAY';
 
         if (!eval { $tag->can('THAW') }) {
-             decode_error('cannot decode perl-object (package does not exist)') if $@;
-             decode_error('cannot decode perl-object (package does not have a THAW method)');
+             $self->_decode_error('cannot decode perl-object (package does not exist)') if $@;
+             $self->_decode_error('cannot decode perl-object (package does not have a THAW method)');
         }
         $tag->THAW('JSON', @$val);
     }
 
-    sub object {
+    sub _object {
+        my $self = shift;
         my $o = $_[0] || {}; # you can use this code to use another hash ref object.
         my $k;
 
-        decode_error('json text or perl structure exceeds maximum nesting level (max_depth set too low?)')
-                                                if (++$depth > $max_depth);
-        next_chr();
-        white();
+        $self->_decode_error('json text or perl structure exceeds maximum nesting level (max_depth set too low?)')
+                                                if (++$self->{depth} > $self->{max_depth});
+        $self->_next_chr();
+        $self->_white();
 
+        my $ch = $self->{ch};
         if(defined $ch and $ch eq '}'){
-            --$depth;
-            next_chr();
-            if ($F_HOOK) {
-                return _json_object_hook($o);
+            --$self->{depth};
+            $self->_next_chr();
+            if ($self->{F_HOOK}) {
+                return $self->__json_object_hook($o);
             }
             return $o;
         }
         else {
             while (defined $ch) {
-                $k = ($allow_barekey and $ch ne '"' and $ch ne "'") ? bareKey() : string();
-                white();
+                $k = ($self->{PROPS}[P_ALLOW_BAREKEY] and $ch ne '"' and $ch ne "'") ? $self->_bareKey() : $self->_string();
+                $self->_white();
 
+                $ch = $self->{ch};
                 if(!defined $ch or $ch ne ':'){
-                    $at--;
-                    decode_error("':' expected");
+                    $self->{at}--;
+                    $self->_decode_error("':' expected");
                 }
 
-                next_chr();
-                $o->{$k} = value();
-                white();
+                $self->_next_chr();
+                $o->{$k} = $self->_value();
+                $self->_white();
 
+                $ch = $self->{ch};
                 last if (!defined $ch);
 
                 if($ch eq '}'){
-                    --$depth;
-                    next_chr();
-                    if ($F_HOOK) {
-                        return _json_object_hook($o);
+                    --$self->{depth};
+                    $self->_next_chr();
+                    if ($self->{F_HOOK}) {
+                        return $self->__json_object_hook($o);
                     }
                     return $o;
                 }
@@ -1137,14 +1083,15 @@ BEGIN {
                     last;
                 }
 
-                next_chr();
-                white();
+                $self->_next_chr();
+                $self->_white();
 
-                if ($relaxed and $ch eq '}') {
-                    --$depth;
-                    next_chr();
-                    if ($F_HOOK) {
-                        return _json_object_hook($o);
+                $ch = $self->{ch};
+                if ($self->{PROPS}[P_RELAXED] and $ch eq '}') {
+                    --$self->{depth};
+                    $self->_next_chr();
+                    if ($self->{F_HOOK}) {
+                        return $self->__json_object_hook($o);
                     }
                     return $o;
                 }
@@ -1153,94 +1100,99 @@ BEGIN {
 
         }
 
-        $at-- if defined $ch and $ch ne '';
-        decode_error(", or } expected while parsing object/hash");
+        $self->{at}-- if defined $ch and $ch ne '';
+        $self->_decode_error(", or } expected while parsing object/hash");
     }
 
 
-    sub bareKey { # doesn't strictly follow Standard ECMA-262 3rd Edition
+    sub _bareKey { # doesn't strictly follow Standard ECMA-262 3rd Edition
+        my $self = shift;
         my $key;
+        my $ch = $self->{ch};
         while($ch =~ /[\$\w[:^ascii:]]/){
             $key .= $ch;
-            next_chr();
+            $ch = $self->_next_chr();
         }
         return $key;
     }
 
 
-    sub word {
-        my $word =  substr($text,$at-1,4);
+    sub _word {
+        my $self = shift;
+        my $word =  substr($self->{text},$self->{at}-1,4);
 
         if($word eq 'true'){
-            $at += 3;
-            next_chr;
-            return defined $alt_true ? $alt_true : $JSON::PP::true;
+            $self->{at} += 3;
+            $self->_next_chr;
+            return defined $self->{true} ? $self->{true} : $JSON::PP::true;
         }
         elsif($word eq 'null'){
-            $at += 3;
-            next_chr;
+            $self->{at} += 3;
+            $self->_next_chr;
             return undef;
         }
         elsif($word eq 'fals'){
-            $at += 3;
-            if(substr($text,$at,1) eq 'e'){
-                $at++;
-                next_chr;
-                return defined $alt_false ? $alt_false : $JSON::PP::false;
+            $self->{at} += 3;
+            if(substr($self->{text},$self->{at},1) eq 'e'){
+                $self->{at}++;
+                $self->_next_chr;
+                return defined $self->{false} ? $self->{false} : $JSON::PP::false;
             }
         }
 
-        $at--; # for decode_error report
+        $self->{at}--; # for decode_error report
 
-        decode_error("'null' expected")  if ($word =~ /^n/);
-        decode_error("'true' expected")  if ($word =~ /^t/);
-        decode_error("'false' expected") if ($word =~ /^f/);
-        decode_error("malformed JSON string, neither array, object, number, string or atom");
+        $self->_decode_error("'null' expected")  if ($word =~ /^n/);
+        $self->_decode_error("'true' expected")  if ($word =~ /^t/);
+        $self->_decode_error("'false' expected") if ($word =~ /^f/);
+        $self->_decode_error("malformed JSON string, neither array, object, number, string or atom");
     }
 
 
-    sub number {
+    sub _number {
+        my $self = shift;
         my $n    = '';
         my $v;
         my $is_dec;
         my $is_exp;
 
+        my $ch = $self->{ch};
         if($ch eq '-'){
             $n = '-';
-            next_chr;
+            $ch = $self->_next_chr;
             if (!defined $ch or $ch !~ /\d/) {
-                decode_error("malformed number (no digits after initial minus)");
+                $self->_decode_error("malformed number (no digits after initial minus)");
             }
         }
 
         # According to RFC4627, hex or oct digits are invalid.
         if($ch eq '0'){
-            my $peek = substr($text,$at,1);
+            my $peek = substr($self->{text},$self->{at},1);
             if($peek =~ /^[0-9a-dfA-DF]/){ # e may be valid (exponential)
-                decode_error("malformed number (leading zero must not be followed by another digit)");
+                $self->_decode_error("malformed number (leading zero must not be followed by another digit)");
             }
             $n .= $ch;
-            next_chr;
+            $ch = $self->_next_chr;
         }
 
         while(defined $ch and $ch =~ /\d/){
             $n .= $ch;
-            next_chr;
+            $ch = $self->_next_chr;
         }
 
         if(defined $ch and $ch eq '.'){
             $n .= '.';
             $is_dec = 1;
 
-            next_chr;
+            $ch = $self->_next_chr;
             if (!defined $ch or $ch !~ /\d/) {
-                decode_error("malformed number (no digits after decimal point)");
+                $self->_decode_error("malformed number (no digits after decimal point)");
             }
             else {
                 $n .= $ch;
             }
 
-            while(defined(next_chr) and $ch =~ /\d/){
+            while(defined($ch = $self->_next_chr) and $ch =~ /\d/){
                 $n .= $ch;
             }
         }
@@ -1248,13 +1200,13 @@ BEGIN {
         if(defined $ch and ($ch eq 'e' or $ch eq 'E')){
             $n .= $ch;
             $is_exp = 1;
-            next_chr;
+            $ch = $self->_next_chr;
 
             if(defined($ch) and ($ch eq '+' or $ch eq '-')){
                 $n .= $ch;
-                next_chr;
+                $ch = $self->_next_chr;
                 if (!defined $ch or $ch =~ /\D/) {
-                    decode_error("malformed number (no digits after exp sign)");
+                    $self->_decode_error("malformed number (no digits after exp sign)");
                 }
                 $n .= $ch;
             }
@@ -1262,10 +1214,10 @@ BEGIN {
                 $n .= $ch;
             }
             else {
-                decode_error("malformed number (no digits after exp sign)");
+                $self->_decode_error("malformed number (no digits after exp sign)");
             }
 
-            while(defined(next_chr) and $ch =~ /\d/){
+            while(defined($ch = $self->_next_chr) and $ch =~ /\d/){
                 $n .= $ch;
             }
 
@@ -1274,13 +1226,13 @@ BEGIN {
         $v .= $n;
 
         if ($is_dec or $is_exp) {
-            if ($allow_bignum) {
+            if ($self->{PROPS}[P_ALLOW_BIGNUM]) {
                 require Math::BigFloat;
                 return Math::BigFloat->new($v);
             }
         } else {
             if (length $v > $max_intsize) {
-                if ($allow_bignum) { # from Adam Sussman
+                if ($self->{PROPS}[P_ALLOW_BIGNUM]) { # from Adam Sussman
                     require Math::BigInt;
                     return Math::BigInt->new($v);
                 }
@@ -1302,13 +1254,14 @@ BEGIN {
     utf8::encode($max_unicode_length);
     $max_unicode_length = length $max_unicode_length;
 
-    sub is_valid_utf8 {
+    sub _is_valid_utf8 {
+        my ($self, $ch, $utf8_len_r) = @_;
 
         # Returns undef (setting $utf8_len to 0) unless the next bytes in $text
         # comprise a well-formed UTF-8 encoded character, in which case,
         # return those bytes, setting $utf8_len to their count.
 
-        my $start_point = substr($text, $at - 1);
+        my $start_point = substr($self->{text}, $self->{at} - 1);
 
         # Look no further than the maximum number of bytes in a single
         # character
@@ -1329,8 +1282,8 @@ BEGIN {
                 # and return those bytes.
                 $copy = substr($copy, 0, 1);
                 utf8::encode($copy);
-                $utf8_len = length $copy;
-                return substr($start_point, 0, $utf8_len);
+                $$utf8_len_r = length $copy;
+                return substr($start_point, 0, $$utf8_len_r);
             }
 
             # If it didn't work, it could be that there is a full legal character
@@ -1340,15 +1293,16 @@ BEGIN {
         }
 
         # Failed to find a legal UTF-8 character.
-        $utf8_len = 0;
+        $$utf8_len_r = 0;
         return;
     }
 
 
-    sub decode_error {
+    sub _decode_error {
+        my $self   = shift;
         my $error  = shift;
         my $no_rep = shift;
-        my $str    = defined $text ? substr($text, $at) : '';
+        my $str    = defined $self->{text} ? substr($self->{text}, $self->{at}) : '';
         my $mess   = '';
         my $type   = 'U*';
 
@@ -1374,18 +1328,19 @@ BEGIN {
         }
 
         Carp::croak (
-            $no_rep ? "$error" : "$error, at character offset $at (before \"$mess\")"
+            $no_rep ? "$error" : "$error, at character offset $self->{at} (before \"$mess\")"
         );
 
     }
 
 
-    sub _json_object_hook {
+    sub __json_object_hook {
+        my $self = shift;
         my $o    = $_[0];
         my @ks = keys %{$o};
 
-        if ( $cb_sk_object and @ks == 1 and exists $cb_sk_object->{ $ks[0] } and ref $cb_sk_object->{ $ks[0] } ) {
-            my @val = $cb_sk_object->{ $ks[0] }->( $o->{$ks[0]} );
+        if ( $self->{cb_sk_object} and @ks == 1 and exists $self->{cb_sk_object}{ $ks[0] } and ref $self->{cb_sk_object}{ $ks[0] } ) {
+            my @val = $self->{cb_sk_object}{ $ks[0] }->( $o->{$ks[0]} );
             if (@val == 0) {
                 return $o;
             }
@@ -1397,7 +1352,7 @@ BEGIN {
             }
         }
 
-        my @val = $cb_object->($o) if ($cb_object);
+        my @val = $self->{cb_object}->($o) if ($self->{cb_object});
         if (@val == 0) {
             return $o;
         }
@@ -1407,19 +1362,6 @@ BEGIN {
         else {
             Carp::croak("filter_json_object callbacks must not return more than one scalar");
         }
-    }
-
-
-    sub PP_decode_box {
-        {
-            text    => $text,
-            at      => $at,
-            ch      => $ch,
-            len     => $len,
-            depth   => $depth,
-            encoding      => $encoding,
-            is_valid_utf8 => $is_valid_utf8,
-        };
     }
 
 } # PARSE
@@ -1849,7 +1791,7 @@ and are also used to represent JSON C<true> and C<false> in Perl strings.
 On perl 5.36 and above, will also return true when given one of perl's
 standard boolean values, such as the result of a comparison.
 
-See L<MAPPING>, below, for more information on how JSON values are mapped to
+See L</MAPPING>, below, for more information on how JSON values are mapped to
 Perl.
 
 =head1 OBJECT-ORIENTED INTERFACE
@@ -2136,7 +2078,7 @@ This setting has currently no effect on tied hashes.
     
     $enabled = $json->get_allow_nonref
 
-Unlike other boolean options, this opotion is enabled by default beginning
+Unlike other boolean options, this option is enabled by default beginning
 with version C<4.0>.
 
 If C<$enable> is true (or missing), then the C<encode> method can convert a
@@ -2508,7 +2450,7 @@ objects into JSON numbers.
    print $json->encode($bigfloat);
    # => 2.000000000000000000000000001
 
-See also L<MAPPING>.
+See also L</MAPPING>.
 
 =head2 loose
 
@@ -2575,7 +2517,7 @@ then the argument will be passed to Perl's C<sort> built-in function.
 
 As the sorting is done in the JSON::PP scope, you usually need to
 prepend C<JSON::PP::> to the subroutine name, and the special variables
-C<$a> and C<$b> used in the subrontine used by C<sort> function.
+C<$a> and C<$b> used in the subroutine used by C<sort> function.
 
 Example:
 
@@ -2940,7 +2882,7 @@ argument being the object to serialise, and the second argument being the
 constant string C<JSON> to distinguish it from other serialisers.
 
 The C<FREEZE> method can return any number of values (i.e. zero or
-more). These values and the paclkage/classname of the object will then be
+more). These values and the package/classname of the object will then be
 encoded as a tagged JSON value in the following format:
 
    ("classname")[FREEZE return values...]

--- a/src/main/perl/lib/JSON/PP/Boolean.pm
+++ b/src/main/perl/lib/JSON/PP/Boolean.pm
@@ -11,7 +11,7 @@ overload::import('overload',
     fallback => 1,
 );
 
-our $VERSION = '4.16';
+our $VERSION = '4.18';
 
 1;
 

--- a/src/main/perl/lib/Pod/perl.pod
+++ b/src/main/perl/lib/Pod/perl.pod
@@ -182,6 +182,7 @@ aux h2ph h2xs perlbug pl2pm pod2html pod2man splain xsubpp
 
     perlhist            Perl history records
     perldelta           Perl changes since previous version
+    perl5440delta       Perl changes in version 5.44.0
     perl5422delta       Perl changes in version 5.42.2
     perl5421delta       Perl changes in version 5.42.1
     perl5420delta       Perl changes in version 5.42.0

--- a/src/main/perl/lib/Pod/perl5440delta.pod
+++ b/src/main/perl/lib/Pod/perl5440delta.pod
@@ -1,0 +1,1393 @@
+=encoding utf8
+
+=head1 NAME
+
+perl5440delta - what is new for perl v5.44.0
+
+=head1 DESCRIPTION
+
+This document describes differences between the 5.42.0 release and the 5.44.0
+release.
+
+=head1 Core Enhancements
+
+=head2 Named Parameters in Signatures
+
+This adds a major new ability to subroutine signatures, allowing callers
+to pass parameters by name/value pairs rather than by position.
+
+    sub f ($x, $y, :$alpha, :$beta = undef) { ... }
+
+    f( 123, 456, alpha => 789 );
+
+Originally specified in
+L<PPC0024|https://github.com/Perl/PPCs/blob/main/ppcs/ppc0024-signature-named-parameters.md>.
+
+This feature is currently considered B<experimental>, and is described in
+further detail in L<perlsub/Signatures>.
+
+=head2 Multi-variable C<foreach> can now use aliased references
+
+Perl version 5.22 introduced reference aliases, allowing a C<foreach> loop
+iteration variable to create new aliases to references. Perl version 5.36
+introduced C<foreach> loops with multiple variables, consuming more than one
+input list item on each iteration. New in this version, the two features may
+now be used together, allowing multiple iteration variables where any of them
+are permitted to be reference aliases.
+
+    use v5.44;
+    use feature qw( refaliasing declared_refs );
+
+    my %hash = (
+        one => [1],
+        two => [2, 2],
+    );
+
+    foreach my ( $key, \@items ) ( %hash ) {
+        say "The $key array contains: @items";
+    }
+
+Currently both the C<refaliasing> and C<declared_refs> features remain
+B<experimental>.
+
+=head2 Enhanced operation of regular expression patterns under /xx
+
+Experimentally, the C</xx> pattern modifier can allow bracketed
+character classes (I<e.g.>, C<[a-zA-Z]> to extend across multiple lines
+and to contain comments, and to warn you of potential cases where a
+portion of a pattern inadvertently has been treated as a comment instead
+of what you intended.  This behavior is enabled by S<C<use feature
+"enhanced_xx">>.  See L<perlre/E<sol>x and  E<sol>xx>.
+
+=head2 Unicode 17.0 is supported
+
+See L<https://www.unicode.org/versions/Unicode17.0.0/>.
+
+=head2 New source of entropy for PRNG seeding
+
+Perl now uses the C<getentropy()> system call to fetch random bytes suitable
+for seeding the internal PRNG. Previously Perl would read raw bytes from the
+F</dev/urandom> device. Perl now seeds itself in this order (and falls through
+upon failure):
+
+=over
+
+=item 1.
+
+C<getentropy()> on systems that support this call (Linux, BSD, MacOS)
+
+=item 2.
+
+F</dev/urandom> on systems that have it
+
+=item 3.
+
+Hash of internal state variables: Unix time, process ID, and pointer value
+
+=back
+
+Note that the internal PRNG is still unsuitable for security applications.
+See L<perlfunc/rand EXPR> for a discussion of security.
+
+=head1 Security
+
+=head2 CVE-2026-8376 - Buffer overflow in Perl_study_chunk
+
+Perl_study_chunk in regcomp_study.c checked the size of the joined substring
+buffer in characters rather than bytes. On 32-bit builds, this can lead to
+an integer overflow of the size of the buffer leading to out-of-bounds writes.
+
+=head2 CVE-2026-57432 - Buffer overflow in S_measure_struct
+
+If you call C<pack> or C<unpack> to operate on a structure whose computed size
+is too large to fit in memory, an integer overflow could happen that would
+result in a buffer overflow. This usually happens as a result of embedding a
+large number as the repeat count for an item.
+
+=head2 CVE-2026-13221 - Regex trie 16-bit field overflow
+
+The trie optimization in the regex engine could overflow in an alternation with more than ~65k branches. This could cause both false positives and false negatives on such regular expressions.
+
+=head1 Incompatible Changes
+
+=head2 Unicode rules are now fully enforced on identifier and regular expression group names.
+
+Before Unicode, Perl accepted any C<\w> character in an identifier or other
+name, except the first character couldn't be a digit.  Later, Unicode
+created two properties that described this.  Even later, they found
+those properties to be insufficient, and created two new similar
+properties.  These are the ones that perl has intended to use since:
+C<\p{XID_Start}> and C<\p{XID_Continue}>.  (The C<X> stands for
+"eXtended" and indicates these are the more modern versions.)
+
+(And even later, long after Perl identifier rules were formed using
+the above properties, Unicode added recommendations to further restrict
+legal identifier names.  These were added to counter cases where, for
+example, programmers snuck code past reviewers using characters that
+look like other ones.  The two properties are C<Identifier_Status> and
+C<Identifier_Type>.  See L<https://www.unicode.org/reports/tr39/>.  Perl
+currently doesn't do anything with these, except to furnish you the
+ability to use them in regular expressions.)
+
+We soon discovered that there were 14 characters that match C<XID_Start>
+and C<XID_Continue> that don't also match C<\w>.  To avoid breaking code
+that had long relied on C<\w>, we chose to not add those to the list of
+acceptable identifier characters.
+
+It turns out that there are about 160 characters that match C<\w> but
+not the Unicode C<XID> properties.  Thus they are illegal according to
+Unicode.  Those are now explicitly forbidden in both Perl identifiers
+and regular expression group names.  Previously, it was likely that
+their use in identifiers wouldn't work anyway; they could be accepted
+initially as legal, but other code would later reject them, but with a
+message that had nothing to do with the underlying problem.  However
+group names in regular expression patterns could contain illegal
+continuation characters and have a higher probability of not being
+caught.  That is now changed.
+
+Only programs that do L<C<use utf8>|utf8> can be affected, and then only
+characters that appear in the 2nd or later positions of the name.  The
+characters that an identifier name can begin with are unchanged.
+
+130 of the now unacceptable characters are 5 sets of 26 Latin letters
+that are enclosed by some shape, such as CIRCLED LATIN CAPITAL LETTER N.
+Another 8 are generic modifiers that add shapes around other characters;
+5 are modifiers to Cyrillic numbers; and 16 are Arabic ligatures and
+isolated forms.  The other two are GREEK YPOGEGRAMMENI and VERTICAL
+TILDE.
+
+=head1 Deprecations
+
+=over 4
+
+=item *
+
+Deprecated since 5.12, using C<goto> to jump into the body of a loop or
+other block construct from outside is no longer permitted.
+[L<GH #23618|https://github.com/Perl/perl5/issues/23618>]
+
+=item *
+
+C<m/...[...].../xx> has new restrictions
+
+Using an unescaped C<#> or literal vertical space is now deprecated in a
+regular expression bracketed character class that is compiled with the
+C</xx> modifier.  These still work, but deprecation warnings will be
+generated unless turned off or the constructs are cured as follows.
+
+=over
+
+=item *
+
+Escape a C<#> by preceding it with a backslash, like in
+
+ m/ [ % \# ( ) ] /xx
+
+=item *
+
+Use constructs like C<\n> instead of literal vertical space.
+
+=back
+
+=back
+
+=head1 Performance Enhancements
+
+=over 4
+
+=item *
+
+Simple (non-overflowing) addition (C<+>), subtraction (C<->) and
+multiplication (C<*>) of integers are slightly sped up, as long as
+sufficient underlying C compiler support is available.
+
+=item *
+
+Populating a hash from a list of key/value pairs when the keys are constant
+string operands known at compile time is commonly now faster. [L<GH #24228|https://github.com/Perl/perl5/issues/24228>]
+
+=item *
+
+Processing of signatures at the start of a subroutine under the C<signatures>
+feature is now more efficient at runtime.
+
+=back
+
+=head1 Modules and Pragmata
+
+=head2 Updated Modules and Pragmata
+
+=over 4
+
+=item *
+
+L<Archive::Tar> has been upgraded from version 3.04 to 3.12.
+
+This fixes CVE-2026-9538, CVE-2026-42496, and CVE-2026-42497.
+
+=item *
+
+L<attributes> has been upgraded from version 0.36 to 0.37.
+
+=item *
+
+L<B> has been upgraded from version 1.89 to 1.92.
+
+=item *
+
+L<B::Concise> has been upgraded from version 1.007 to 1.012.
+
+=item *
+
+L<B::Deparse> has been upgraded from version 1.85 to 1.89.
+
+=item *
+
+L<charnames> has been upgraded from version 1.50 to 1.51.
+
+=item *
+
+L<Compress::Raw::Bzip2> has been upgraded from version 2.213 to 2.218.
+
+=item *
+
+L<Compress::Raw::Zlib> has been upgraded from version 2.213 to 2.222.
+
+=item *
+
+L<Config::Perl::V> has been upgraded from version 0.38 to 0.39.
+
+=item *
+
+L<CPAN::Meta> has been upgraded from version 2.150010 to 2.150013.
+
+=item *
+
+L<CPAN::Meta::Requirements> has been upgraded from version 2.143 to 2.145.
+
+=item *
+
+L<DB_File> has been upgraded from version 1.859 to 1.860.
+
+=item *
+
+L<Encode> has been upgraded from version 3.21 to 3.24.
+
+=item *
+
+L<English> has been upgraded from version 1.11 to 1.12.
+
+=item *
+
+L<Errno> has been upgraded from version 1.38 to 1.39.
+
+=item *
+
+L<experimental> has been upgraded from version 0.035 to 0.036.
+
+=item *
+
+L<ExtUtils::CBuilder> has been upgraded from version 0.280242 to 0.280243.
+
+=item *
+
+L<ExtUtils::MakeMaker> has been upgraded from version 7.76 to 7.78.
+
+=item *
+
+L<ExtUtils::Miniperl> has been upgraded from version 1.14 to 1.15.
+
+=item *
+
+L<ExtUtils::ParseXS> has been upgraded from version 3.57 to 3.63.
+
+=item *
+
+L<ExtUtils::Typemaps> has been upgraded from version 3.57 to 3.63.
+
+=item *
+
+L<feature> has been upgraded from version 1.97 to 2.02.
+
+=item *
+
+L<File::Copy> has been upgraded from version 2.41 to 2.43.
+
+=item *
+
+L<File::Fetch> has been upgraded from version 1.04 to 1.08.
+
+=item *
+
+L<File::Glob> has been upgraded from version 1.42 to 1.44.
+
+=item *
+
+L<File::Spec> has been upgraded from version 3.94 to 3.95.
+
+=item *
+
+L<File::stat> has been upgraded from version 1.14 to 1.15.
+
+=item *
+
+L<File::Temp> has been upgraded from version 0.2311 to 0.2312.
+
+=item *
+
+L<Filter::Simple> has been upgraded from version 0.96 to 0.97.
+
+=item *
+
+L<Filter::Util::Call> has been upgraded from version 1.64 to 1.65.
+
+=item *
+
+L<Getopt::Std> has been upgraded from version 1.14 to 1.15.
+
+=item *
+
+L<HTTP::Tiny> has been upgraded from version 0.090 to 0.096.
+
+This fixes CVE-2026-7010 and CVE-2026-7017.
+
+=item *
+
+L<IO> has been upgraded from version 1.55 to 1.56.
+
+=item *
+
+L<IO::Compress> has been upgraded from version 2.213 to 2.223.
+
+This fixes CVE-2025-15649, CVE-2026-48961, CVE-2026-48962, and CVE-2026-48959.
+
+=item *
+
+L<IO::Socket::IP> has been upgraded from version 0.43 to 0.44.
+
+=item *
+
+L<Math::BigInt> has been upgraded from version 2.005002 to 2.005003.
+
+=item *
+
+L<Module::CoreList> has been upgraded from version 5.20250702 to 5.20260708.
+
+=item *
+
+L<Module::Metadata> has been upgraded from version 1.000038 to 1.000039.
+
+=item *
+
+L<mro> has been upgraded from version 1.29 to 1.30.
+
+=item *
+
+L<Net::Ping> has been upgraded from version 2.76 to 2.77.
+
+=item *
+
+L<Opcode> has been upgraded from version 1.69 to 1.71.
+
+=item *
+
+L<overloading> has been upgraded from version 0.02 to 0.03.
+
+=item *
+
+L<PerlIO::via> has been upgraded from version 0.19 to 0.21.
+
+=item *
+
+L<Pod::Html> has been upgraded from version 1.35 to 1.36.
+
+=item *
+
+L<Pod::Simple> has been upgraded from version 3.45 to 3.48.
+
+=item *
+
+L<POSIX> has been upgraded from version 2.23 to 2.26.
+
+=item *
+
+L<Scalar::Util> has been upgraded from version 1.68_01 to 1.70.
+
+=item *
+
+L<SelectSaver> has been upgraded from version 1.02 to 1.03.
+
+=item *
+
+L<SelfLoader> has been upgraded from version 1.28 to 1.29.
+
+=item *
+
+L<Socket> has been upgraded from version 2.038 to 2.041.
+
+This fixes CVE-2026-12087.
+
+=item *
+
+L<Storable> has been upgraded from version 3.37 to 3.41.
+
+This fixes CVE-2026-57433.
+
+=item *
+
+L<Term::Table> has been upgraded from version 0.024 to 0.028.
+
+=item *
+
+L<Test::Harness> has been upgraded from version 3.50 to 3.52.
+
+=item *
+
+L<Test::Simple> has been upgraded from version 1.302210 to 1.302219.
+
+=item *
+
+L<Text::Balanced> has been upgraded from version 2.06 to 2.07.
+
+=item *
+
+L<threads> has been upgraded from version 2.43 to 2.45.
+
+=item *
+
+L<threads::shared> has been upgraded from version 1.70 to 1.73.
+
+=item *
+
+L<Time::HiRes> has been upgraded from version 1.9778 to 1.9780.
+
+=item *
+
+L<Time::Piece> has been upgraded from version 1.36 to 1.41.
+
+=item *
+
+L<Unicode::UCD> has been upgraded from version 0.81 to 0.83.
+
+=item *
+
+L<UNIVERSAL> has been upgraded from version 1.17 to 1.18.
+
+=item *
+
+L<utf8> has been upgraded from version 1.27 to 1.29.
+
+=item *
+
+L<version> has been upgraded from version 0.9933 to 0.9934.
+
+=item *
+
+L<warnings> has been upgraded from version 1.74 to 1.78.
+
+=item *
+
+L<XS::APItest> has been upgraded from version 1.43 to 1.50.
+
+=item *
+
+L<XS::Typemap> has been upgraded from version 0.20 to 0.22.
+
+=back
+
+=head1 Documentation
+
+=head2 Changes to Existing Documentation
+
+We have attempted to update the documentation to reflect the changes
+listed in this document. If you find any we have missed, open an issue
+at L<https://github.com/Perl/perl5/issues>.
+
+Additionally, the following selected changes have been made:
+
+=head3 L<perlapi>
+
+=over 4
+
+=item *
+
+Auto-generation of this document now includes the line number of the source
+code, as well as its documentation.
+
+=item *
+
+It now contains information about how to find what release of
+Perl first contained an API element.
+
+=back
+
+=head3 L<perlexperiment>
+
+=over 4
+
+=item *
+
+New entry for "New object system and C<class> syntax".
+
+=back
+
+=head3 L<perlxs>
+
+=over 4
+
+=item *
+
+The reference manual for writing Perl XS code has been completely rewritten and
+modernized.  It is about twice the size of the old file, and promotes more
+modern XS syntax, such as ANSI signatures.
+
+=back
+
+=head1 Diagnostics
+
+The following additions or changes have been made to diagnostic output,
+including warnings and fatal error messages. For the complete list of
+diagnostic messages, see L<perldiag>.
+
+=head2 Changes to Existing Diagnostics
+
+=over 4
+
+=item *
+
+L<Use of uninitialized value%s|perldiag/"Use of uninitialized value%s">
+
+This warning was issued in the reverse order (right-to-left) when both
+operands of a binary operator are uninitialized values.  This is now
+fixed to be consistent with evaluation order of operands.
+
+=item *
+
+Certain diagnostics about byte sequences that are supposed to comprise a
+UTF-8 encoded character, but that are invalid in some way, now don't
+include bytes irrelevant to that determination.  An example is
+
+=over
+
+=item old message
+
+Malformed UTF-8 character: C<\xc1\x27> (any UTF-8 sequence that starts with
+C<\xc1> is overlong which can and should be represented with a different,
+shorter sequence)
+
+=item new message
+
+Malformed UTF-8 character: C<\xc1> (any UTF-8 sequence that starts with
+C<\xc1> is overlong which can and should be represented with a different,
+shorter sequence)
+
+=back
+
+In this case the C<\xc1> is all that is needed to make the sequence
+invalid.  Whatever comes after it is irrelevant (in this case, C<\x27>),
+and including it in the message might lead the reader to think that it
+somehow does matter.
+
+=item *
+
+The error C<Unrecognised parameters for "%s" constructor: %s> has been changed
+to C<Unrecognized parameters for "%s" constructor: %s>.
+
+=item *
+
+Variables whose name started with C<^_> were incorrectly shown in
+diagnostics with a literal C<Ctrl-_> (which is an invisible ASCII
+character) in their name.
+
+The names of variables whose names begin with a caret and are longer
+than two characters are now wrapped in braces, just as they have to be
+in the source code.
+
+Therefore, using an undefined C<${^_FOO}> will now correctly warn with
+C<Use of uninitialized value ${^_FOO}>, instead of the earlier C<Use of
+uninitialized value $FOO> (with a literal C<Ctrl-_> after the dollar
+sign).
+
+[L<GH #24135|https://github.com/Perl/perl5/issues/24135>]
+
+=item *
+
+Calling the C<import> method on a package with no C<import> method now
+produces a regular warning rather than a deprecation warning or error.
+
+Since Perl 5.39.1, calling C<import> with arguments on a package without
+such a method has triggered a deprecation warning. In Perl 5.43.6, this
+deprecation was promoted into an error. This broke a significant amount
+of code while providing very little advantage over the warning. This
+fatal error has been converted back to a warning, with its deprecation
+status removed. There are no longer any plans to make this fatal in the
+future. The category for this warning is C<missing_import> and it is
+enabled by default.
+
+=back
+
+=head2 New Diagnostics
+
+=head3 New Errors
+
+=over 4
+
+=item *
+
+L<Can't redeclare catch variable as "%s"|perldiag/"Can't redeclare catch variable as "%s"">
+
+(F) A C<my>, C<our> or C<state> keyword was used with the exception variable in
+a C<catch> block:
+
+    try { ... }
+    catch (my $e) { ... }
+    # or catch (our $e) { ... }
+    # or catch (state $e) { ... }
+
+This is not valid syntax. C<catch> takes a bare variable name, which is
+automatically lexically declared.
+[L<GH #23222|https://github.com/Perl/perl5/issues/23222>]
+
+=item *
+
+L<Use of "goto" to jump into a construct is no longer permitted|perldiag/"Use of "goto" to jump into a construct is no longer permitted">
+
+(F) You have used C<goto LABEL;> or C<goto EXPR;> in an attempt to jump into
+the body of a loop or other block construct from the outside.  As of Perl 5.44,
+this throws an exception.
+
+=item *
+
+L<\x{%X} is a \w char that isn't valid in a name "%s"
+|perldiag/\x{%X} is a \w char that isn't valid in a name "%s">
+
+In most cases where this message now appears, an error would have
+occurred anyway, but the text would not have been helpful in finding the
+problem.
+
+=back
+
+=head3 New Warnings
+
+=over 4
+
+=item *
+
+L<Possible attempt to escape whitespace in qw() list|perldiag/"Possible attempt to escape whitespace in qw() list">
+
+(W qw) qw() lists contain items separated by whitespace; contrary to
+what some might expect, backslash characters cannot be used to "protect"
+whitespace from being split, but are instead treated as literal data.
+
+Note that this warning is I<only> emitted when the backslash is followed
+by actual whitespace (that C<qw> splits on).
+
+=back
+
+=head1 Configuration and Compilation
+
+=over 4
+
+=item *
+
+C23 F<< <stdckdint.h> >> and associated macros are now used if available.
+
+=item *
+
+It is now possible to pass to F<Configure> the values dealing with POSIX
+locale categories, overriding its automatic calculation of these.  This
+enables cross-compilation to work.  The easiest way to do this is to
+extract the C program that does the calculation from F<Configure> and
+then run it on the target machine, and then pass the values it outputs
+to F<Configure> on the other machine.  F<Porting/Glossary> has examples.
+[L<GH #22992|https://github.com/Perl/perl5/issues/22992>]
+
+=item *
+
+The C<PERL_CREATE_GVSV> configuration macro has been removed. It was almost
+undocumented and it has been disabled by default since Perl 5.10.0. Its purpose
+was to force all GVs to initialize their SV slot on creation. [L<GH #24177|https://github.com/Perl/perl5/issues/24177>]
+
+=back
+
+=head1 Testing
+
+Tests were added and changed to reflect the other additions and
+changes in this release. Furthermore, these changes were
+made:
+
+=over 4
+
+=item *
+
+Karl Williamson gave a talk at TPRC 2025 asking people to contribute
+tests to find old issues that are no longer a problem, and todo tests
+to reflect reproduction cases for known outstanding bugs.
+(L<video link|https://www.youtube.com/watch?v=CwX4Xsf5y5E>)
+It gained renewed interest this year,
+leading to an uptick in test submissions from new authors,
+for which we are extremely grateful.
+
+=item *
+
+When testing embedding, add a sanity check to ensure the C<libperl> we
+link against matches the perl we are building.  [L<GH #22125|https://github.com/Perl/perl5/issues/22125>]
+
+=back
+
+=head1 Platform Support
+
+=head2 Platform-Specific Notes
+
+=over 4
+
+=item Windows
+
+=over
+
+=item * Fix builds with C<USE_IMP_SYS> defined but C<USE_ITHREADS> not
+defined.
+
+=back
+
+=item OpenBSD
+
+=over 4
+
+=item * When testing embedding, ensure we link against the correct static
+libperl. [L<GH #22125|https://github.com/Perl/perl5/issues/22125>]
+
+=back
+
+=item AIX
+
+=over
+
+=item * Thread-safe locale handling has been turned off on all releases due to
+apparent bugs in the underlying operating system support.
+
+=item * The ibm-clang/ibm-clang_r IBM Open XL C/C++ compiler is now supported for AIX
+7.2 and 7.3. This is the recommended compiler to use when compiling Perl on
+these versions of AIX.
+
+=back
+
+=item z/OS
+
+=over
+
+=item * clang is now the only supported compiler
+
+=item * A single test failure remains for the core Perl test suite
+
+It is for a misleading warning message in an edge case for reading
+malformed UTF-8 in F<XS-APItest/t/utf8_warn00.t>.  (Several instances of
+the same failure occur.)
+
+=item * Some cpan modules shipped with core have known problems:
+
+=over
+
+=item Encode
+
+=item ExtUtils-MakeMaker
+
+=item HTTP-Tiny
+
+=item IO-Compress
+
+=item JSON-PP
+
+=item libnet
+
+=item MIME-Base64
+
+=item PerlIO-via-QuotedPrint
+
+=item Pod-Checker
+
+=item podlators
+
+=item Pod-Simple
+
+=back
+
+Check for updates to these on cpan.
+
+=item * You can get a perl that works in ASCII mode
+
+An open source project has been created to modify the official perl to
+work on z/OS in ASCII mode.  See L<https://github.com/zopencommunity/perlport>.
+
+=back
+
+=back
+
+=head1 Internal Changes
+
+=over 4
+
+=item *
+
+The XS parser, L<ExtUtils::ParseXS>, has been further extensively restructured
+internally.  Most of these changes shouldn't be visible externally, but might
+affect XS code which was using invalid or unsupported syntax.  Several minor
+bug-fixes were included.
+
+=item *
+
+Removed the deprecated (since 5.32) functions C<sv_locking()> and
+C<sv_unlocking>.
+
+=item *
+
+C<Perl_expected_size> has been added as an experimental stub macro. The
+intention is to build on this such that it can be passed a size in bytes,
+then returns the interpreter's best informed guess of what actual usable
+allocation size would be returned by the malloc implementation in use.
+
+This would help with sizing allocations such that SvLEN is more accurate
+and not trying to shrink string buffers to save size when the intended
+saving is unrealistic.
+
+=item *
+
+C<SvPV_shrink_to_cur> has been revised to include a byte for copy-on-write
+(COW), so that the resulting string could be COWed in the future.
+
+It also now uses C<Perl_expected_size>, compared against the current
+buffer size, and does not try to do a reallocation if the requested
+memory saving is unrealistic.
+
+=item *
+
+C<sv_vcatpvfn_flags()> now substitutes the Unicode REPLACEMENT CHARACTER
+for malformed input.  Previously it used the NUL character.
+
+=item *
+
+For core Perl maintainers, the syntax of F<embed.fnc> has been extended.
+Every function, C<foo()>, named in that file has generated for it a
+macro named C<PERL_ARGS_ASSERT_FOO>.  The macro expands to C<assert()>
+calls that do basic sanity checking for each argument to C<foo()> that
+we currently deem as being appropriate to have such checking.  (That
+means that many arguments are not checked, and that the generated macro
+may currently expand to nothing.)  With this release, you can add
+C<assert()> statements yourself to F<embed.fnc> that will be
+incorporated into the generated macro, beyond the system-generated ones.
+Comments and examples in F<embed.fnc> give details.
+
+=item *
+
+A new function C<valid_utf8_to_uv> has been added.  This is synonymous
+with C<valid_utf8_to_uvchr>; its reason for existence is to have
+consistent spelling with the names of the other functions that translate
+from UTF-8, so you don't have to remember a different spelling.
+
+=item *
+
+L<perlapi/C<newSVsv_flags_NN>> is a new function for creating a new SV
+and assigning the value(s) of an existing SV to it.
+
+Historically, C<Perl_newSVsv_flags> and C<Perl_sv_mortalcopy_flags> would
+pass a new SV head and the original SV to C<Perl_sv_setsv_flags>. However,
+the latter contains many branches of no relevance to a fresh SV, so they
+now make use of the new function to streamline the process.
+
+C<Perl_newSVsv_flags> is now essentially a NULL pointer check and wrapper
+around the new function, so has been moved into F<sv_inline.h>.
+
+=item *
+
+L<perlapi/C<STATIC_ASSERT_DECL>> and C<STATIC_ASSERT_STMT> are like
+C<assert()>, but are evaluated at compile time.  That means their
+argument must be a constant expression that can be verified by the
+compiler, and so they effectively have no cost, not appearing in the
+code that gets executed.  These were added in v5.28, but not until now
+have we opened their use up to XS writers.  At the same time, a new
+variant has been added, C<STATIC_ASSERT_EXPR> which is suitable for use
+in an expression, such as a comma expression in a C macro.
+
+=item *
+
+C<Perl_sv_backoff>, which undoes the C<OOK> string offset mechanism now only moves
+the string buffer contents to the start of the buffer if C<SvOK(sv)> is true.
+Historically, the buffer contents were always moved, but if the buffer contents
+are defunct and no longer required, doing that incurs an unnecessary cost
+proportional to the size of the shifted contents.
+
+(The assumption in this change is that C<SvOK(sv)> is a valid indicator of
+whether the string buffer contents are "live" or not.)
+
+See [L<GH #23967|https://github.com/Perl/perl5/issues/23967>] for an example of
+where such a copy was noticeable.
+
+=item *
+
+Fixed a bug in the L<perlapi/sv_numeq> API where values with numeric
+("0+") overloading but not equality or numeric comparison overloading
+would always be compared as floating point values.  This could lead to
+large integers being reported as equal when they weren't.
+
+=item *
+
+Fixed a bug in L<perlapi/sv_numeq> where the C<SV_SKIP_OVERLOAD> flag
+would skip operator overloading, but would still honor numeric ("0+")
+overloading.
+
+=item *
+
+Added L<perlapi/sv_numne>, sv_numle, sv_numlt, sv_numge, sv_numgt and
+L<perlapi/sv_numcmp> APIs that perform numeric comparison in the same
+way perl does, including overloading.  Separate APIs for each
+comparison are needed to invoke their corresponding overload when
+needed.  Inspired by [L<GH #23918|https://github.com/Perl/perl5/issues/23918>]
+
+This also extends the sv_numeq API to support C<SV_FORCE_OVERLOAD>.
+
+=item *
+
+Added the C<AMGf_force_scalar> flag to the L<perlapi/C<amagic_call>>
+API to force scalar context for overload calls.
+
+=item *
+
+Added the C<AMGf_force_overload> flag to the L<perlapi/C<amagic_call>>
+API to allow forcing overloading to be honored even in the context of
+C<no overloading;>.
+
+=item *
+
+The C<SvFLAGS> bits used by C<SvPCS_IMPORTED()> and C<SvOOK()> have now been
+merged into the same position, thus freeing up a flags bit for possible future
+purposes. This merge is distinguished by the fact that the C<PCS_IMPORTED>
+behaviour is only used on references (when C<SvROK> is true), whereas the
+C<OOK> only applies to string buffers (when C<SvROK> is false).
+
+This change shouldn't affect any C<XS> module code that is using the test
+macros correctly, though might cause confusion to code that attempts to analyse
+C<SvFLAGS> bits directly outside of the helper macros.
+
+=item *
+
+An upper limit has been applied to the multiplier operand of the
+repetition operator. Constant folding will not be attempted if the
+operand is a numerical constant above C<PERL_FOLD_REPEAT_LIMIT>.
+See [L<GH #20586|https://github.com/Perl/perl5/issues/20586>] and [L<GH #23561|https://github.com/Perl/perl5/issues/23561>] for background.
+
+=item *
+
+Dedicated check functions C<Perl_ck_anonhash> and C<Perl_ck_aassign> have been
+added and are used to hekify some C<OP_CONST> hash keys at compile time.
+[L<GH #24228|https://github.com/Perl/perl5/issues/24228>]
+
+=item *
+
+The macro L<perlapi/C<fromCTRL>> has been added to be the inverse of the
+existing L<perlapi/C<toCTRL>>.  C<toCTRL('A')> yields 1 (the control
+character C<SOH> on all platforms Perl works on); C<fromCTRL(1)>
+yields 'A'.
+
+=item *
+
+C<Perl_check_hash_fields_and_hekify>, partly called as a compile-time
+optimization, no longer preemptively converts an NV to a HEK if the
+compile time and run time locales could differ.
+[L<GH #24252|https://github.com/Perl/perl5/issues/24252>]
+
+=item *
+
+When a UTF-8 constant string was used as the hash key in an insert
+operation, such as C<$hash{'über maus'} = 1;>, and the string could
+be converted into a single byte representation, the flag noting the
+original encoding (C<HVhek_WASUTF8>) was not always retained.
+
+When this occurred, the relevant scalars returned by C<keys %hash>
+would not be in the original, expected UTF-8 encoding.
+
+The original encoding is now captured and propagated.
+[L<GH #24266|https://github.com/Perl/perl5/issues/24266>]
+[L<GH #24290|https://github.com/Perl/perl5/pull/24290>]
+
+=item *
+
+When a constant IV or NV was used as a hash key, such as in
+C<< my %hash = ( 42 => 0 ); >>, and was preemptively stringified
+into a hash key, the fact that the numerical value came first
+was lost. This unintentionally modified deparse output for
+such keys.
+
+The numerical values are now carried across, and flags on the
+key variable reflect the original data type.
+
+Note: This now preserves the form of constant keys supplied
+to tied hashes in list assignments.
+[L<GH #24302|https://github.com/Perl/perl5/issues/24302>]
+
+=item *
+
+A new function, L<perlapi/defer_error>, has been added to report
+errors in compiling a perl program.  L<perlapi/qerror> is a deprecated
+alias for it.  Previously, C<qerror> existed but was undocumented.
+
+[L<GH #23676|https://github.com/Perl/perl5/issues/23676>]
+
+=item *
+
+L<perlapi/op_clear> is now part of the API.
+
+[L<GH #23676|https://github.com/Perl/perl5/issues/23676>]
+
+=back
+
+=head1 Selected Bug Fixes
+
+=over 4
+
+=item *
+
+Reported argument counts in C<method> signatures now account for C<$self>
+
+In previous versions of Perl, the exception message thrown by a C<method>
+subroutine with a signature when it does not receive an appropriate number of
+arguments to match its declared parameters failed to account for the implied
+C<$self> parameter, causing the numbers in the message to be 1 fewer than
+intended.
+
+This has now been fixed, so messages report the correct number of arguments
+including the object invocant.
+
+=item *
+
+When both operands of arithmetic operators (C<+>, C<->, etc.) are
+L<overload>ed objects which have no method for that operator but have
+a C<0+> method and the C<fallback> option set to TRUE,
+perl will normally call the C<0+> method for the left operand first
+and then call one for the right operand, i.e. in the same order
+as operand evaluation.
+But if C<S<use integer;>> is in effect, the C<0+> methods used to be
+called in wrong (reverse) order.
+
+=item *
+
+Certain constructs involving a two-variable C<for> loop would crash the perl
+compiler in v5.42.0:
+
+    # Two-variable for loop over a list returned from a method call:
+    for my ($x, $y) (Some::Class->foo()) { ... }
+    for my ($x, $y) ($object->foo()) { ... }
+
+and
+
+    # Two-variable for loop over a list returned from a call to a
+    # lexical(ly imported) subroutine, all inside a lexically scoped
+    # or anonymous subroutine:
+    my sub foo { ... }
+    my $fn = sub {
+        for my ($x, $y) (foo()) { ... }
+    };
+
+    use builtin qw(indexed);  # lexical import!
+    my sub bar {
+        for my ($x, $y) (indexed(...)) { ... }
+    }
+
+These have been fixed.  [L<GH #23405|https://github.com/Perl/perl5/issues/23405>]
+
+=item *
+
+Several error conditions in the C<pack> and C<unpack> operations were
+not detected and now are.
+
+=item * INTERFACE keyword in XS
+
+C<INTERFACE> is now compatible with ISO/IEC 9899:2024 ("C23"), which is the
+default language version used by GCC 15. Previously, it generated code that
+failed to compile as C23.
+
+Secondly, C<INTERFACE> now supports Perl package names as C types (i.e.
+C<Foo::Bar> gets auto-converted to C<Foo__Bar>).
+
+[L<GH #23192|https://github.com/Perl/perl5/issues/23192>]
+
+=item * C<&CORE::__CLASS__> no longer returns invalid results
+
+C<CORE::__CLASS__> would work as expected when used as a bareword or aliased:
+
+    use feature qw(class);
+    class Foo {
+        BEGIN { *cls = \&CORE::__CLASS__; }
+        method bar() {
+            my $class1 = CORE::__CLASS__;  # ok
+            my $class2 = cls;              # ok
+        }
+    }
+
+But when called with an ampersand (C<&CORE::__CLASS__()>) or through a
+reference (C<< my $ref = \&CORE::__CLASS__; $ref->() >>), it would return
+unrelated strings. These runtime calls have been fixed to throw an error of the
+form C<&CORE::__CLASS__ cannot be called directly> instead of silently
+returning incorrect results.
+
+[L<GH #23737|https://github.com/Perl/perl5/issues/23737>]
+
+=item * C<parse_subsignature()> can now handle empty subroutine signatures
+
+Previously, calling the C<parse_subsignature()> API function with an empty
+signature would cause a "Syntax error" failure, requiring code which calls it
+to detect the special case and take appropriate steps.  This is now fixed,
+returning the same optree that the parser would yield for a regular empty
+signature during normal parse time.
+
+[L<GH #17689|https://github.com/Perl/perl5/issues/17689>]
+
+=item *
+
+The C<-CA> flag (or equivalently, the C<PERL_UNICODE=A> environment setting)
+tells perl to treat command-line arguments as UTF-8 strings. (See L<perlrun>
+for details.) However, this did not extend to the global variables implicitly
+created by the C<-s> option:
+
+ $ perl -CA -s -e 'printf "%vx\n", $_ for $foo, $ARGV[0]' -- -foo=é é
+ c3.a9
+ e9
+
+Here C<$foo> would end up containing the two-byte UTF-8 representation of
+"LATIN SMALL LETTER E WITH ACUTE", but C<$ARGV[0]> would contain a single
+codepoint corresponding to U+00E9.
+
+This has been fixed: If C<-CA> is in effect, options parsed by C<-s> are
+treated as UTF-8, too. In the example above, C<$foo> and C<$ARGV[0]> now both
+contain C<chr(0xE9)>. [L<GH #23377|https://github.com/Perl/perl5/issues/23377>]
+
+=item *
+
+We have long claimed to support identifiers up to about 255 characters
+long.  However this was actually true only for identifiers that
+consisted of only ASCII characters.  The real upper limit was as few as
+64 characters for identifiers written in languages using non-ASCII
+characters, for example, Chinese or Osage.  Now an identifier in any
+language may contain at least 255 characters.
+
+=item *
+
+Fixed parsing of array names starting with a digit in double-quotish
+context under C<use utf8;>.
+
+=item *
+
+S<C<use 5.42>> now turns on S<C<use source::encoding "ascii">> for the
+remainder of the line (besides subsequent lines). [L<GH #23881|https://github.com/Perl/perl5/issues/23881>]
+
+=item *
+
+Since 5.32.0, the second branch of a ternary condition operator wasn't
+getting the correct autovivification context applied. For example in
+something like
+
+    @{ $cond ? $h{foo} : $h{bar} } = ...;
+
+the first branch would correctly autovivify C<$h{foo}> to an array ref,
+but the second branch might incorrectly autovivify C<$h{bar}> to a hash
+ref. [L<GH #18669|https://github.com/Perl/perl5/issues/18669>].
+
+=item *
+
+Don't warn about jumping into a construct if we're DIE-ing [L<GH #23922|https://github.com/Perl/perl5/pull/23922>].
+
+=item *
+
+Regexes which include both a sub-pattern (e.g. C<(??{...})> or C<(?&FOO)>) and
+a cut (i.e. C<< (?>...) >>) could sometimes cause a premature scope exit in
+other code during a match.  For example, in something like
+C<(?{ local $x = ... })>, the C<local> might have been unwound before the
+pattern has finished matching.
+[L<GH #16197|https://github.com/Perl/perl5/issues/16197>]
+
+=item *
+
+C<DB::sub> is not meant to be called for sub calls from the DB package, but
+calls to overloaded subs for overloaded values used in the DB package would
+result in calls to DB::sub.  Fixed the check for the current package in
+amagic_call().  [L<GH #24001|https://github.com/Perl/perl5/issues/24001>].
+
+=item *
+
+Fix parsing of hexadecimal floating-point numbers whose significand
+(aka "mantissa") values are too large to fit in UV range.
+Such literals (for example, C<0x1234567890.1p+0> for 32-bit IV/UV
+platform, or C<0x1234567890_1234567890.1p+0> for 64-bit IV/UV)
+used to be parsed incorrectly.
+
+=item *
+
+Perl 5.42.0 did not handle the transition to/from daylight savings time
+properly, fixed in 5.42.1.  The time and/or timezone could be off by an
+hour in the intervals surrounding such transitions.  This was a
+regression from earlier releases.  This bug was evident from perl space
+in the L<POSIX/strftime> function, and in XS code with any of
+L<perlapi/my_strftime>, L<perlapi/sv_strftime_ints>, or
+L<perlapi/sv_strftime_tm>.
+
+=item *
+
+sort() optimizes common comparisons from calling the OP tree for a
+comparison block into a call to a C function.  The C function used for
+overloaded numeric comparisons did not handle the case where there was
+no comparison overload but there was a numeric ("0+") overload
+correctly, losing precision for large overloaded integer arguments that
+are not exactly representable as a Perl floating point value (NV).
+[L<GH #23956|https://github.com/Perl/perl5/issues/23956>]
+
+=item *
+
+When a scalar variable used as the target of a filehandle is C<undef>'ed
+while being output, garbage bytes would be left in that scalar.
+[L<GH #24008|https://github.com/Perl/perl5/issues/24008>]
+
+=item *
+
+When a scalar variable was used as the target of a filehandle and also
+was output onto itself, garbage could result, or even trigger a
+segmentation fault (as in C<< open $fh, '>', \$str; print $fh $str; >>).
+[L<GH #24199|https://github.com/Perl/perl5/issues/24199>]
+
+=item *
+
+C<close(STDOUT)> when C<STDOUT> has been opened as a pipe will now
+properly wait for the child to exit on Windows.  [L<GH #4106|https://github.com/Perl/perl5/issues/4106>]
+
+=item *
+
+Calling an XSUB via goto in scalar context, where the XSUB didn't return
+exactly one value, could result in the return of the wrong number of
+items, leading to potential stack corruption. For example:
+
+    sub wrap { goto \&an_xsub_which_returns_no_values }
+    $ret = wrap();
+
+[L<GH #24212|https://github.com/Perl/perl5/issues/24212>]
+
+=item *
+
+On debugging perls, instantiating a class with an array field with an empty
+initializer list would abort with an error:
+
+    class Foo {
+        field @bar = ();
+    }
+    Foo->new();
+
+Error message: C<< perl: inline.h:194: Perl_av_new_alloc: Assertion `size > 0'
+failed. >>
+
+This has been fixed. [L<GH #24246|https://github.com/Perl/perl5/issues/24246>]
+
+=item *
+
+Refassigning to a class field in a method could result in the SV for
+that field being released when the method exited.  The next access to
+that field could result in a crash or an assertion, or if the freed SV
+had been re-used, random data.  Discussed in [L<GH #24187|https://github.com/Perl/perl5/issues/24187>]
+
+=back
+
+=head1 Known Problems
+
+None
+
+=head1 Obituary
+
+"WELL VOLUNTEERED!" echoed across conference rooms and IRC channels. Matt S. Trout's battle
+cry that transformed reluctant volunteers into community leaders.
+
+With profound sadness, we announce Matt's passing. Since the early 2000s, Matt
+shaped Perl through sheer force of will: IRC operator, PAUSE administrator,
+Shadowcat Systems co-founder, architect of DBIx::Class. His opinions came wrapped in
+profanity and delivered at maximum volume. He suffered no fools and grew to
+sometimes realize he should apologize. Yet this same abrasive exterior
+protected fierce dedication to mentoring, developers he harangued into
+volunteering now lead the community themselves. Matt's deliberately
+mind-bending code pushed Perl forward. Every modern Perl developer touches his
+legacy daily.
+
+Well volunteered, Matt. Rest in peace.
+
+=head1 Acknowledgements
+
+Perl 5.44.0 represents approximately 12 months of development since Perl
+5.42.0 and contains approximately 270,000 lines of changes across 1,300
+files from 71 authors.
+
+Excluding auto-generated files, documentation and release tools, there were
+approximately 110,000 lines of changes to 860 .pm, .t, .c and .h files.
+
+Perl continues to flourish into its fourth decade thanks to a vibrant
+community of users and developers. The following people are known to have
+contributed the improvements that became Perl 5.44.0:
+
+Alexander Karelas, Aristotle Pagaltzis, Arne Johannessen, Bartosz Jarzyna,
+Branislav Zahradník, brian d foy, Chad Granum, Chris 'BinGOs' Williams,
+Chris Prather, Christian Hansen, Craig A. Berry, Dagfinn Ilmari Mannsåker,
+Dan Book, Dan Church, Daniel Dragan, Daniel Laügt, Daniel Tang, Dan Kogai,
+Dave Cross, David Mitchell, Dmitrii Kuvaiskii, E. Choroba, Ed J, Elvin
+Aslanov, Eric Herman, Eugen Konkov, Graham Knop, Harald Jörg, H.Merijn
+Brand, Igor Todorovski, James Cook, James E Keenan, James Raspass, Jörg
+Thomas, Karen Etheridge, Karl Williamson, Leon Timmermans, Lukas Mai, Marc
+Reisner, Masahiro Iuchi, Matthew Horsfall, Maxim Vuets, Max Maischein,
+Nicolas R, Olaf Alders, Paul Evans, Paul Marquess, Peter John Acklam,
+Philippe Bruhat (BooK), Ricardo Signes, Richard Leach, Robert Rothenberg,
+Ryan Carsten Schmidt, Samuel Smith, Samuel Young, Scott Baker, Sevan
+Janiyan, Shirakata Kentaro, Sisyphus, Stan Ulbrych, Stefan Adams, Štěpán
+Němec, Steve Hay, TAKAI Kousuke, Thibault Duponchelle, Toby Inkster, Tomasz
+Konojacki, Tom Wyant, Tony Cook, Unicode Consortium, Yitzchak
+Scott-Thoennes.
+
+The list above is almost certainly incomplete as it is automatically
+generated from version control history. In particular, it does not include
+the names of the (very much appreciated) contributors who reported issues to
+the Perl bug tracker.
+
+Many of the changes included in this version originated in the CPAN modules
+included in Perl's core. We're grateful to the entire CPAN community for
+helping Perl to flourish.
+
+For a more complete list of all of Perl's historical contributors, please
+see the F<AUTHORS> file in the Perl source distribution.
+
+=head1 Reporting Bugs
+
+If you find what you think is a bug, you might check the perl bug database
+at L<https://github.com/Perl/perl5/issues>. There may also be information at
+L<https://www.perl.org/>, the Perl Home Page.
+
+If you believe you have an unreported bug, please open an issue at
+L<https://github.com/Perl/perl5/issues>. Be sure to trim your bug down to a
+tiny but sufficient test case.
+
+If the bug you are reporting has security implications which make it
+inappropriate to send to a public issue tracker, then see
+L<perlsec/SECURITY VULNERABILITY CONTACT INFORMATION>
+for details of how to report the issue.
+
+=head1 Give Thanks
+
+If you wish to thank the Perl 5 Porters for the work we had done in Perl 5,
+you can do so by running the C<perlthanks> program:
+
+    perlthanks
+
+This will send an email to the Perl 5 Porters list with your show of thanks.
+
+=head1 SEE ALSO
+
+The F<Changes> file for an explanation of how to view exhaustive details on
+what changed.
+
+The F<INSTALL> file for how to build Perl.
+
+The F<README> file for general stuff.
+
+The F<Artistic> and F<Copying> files for copyright information.
+
+=cut

--- a/src/main/perl/lib/Pod/perldelta.pod
+++ b/src/main/perl/lib/Pod/perldelta.pod
@@ -2,218 +2,122 @@
 
 =head1 NAME
 
-perldelta - what is new for perl v5.44.0
+[ this is a template for a new perldelta file. Any text flagged as XXX needs
+to be processed before release. ]
+
+perldelta - what is new for perl v5.45.0
 
 =head1 DESCRIPTION
 
-This document describes differences between the 5.42.0 release and the 5.44.0
+This document describes differences between the 5.44.0 release and the 5.45.0
 release.
+
+If you are upgrading from an earlier release such as 5.43.0, first read
+L<perl5440delta>, which describes differences between 5.43.0 and 5.44.0.
+
+=head1 Notice
+
+XXX Any important notices here
 
 =head1 Core Enhancements
 
-=head2 Named Parameters in Signatures
+XXX New core language features go here. Summarize user-visible core language
+enhancements. Particularly prominent performance optimisations could go
+here, but most should go in the L</Performance Enhancements> section.
 
-This adds a major new ability to subroutine signatures, allowing callers
-to pass parameters by name/value pairs rather than by position.
-
-    sub f ($x, $y, :$alpha, :$beta = undef) { ... }
-
-    f( 123, 456, alpha => 789 );
-
-Originally specified in
-L<PPC0024|https://github.com/Perl/PPCs/blob/main/ppcs/ppc0024-signature-named-parameters.md>.
-
-This feature is currently considered B<experimental>, and is described in
-further detail in L<perlsub/Signatures>.
-
-=head2 Multi-variable C<foreach> can now use aliased references
-
-Perl version 5.22 introduced reference aliases, allowing a C<foreach> loop
-iteration variable to create new aliases to references. Perl version 5.36
-introduced C<foreach> loops with multiple variables, consuming more than one
-input list item on each iteration. New in this version, the two features may
-now be used together, allowing multiple iteration variables where any of them
-are permitted to be reference aliases.
-
-    use v5.44;
-    use feature qw( refaliasing declared_refs );
-
-    my %hash = (
-        one => [1],
-        two => [2, 2],
-    );
-
-    foreach my ( $key, \@items ) ( %hash ) {
-        say "The $key array contains: @items";
-    }
-
-Currently both the C<refaliasing> and C<declared_refs> features remain
-B<experimental>.
-
-=head2 Enhanced operation of regular expression patterns under /xx
-
-Experimentally, the C</xx> pattern modifier can allow bracketed
-character classes (I<e.g.>, C<[a-zA-Z]> to extend across multiple lines
-and to contain comments, and to warn you of potential cases where a
-portion of a pattern inadvertently has been treated as a comment instead
-of what you intended.  This behavior is enabled by S<C<use feature
-"enhanced_xx">>.  See L<perlre/E<sol>x and  E<sol>xx>.
-
-=head2 Unicode 17.0 is supported
-
-See L<https://www.unicode.org/versions/Unicode17.0.0/>.
-
-=head2 New source of entropy for PRNG seeding
-
-Perl now uses the C<getentropy()> system call to fetch random bytes suitable
-for seeding the internal PRNG. Previously Perl would read raw bytes from the
-F</dev/urandom> device. Perl now seeds itself in this order (and falls through
-upon failure):
-
-=over
-
-=item 1.
-
-C<getentropy()> on systems that support this call (Linux, BSD, MacOS)
-
-=item 2.
-
-F</dev/urandom> on systems that have it
-
-=item 3.
-
-Hash of internal state variables: Unix time, process ID, and pointer value
-
-=back
-
-Note that the internal PRNG is still unsuitable for security applications.
-See L<perlfunc/rand EXPR> for a discussion of security.
+[ List each enhancement as a =head2 entry ]
 
 =head1 Security
 
-=head2 CVE-2026-8376 - Buffer overflow in Perl_study_chunk
+XXX Any security-related notices go here. In particular, any security
+vulnerabilities closed should be noted here rather than in the
+L</Selected Bug Fixes> section.
 
-Perl_study_chunk in regcomp_study.c checked the size of the joined substring
-buffer in characters rather than bytes. On 32-bit builds, this can lead to
-an integer overflow of the size of the buffer leading to out-of-bounds writes.
-
-=head2 CVE-2026-57432 - Buffer overflow in S_measure_struct
-
-If you call C<pack> or C<unpack> to operate on a structure whose computed size
-is too large to fit in memory, an integer overflow could happen that would
-result in a buffer overflow. This usually happens as a result of embedding a
-large number as the repeat count for an item.
-
-=head2 CVE-2026-13221 - Regex trie 16-bit field overflow
-
-The trie optimization in the regex engine could overflow in an alternation with more than ~65k branches. This could cause both false positives and false negatives on such regular expressions.
+[ List each security issue as a =head2 entry ]
 
 =head1 Incompatible Changes
 
-=head2 Unicode rules are now fully enforced on identifier and regular expression group names.
+XXX For a release on a stable branch, this section aspires to be:
 
-Before Unicode, Perl accepted any C<\w> character in an identifier or other
-name, except the first character couldn't be a digit.  Later, Unicode
-created two properties that described this.  Even later, they found
-those properties to be insufficient, and created two new similar
-properties.  These are the ones that perl has intended to use since:
-C<\p{XID_Start}> and C<\p{XID_Continue}>.  (The C<X> stands for
-"eXtended" and indicates these are the more modern versions.)
+    There are no changes intentionally incompatible with 5.XXX.XXX
+    If any exist, they are bugs, and we request that you submit a
+    report. See L</Reporting Bugs> below.
 
-(And even later, long after Perl identifier rules were formed using
-the above properties, Unicode added recommendations to further restrict
-legal identifier names.  These were added to counter cases where, for
-example, programmers snuck code past reviewers using characters that
-look like other ones.  The two properties are C<Identifier_Status> and
-C<Identifier_Type>.  See L<https://www.unicode.org/reports/tr39/>.  Perl
-currently doesn't do anything with these, except to furnish you the
-ability to use them in regular expressions.)
-
-We soon discovered that there were 14 characters that match C<XID_Start>
-and C<XID_Continue> that don't also match C<\w>.  To avoid breaking code
-that had long relied on C<\w>, we chose to not add those to the list of
-acceptable identifier characters.
-
-It turns out that there are about 160 characters that match C<\w> but
-not the Unicode C<XID> properties.  Thus they are illegal according to
-Unicode.  Those are now explicitly forbidden in both Perl identifiers
-and regular expression group names.  Previously, it was likely that
-their use in identifiers wouldn't work anyway; they could be accepted
-initially as legal, but other code would later reject them, but with a
-message that had nothing to do with the underlying problem.  However
-group names in regular expression patterns could contain illegal
-continuation characters and have a higher probability of not being
-caught.  That is now changed.
-
-Only programs that do L<C<use utf8>|utf8> can be affected, and then only
-characters that appear in the 2nd or later positions of the name.  The
-characters that an identifier name can begin with are unchanged.
-
-130 of the now unacceptable characters are 5 sets of 26 Latin letters
-that are enclosed by some shape, such as CIRCLED LATIN CAPITAL LETTER N.
-Another 8 are generic modifiers that add shapes around other characters;
-5 are modifiers to Cyrillic numbers; and 16 are Arabic ligatures and
-isolated forms.  The other two are GREEK YPOGEGRAMMENI and VERTICAL
-TILDE.
+[ List each incompatible change as a =head2 entry ]
 
 =head1 Deprecations
 
-=over 4
+XXX Any deprecated features, syntax, modules etc. should be listed here.
 
-=item *
+=head2 Module removals
 
-Deprecated since 5.12, using C<goto> to jump into the body of a loop or
-other block construct from outside is no longer permitted.
-[L<GH #23618|https://github.com/Perl/perl5/issues/23618>]
+XXX Remove this section if not applicable.
 
-=item *
+The following modules will be removed from the core distribution in a
+future release, and will at that time need to be installed from CPAN.
+Distributions on CPAN which require these modules will need to list them as
+prerequisites.
 
-C<m/...[...].../xx> has new restrictions
+The core versions of these modules will now issue C<deprecated>-category
+warnings to alert you to this fact. To silence these deprecation warnings,
+install the modules in question from CPAN.
 
-Using an unescaped C<#> or literal vertical space is now deprecated in a
-regular expression bracketed character class that is compiled with the
-C</xx> modifier.  These still work, but deprecation warnings will be
-generated unless turned off or the constructs are cured as follows.
+Note that these are (with rare exceptions) fine modules that you are encouraged
+to continue to use. Their disinclusion from core primarily hinges on their
+necessity to bootstrapping a fully functional, CPAN-capable Perl installation,
+not usually on concerns over their design.
 
 =over
 
-=item *
+=item XXX
 
-Escape a C<#> by preceding it with a backslash, like in
-
- m/ [ % \# ( ) ] /xx
-
-=item *
-
-Use constructs like C<\n> instead of literal vertical space.
+XXX Note that deprecated modules should be listed here even if they are listed
+as an updated module in the L</Modules and Pragmata> section.
 
 =back
 
-=back
+[ List each other deprecation as a =head2 entry ]
 
 =head1 Performance Enhancements
+
+XXX Changes which enhance performance without changing behaviour go here.
+There may well be none in a stable release.
+
+[ List each enhancement as an =item entry ]
 
 =over 4
 
 =item *
 
-Simple (non-overflowing) addition (C<+>), subtraction (C<->) and
-multiplication (C<*>) of integers are slightly sped up, as long as
-sufficient underlying C compiler support is available.
-
-=item *
-
-Populating a hash from a list of key/value pairs when the keys are constant
-string operands known at compile time is commonly now faster. [L<GH #24228|https://github.com/Perl/perl5/issues/24228>]
-
-=item *
-
-Processing of signatures at the start of a subroutine under the C<signatures>
-feature is now more efficient at runtime.
+XXX
 
 =back
 
 =head1 Modules and Pragmata
+
+XXX All changes to installed files in F<cpan/>, F<dist/>, F<ext/> and F<lib/>
+go here. If L<Module::CoreList> is updated, generate an initial draft of the
+following sections using F<Porting/corelist-perldelta.pl>. A paragraph summary
+for important changes should then be added by hand. In an ideal world,
+dual-life modules would have a F<Changes> file that could be cribbed.
+
+The list of new and updated modules is modified automatically as part of
+preparing a Perl release, so the only reason to manually add entries here is if
+you're summarising the important changes in the module update. (Also, if the
+manually-added details don't match the automatically-generated ones, the
+release manager will have to investigate the situation carefully.)
+
+[ Within each section, list entries as an =item entry ]
+
+=head2 New Modules and Pragmata
+
+=over 4
+
+=item *
+
+XXX Remove this section if F<Porting/corelist-perldelta.pl> did not add any content here.
+
+=back
 
 =head2 Updated Modules and Pragmata
 
@@ -221,281 +125,34 @@ feature is now more efficient at runtime.
 
 =item *
 
-L<Archive::Tar> has been upgraded from version 3.04 to 3.12.
+L<XXX> has been upgraded from version A.xx to B.yy.
 
-This fixes CVE-2026-9538, CVE-2026-42496, and CVE-2026-42497.
+XXX If there was something important to note about this change, include that here.
 
-=item *
-
-L<attributes> has been upgraded from version 0.36 to 0.37.
-
-=item *
-
-L<B> has been upgraded from version 1.89 to 1.92.
-
-=item *
-
-L<B::Concise> has been upgraded from version 1.007 to 1.012.
-
-=item *
-
-L<B::Deparse> has been upgraded from version 1.85 to 1.89.
-
-=item *
-
-L<charnames> has been upgraded from version 1.50 to 1.51.
-
-=item *
-
-L<Compress::Raw::Bzip2> has been upgraded from version 2.213 to 2.218.
-
-=item *
-
-L<Compress::Raw::Zlib> has been upgraded from version 2.213 to 2.222.
-
-=item *
-
-L<Config::Perl::V> has been upgraded from version 0.38 to 0.39.
-
-=item *
-
-L<CPAN::Meta> has been upgraded from version 2.150010 to 2.150013.
-
-=item *
-
-L<CPAN::Meta::Requirements> has been upgraded from version 2.143 to 2.145.
-
-=item *
-
-L<DB_File> has been upgraded from version 1.859 to 1.860.
-
-=item *
-
-L<Encode> has been upgraded from version 3.21 to 3.24.
-
-=item *
-
-L<English> has been upgraded from version 1.11 to 1.12.
-
-=item *
-
-L<Errno> has been upgraded from version 1.38 to 1.39.
-
-=item *
-
-L<experimental> has been upgraded from version 0.035 to 0.036.
-
-=item *
-
-L<ExtUtils::CBuilder> has been upgraded from version 0.280242 to 0.280243.
-
-=item *
-
-L<ExtUtils::MakeMaker> has been upgraded from version 7.76 to 7.78.
-
-=item *
-
-L<ExtUtils::Miniperl> has been upgraded from version 1.14 to 1.15.
-
-=item *
-
-L<ExtUtils::ParseXS> has been upgraded from version 3.57 to 3.63.
-
-=item *
-
-L<ExtUtils::Typemaps> has been upgraded from version 3.57 to 3.63.
-
-=item *
-
-L<feature> has been upgraded from version 1.97 to 2.02.
-
-=item *
-
-L<File::Copy> has been upgraded from version 2.41 to 2.43.
-
-=item *
-
-L<File::Fetch> has been upgraded from version 1.04 to 1.08.
-
-=item *
-
-L<File::Glob> has been upgraded from version 1.42 to 1.44.
-
-=item *
-
-L<File::Spec> has been upgraded from version 3.94 to 3.95.
-
-=item *
-
-L<File::stat> has been upgraded from version 1.14 to 1.15.
-
-=item *
-
-L<File::Temp> has been upgraded from version 0.2311 to 0.2312.
-
-=item *
-
-L<Filter::Simple> has been upgraded from version 0.96 to 0.97.
-
-=item *
-
-L<Filter::Util::Call> has been upgraded from version 1.64 to 1.65.
-
-=item *
-
-L<Getopt::Std> has been upgraded from version 1.14 to 1.15.
-
-=item *
-
-L<HTTP::Tiny> has been upgraded from version 0.090 to 0.096.
-
-This fixes CVE-2026-7010 and CVE-2026-7017.
-
-=item *
-
-L<IO> has been upgraded from version 1.55 to 1.56.
+=back
 
-=item *
-
-L<IO::Compress> has been upgraded from version 2.213 to 2.223.
-
-This fixes CVE-2025-15649, CVE-2026-48961, CVE-2026-48962, and CVE-2026-48959.
-
-=item *
-
-L<IO::Socket::IP> has been upgraded from version 0.43 to 0.44.
-
-=item *
-
-L<Math::BigInt> has been upgraded from version 2.005002 to 2.005003.
-
-=item *
-
-L<Module::CoreList> has been upgraded from version 5.20250702 to 5.20260708.
-
-=item *
-
-L<Module::Metadata> has been upgraded from version 1.000038 to 1.000039.
-
-=item *
-
-L<mro> has been upgraded from version 1.29 to 1.30.
-
-=item *
-
-L<Net::Ping> has been upgraded from version 2.76 to 2.77.
-
-=item *
-
-L<Opcode> has been upgraded from version 1.69 to 1.71.
-
-=item *
-
-L<overloading> has been upgraded from version 0.02 to 0.03.
-
-=item *
-
-L<PerlIO::via> has been upgraded from version 0.19 to 0.21.
-
-=item *
-
-L<Pod::Html> has been upgraded from version 1.35 to 1.36.
-
-=item *
-
-L<Pod::Simple> has been upgraded from version 3.45 to 3.48.
-
-=item *
-
-L<POSIX> has been upgraded from version 2.23 to 2.26.
-
-=item *
-
-L<Scalar::Util> has been upgraded from version 1.68_01 to 1.70.
-
-=item *
-
-L<SelectSaver> has been upgraded from version 1.02 to 1.03.
-
-=item *
-
-L<SelfLoader> has been upgraded from version 1.28 to 1.29.
-
-=item *
-
-L<Socket> has been upgraded from version 2.038 to 2.041.
-
-This fixes CVE-2026-12087.
-
-=item *
-
-L<Storable> has been upgraded from version 3.37 to 3.41.
-
-This fixes CVE-2026-57433.
-
-=item *
-
-L<Term::Table> has been upgraded from version 0.024 to 0.028.
-
-=item *
-
-L<Test::Harness> has been upgraded from version 3.50 to 3.52.
-
-=item *
-
-L<Test::Simple> has been upgraded from version 1.302210 to 1.302219.
-
-=item *
-
-L<Text::Balanced> has been upgraded from version 2.06 to 2.07.
-
-=item *
-
-L<threads> has been upgraded from version 2.43 to 2.45.
-
-=item *
-
-L<threads::shared> has been upgraded from version 1.70 to 1.73.
-
-=item *
-
-L<Time::HiRes> has been upgraded from version 1.9778 to 1.9780.
-
-=item *
-
-L<Time::Piece> has been upgraded from version 1.36 to 1.41.
-
-=item *
-
-L<Unicode::UCD> has been upgraded from version 0.81 to 0.83.
-
-=item *
-
-L<UNIVERSAL> has been upgraded from version 1.17 to 1.18.
-
-=item *
-
-L<utf8> has been upgraded from version 1.27 to 1.29.
-
-=item *
-
-L<version> has been upgraded from version 0.9933 to 0.9934.
-
-=item *
-
-L<warnings> has been upgraded from version 1.74 to 1.78.
-
-=item *
+=head2 Removed Modules and Pragmata
 
-L<XS::APItest> has been upgraded from version 1.43 to 1.50.
+=over 4
 
 =item *
 
-L<XS::Typemap> has been upgraded from version 0.20 to 0.22.
+XXX Remove this section if F<Porting/corelist-perldelta.pl> did not add any content here.
 
 =back
 
 =head1 Documentation
+
+XXX Changes to files in F<pod/> go here. Consider grouping entries by
+file and be sure to link to the appropriate page, e.g. L<perlfunc>.
+
+=head2 New Documentation
+
+XXX Changes which create B<new> files in F<pod/> go here.
+
+=head3 L<XXX>
+
+XXX Description of the purpose of the new file here
 
 =head2 Changes to Existing Documentation
 
@@ -503,43 +160,19 @@ We have attempted to update the documentation to reflect the changes
 listed in this document. If you find any we have missed, open an issue
 at L<https://github.com/Perl/perl5/issues>.
 
+XXX Changes which significantly change existing files in F<pod/> go here.
+However, any changes to F<pod/perldiag.pod> should go in the L</Diagnostics>
+section.
+
 Additionally, the following selected changes have been made:
 
-=head3 L<perlapi>
+=head3 L<XXX>
 
 =over 4
 
 =item *
 
-Auto-generation of this document now includes the line number of the source
-code, as well as its documentation.
-
-=item *
-
-It now contains information about how to find what release of
-Perl first contained an API element.
-
-=back
-
-=head3 L<perlexperiment>
-
-=over 4
-
-=item *
-
-New entry for "New object system and C<class> syntax".
-
-=back
-
-=head3 L<perlxs>
-
-=over 4
-
-=item *
-
-The reference manual for writing Perl XS code has been completely rewritten and
-modernized.  It is about twice the size of the old file, and promotes more
-modern XS syntax, such as ANSI signatures.
+XXX Description of the change here
 
 =back
 
@@ -549,84 +182,13 @@ The following additions or changes have been made to diagnostic output,
 including warnings and fatal error messages. For the complete list of
 diagnostic messages, see L<perldiag>.
 
-=head2 Changes to Existing Diagnostics
-
-=over 4
-
-=item *
-
-L<Use of uninitialized value%s|perldiag/"Use of uninitialized value%s">
-
-This warning was issued in the reverse order (right-to-left) when both
-operands of a binary operator are uninitialized values.  This is now
-fixed to be consistent with evaluation order of operands.
-
-=item *
-
-Certain diagnostics about byte sequences that are supposed to comprise a
-UTF-8 encoded character, but that are invalid in some way, now don't
-include bytes irrelevant to that determination.  An example is
-
-=over
-
-=item old message
-
-Malformed UTF-8 character: C<\xc1\x27> (any UTF-8 sequence that starts with
-C<\xc1> is overlong which can and should be represented with a different,
-shorter sequence)
-
-=item new message
-
-Malformed UTF-8 character: C<\xc1> (any UTF-8 sequence that starts with
-C<\xc1> is overlong which can and should be represented with a different,
-shorter sequence)
-
-=back
-
-In this case the C<\xc1> is all that is needed to make the sequence
-invalid.  Whatever comes after it is irrelevant (in this case, C<\x27>),
-and including it in the message might lead the reader to think that it
-somehow does matter.
-
-=item *
-
-The error C<Unrecognised parameters for "%s" constructor: %s> has been changed
-to C<Unrecognized parameters for "%s" constructor: %s>.
-
-=item *
-
-Variables whose name started with C<^_> were incorrectly shown in
-diagnostics with a literal C<Ctrl-_> (which is an invisible ASCII
-character) in their name.
-
-The names of variables whose names begin with a caret and are longer
-than two characters are now wrapped in braces, just as they have to be
-in the source code.
-
-Therefore, using an undefined C<${^_FOO}> will now correctly warn with
-C<Use of uninitialized value ${^_FOO}>, instead of the earlier C<Use of
-uninitialized value $FOO> (with a literal C<Ctrl-_> after the dollar
-sign).
-
-[L<GH #24135|https://github.com/Perl/perl5/issues/24135>]
-
-=item *
-
-Calling the C<import> method on a package with no C<import> method now
-produces a regular warning rather than a deprecation warning or error.
-
-Since Perl 5.39.1, calling C<import> with arguments on a package without
-such a method has triggered a deprecation warning. In Perl 5.43.6, this
-deprecation was promoted into an error. This broke a significant amount
-of code while providing very little advantage over the warning. This
-fatal error has been converted back to a warning, with its deprecation
-status removed. There are no longer any plans to make this fatal in the
-future. The category for this warning is C<missing_import> and it is
-enabled by default.
-
-=back
+XXX New or changed warnings emitted by the core's C<C> code go here. Also
+include any changes in L<perldiag> that reconcile it to the C<C> code.
 
 =head2 New Diagnostics
+
+XXX Newly added diagnostic messages go under here, separated into L</New Errors>
+and L</New Warnings>
 
 =head3 New Errors
 
@@ -634,36 +196,7 @@ enabled by default.
 
 =item *
 
-L<Can't redeclare catch variable as "%s"|perldiag/"Can't redeclare catch variable as "%s"">
-
-(F) A C<my>, C<our> or C<state> keyword was used with the exception variable in
-a C<catch> block:
-
-    try { ... }
-    catch (my $e) { ... }
-    # or catch (our $e) { ... }
-    # or catch (state $e) { ... }
-
-This is not valid syntax. C<catch> takes a bare variable name, which is
-automatically lexically declared.
-[L<GH #23222|https://github.com/Perl/perl5/issues/23222>]
-
-=item *
-
-L<Use of "goto" to jump into a construct is no longer permitted|perldiag/"Use of "goto" to jump into a construct is no longer permitted">
-
-(F) You have used C<goto LABEL;> or C<goto EXPR;> in an attempt to jump into
-the body of a loop or other block construct from the outside.  As of Perl 5.44,
-this throws an exception.
-
-=item *
-
-L<\x{%X} is a \w char that isn't valid in a name "%s"
-|perldiag/\x{%X} is a \w char that isn't valid in a name "%s">
-
-In most cases where this message now appears, an error would have
-occurred anyway, but the text would not have been helpful in finding the
-problem.
+XXX L<message|perldiag/"message">
 
 =back
 
@@ -673,687 +206,220 @@ problem.
 
 =item *
 
-L<Possible attempt to escape whitespace in qw() list|perldiag/"Possible attempt to escape whitespace in qw() list">
+XXX L<message|perldiag/"message">
 
-(W qw) qw() lists contain items separated by whitespace; contrary to
-what some might expect, backslash characters cannot be used to "protect"
-whitespace from being split, but are instead treated as literal data.
+=back
 
-Note that this warning is I<only> emitted when the backslash is followed
-by actual whitespace (that C<qw> splits on).
+=head2 Changes to Existing Diagnostics
+
+XXX Changes (i.e. rewording) of diagnostic messages go here
+
+=over 4
+
+=item *
+
+XXX Describe change here
+
+=back
+
+=head1 Utility Changes
+
+XXX Changes to installed programs such as F<perldoc> and F<xsubpp> go here.
+Most of these are built within the directory F<utils>.
+
+[ List utility changes as a =head2 entry for each utility and =item
+entries for each change
+Use F<XXX> with program names to get proper documentation linking. ]
+
+=head2 F<XXX>
+
+=over 4
+
+=item *
+
+XXX
 
 =back
 
 =head1 Configuration and Compilation
 
+XXX Changes to F<Configure>, F<installperl>, F<installman>, and analogous tools
+go here. Any other changes to the Perl build process should be listed here.
+However, any platform-specific changes should be listed in the
+L</Platform Support> section, instead.
+
+[ List changes as an =item entry ].
+
 =over 4
 
 =item *
 
-C23 F<< <stdckdint.h> >> and associated macros are now used if available.
-
-=item *
-
-It is now possible to pass to F<Configure> the values dealing with POSIX
-locale categories, overriding its automatic calculation of these.  This
-enables cross-compilation to work.  The easiest way to do this is to
-extract the C program that does the calculation from F<Configure> and
-then run it on the target machine, and then pass the values it outputs
-to F<Configure> on the other machine.  F<Porting/Glossary> has examples.
-[L<GH #22992|https://github.com/Perl/perl5/issues/22992>]
-
-=item *
-
-The C<PERL_CREATE_GVSV> configuration macro has been removed. It was almost
-undocumented and it has been disabled by default since Perl 5.10.0. Its purpose
-was to force all GVs to initialize their SV slot on creation. [L<GH #24177|https://github.com/Perl/perl5/issues/24177>]
+XXX
 
 =back
 
 =head1 Testing
 
+XXX Any significant changes to the testing of a freshly built perl should be
+listed here. Changes which create B<new> files in F<t/> go here as do any
+large changes to the testing harness (e.g. when parallel testing was added).
+Changes to existing files in F<t/> aren't worth summarizing, although the bugs
+that they represent may be covered elsewhere.
+
+XXX If there were no significant test changes, say this:
+
+Tests were added and changed to reflect the other additions and changes
+in this release.
+
+XXX If instead there were significant changes, say this:
+
 Tests were added and changed to reflect the other additions and
-changes in this release. Furthermore, these changes were
+changes in this release. Furthermore, these significant changes were
 made:
+
+[ List each test improvement as an =item entry ]
 
 =over 4
 
 =item *
 
-Karl Williamson gave a talk at TPRC 2025 asking people to contribute
-tests to find old issues that are no longer a problem, and todo tests
-to reflect reproduction cases for known outstanding bugs.
-(L<video link|https://www.youtube.com/watch?v=CwX4Xsf5y5E>)
-It gained renewed interest this year,
-leading to an uptick in test submissions from new authors,
-for which we are extremely grateful.
-
-=item *
-
-When testing embedding, add a sanity check to ensure the C<libperl> we
-link against matches the perl we are building.  [L<GH #22125|https://github.com/Perl/perl5/issues/22125>]
+XXX
 
 =back
 
 =head1 Platform Support
 
+XXX Any changes to platform support should be listed in the sections below.
+
+[ Within the sections, list each platform as an =item entry with specific
+changes as paragraphs below it. ]
+
+=head2 New Platforms
+
+XXX List any platforms that this version of perl compiles on, that previous
+versions did not. These will either be enabled by new files in the F<hints/>
+directories, or new subdirectories and F<README> files at the top level of the
+source tree.
+
+=over 4
+
+=item XXX-some-platform
+
+XXX
+
+=back
+
+=head2 Discontinued Platforms
+
+XXX List any platforms that this version of perl no longer compiles on.
+
+=over 4
+
+=item XXX-some-platform
+
+XXX
+
+=back
+
 =head2 Platform-Specific Notes
 
-=over 4
-
-=item Windows
-
-=over
-
-=item * Fix builds with C<USE_IMP_SYS> defined but C<USE_ITHREADS> not
-defined.
-
-=back
-
-=item OpenBSD
+XXX List any changes for specific platforms. This could include configuration
+and compilation changes or changes in portability/compatibility. However,
+changes within modules for platforms should generally be listed in the
+L</Modules and Pragmata> section.
 
 =over 4
 
-=item * When testing embedding, ensure we link against the correct static
-libperl. [L<GH #22125|https://github.com/Perl/perl5/issues/22125>]
+=item XXX-some-platform
 
-=back
-
-=item AIX
-
-=over
-
-=item * Thread-safe locale handling has been turned off on all releases due to
-apparent bugs in the underlying operating system support.
-
-=item * The ibm-clang/ibm-clang_r IBM Open XL C/C++ compiler is now supported for AIX
-7.2 and 7.3. This is the recommended compiler to use when compiling Perl on
-these versions of AIX.
-
-=back
-
-=item z/OS
-
-=over
-
-=item * clang is now the only supported compiler
-
-=item * A single test failure remains for the core Perl test suite
-
-It is for a misleading warning message in an edge case for reading
-malformed UTF-8 in F<XS-APItest/t/utf8_warn00.t>.  (Several instances of
-the same failure occur.)
-
-=item * Some cpan modules shipped with core have known problems:
-
-=over
-
-=item Encode
-
-=item ExtUtils-MakeMaker
-
-=item HTTP-Tiny
-
-=item IO-Compress
-
-=item JSON-PP
-
-=item libnet
-
-=item MIME-Base64
-
-=item PerlIO-via-QuotedPrint
-
-=item Pod-Checker
-
-=item podlators
-
-=item Pod-Simple
-
-=back
-
-Check for updates to these on cpan.
-
-=item * You can get a perl that works in ASCII mode
-
-An open source project has been created to modify the official perl to
-work on z/OS in ASCII mode.  See L<https://github.com/zopencommunity/perlport>.
-
-=back
+XXX
 
 =back
 
 =head1 Internal Changes
 
+XXX Changes which affect the interface available to C<XS> code go here. Other
+significant internal changes for future core maintainers should be noted as
+well.
+
+[ List each change as an =item entry ]
+
 =over 4
 
 =item *
 
-The XS parser, L<ExtUtils::ParseXS>, has been further extensively restructured
-internally.  Most of these changes shouldn't be visible externally, but might
-affect XS code which was using invalid or unsupported syntax.  Several minor
-bug-fixes were included.
-
-=item *
-
-Removed the deprecated (since 5.32) functions C<sv_locking()> and
-C<sv_unlocking>.
-
-=item *
-
-C<Perl_expected_size> has been added as an experimental stub macro. The
-intention is to build on this such that it can be passed a size in bytes,
-then returns the interpreter's best informed guess of what actual usable
-allocation size would be returned by the malloc implementation in use.
-
-This would help with sizing allocations such that SvLEN is more accurate
-and not trying to shrink string buffers to save size when the intended
-saving is unrealistic.
-
-=item *
-
-C<SvPV_shrink_to_cur> has been revised to include a byte for copy-on-write
-(COW), so that the resulting string could be COWed in the future.
-
-It also now uses C<Perl_expected_size>, compared against the current
-buffer size, and does not try to do a reallocation if the requested
-memory saving is unrealistic.
-
-=item *
-
-C<sv_vcatpvfn_flags()> now substitutes the Unicode REPLACEMENT CHARACTER
-for malformed input.  Previously it used the NUL character.
-
-=item *
-
-For core Perl maintainers, the syntax of F<embed.fnc> has been extended.
-Every function, C<foo()>, named in that file has generated for it a
-macro named C<PERL_ARGS_ASSERT_FOO>.  The macro expands to C<assert()>
-calls that do basic sanity checking for each argument to C<foo()> that
-we currently deem as being appropriate to have such checking.  (That
-means that many arguments are not checked, and that the generated macro
-may currently expand to nothing.)  With this release, you can add
-C<assert()> statements yourself to F<embed.fnc> that will be
-incorporated into the generated macro, beyond the system-generated ones.
-Comments and examples in F<embed.fnc> give details.
-
-=item *
-
-A new function C<valid_utf8_to_uv> has been added.  This is synonymous
-with C<valid_utf8_to_uvchr>; its reason for existence is to have
-consistent spelling with the names of the other functions that translate
-from UTF-8, so you don't have to remember a different spelling.
-
-=item *
-
-L<perlapi/C<newSVsv_flags_NN>> is a new function for creating a new SV
-and assigning the value(s) of an existing SV to it.
-
-Historically, C<Perl_newSVsv_flags> and C<Perl_sv_mortalcopy_flags> would
-pass a new SV head and the original SV to C<Perl_sv_setsv_flags>. However,
-the latter contains many branches of no relevance to a fresh SV, so they
-now make use of the new function to streamline the process.
-
-C<Perl_newSVsv_flags> is now essentially a NULL pointer check and wrapper
-around the new function, so has been moved into F<sv_inline.h>.
-
-=item *
-
-L<perlapi/C<STATIC_ASSERT_DECL>> and C<STATIC_ASSERT_STMT> are like
-C<assert()>, but are evaluated at compile time.  That means their
-argument must be a constant expression that can be verified by the
-compiler, and so they effectively have no cost, not appearing in the
-code that gets executed.  These were added in v5.28, but not until now
-have we opened their use up to XS writers.  At the same time, a new
-variant has been added, C<STATIC_ASSERT_EXPR> which is suitable for use
-in an expression, such as a comma expression in a C macro.
-
-=item *
-
-C<Perl_sv_backoff>, which undoes the C<OOK> string offset mechanism now only moves
-the string buffer contents to the start of the buffer if C<SvOK(sv)> is true.
-Historically, the buffer contents were always moved, but if the buffer contents
-are defunct and no longer required, doing that incurs an unnecessary cost
-proportional to the size of the shifted contents.
-
-(The assumption in this change is that C<SvOK(sv)> is a valid indicator of
-whether the string buffer contents are "live" or not.)
-
-See [L<GH #23967|https://github.com/Perl/perl5/issues/23967>] for an example of
-where such a copy was noticeable.
-
-=item *
-
-Fixed a bug in the L<perlapi/sv_numeq> API where values with numeric
-("0+") overloading but not equality or numeric comparison overloading
-would always be compared as floating point values.  This could lead to
-large integers being reported as equal when they weren't.
-
-=item *
-
-Fixed a bug in L<perlapi/sv_numeq> where the C<SV_SKIP_OVERLOAD> flag
-would skip operator overloading, but would still honor numeric ("0+")
-overloading.
-
-=item *
-
-Added L<perlapi/sv_numne>, sv_numle, sv_numlt, sv_numge, sv_numgt and
-L<perlapi/sv_numcmp> APIs that perform numeric comparison in the same
-way perl does, including overloading.  Separate APIs for each
-comparison are needed to invoke their corresponding overload when
-needed.  Inspired by [L<GH #23918|https://github.com/Perl/perl5/issues/23918>]
-
-This also extends the sv_numeq API to support C<SV_FORCE_OVERLOAD>.
-
-=item *
-
-Added the C<AMGf_force_scalar> flag to the L<perlapi/C<amagic_call>>
-API to force scalar context for overload calls.
-
-=item *
-
-Added the C<AMGf_force_overload> flag to the L<perlapi/C<amagic_call>>
-API to allow forcing overloading to be honored even in the context of
-C<no overloading;>.
-
-=item *
-
-The C<SvFLAGS> bits used by C<SvPCS_IMPORTED()> and C<SvOOK()> have now been
-merged into the same position, thus freeing up a flags bit for possible future
-purposes. This merge is distinguished by the fact that the C<PCS_IMPORTED>
-behaviour is only used on references (when C<SvROK> is true), whereas the
-C<OOK> only applies to string buffers (when C<SvROK> is false).
-
-This change shouldn't affect any C<XS> module code that is using the test
-macros correctly, though might cause confusion to code that attempts to analyse
-C<SvFLAGS> bits directly outside of the helper macros.
-
-=item *
-
-An upper limit has been applied to the multiplier operand of the
-repetition operator. Constant folding will not be attempted if the
-operand is a numerical constant above C<PERL_FOLD_REPEAT_LIMIT>.
-See [L<GH #20586|https://github.com/Perl/perl5/issues/20586>] and [L<GH #23561|https://github.com/Perl/perl5/issues/23561>] for background.
-
-=item *
-
-Dedicated check functions C<Perl_ck_anonhash> and C<Perl_ck_aassign> have been
-added and are used to hekify some C<OP_CONST> hash keys at compile time.
-[L<GH #24228|https://github.com/Perl/perl5/issues/24228>]
-
-=item *
-
-The macro L<perlapi/C<fromCTRL>> has been added to be the inverse of the
-existing L<perlapi/C<toCTRL>>.  C<toCTRL('A')> yields 1 (the control
-character C<SOH> on all platforms Perl works on); C<fromCTRL(1)>
-yields 'A'.
-
-=item *
-
-C<Perl_check_hash_fields_and_hekify>, partly called as a compile-time
-optimization, no longer preemptively converts an NV to a HEK if the
-compile time and run time locales could differ.
-[L<GH #24252|https://github.com/Perl/perl5/issues/24252>]
-
-=item *
-
-When a UTF-8 constant string was used as the hash key in an insert
-operation, such as C<$hash{'über maus'} = 1;>, and the string could
-be converted into a single byte representation, the flag noting the
-original encoding (C<HVhek_WASUTF8>) was not always retained.
-
-When this occurred, the relevant scalars returned by C<keys %hash>
-would not be in the original, expected UTF-8 encoding.
-
-The original encoding is now captured and propagated.
-[L<GH #24266|https://github.com/Perl/perl5/issues/24266>]
-[L<GH #24290|https://github.com/Perl/perl5/pull/24290>]
-
-=item *
-
-When a constant IV or NV was used as a hash key, such as in
-C<< my %hash = ( 42 => 0 ); >>, and was preemptively stringified
-into a hash key, the fact that the numerical value came first
-was lost. This unintentionally modified deparse output for
-such keys.
-
-The numerical values are now carried across, and flags on the
-key variable reflect the original data type.
-
-Note: This now preserves the form of constant keys supplied
-to tied hashes in list assignments.
-[L<GH #24302|https://github.com/Perl/perl5/issues/24302>]
-
-=item *
-
-A new function, L<perlapi/defer_error>, has been added to report
-errors in compiling a perl program.  L<perlapi/qerror> is a deprecated
-alias for it.  Previously, C<qerror> existed but was undocumented.
-
-[L<GH #23676|https://github.com/Perl/perl5/issues/23676>]
-
-=item *
-
-L<perlapi/op_clear> is now part of the API.
-
-[L<GH #23676|https://github.com/Perl/perl5/issues/23676>]
+XXX
 
 =back
 
 =head1 Selected Bug Fixes
 
+XXX Important bug fixes in the core language are summarized here. Bug fixes in
+files in F<ext/> and F<lib/> are best summarized in L</Modules and Pragmata>.
+
+XXX Include references to GitHub issues and PRs as: [GH #12345] and the release
+manager will later use a regex to expand these into links.
+
+[ List each fix as an =item entry ]
+
 =over 4
 
 =item *
 
-Reported argument counts in C<method> signatures now account for C<$self>
+Allow field lookups within methods in nested scopes to succeed,
+previously they could complain that C<Field $fieldname is not
+accessible outside a method...>.
 
-In previous versions of Perl, the exception message thrown by a C<method>
-subroutine with a signature when it does not receive an appropriate number of
-arguments to match its declared parameters failed to account for the implied
-C<$self> parameter, causing the numbers in the message to be 1 fewer than
-intended.
+This was most confusingly broken with a use:
 
-This has now been fixed, so messages report the correct number of arguments
-including the object invocant.
+  class A {
+    field $fieldname;
+    use overload '""' => method (@) { $fieldname };
+  }
 
-=item *
+since the syntax hides the C<BEGIN> sub.
 
-When both operands of arithmetic operators (C<+>, C<->, etc.) are
-L<overload>ed objects which have no method for that operator but have
-a C<0+> method and the C<fallback> option set to TRUE,
-perl will normally call the C<0+> method for the left operand first
-and then call one for the right operand, i.e. in the same order
-as operand evaluation.
-But if C<S<use integer;>> is in effect, the C<0+> methods used to be
-called in wrong (reverse) order.
-
-=item *
-
-Certain constructs involving a two-variable C<for> loop would crash the perl
-compiler in v5.42.0:
-
-    # Two-variable for loop over a list returned from a method call:
-    for my ($x, $y) (Some::Class->foo()) { ... }
-    for my ($x, $y) ($object->foo()) { ... }
-
-and
-
-    # Two-variable for loop over a list returned from a call to a
-    # lexical(ly imported) subroutine, all inside a lexically scoped
-    # or anonymous subroutine:
-    my sub foo { ... }
-    my $fn = sub {
-        for my ($x, $y) (foo()) { ... }
-    };
-
-    use builtin qw(indexed);  # lexical import!
-    my sub bar {
-        for my ($x, $y) (indexed(...)) { ... }
-    }
-
-These have been fixed.  [L<GH #23405|https://github.com/Perl/perl5/issues/23405>]
-
-=item *
-
-Several error conditions in the C<pack> and C<unpack> operations were
-not detected and now are.
-
-=item * INTERFACE keyword in XS
-
-C<INTERFACE> is now compatible with ISO/IEC 9899:2024 ("C23"), which is the
-default language version used by GCC 15. Previously, it generated code that
-failed to compile as C23.
-
-Secondly, C<INTERFACE> now supports Perl package names as C types (i.e.
-C<Foo::Bar> gets auto-converted to C<Foo__Bar>).
-
-[L<GH #23192|https://github.com/Perl/perl5/issues/23192>]
-
-=item * C<&CORE::__CLASS__> no longer returns invalid results
-
-C<CORE::__CLASS__> would work as expected when used as a bareword or aliased:
-
-    use feature qw(class);
-    class Foo {
-        BEGIN { *cls = \&CORE::__CLASS__; }
-        method bar() {
-            my $class1 = CORE::__CLASS__;  # ok
-            my $class2 = cls;              # ok
-        }
-    }
-
-But when called with an ampersand (C<&CORE::__CLASS__()>) or through a
-reference (C<< my $ref = \&CORE::__CLASS__; $ref->() >>), it would return
-unrelated strings. These runtime calls have been fixed to throw an error of the
-form C<&CORE::__CLASS__ cannot be called directly> instead of silently
-returning incorrect results.
-
-[L<GH #23737|https://github.com/Perl/perl5/issues/23737>]
-
-=item * C<parse_subsignature()> can now handle empty subroutine signatures
-
-Previously, calling the C<parse_subsignature()> API function with an empty
-signature would cause a "Syntax error" failure, requiring code which calls it
-to detect the special case and take appropriate steps.  This is now fixed,
-returning the same optree that the parser would yield for a regular empty
-signature during normal parse time.
-
-[L<GH #17689|https://github.com/Perl/perl5/issues/17689>]
-
-=item *
-
-The C<-CA> flag (or equivalently, the C<PERL_UNICODE=A> environment setting)
-tells perl to treat command-line arguments as UTF-8 strings. (See L<perlrun>
-for details.) However, this did not extend to the global variables implicitly
-created by the C<-s> option:
-
- $ perl -CA -s -e 'printf "%vx\n", $_ for $foo, $ARGV[0]' -- -foo=é é
- c3.a9
- e9
-
-Here C<$foo> would end up containing the two-byte UTF-8 representation of
-"LATIN SMALL LETTER E WITH ACUTE", but C<$ARGV[0]> would contain a single
-codepoint corresponding to U+00E9.
-
-This has been fixed: If C<-CA> is in effect, options parsed by C<-s> are
-treated as UTF-8, too. In the example above, C<$foo> and C<$ARGV[0]> now both
-contain C<chr(0xE9)>. [L<GH #23377|https://github.com/Perl/perl5/issues/23377>]
-
-=item *
-
-We have long claimed to support identifiers up to about 255 characters
-long.  However this was actually true only for identifiers that
-consisted of only ASCII characters.  The real upper limit was as few as
-64 characters for identifiers written in languages using non-ASCII
-characters, for example, Chinese or Osage.  Now an identifier in any
-language may contain at least 255 characters.
-
-=item *
-
-Fixed parsing of array names starting with a digit in double-quotish
-context under C<use utf8;>.
-
-=item *
-
-S<C<use 5.42>> now turns on S<C<use source::encoding "ascii">> for the
-remainder of the line (besides subsequent lines). [L<GH #23881|https://github.com/Perl/perl5/issues/23881>]
-
-=item *
-
-Since 5.32.0, the second branch of a ternary condition operator wasn't
-getting the correct autovivification context applied. For example in
-something like
-
-    @{ $cond ? $h{foo} : $h{bar} } = ...;
-
-the first branch would correctly autovivify C<$h{foo}> to an array ref,
-but the second branch might incorrectly autovivify C<$h{bar}> to a hash
-ref. [L<GH #18669|https://github.com/Perl/perl5/issues/18669>].
-
-=item *
-
-Don't warn about jumping into a construct if we're DIE-ing [L<GH #23922|https://github.com/Perl/perl5/pull/23922>].
-
-=item *
-
-Regexes which include both a sub-pattern (e.g. C<(??{...})> or C<(?&FOO)>) and
-a cut (i.e. C<< (?>...) >>) could sometimes cause a premature scope exit in
-other code during a match.  For example, in something like
-C<(?{ local $x = ... })>, the C<local> might have been unwound before the
-pattern has finished matching.
-[L<GH #16197|https://github.com/Perl/perl5/issues/16197>]
-
-=item *
-
-C<DB::sub> is not meant to be called for sub calls from the DB package, but
-calls to overloaded subs for overloaded values used in the DB package would
-result in calls to DB::sub.  Fixed the check for the current package in
-amagic_call().  [L<GH #24001|https://github.com/Perl/perl5/issues/24001>].
-
-=item *
-
-Fix parsing of hexadecimal floating-point numbers whose significand
-(aka "mantissa") values are too large to fit in UV range.
-Such literals (for example, C<0x1234567890.1p+0> for 32-bit IV/UV
-platform, or C<0x1234567890_1234567890.1p+0> for 64-bit IV/UV)
-used to be parsed incorrectly.
-
-=item *
-
-Perl 5.42.0 did not handle the transition to/from daylight savings time
-properly, fixed in 5.42.1.  The time and/or timezone could be off by an
-hour in the intervals surrounding such transitions.  This was a
-regression from earlier releases.  This bug was evident from perl space
-in the L<POSIX/strftime> function, and in XS code with any of
-L<perlapi/my_strftime>, L<perlapi/sv_strftime_ints>, or
-L<perlapi/sv_strftime_tm>.
-
-=item *
-
-sort() optimizes common comparisons from calling the OP tree for a
-comparison block into a call to a C function.  The C function used for
-overloaded numeric comparisons did not handle the case where there was
-no comparison overload but there was a numeric ("0+") overload
-correctly, losing precision for large overloaded integer arguments that
-are not exactly representable as a Perl floating point value (NV).
-[L<GH #23956|https://github.com/Perl/perl5/issues/23956>]
-
-=item *
-
-When a scalar variable used as the target of a filehandle is C<undef>'ed
-while being output, garbage bytes would be left in that scalar.
-[L<GH #24008|https://github.com/Perl/perl5/issues/24008>]
-
-=item *
-
-When a scalar variable was used as the target of a filehandle and also
-was output onto itself, garbage could result, or even trigger a
-segmentation fault (as in C<< open $fh, '>', \$str; print $fh $str; >>).
-[L<GH #24199|https://github.com/Perl/perl5/issues/24199>]
-
-=item *
-
-C<close(STDOUT)> when C<STDOUT> has been opened as a pipe will now
-properly wait for the child to exit on Windows.  [L<GH #4106|https://github.com/Perl/perl5/issues/4106>]
-
-=item *
-
-Calling an XSUB via goto in scalar context, where the XSUB didn't return
-exactly one value, could result in the return of the wrong number of
-items, leading to potential stack corruption. For example:
-
-    sub wrap { goto \&an_xsub_which_returns_no_values }
-    $ret = wrap();
-
-[L<GH #24212|https://github.com/Perl/perl5/issues/24212>]
-
-=item *
-
-On debugging perls, instantiating a class with an array field with an empty
-initializer list would abort with an error:
-
-    class Foo {
-        field @bar = ();
-    }
-    Foo->new();
-
-Error message: C<< perl: inline.h:194: Perl_av_new_alloc: Assertion `size > 0'
-failed. >>
-
-This has been fixed. [L<GH #24246|https://github.com/Perl/perl5/issues/24246>]
-
-=item *
-
-Refassigning to a class field in a method could result in the SV for
-that field being released when the method exited.  The next access to
-that field could result in a crash or an assertion, or if the freed SV
-had been re-used, random data.  Discussed in [L<GH #24187|https://github.com/Perl/perl5/issues/24187>]
+[GH #24464]
 
 =back
 
 =head1 Known Problems
 
-None
+XXX Descriptions of platform agnostic bugs we know we can't fix go here. Any
+tests that had to be C<TODO>ed for the release would be noted here. Unfixed
+platform specific bugs also go here.
+
+[ List each fix as an =item entry ]
+
+=over 4
+
+=item *
+
+XXX
+
+=back
+
+=head1 Errata From Previous Releases
+
+=over 4
+
+=item *
+
+XXX Add anything here that we forgot to add, or were mistaken about, in
+the F<perldelta> of a previous release.
+
+=back
 
 =head1 Obituary
 
-"WELL VOLUNTEERED!" echoed across conference rooms and IRC channels. Matt S. Trout's battle
-cry that transformed reluctant volunteers into community leaders.
-
-With profound sadness, we announce Matt's passing. Since the early 2000s, Matt
-shaped Perl through sheer force of will: IRC operator, PAUSE administrator,
-Shadowcat Systems co-founder, architect of DBIx::Class. His opinions came wrapped in
-profanity and delivered at maximum volume. He suffered no fools and grew to
-sometimes realize he should apologize. Yet this same abrasive exterior
-protected fierce dedication to mentoring, developers he harangued into
-volunteering now lead the community themselves. Matt's deliberately
-mind-bending code pushed Perl forward. Every modern Perl developer touches his
-legacy daily.
-
-Well volunteered, Matt. Rest in peace.
+XXX If any significant core contributor or member of the CPAN community has
+died, add a short obituary here.
 
 =head1 Acknowledgements
 
-Perl 5.44.0 represents approximately 12 months of development since Perl
-5.42.0 and contains approximately 270,000 lines of changes across 1,300
-files from 71 authors.
+XXX Generate this with:
 
-Excluding auto-generated files, documentation and release tools, there were
-approximately 110,000 lines of changes to 860 .pm, .t, .c and .h files.
-
-Perl continues to flourish into its fourth decade thanks to a vibrant
-community of users and developers. The following people are known to have
-contributed the improvements that became Perl 5.44.0:
-
-Alexander Karelas, Aristotle Pagaltzis, Arne Johannessen, Bartosz Jarzyna,
-Branislav Zahradník, brian d foy, Chad Granum, Chris 'BinGOs' Williams,
-Chris Prather, Christian Hansen, Craig A. Berry, Dagfinn Ilmari Mannsåker,
-Dan Book, Dan Church, Daniel Dragan, Daniel Laügt, Daniel Tang, Dan Kogai,
-Dave Cross, David Mitchell, Dmitrii Kuvaiskii, E. Choroba, Ed J, Elvin
-Aslanov, Eric Herman, Eugen Konkov, Graham Knop, Harald Jörg, H.Merijn
-Brand, Igor Todorovski, James Cook, James E Keenan, James Raspass, Jörg
-Thomas, Karen Etheridge, Karl Williamson, Leon Timmermans, Lukas Mai, Marc
-Reisner, Masahiro Iuchi, Matthew Horsfall, Maxim Vuets, Max Maischein,
-Nicolas R, Olaf Alders, Paul Evans, Paul Marquess, Peter John Acklam,
-Philippe Bruhat (BooK), Ricardo Signes, Richard Leach, Robert Rothenberg,
-Ryan Carsten Schmidt, Samuel Smith, Samuel Young, Scott Baker, Sevan
-Janiyan, Shirakata Kentaro, Sisyphus, Stan Ulbrych, Stefan Adams, Štěpán
-Němec, Steve Hay, TAKAI Kousuke, Thibault Duponchelle, Toby Inkster, Tomasz
-Konojacki, Tom Wyant, Tony Cook, Unicode Consortium, Yitzchak
-Scott-Thoennes.
-
-The list above is almost certainly incomplete as it is automatically
-generated from version control history. In particular, it does not include
-the names of the (very much appreciated) contributors who reported issues to
-the Perl bug tracker.
-
-Many of the changes included in this version originated in the CPAN modules
-included in Perl's core. We're grateful to the entire CPAN community for
-helping Perl to flourish.
-
-For a more complete list of all of Perl's historical contributors, please
-see the F<AUTHORS> file in the Perl source distribution.
+  perl Porting/acknowledgements.pl v5.44.0..HEAD
 
 =head1 Reporting Bugs
 

--- a/src/main/perl/lib/Pod/perldiag.pod
+++ b/src/main/perl/lib/Pod/perldiag.pod
@@ -911,6 +911,19 @@ not permitted.
 (F) Similar to above, but involving a C<finally> block at the end of a
 C<try>/C<catch> construction rather than a C<defer> block.
 
+=item Can't assign reference to %s into a GLOB
+
+(F) An attempt was made to assign a reference to something into a GLOB, but
+the thing being referred to by that reference is not something that can be
+stored in a GLOB.  Typically this is because you attempted to store an object
+(as created by C<use feature 'class'>) directly in the GLOB, rather than
+storing a scalar containing a reference to the object.
+
+  *xyz = My::Object::Class->new;   # incorrect, will cause this error
+
+  *xyz = \My::Object::Class->new;  # correct, $xyz will now store the
+                                   # object reference
+
 =item Can't bless an object reference
 
 (F) You attempted to call C<bless> on a value that already refers to a real
@@ -1790,12 +1803,11 @@ The required syntax is
     try { ... }
     catch ($var) { ... }
 
-=item Changing use VERSION while another use VERSION is in scope is now deprecated
+=item Changing use VERSION while another use VERSION is in scope is not permitted
 
-(W deprecated) Once you have a C<use VERSION> statement in scope, any
-C<use VERSION> statement that requests a different version is now deprecated,
-due to the increasing complexity of swapping from one prevailing version to
-another.
+(F) Once you have a C<use VERSION> statement in scope, any C<use VERSION>
+statement that requests a different version is not permitted, due to the
+increasing complexity of swapping from one prevailing version to another.
 
 It is suggested that you do not try to mix multiple different version
 declarations within the same file as it leads to complex behaviours about the
@@ -6452,6 +6464,13 @@ so there can't be any left to fill later parameters.
 (F) You should not use the C<~~> operator on an object that does not
 overload it: Perl refuses to use the object's underlying structure
 for the smart match.
+
+=item Socket address truncated in %s()
+
+(W io) The operating system reported a socket address length larger than
+Perl's supplied buffer for the C<%s()> call.  Perl truncated the address
+to the buffer size to avoid reading or writing past the end of that
+buffer.
 
 =item Sorry, hash keys must be smaller than 2**31 bytes
 

--- a/src/main/perl/lib/Pod/perlguts.pod
+++ b/src/main/perl/lib/Pod/perlguts.pod
@@ -3854,9 +3854,13 @@ comparison of two SVs, and handle UTF-8ness properly.  Note, however,
 that Unicode specifies a much fancier mechanism for collation, available
 via the L<Unicode::Collate> module.
 
-To just compare two strings for equality/non-equality, you can just use
-L<C<memEQ()>|perlapi/memEQ> and L<C<memNE()>|perlapi/memEQ> as usual,
-except the strings must be both UTF-8 or not UTF-8 encoded.
+To compare two strings for equality/non-equality, use
+L<C<memEQ()>|perlapi/memEQ> and L<C<memNE()>|perlapi/memNE> when both operands
+are buffers and you have already established the length to compare.  If you are
+comparing a C<ptr>/length pair against a string literal, prefer
+L<C<memEQs()>|perlapi/memEQs> and L<C<memNEs()>|perlapi/memNEs>, which also
+check that the lengths match.  In all cases, the strings must be both UTF-8 or
+not UTF-8 encoded.
 
 To compare two strings case-insensitively, use
 L<C<foldEQ_utf8()>|perlapi/foldEQ_utf8> (the strings don't have to have

--- a/src/main/perl/lib/Pod/perlhist.pod
+++ b/src/main/perl/lib/Pod/perlhist.pod
@@ -846,6 +846,9 @@ the strings?).
  Paul E     5.43.11      2026-Jun-01
  Leon T     5.44.0-RC1   2026-Jun-22
  Leon T     5.44.0-RC2   2026-Jul-08
+ Leon T     5.44.0       2026-Jul-15
+
+ Leon T     5.45.0       2026-Jul-16
 
 =head2 SELECTED RELEASE SIZES
 
@@ -938,6 +941,7 @@ explained below.
  5.38.0        15793 139  29070 1270 48250 3219  11950 2863   9129 239
  5.40.0        15995 139  28627 1406 49524 3482  12448 2995   9471 234
  5.42.0        11659 139  33084 1464 49895 3492  12725 3016   9793 239
+ 5.44.0        12153 140  33870 1484 50502 3516  12991 3043   9997 245
 
 The "core"..."doc" mean the following files from the Perl source code
 distribution.  The glob notation ** means recursively, (.) means
@@ -1320,6 +1324,23 @@ the Perl source distribution for somewhat more selected releases.
  vms          544     12       548     12       547     12
  vos            8      7        12      7        12      7
  win32        982     45      1016     47      1025     47
+
+ ======================================================================
+
+                   5.44.0
+
+ Configure     616      1
+ Cross         126     15
+ h2pl           24     15
+ hints         363     84
+ os2           580     70
+ plan9         330     20
+ Porting      1702     79
+ qnx             5      4
+ utils         782     52
+ vms           547     12
+ vos            12      7
+ win32        1030     48
 
 =head2 SELECTED PATCH SIZES
 

--- a/src/main/perl/lib/Pod/perlperf.pod
+++ b/src/main/perl/lib/Pod/perlperf.pod
@@ -137,15 +137,13 @@ comparative code in a file and running a C<Benchmark> test.
          },
  };
 
- timethese(1000000, {
+ timethese(10_000_000, {
          'direct'       => sub {
-           my $x = $ref->{ref}->{_myscore} . $ref->{ref}->{_yourscore} ;
+             my $x = $ref->{ref}->{_myscore} . $ref->{ref}->{_yourscore} ;
          },
          'dereference'  => sub {
              my $ref  = $ref->{ref};
-             my $myscore = $ref->{_myscore};
-             my $yourscore = $ref->{_yourscore};
-             my $x = $myscore . $yourscore;
+             my $x = $ref->{_myscore} . $ref->{_yourscore};
          },
  });
 
@@ -153,22 +151,25 @@ It's essential to run any timing measurements a sufficient number of times so
 the numbers settle on a numerical average, otherwise each run will naturally
 fluctuate due to variations in the environment, to reduce the effect of
 contention for C<CPU> resources and network bandwidth for instance.  Running
-the above code for one million iterations, we can take a look at the report
+the above code for ten million iterations, we can take a look at the report
 output by the C<Benchmark> module, to see which approach is the most effective.
 
  $> perl dereference
 
- Benchmark: timing 1000000 iterations of dereference, direct...
- dereference:  2 wallclock secs ( 1.59 usr +  0.00 sys =  1.59 CPU) @ 628930.82/s (n=1000000)
-     direct:  1 wallclock secs ( 1.20 usr +  0.00 sys =  1.20 CPU) @ 833333.33/s (n=1000000)
+ Benchmark: timing 10000000 iterations of dereference, direct...
+ dereference:  2 wallclock secs ( 1.11 usr +  0.00 sys =  1.11 CPU) @ 9009009.01/s (n=10000000)
+     direct:  0 wallclock secs ( 0.89 usr +  0.00 sys =  0.89 CPU) @ 11235955.06/s (n=10000000)
 
-The difference is clear to see and the dereferencing approach is slower.  While
-it managed to execute an average of 628,930 times a second during our test, the
-direct approach managed to run an additional 204,403 times, unfortunately.
-Unfortunately, because there are many examples of code written using the
-multiple layer direct variable access, and it's usually horrible.  It is,
-however, minusculely faster.  The question remains whether the minute gain is
-actually worth the eyestrain, or the loss of maintainability.
+The difference is clear to see: the C<direct> approach is faster.  C<direct>
+ran 2,226,946 times/second more or 24% faster than the C<dereference>
+approach.  The question remains, however, whether C<direct>'s relatively
+modest performance gain outweighs its poorer readability and
+maintainability.
+
+Be aware that the exact results depend on the version of perl, the
+compiler and options used to build perl and the hardware you're
+running on.  The above results are from a threaded build of perl
+5.42.1 built with gcc 14.2.0 on a Core i7-10700F.
 
 =head2  Search and replace or tr
 

--- a/src/main/perl/lib/Pod/perlpolicy.pod
+++ b/src/main/perl/lib/Pod/perlpolicy.pod
@@ -102,7 +102,7 @@ as of the release of Perl 5.42:
 
     Version track    Start date      Support status
     -------------    -----------     --------------
-    5.44.x           2026-unknown    Full support (current stable)
+    5.44.x           2026-Jul-15     Full support (current stable)
     5.42.x           2025-Jul-03     Full support (previous stable)
     5.40.x           2024-Jun-09     Security fixes only
     [ Any older stable release ]     End of life

--- a/src/main/perl/lib/Test/Builder.pm
+++ b/src/main/perl/lib/Test/Builder.pm
@@ -4,7 +4,7 @@ use 5.006;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Scalar::Util qw/blessed reftype weaken/;
 

--- a/src/main/perl/lib/Test/Builder/Formatter.pm
+++ b/src/main/perl/lib/Test/Builder/Formatter.pm
@@ -2,7 +2,7 @@ package Test::Builder::Formatter;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Test2::Formatter::TAP; our @ISA = qw(Test2::Formatter::TAP) }
 

--- a/src/main/perl/lib/Test/Builder/Module.pm
+++ b/src/main/perl/lib/Test/Builder/Module.pm
@@ -7,7 +7,7 @@ use Test::Builder;
 require Exporter;
 our @ISA = qw(Exporter);
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 =head1 NAME

--- a/src/main/perl/lib/Test/Builder/Tester.pm
+++ b/src/main/perl/lib/Test/Builder/Tester.pm
@@ -1,7 +1,7 @@
 package Test::Builder::Tester;
 
 use strict;
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test::Builder;
 use Symbol;

--- a/src/main/perl/lib/Test/Builder/Tester/Color.pm
+++ b/src/main/perl/lib/Test/Builder/Tester/Color.pm
@@ -1,7 +1,7 @@
 package Test::Builder::Tester::Color;
 
 use strict;
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 require Test::Builder::Tester;
 

--- a/src/main/perl/lib/Test/Builder/TodoDiag.pm
+++ b/src/main/perl/lib/Test/Builder/TodoDiag.pm
@@ -2,7 +2,7 @@ package Test::Builder::TodoDiag;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Test2::Event::Diag; our @ISA = qw(Test2::Event::Diag) }
 

--- a/src/main/perl/lib/Test/More.pm
+++ b/src/main/perl/lib/Test/More.pm
@@ -17,7 +17,7 @@ sub _carp {
     return warn @_, " at $file line $line\n";
 }
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test::Builder::Module;
 our @ISA    = qw(Test::Builder::Module);

--- a/src/main/perl/lib/Test/Simple.pm
+++ b/src/main/perl/lib/Test/Simple.pm
@@ -4,7 +4,7 @@ use 5.006;
 
 use strict;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test::Builder::Module;
 our @ISA    = qw(Test::Builder::Module);

--- a/src/main/perl/lib/Test/Tester.pm
+++ b/src/main/perl/lib/Test/Tester.pm
@@ -16,7 +16,7 @@ use Test::Tester::Delegate;
 
 require Exporter;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 our @EXPORT = qw( run_tests check_tests check_test cmp_results show_space );
 our @ISA = qw( Exporter );

--- a/src/main/perl/lib/Test/Tester/Capture.pm
+++ b/src/main/perl/lib/Test/Tester/Capture.pm
@@ -2,7 +2,7 @@ use strict;
 
 package Test::Tester::Capture;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 use Test::Builder;

--- a/src/main/perl/lib/Test/Tester/CaptureRunner.pm
+++ b/src/main/perl/lib/Test/Tester/CaptureRunner.pm
@@ -3,7 +3,7 @@ use strict;
 
 package Test::Tester::CaptureRunner;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 use Test::Tester::Capture;

--- a/src/main/perl/lib/Test/Tester/Delegate.pm
+++ b/src/main/perl/lib/Test/Tester/Delegate.pm
@@ -3,7 +3,7 @@ use warnings;
 
 package Test::Tester::Delegate;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Scalar::Util();
 

--- a/src/main/perl/lib/Test/use/ok.pm
+++ b/src/main/perl/lib/Test/use/ok.pm
@@ -1,7 +1,7 @@
 package Test::use::ok;
 use 5.005;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 __END__

--- a/src/main/perl/lib/Test2.pm
+++ b/src/main/perl/lib/Test2.pm
@@ -2,7 +2,7 @@ package Test2;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 1;

--- a/src/main/perl/lib/Test2/API.pm
+++ b/src/main/perl/lib/Test2/API.pm
@@ -10,7 +10,7 @@ BEGIN {
     $ENV{TEST2_ACTIVE} = 1;
 }
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 my $INST;

--- a/src/main/perl/lib/Test2/API/Breakage.pm
+++ b/src/main/perl/lib/Test2/API/Breakage.pm
@@ -2,7 +2,7 @@ package Test2::API::Breakage;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 use Test2::Util qw/pkg_to_file/;
@@ -43,7 +43,6 @@ sub upgrade_required {
 
 sub known_broken {
     return (
-        'Net::BitTorrent'       => '0.052',
         'Test::Able'            => '0.11',
         'Test::Aggregate'       => '0.373',
         'Test::Flatten'         => '0.11',

--- a/src/main/perl/lib/Test2/API/Context.pm
+++ b/src/main/perl/lib/Test2/API/Context.pm
@@ -2,7 +2,7 @@ package Test2::API::Context;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 use Carp qw/confess croak/;

--- a/src/main/perl/lib/Test2/API/Instance.pm
+++ b/src/main/perl/lib/Test2/API/Instance.pm
@@ -2,7 +2,7 @@ package Test2::API::Instance;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 our @CARP_NOT = qw/Test2::API Test2::API::Instance Test2::IPC::Driver Test2::Formatter/;
 use Carp qw/confess carp/;

--- a/src/main/perl/lib/Test2/API/InterceptResult.pm
+++ b/src/main/perl/lib/Test2/API/InterceptResult.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Scalar::Util qw/blessed/;
 use Test2::Util  qw/pkg_to_file/;

--- a/src/main/perl/lib/Test2/API/InterceptResult/Event.pm
+++ b/src/main/perl/lib/Test2/API/InterceptResult/Event.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use List::Util   qw/first/;
 use Test2::Util  qw/pkg_to_file/;

--- a/src/main/perl/lib/Test2/API/InterceptResult/Facet.pm
+++ b/src/main/perl/lib/Test2/API/InterceptResult/Facet.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Facet;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN {
     require Test2::EventFacet;

--- a/src/main/perl/lib/Test2/API/InterceptResult/Hub.pm
+++ b/src/main/perl/lib/Test2/API/InterceptResult/Hub.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Test2::Hub; our @ISA = qw(Test2::Hub) }
 use Test2::Util::HashBase;

--- a/src/main/perl/lib/Test2/API/InterceptResult/Squasher.pm
+++ b/src/main/perl/lib/Test2/API/InterceptResult/Squasher.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Squasher;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 use List::Util qw/first/;

--- a/src/main/perl/lib/Test2/API/Stack.pm
+++ b/src/main/perl/lib/Test2/API/Stack.pm
@@ -2,7 +2,7 @@ package Test2::API::Stack;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 use Test2::Hub();

--- a/src/main/perl/lib/Test2/AsyncSubtest.pm
+++ b/src/main/perl/lib/Test2/AsyncSubtest.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Test2::IPC;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 our @CARP_NOT = qw/Test2::Util::HashBase/;
 

--- a/src/main/perl/lib/Test2/AsyncSubtest/Event/Attach.pm
+++ b/src/main/perl/lib/Test2/AsyncSubtest/Event/Attach.pm
@@ -2,7 +2,7 @@ package Test2::AsyncSubtest::Event::Attach;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use base 'Test2::Event';
 use Test2::Util::HashBase qw/id/;

--- a/src/main/perl/lib/Test2/AsyncSubtest/Event/Detach.pm
+++ b/src/main/perl/lib/Test2/AsyncSubtest/Event/Detach.pm
@@ -2,7 +2,7 @@ package Test2::AsyncSubtest::Event::Detach;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use base 'Test2::Event';
 use Test2::Util::HashBase qw/id/;

--- a/src/main/perl/lib/Test2/AsyncSubtest/Formatter.pm
+++ b/src/main/perl/lib/Test2/AsyncSubtest/Formatter.pm
@@ -2,7 +2,7 @@ package Test2::AsyncSubtest::Formatter;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 die "Should not load this anymore";
 

--- a/src/main/perl/lib/Test2/AsyncSubtest/Hub.pm
+++ b/src/main/perl/lib/Test2/AsyncSubtest/Hub.pm
@@ -2,7 +2,7 @@ package Test2::AsyncSubtest::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use base 'Test2::Hub::Subtest';
 use Test2::Util::HashBase qw/ast_ids ast/;

--- a/src/main/perl/lib/Test2/Bundle.pm
+++ b/src/main/perl/lib/Test2/Bundle.pm
@@ -2,7 +2,7 @@ package Test2::Bundle;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Bundle/Extended.pm
+++ b/src/main/perl/lib/Test2/Bundle/Extended.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Test2::V0;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN {
     push @Test2::Bundle::Extended::ISA => 'Test2::V0';

--- a/src/main/perl/lib/Test2/Bundle/More.pm
+++ b/src/main/perl/lib/Test2/Bundle/More.pm
@@ -2,7 +2,7 @@ package Test2::Bundle::More;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Plugin::ExitSummary;
 

--- a/src/main/perl/lib/Test2/Bundle/Simple.pm
+++ b/src/main/perl/lib/Test2/Bundle/Simple.pm
@@ -2,7 +2,7 @@ package Test2::Bundle::Simple;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Plugin::ExitSummary;
 

--- a/src/main/perl/lib/Test2/Compare.pm
+++ b/src/main/perl/lib/Test2/Compare.pm
@@ -2,7 +2,7 @@ package Test2::Compare;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Scalar::Util qw/blessed/;
 use Test2::Util qw/try/;

--- a/src/main/perl/lib/Test2/Compare/Array.pm
+++ b/src/main/perl/lib/Test2/Compare/Array.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/inref meta ending items order for_each/;
 

--- a/src/main/perl/lib/Test2/Compare/Bag.pm
+++ b/src/main/perl/lib/Test2/Compare/Bag.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/ending meta items for_each/;
 

--- a/src/main/perl/lib/Test2/Compare/Base.pm
+++ b/src/main/perl/lib/Test2/Compare/Base.pm
@@ -2,7 +2,7 @@ package Test2::Compare::Base;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/confess croak/;
 use Scalar::Util qw/blessed/;

--- a/src/main/perl/lib/Test2/Compare/Bool.pm
+++ b/src/main/perl/lib/Test2/Compare/Bool.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/src/main/perl/lib/Test2/Compare/Custom.pm
+++ b/src/main/perl/lib/Test2/Compare/Custom.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/code name operator stringify_got/;
 

--- a/src/main/perl/lib/Test2/Compare/DeepRef.pm
+++ b/src/main/perl/lib/Test2/Compare/DeepRef.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/src/main/perl/lib/Test2/Compare/Delta.pm
+++ b/src/main/perl/lib/Test2/Compare/Delta.pm
@@ -2,7 +2,7 @@ package Test2::Compare::Delta;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw{verified id got chk children dne exception note};
 

--- a/src/main/perl/lib/Test2/Compare/Event.pm
+++ b/src/main/perl/lib/Test2/Compare/Event.pm
@@ -8,7 +8,7 @@ use Test2::Compare::EventMeta();
 
 use base 'Test2::Compare::Object';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/etype/;
 

--- a/src/main/perl/lib/Test2/Compare/EventMeta.pm
+++ b/src/main/perl/lib/Test2/Compare/EventMeta.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Meta';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase;
 

--- a/src/main/perl/lib/Test2/Compare/Float.pm
+++ b/src/main/perl/lib/Test2/Compare/Float.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 our $DEFAULT_TOLERANCE = 1e-08;
 

--- a/src/main/perl/lib/Test2/Compare/Hash.pm
+++ b/src/main/perl/lib/Test2/Compare/Hash.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/inref meta ending items order for_each_key for_each_val/;
 

--- a/src/main/perl/lib/Test2/Compare/Isa.pm
+++ b/src/main/perl/lib/Test2/Compare/Isa.pm
@@ -7,7 +7,7 @@ use Scalar::Util qw/blessed/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/src/main/perl/lib/Test2/Compare/Meta.pm
+++ b/src/main/perl/lib/Test2/Compare/Meta.pm
@@ -7,7 +7,7 @@ use Test2::Compare::Isa();
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/items/;
 

--- a/src/main/perl/lib/Test2/Compare/Negatable.pm
+++ b/src/main/perl/lib/Test2/Compare/Negatable.pm
@@ -2,7 +2,7 @@ package Test2::Compare::Negatable;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 require overload;
 require Test2::Util::HashBase;

--- a/src/main/perl/lib/Test2/Compare/Number.pm
+++ b/src/main/perl/lib/Test2/Compare/Number.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/input mode/;
 

--- a/src/main/perl/lib/Test2/Compare/Object.pm
+++ b/src/main/perl/lib/Test2/Compare/Object.pm
@@ -8,7 +8,7 @@ use Test2::Compare::Meta();
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/calls meta refcheck ending/;
 

--- a/src/main/perl/lib/Test2/Compare/OrderedSubset.pm
+++ b/src/main/perl/lib/Test2/Compare/OrderedSubset.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/inref items/;
 

--- a/src/main/perl/lib/Test2/Compare/Pattern.pm
+++ b/src/main/perl/lib/Test2/Compare/Pattern.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/pattern stringify_got/;
 

--- a/src/main/perl/lib/Test2/Compare/Ref.pm
+++ b/src/main/perl/lib/Test2/Compare/Ref.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/src/main/perl/lib/Test2/Compare/Regex.pm
+++ b/src/main/perl/lib/Test2/Compare/Regex.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/src/main/perl/lib/Test2/Compare/Scalar.pm
+++ b/src/main/perl/lib/Test2/Compare/Scalar.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/item/;
 

--- a/src/main/perl/lib/Test2/Compare/Set.pm
+++ b/src/main/perl/lib/Test2/Compare/Set.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/checks _reduction/;
 

--- a/src/main/perl/lib/Test2/Compare/String.pm
+++ b/src/main/perl/lib/Test2/Compare/String.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/src/main/perl/lib/Test2/Compare/Undef.pm
+++ b/src/main/perl/lib/Test2/Compare/Undef.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase;
 

--- a/src/main/perl/lib/Test2/Compare/Wildcard.pm
+++ b/src/main/perl/lib/Test2/Compare/Wildcard.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/expect/;
 

--- a/src/main/perl/lib/Test2/Env.pm
+++ b/src/main/perl/lib/Test2/Env.pm
@@ -2,7 +2,7 @@ package Test2::Env;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Event.pm
+++ b/src/main/perl/lib/Test2/Event.pm
@@ -2,7 +2,7 @@ package Test2::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Scalar::Util qw/blessed reftype/;
 use Carp qw/croak/;

--- a/src/main/perl/lib/Test2/Event/Bail.pm
+++ b/src/main/perl/lib/Test2/Event/Bail.pm
@@ -2,7 +2,7 @@ package Test2::Event::Bail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/Event/Diag.pm
+++ b/src/main/perl/lib/Test2/Event/Diag.pm
@@ -2,7 +2,7 @@ package Test2::Event::Diag;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/Event/Encoding.pm
+++ b/src/main/perl/lib/Test2/Event/Encoding.pm
@@ -2,7 +2,7 @@ package Test2::Event::Encoding;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/Test2/Event/Exception.pm
+++ b/src/main/perl/lib/Test2/Event/Exception.pm
@@ -2,7 +2,7 @@ package Test2::Event::Exception;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/Event/Fail.pm
+++ b/src/main/perl/lib/Test2/Event/Fail.pm
@@ -2,7 +2,7 @@ package Test2::Event::Fail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::EventFacet::Info;
 

--- a/src/main/perl/lib/Test2/Event/Generic.pm
+++ b/src/main/perl/lib/Test2/Event/Generic.pm
@@ -5,7 +5,7 @@ use warnings;
 use Carp qw/croak/;
 use Scalar::Util qw/reftype/;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }
 use Test2::Util::HashBase;

--- a/src/main/perl/lib/Test2/Event/Note.pm
+++ b/src/main/perl/lib/Test2/Event/Note.pm
@@ -2,7 +2,7 @@ package Test2::Event::Note;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/Event/Ok.pm
+++ b/src/main/perl/lib/Test2/Event/Ok.pm
@@ -2,7 +2,7 @@ package Test2::Event::Ok;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/Event/Pass.pm
+++ b/src/main/perl/lib/Test2/Event/Pass.pm
@@ -2,7 +2,7 @@ package Test2::Event::Pass;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::EventFacet::Info;
 

--- a/src/main/perl/lib/Test2/Event/Plan.pm
+++ b/src/main/perl/lib/Test2/Event/Plan.pm
@@ -2,7 +2,7 @@ package Test2::Event::Plan;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/Event/Skip.pm
+++ b/src/main/perl/lib/Test2/Event/Skip.pm
@@ -2,7 +2,7 @@ package Test2::Event::Skip;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 BEGIN { require Test2::Event::Ok; our @ISA = qw(Test2::Event::Ok) }

--- a/src/main/perl/lib/Test2/Event/Subtest.pm
+++ b/src/main/perl/lib/Test2/Event/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Event::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Test2::Event::Ok; our @ISA = qw(Test2::Event::Ok) }
 use Test2::Util::HashBase qw{subevents buffered subtest_id subtest_uuid start_stamp stop_stamp};

--- a/src/main/perl/lib/Test2/Event/TAP/Version.pm
+++ b/src/main/perl/lib/Test2/Event/TAP/Version.pm
@@ -2,7 +2,7 @@ package Test2::Event::TAP::Version;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/Test2/Event/V2.pm
+++ b/src/main/perl/lib/Test2/Event/V2.pm
@@ -2,7 +2,7 @@ package Test2::Event::V2;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Scalar::Util qw/reftype/;
 use Carp qw/croak/;

--- a/src/main/perl/lib/Test2/Event/Waiting.pm
+++ b/src/main/perl/lib/Test2/Event/Waiting.pm
@@ -2,7 +2,7 @@ package Test2::Event::Waiting;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/EventFacet.pm
+++ b/src/main/perl/lib/Test2/EventFacet.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/-details/;
 use Carp qw/croak/;

--- a/src/main/perl/lib/Test2/EventFacet/About.pm
+++ b/src/main/perl/lib/Test2/EventFacet/About.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::About;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -package -no_display -uuid -eid };

--- a/src/main/perl/lib/Test2/EventFacet/Amnesty.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Amnesty.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Amnesty;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub is_list { 1 }
 

--- a/src/main/perl/lib/Test2/EventFacet/Assert.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Assert.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Assert;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -pass -no_debug -number };

--- a/src/main/perl/lib/Test2/EventFacet/Control.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Control.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Control;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -global -terminate -halt -has_callback -encoding -phase };

--- a/src/main/perl/lib/Test2/EventFacet/Error.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Error.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Error;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub facet_key { 'errors' }
 sub is_list { 1 }

--- a/src/main/perl/lib/Test2/EventFacet/Hub.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Hub.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub is_list { 1 }
 sub facet_key { 'hubs' }

--- a/src/main/perl/lib/Test2/EventFacet/Info.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Info.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Info;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub is_list { 1 }
 

--- a/src/main/perl/lib/Test2/EventFacet/Info/Table.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Info/Table.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Info::Table;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/confess/;
 

--- a/src/main/perl/lib/Test2/EventFacet/Meta.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Meta.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Meta;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 

--- a/src/main/perl/lib/Test2/EventFacet/Parent.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Parent.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Parent;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/confess/;
 

--- a/src/main/perl/lib/Test2/EventFacet/Plan.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Plan.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Plan;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -count -skip -none };

--- a/src/main/perl/lib/Test2/EventFacet/Render.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Render.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Render;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub is_list { 1 }
 

--- a/src/main/perl/lib/Test2/EventFacet/Trace.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Trace.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Trace;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 

--- a/src/main/perl/lib/Test2/Formatter.pm
+++ b/src/main/perl/lib/Test2/Formatter.pm
@@ -2,7 +2,7 @@ package Test2::Formatter;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 my %ADDED;

--- a/src/main/perl/lib/Test2/Formatter/TAP.pm
+++ b/src/main/perl/lib/Test2/Formatter/TAP.pm
@@ -2,7 +2,7 @@ package Test2::Formatter::TAP;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util qw/clone_io/;
 

--- a/src/main/perl/lib/Test2/Handle.pm
+++ b/src/main/perl/lib/Test2/Handle.pm
@@ -2,7 +2,7 @@ package Test2::Handle;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 require Carp;
 require Test2::Util;

--- a/src/main/perl/lib/Test2/Hub.pm
+++ b/src/main/perl/lib/Test2/Hub.pm
@@ -2,7 +2,7 @@ package Test2::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 use Carp qw/carp croak confess/;

--- a/src/main/perl/lib/Test2/Hub/Interceptor.pm
+++ b/src/main/perl/lib/Test2/Hub/Interceptor.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Interceptor;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 use Test2::Hub::Interceptor::Terminator();

--- a/src/main/perl/lib/Test2/Hub/Interceptor/Terminator.pm
+++ b/src/main/perl/lib/Test2/Hub/Interceptor/Terminator.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Interceptor::Terminator;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 1;

--- a/src/main/perl/lib/Test2/Hub/Subtest.pm
+++ b/src/main/perl/lib/Test2/Hub/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Test2::Hub; our @ISA = qw(Test2::Hub) }
 use Test2::Util::HashBase qw/nested exit_code manual_skip_all/;

--- a/src/main/perl/lib/Test2/IPC.pm
+++ b/src/main/perl/lib/Test2/IPC.pm
@@ -2,7 +2,7 @@ package Test2::IPC;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 use Test2::API::Instance;

--- a/src/main/perl/lib/Test2/IPC/Driver.pm
+++ b/src/main/perl/lib/Test2/IPC/Driver.pm
@@ -2,7 +2,7 @@ package Test2::IPC::Driver;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 use Carp qw/confess/;

--- a/src/main/perl/lib/Test2/IPC/Driver/Files.pm
+++ b/src/main/perl/lib/Test2/IPC/Driver/Files.pm
@@ -2,7 +2,7 @@ package Test2::IPC::Driver::Files;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Test2::IPC::Driver; our @ISA = qw(Test2::IPC::Driver) }
 

--- a/src/main/perl/lib/Test2/Manual.pm
+++ b/src/main/perl/lib/Test2/Manual.pm
@@ -2,7 +2,7 @@ package Test2::Manual;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/API.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/API.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::API;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/Context.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/Context.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::Context;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/EndToEnd.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/EndToEnd.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::EndToEnd;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/Event.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/Event.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/Hubs.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/Hubs.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::Hubs;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/IPC.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/IPC.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::IPC;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/Utilities.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/Utilities.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::Utilities;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Concurrency.pm
+++ b/src/main/perl/lib/Test2/Manual/Concurrency.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Concurrency;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Contributing.pm
+++ b/src/main/perl/lib/Test2/Manual/Contributing.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Contributing;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Testing.pm
+++ b/src/main/perl/lib/Test2/Manual/Testing.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Testing/Introduction.pm
+++ b/src/main/perl/lib/Test2/Manual/Testing/Introduction.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing::Introduction;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Testing/Migrating.pm
+++ b/src/main/perl/lib/Test2/Manual/Testing/Migrating.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing::Migrating;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Testing/Planning.pm
+++ b/src/main/perl/lib/Test2/Manual/Testing/Planning.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing::Planning;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Testing/Todo.pm
+++ b/src/main/perl/lib/Test2/Manual/Testing/Todo.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing::Todo;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Tooling;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/FirstTool.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/FirstTool.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::FirstTool;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Formatter.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Formatter.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Formatter;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Nesting.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Nesting.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Tooling::Nesting;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Plugin/TestExit.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Plugin/TestExit.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Plugin::TestExit;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Plugin/TestingDone.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Plugin/TestingDone.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Plugin::TestingDone;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Plugin/ToolCompletes.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Plugin/ToolCompletes.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Plugin::ToolCompletes;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Plugin/ToolStarts.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Plugin/ToolStarts.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Plugin::ToolStarts;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Subtest.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Tooling::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/TestBuilder.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/TestBuilder.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::TestBuilder;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Testing.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Testing.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Tooling::Testing;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Mock.pm
+++ b/src/main/perl/lib/Test2/Mock.pm
@@ -2,7 +2,7 @@ package Test2::Mock;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak confess/;
 our @CARP_NOT = (__PACKAGE__);

--- a/src/main/perl/lib/Test2/Plugin.pm
+++ b/src/main/perl/lib/Test2/Plugin.pm
@@ -2,7 +2,7 @@ package Test2::Plugin;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Plugin/BailOnFail.pm
+++ b/src/main/perl/lib/Test2/Plugin/BailOnFail.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::BailOnFail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::API qw/test2_add_callback_context_release/;
 

--- a/src/main/perl/lib/Test2/Plugin/DieOnFail.pm
+++ b/src/main/perl/lib/Test2/Plugin/DieOnFail.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::DieOnFail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::API qw/test2_add_callback_context_release/;
 

--- a/src/main/perl/lib/Test2/Plugin/ExitSummary.pm
+++ b/src/main/perl/lib/Test2/Plugin/ExitSummary.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::ExitSummary;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::API qw/test2_add_callback_exit/;
 

--- a/src/main/perl/lib/Test2/Plugin/SRand.pm
+++ b/src/main/perl/lib/Test2/Plugin/SRand.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::SRand;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/carp/;
 

--- a/src/main/perl/lib/Test2/Plugin/Times.pm
+++ b/src/main/perl/lib/Test2/Plugin/Times.pm
@@ -10,7 +10,7 @@ use Test2::API qw{
 
 use Time::HiRes qw/time/;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 my $ADDED_HOOK = 0;
 my $START;

--- a/src/main/perl/lib/Test2/Plugin/UTF8.pm
+++ b/src/main/perl/lib/Test2/Plugin/UTF8.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::UTF8;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/Test2/Require.pm
+++ b/src/main/perl/lib/Test2/Require.pm
@@ -2,7 +2,7 @@ package Test2::Require;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::API qw/context/;
 use Carp qw/croak/;

--- a/src/main/perl/lib/Test2/Require/AuthorTesting.pm
+++ b/src/main/perl/lib/Test2/Require/AuthorTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub skip {
     my $class = shift;

--- a/src/main/perl/lib/Test2/Require/AutomatedTesting.pm
+++ b/src/main/perl/lib/Test2/Require/AutomatedTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub skip {
     my $class = shift;

--- a/src/main/perl/lib/Test2/Require/EnvVar.pm
+++ b/src/main/perl/lib/Test2/Require/EnvVar.pm
@@ -5,7 +5,7 @@ use warnings;
 use Carp qw/confess/;
 use base 'Test2::Require';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub skip {
     my $class = shift;

--- a/src/main/perl/lib/Test2/Require/ExtendedTesting.pm
+++ b/src/main/perl/lib/Test2/Require/ExtendedTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub skip {
     my $class = shift;

--- a/src/main/perl/lib/Test2/Require/Fork.pm
+++ b/src/main/perl/lib/Test2/Require/Fork.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util qw/CAN_FORK/;
 

--- a/src/main/perl/lib/Test2/Require/Module.pm
+++ b/src/main/perl/lib/Test2/Require/Module.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util qw/pkg_to_file/;
 

--- a/src/main/perl/lib/Test2/Require/NonInteractiveTesting.pm
+++ b/src/main/perl/lib/Test2/Require/NonInteractiveTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub skip {
     my $class = shift;

--- a/src/main/perl/lib/Test2/Require/Perl.pm
+++ b/src/main/perl/lib/Test2/Require/Perl.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util qw/pkg_to_file/;
 use Scalar::Util qw/reftype/;

--- a/src/main/perl/lib/Test2/Require/RealFork.pm
+++ b/src/main/perl/lib/Test2/Require/RealFork.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util qw/CAN_REALLY_FORK/;
 

--- a/src/main/perl/lib/Test2/Require/ReleaseTesting.pm
+++ b/src/main/perl/lib/Test2/Require/ReleaseTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub skip {
     my $class = shift;

--- a/src/main/perl/lib/Test2/Require/Threads.pm
+++ b/src/main/perl/lib/Test2/Require/Threads.pm
@@ -4,7 +4,7 @@ use warnings;
 
 BEGIN { require Test2::Require; our @ISA = qw(Test2::Require) }
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util qw/CAN_THREAD/;
 

--- a/src/main/perl/lib/Test2/Suite.pm
+++ b/src/main/perl/lib/Test2/Suite.pm
@@ -2,7 +2,7 @@ package Test2::Suite;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Todo.pm
+++ b/src/main/perl/lib/Test2/Todo.pm
@@ -9,7 +9,7 @@ use Test2::API qw/test2_stack/;
 
 use overload '""' => \&reason, fallback => 1;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub init {
     my $self = shift;

--- a/src/main/perl/lib/Test2/Tools.pm
+++ b/src/main/perl/lib/Test2/Tools.pm
@@ -2,7 +2,7 @@ package Test2::Tools;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/Tools/AsyncSubtest.pm
+++ b/src/main/perl/lib/Test2/Tools/AsyncSubtest.pm
@@ -2,7 +2,7 @@ package Test2::Tools::AsyncSubtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::IPC;
 use Test2::AsyncSubtest;

--- a/src/main/perl/lib/Test2/Tools/Basic.pm
+++ b/src/main/perl/lib/Test2/Tools/Basic.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Basic;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 use Test2::API qw/context/;

--- a/src/main/perl/lib/Test2/Tools/Class.pm
+++ b/src/main/perl/lib/Test2/Tools/Class.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Class;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::API qw/context/;
 use Test2::Util::Ref qw/render_ref/;

--- a/src/main/perl/lib/Test2/Tools/ClassicCompare.pm
+++ b/src/main/perl/lib/Test2/Tools/ClassicCompare.pm
@@ -2,7 +2,7 @@ package Test2::Tools::ClassicCompare;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 our @EXPORT = qw/is is_deeply isnt like unlike cmp_ok/;
 use base 'Exporter';

--- a/src/main/perl/lib/Test2/Tools/Compare.pm
+++ b/src/main/perl/lib/Test2/Tools/Compare.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Compare;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 use Scalar::Util qw/reftype/;

--- a/src/main/perl/lib/Test2/Tools/Defer.pm
+++ b/src/main/perl/lib/Test2/Tools/Defer.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Defer;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/Test2/Tools/Encoding.pm
+++ b/src/main/perl/lib/Test2/Tools/Encoding.pm
@@ -8,7 +8,7 @@ use Test2::API qw/test2_stack/;
 
 use base 'Exporter';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 our @EXPORT = qw/set_encoding/;
 

--- a/src/main/perl/lib/Test2/Tools/Event.pm
+++ b/src/main/perl/lib/Test2/Tools/Event.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util qw/pkg_to_file/;
 

--- a/src/main/perl/lib/Test2/Tools/Exception.pm
+++ b/src/main/perl/lib/Test2/Tools/Exception.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Exception;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/carp/;
 use Test2::API qw/context test2_add_pending_diag test2_clear_pending_diags/;

--- a/src/main/perl/lib/Test2/Tools/Exports.pm
+++ b/src/main/perl/lib/Test2/Tools/Exports.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Exports;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak carp/;
 use Test2::API qw/context/;

--- a/src/main/perl/lib/Test2/Tools/GenTemp.pm
+++ b/src/main/perl/lib/Test2/Tools/GenTemp.pm
@@ -3,7 +3,7 @@ package Test2::Tools::GenTemp;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use File::Temp qw/tempdir/;
 use File::Spec;

--- a/src/main/perl/lib/Test2/Tools/Grab.pm
+++ b/src/main/perl/lib/Test2/Tools/Grab.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Grab;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::Grabber;
 use Test2::EventFacet::Trace();

--- a/src/main/perl/lib/Test2/Tools/Mock.pm
+++ b/src/main/perl/lib/Test2/Tools/Mock.pm
@@ -11,7 +11,7 @@ use Test2::Mock();
 
 use base 'Exporter';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 our @CARP_NOT = (__PACKAGE__, 'Test2::Mock');
 our @EXPORT = qw/mock mocked/;
@@ -188,7 +188,11 @@ sub _generate_class {
     my $prefix = __PACKAGE__;
 
     for (1 .. 100) {
-        my $postfix = join '', map { chr(rand(26) + 65) } 1 .. 32;
+        my $postfix = join '', map {
+            my $cp = rand(26) + 65;
+            $cp = utf8::unicode_to_native($cp) if "$]" >= 5.008;
+            chr($cp);
+        } 1 .. 32;
         my $class = $prefix . '::__TEMP__::' . $postfix;
         my $file = $class;
         $file =~ s{::}{/}g;

--- a/src/main/perl/lib/Test2/Tools/Ref.pm
+++ b/src/main/perl/lib/Test2/Tools/Ref.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Ref;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Scalar::Util qw/reftype refaddr/;
 use Test2::API qw/context/;

--- a/src/main/perl/lib/Test2/Tools/Refcount.pm
+++ b/src/main/perl/lib/Test2/Tools/Refcount.pm
@@ -13,7 +13,7 @@ use Test2::API qw(context release);
 use Scalar::Util qw( weaken refaddr );
 use B qw( svref_2object );
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 our @EXPORT = qw(
    is_refcount

--- a/src/main/perl/lib/Test2/Tools/Spec.pm
+++ b/src/main/perl/lib/Test2/Tools/Spec.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Spec;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 use Test2::Workflow qw/parse_args build current_build root_build init_root build_stack/;

--- a/src/main/perl/lib/Test2/Tools/Subtest.pm
+++ b/src/main/perl/lib/Test2/Tools/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::API qw/context run_subtest/;
 use Test2::Util qw/try/;

--- a/src/main/perl/lib/Test2/Tools/Target.pm
+++ b/src/main/perl/lib/Test2/Tools/Target.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Target;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/Test2/Tools/Tester.pm
+++ b/src/main/perl/lib/Test2/Tools/Tester.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Tester;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 use Test2::Util::Ref qw/rtype/;

--- a/src/main/perl/lib/Test2/Tools/Tiny.pm
+++ b/src/main/perl/lib/Test2/Tools/Tiny.pm
@@ -10,7 +10,7 @@ use Test2::API qw/context run_subtest test2_stack/;
 use Test2::Hub::Interceptor();
 use Test2::Hub::Interceptor::Terminator();
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 BEGIN { require Exporter; our @ISA = qw(Exporter) }
 our @EXPORT = qw{

--- a/src/main/perl/lib/Test2/Tools/Warnings.pm
+++ b/src/main/perl/lib/Test2/Tools/Warnings.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Warnings;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/carp/;
 use Test2::API qw/context test2_add_pending_diag/;

--- a/src/main/perl/lib/Test2/Transition.pod
+++ b/src/main/perl/lib/Test2/Transition.pod
@@ -306,14 +306,6 @@ something new (Test2) to completely rewrite it in a sane way.
 
 Still broken as of version: 0.32
 
-=item Net::BitTorrent
-
-The tests for this module directly access L<Test::Builder> hash keys. Most, if
-not all of these hash keys have public API methods that could be used instead
-to avoid the problem.
-
-Still broken in version: 0.052
-
 =item Test::Group
 
 It monkeypatches Test::Builder, and calls it "black magic" in the code.

--- a/src/main/perl/lib/Test2/Util.pm
+++ b/src/main/perl/lib/Test2/Util.pm
@@ -2,7 +2,7 @@ package Test2::Util;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Config qw/%Config/;
 use Carp qw/croak/;

--- a/src/main/perl/lib/Test2/Util/ExternalMeta.pm
+++ b/src/main/perl/lib/Test2/Util/ExternalMeta.pm
@@ -2,7 +2,7 @@ package Test2::Util::ExternalMeta;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 
 use Carp qw/croak/;

--- a/src/main/perl/lib/Test2/Util/Facets2Legacy.pm
+++ b/src/main/perl/lib/Test2/Util/Facets2Legacy.pm
@@ -2,7 +2,7 @@ package Test2::Util::Facets2Legacy;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak confess/;
 use Scalar::Util qw/blessed/;

--- a/src/main/perl/lib/Test2/Util/Grabber.pm
+++ b/src/main/perl/lib/Test2/Util/Grabber.pm
@@ -2,7 +2,7 @@ package Test2::Util::Grabber;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Hub::Interceptor();
 use Test2::EventFacet::Trace();

--- a/src/main/perl/lib/Test2/Util/Guard.pm
+++ b/src/main/perl/lib/Test2/Util/Guard.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use Carp qw(confess);
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub new {
     confess "Can't create a Test2::Util::Guard in void context" unless (defined wantarray);

--- a/src/main/perl/lib/Test2/Util/HashBase.pm
+++ b/src/main/perl/lib/Test2/Util/HashBase.pm
@@ -2,7 +2,7 @@ package Test2::Util::HashBase;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 #################################################################
 #                                                               #

--- a/src/main/perl/lib/Test2/Util/Importer.pm
+++ b/src/main/perl/lib/Test2/Util/Importer.pm
@@ -2,7 +2,7 @@ package Test2::Util::Importer;
 use strict; no strict 'refs';
 use warnings; no warnings 'once';
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 my %SIG_TO_SLOT = (
     '&' => 'CODE',

--- a/src/main/perl/lib/Test2/Util/Ref.pm
+++ b/src/main/perl/lib/Test2/Util/Ref.pm
@@ -2,7 +2,7 @@ package Test2::Util::Ref;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Scalar::Util qw/reftype blessed refaddr/;
 

--- a/src/main/perl/lib/Test2/Util/Sig.pm
+++ b/src/main/perl/lib/Test2/Util/Sig.pm
@@ -2,7 +2,7 @@ package Test2::Util::Sig;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use POSIX();
 use Test2::Util qw/try IS_WIN32/;

--- a/src/main/perl/lib/Test2/Util/Stash.pm
+++ b/src/main/perl/lib/Test2/Util/Stash.pm
@@ -2,7 +2,7 @@ package Test2::Util::Stash;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 use B;

--- a/src/main/perl/lib/Test2/Util/Sub.pm
+++ b/src/main/perl/lib/Test2/Util/Sub.pm
@@ -2,7 +2,7 @@ package Test2::Util::Sub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak carp/;
 use B();

--- a/src/main/perl/lib/Test2/Util/Table.pm
+++ b/src/main/perl/lib/Test2/Util/Table.pm
@@ -2,7 +2,7 @@ package Test2::Util::Table;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use base 'Term::Table';
 

--- a/src/main/perl/lib/Test2/Util/Table/Cell.pm
+++ b/src/main/perl/lib/Test2/Util/Table/Cell.pm
@@ -2,7 +2,7 @@ package Test2::Util::Table::Cell;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use base 'Term::Table::Cell';
 

--- a/src/main/perl/lib/Test2/Util/Table/LineBreak.pm
+++ b/src/main/perl/lib/Test2/Util/Table/LineBreak.pm
@@ -2,7 +2,7 @@ package Test2::Util::Table::LineBreak;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use base 'Term::Table::LineBreak';
 

--- a/src/main/perl/lib/Test2/Util/Term.pm
+++ b/src/main/perl/lib/Test2/Util/Term.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Term::Table::Util qw/term_size USE_GCS USE_TERM_READKEY uni_length/;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::Importer 'Test2::Util::Importer' => 'import';
 our @EXPORT_OK = qw/term_size USE_GCS USE_TERM_READKEY uni_length/;

--- a/src/main/perl/lib/Test2/Util/Times.pm
+++ b/src/main/perl/lib/Test2/Util/Times.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use List::Util qw/sum/;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 our @EXPORT_OK = qw/render_bench render_duration/;
 use base 'Exporter';

--- a/src/main/perl/lib/Test2/Util/Trace.pm
+++ b/src/main/perl/lib/Test2/Util/Trace.pm
@@ -6,7 +6,7 @@ use strict;
 
 our @ISA = ('Test2::EventFacet::Trace');
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 1;
 

--- a/src/main/perl/lib/Test2/V0.pm
+++ b/src/main/perl/lib/Test2/V0.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Test2::Util::Importer;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/Test2/V1.pm
+++ b/src/main/perl/lib/Test2/V1.pm
@@ -2,7 +2,7 @@ package Test2::V1;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/Test2/V1/Base.pm
+++ b/src/main/perl/lib/Test2/V1/Base.pm
@@ -2,7 +2,7 @@ package Test2::V1::Base;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::API qw/intercept context/;
 

--- a/src/main/perl/lib/Test2/V1/Handle.pm
+++ b/src/main/perl/lib/Test2/V1/Handle.pm
@@ -2,7 +2,7 @@ package Test2::V1::Handle;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 sub DEFAULT_HANDLE_BASE { 'Test2::V1::Base' }
 

--- a/src/main/perl/lib/Test2/Workflow.pm
+++ b/src/main/perl/lib/Test2/Workflow.pm
@@ -2,7 +2,7 @@ package Test2::Workflow;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 our @EXPORT_OK = qw/parse_args current_build build root_build init_root build_stack/;
 use base 'Exporter';

--- a/src/main/perl/lib/Test2/Workflow/BlockBase.pm
+++ b/src/main/perl/lib/Test2/Workflow/BlockBase.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::BlockBase;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Util::HashBase qw/code frame _info _lines/;
 use Test2::Util::Sub qw/sub_info/;

--- a/src/main/perl/lib/Test2/Workflow/Build.pm
+++ b/src/main/perl/lib/Test2/Workflow/Build.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Build;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::Workflow::Task::Group;
 

--- a/src/main/perl/lib/Test2/Workflow/Runner.pm
+++ b/src/main/perl/lib/Test2/Workflow/Runner.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Runner;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::API();
 use Test2::Todo();

--- a/src/main/perl/lib/Test2/Workflow/Task.pm
+++ b/src/main/perl/lib/Test2/Workflow/Task.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Task;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Test2::API();
 use Test2::Event::Exception();

--- a/src/main/perl/lib/Test2/Workflow/Task/Action.pm
+++ b/src/main/perl/lib/Test2/Workflow/Task/Action.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Task::Action;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use base 'Test2::Workflow::Task';
 use Test2::Util::HashBase qw/around/;

--- a/src/main/perl/lib/Test2/Workflow/Task/Group.pm
+++ b/src/main/perl/lib/Test2/Workflow/Task/Group.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Task::Group;
 use strict;
 use warnings;
 
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/autouse.pm
+++ b/src/main/perl/lib/autouse.pm
@@ -1,11 +1,11 @@
 package autouse;
+use 5.006;
+use strict;
+use warnings;
 
-#use strict;		# debugging only
-use 5.006;		# use warnings
+our $VERSION = '1.12';
 
-$autouse::VERSION = '1.11';
-
-$autouse::DEBUG ||= 0;
+our $DEBUG ||= 0;
 
 sub vet_import ($);
 
@@ -22,61 +22,63 @@ sub import {
     (my $pm = $module) =~ s{::}{/}g;
     $pm .= '.pm';
     if (exists $INC{$pm}) {
-	vet_import $module;
-	local $Exporter::ExportLevel = $Exporter::ExportLevel + 1;
-	# $Exporter::Verbose = 1;
-	return $module->import(map { (my $f = $_) =~ s/\(.*?\)$//; $f } @_);
+        vet_import $module;
+        local $Exporter::ExportLevel = $Exporter::ExportLevel + 1;
+        # $Exporter::Verbose = 1;
+        return $module->import(map { (my $f = $_) =~ s/\(.*?\)$//; $f } @_);
     }
 
     # It is not loaded: need to do real work.
     my $callpkg = caller(0);
-    print "autouse called from $callpkg\n" if $autouse::DEBUG;
+    print "autouse called from $callpkg\n" if $DEBUG;
 
     my $index;
     for my $f (@_) {
-	my $proto;
-	$proto = $1 if (my $func = $f) =~ s/\((.*)\)$//;
+        my $proto;
+        $proto = $1 if (my $func = $f) =~ s/\((.*)\)$//;
 
-	my $closure_import_func = $func;	# Full name
-	my $closure_func = $func;		# Name inside package
-	my $index = rindex($func, '::');
-	if ($index == -1) {
-	    $closure_import_func = "${callpkg}::$func";
-	} else {
-	    $closure_func = substr $func, $index + 2;
-	    croak "autouse into different package attempted"
-		unless substr($func, 0, $index) eq $module;
-	}
+        my $closure_import_func = $func;        # Full name
+        my $closure_func = $func;               # Name inside package
+        my $index = rindex($func, '::');
+        if ($index == -1) {
+            $closure_import_func = "${callpkg}::$func";
+        } else {
+            $closure_func = substr $func, $index + 2;
+            croak "autouse into different package attempted"
+                unless substr($func, 0, $index) eq $module;
+        }
 
-	my $load_sub = sub {
-	    unless ($INC{$pm}) {
-		require $pm;
-		vet_import $module;
-	    }
+        my $load_sub = sub {
+            unless ($INC{$pm}) {
+                require $pm;
+                vet_import $module;
+            }
             no warnings qw(redefine prototype);
-	    *$closure_import_func = \&{"${module}::$closure_func"};
-	    print "autousing $module; "
-		  ."imported $closure_func as $closure_import_func\n"
-		if $autouse::DEBUG;
-	    goto &$closure_import_func;
-	};
+            no strict 'refs';
+            *$closure_import_func = \&{"${module}::$closure_func"};
+            print "autousing $module; "
+                  ."imported $closure_func as $closure_import_func\n"
+                if $DEBUG;
+            goto &$closure_import_func;
+        };
 
-	if (defined $proto) {
-	    *$closure_import_func = eval "sub ($proto) { goto &\$load_sub }"
-	        || die;
-	} else {
-	    *$closure_import_func = $load_sub;
-	}
+        no strict 'refs';
+        if (defined $proto) {
+            *$closure_import_func = eval "sub ($proto) { goto &\$load_sub }"
+                || die;
+        } else {
+            *$closure_import_func = $load_sub;
+        }
     }
 }
 
 sub vet_import ($) {
     my $module = shift;
     if (my $import = $module->can('import')) {
-	croak "autoused module $module has unique import() method"
-	    unless defined(&Exporter::import)
-		   && ($import == \&Exporter::import ||
-		       $import == \&UNIVERSAL::import)
+        croak "autoused module $module has unique import() method"
+            unless defined(&Exporter::import)
+                  && ($import == \&Exporter::import ||
+                      $import == \&UNIVERSAL::import)
     }
 }
 
@@ -90,18 +92,18 @@ autouse - postpone load of modules until a function is used
 
 =head1 SYNOPSIS
 
-  use autouse 'Carp' => qw(carp croak);
-  carp "this carp was predeclared and autoused ";
+    use autouse 'Carp' => qw(carp croak);
+    carp "this carp was predeclared and autoused ";
 
 =head1 DESCRIPTION
 
 If the module C<Module> is already loaded, then the declaration
 
-  use autouse 'Module' => qw(func1 func2($;$));
+    use autouse 'Module' => qw(func1 func2($;$));
 
 is equivalent to
 
-  use Module qw(func1 func2);
+    use Module qw(func1 func2);
 
 if C<Module> defines func2() with prototype C<($;$)>, and func1() has
 no prototypes.  (At least if C<Module> uses C<Exporter>'s C<import>,
@@ -114,11 +116,11 @@ and substitute themselves with the correct definitions.
 
 =begin _deprecated
 
-   use Module qw(Module::func3);
+    use Module qw(Module::func3);
 
 will work and is the equivalent to:
 
-   use Module qw(func3);
+    use Module qw(func3);
 
 It is not a very useful feature and has been deprecated.
 

--- a/src/main/perl/lib/ok.pm
+++ b/src/main/perl/lib/ok.pm
@@ -1,5 +1,5 @@
 package ok;
-our $VERSION = '1.302219';
+our $VERSION = '1.302222';
 
 use strict;
 use Test::More ();


### PR DESCRIPTION
## Summary

- synchronize bundled Perl libraries and documentation with the Perl 5.44 baseline
- add the Perl 5.44.0 delta document
- update JUnit Jupiter to 6.1.2 and Bouncy Castle to 1.85 in both dependency manifests
- retain the current PerlOnJava version; the project-wide 5.44 version bump will follow after this PR is merged

## Testing

- upgraded libraries were tested before this snapshot was committed