### PR TITLE
Fix Pod::Spell and scalar temporary weak references

### DIFF
--- a/dev/architecture/weaken-destroy.md
+++ b/dev/architecture/weaken-destroy.md
@@ -1,6 +1,6 @@
 # Weaken & DESTROY - Architecture Guide
 
-**Last Updated:** 2026-04-30
+**Last Updated:** 2026-07-24
 **Status:** PRODUCTION READY
 - 841/841 Moo subtests (100%)
 - 13858/13858 DBIx::Class subtests across 314 test files (100%, 0 Dubious) — measured on branch `perf/dbic-safe-port` at `2ef41907d`
@@ -134,6 +134,18 @@ back-references) and cascade to break Moo's accessor inlining.
 | `> 0` | **Tracked.** N strong references exist in named variables. Each `setLarge()` assignment increments; each scope exit or reassignment decrements. |
 | `-2` | **WEAKLY_TRACKED.** Entered when `weaken()` is called on an untracked non-CODE object (refCount == -1). A heuristic allowing weak ref clearing when a strong ref is explicitly dropped via `undefine()`. `setLarge()` and `scopeExitCleanup()` do NOT clear weak refs for this state — only explicit `undefine()`. |
 | `MIN_VALUE` | **Destroyed.** DESTROY has been called (or is in progress). Prevents double-destruction. |
+
+### Scalar-reference temporaries
+
+`RuntimeScalar.createReference()` birth-tracks an unbound scalar return value
+when it has no lexical registration, closure capture, package-global root, or
+aggregate owner. This makes `weaken(\(sub_return()))` clear immediately, as in
+Perl, while references to named scalars and aggregate elements remain alive.
+
+The promoted scalar is marked `ephemeralScalarReferenceReferent`. When its sole
+counted reference is weakened, `WeakRefRegistry` can clear it directly without
+calling `ReachabilityWalker`: the ownership checks performed at promotion prove
+there is no hidden strong owner. This keeps the hot operation constant-time.
 
 ### Ownership: `refCountOwned`
 
@@ -966,8 +978,10 @@ decrement per reference assignment), but this is by design.
 
 - **Per-referent:** `refCount` (int, 4 bytes) and `blessId` (int, 4 bytes) on
   `RuntimeBase`. Always present but unused when untracked.
-- **Per-scalar:** `refCountOwned` (boolean, 1 byte) and `captureCount` (int,
-  4 bytes) on `RuntimeScalar`. Always present.
+- **Per-scalar:** `refCountOwned` and
+  `ephemeralScalarReferenceReferent` (booleans), plus `captureCount` (int,
+  4 bytes), on `RuntimeScalar`. Always present; the JVM may pack the booleans
+  into existing object-alignment padding.
 - **WeakRefRegistry:** External identity maps. Only allocated when `weaken()`
   is called. Zero memory when no weak refs exist.
 - **DestroyDispatch caches:** `BitSet` + `ConcurrentHashMap`. Negligible.

--- a/src/main/java/org/perlonjava/runtime/io/LayeredIOHandle.java
+++ b/src/main/java/org/perlonjava/runtime/io/LayeredIOHandle.java
@@ -1,5 +1,6 @@
 package org.perlonjava.runtime.io;
 
+import org.perlonjava.runtime.operators.ModuleOperators;
 import org.perlonjava.runtime.runtimetypes.PerlJavaUnimplementedException;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
@@ -453,6 +454,11 @@ public class LayeredIOHandle implements IOHandle {
                     String charsetName = layerSpec.substring(9, layerSpec.length() - 1);
                     try {
                         Charset charset = resolveEncodingCharset(charsetName);
+                        // Perl's :encoding(...) layer is provided by PerlIO::encoding
+                        // and loads Encode as a visible side effect. Some CPAN modules
+                        // (including Pod::Spell) rely on Encode::* being available
+                        // after an encoded handle has been opened.
+                        ModuleOperators.require(new RuntimeScalar("Encode.pm"));
                         EncodingLayer layer = new EncodingLayer(charset, layerSpec);
                         activeLayers.add(layer);
                         Function<String, String> inputTransform = s -> layer.processInput(s);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -281,6 +281,14 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
      */
     public boolean referencedByScalarReference;
 
+    /**
+     * True when {@link #createReference()} promoted an otherwise-unbound
+     * scalar temporary into selective reference counting. Such a referent has
+     * no hidden lexical, closure, global, or aggregate owner, so weakening its
+     * sole reference can clear it without a reachability walk.
+     */
+    boolean ephemeralScalarReferenceReferent;
+
     // Constructors
     public RuntimeScalar() {
         this.type = UNDEF;
@@ -2780,11 +2788,25 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     // Internals::SvREADONLY needs the container to set/get readonly status.
     public RuntimeScalar createReference() {
         referencedByScalarReference = true;
+        boolean isRegisteredLexical =
+                this.refCount == -1 && MyVarCleanupStack.isRegistered(this);
         if (this.refCount == -1
-                && MyVarCleanupStack.isRegistered(this)
+                && isRegisteredLexical
                 && !RuntimeCode.hasActiveCode()) {
             this.refCount = 0;
             this.localBindingExists = true;
+        } else if (this.refCount == -1
+                && !isRegisteredLexical
+                && captureCount == 0
+                && !isPackageGlobalRoot
+                && containerOwner == null) {
+            // An unbound scalar value returned from a subroutine is an
+            // ephemeral Perl SV. Birth-track it so weaken(\(sub_return()))
+            // consumes its sole owner immediately. Bound lexicals, closure
+            // captures, globals, aggregate elements, and active @_ arguments
+            // retain the established untracked/WEAKLY_TRACKED behavior.
+            this.refCount = 0;
+            this.ephemeralScalarReferenceReferent = true;
         }
         RuntimeScalar result = new RuntimeScalar();
         result.type = RuntimeScalarType.REFERENCE;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/WeakRefRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/WeakRefRegistry.java
@@ -141,7 +141,9 @@ public class WeakRefRegistry {
                     // slot holds a strong reference not counted in refCount.
                     // Don't call callDestroy — the container is still alive.
                     // Cleanup will happen at scope exit (scopeExitCleanupHash/Array).
-                } else if (hasWeakRefsTo(base)
+                } else if (!(base instanceof RuntimeScalar scalar
+                        && scalar.ephemeralScalarReferenceReferent)
+                        && hasWeakRefsTo(base)
                         && (ReachabilityWalker.isReachableFromRoots(base)
                         || ReachabilityWalker.isReachableFromLiveScalarRegistry(base)
                         || ReachabilityWalker.isReachableFromLiveCodeCaptures(base))) {

--- a/src/test/resources/unit/perlio_encoding_loads_encode.t
+++ b/src/test/resources/unit/perlio_encoding_loads_encode.t
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw(tempfile);
+
+my ($raw_fh, $filename) = tempfile();
+close $raw_fh;
+
+open my $encoded_fh, '>:encoding(UTF-8)', $filename
+    or die "open with encoding layer: $!";
+
+ok(defined(&Encode::encode),
+    ':encoding(...) loads Encode functions');
+
+close $encoded_fh;
+unlink $filename;
+
+done_testing;


### PR DESCRIPTION
## Summary

- load `Encode.pm` when applying a PerlIO `:encoding(...)` layer
- match the visible side effect provided by standard Perl's `PerlIO::encoding`
- keep `unit/refcount/weaken_edge_cases.t` unchanged and fix its scalar-temporary weak-reference failure
- avoid a reachability walk for the scalar-temporary case by using constant-time ownership metadata

## Root causes

`Pod::Wordlist` opens its bundled wordlist with `:encoding(UTF-8)`.
Standard Perl loads `Encode` while applying that layer, and `Pod::Spell`
later calls `Encode::encode`. PerlOnJava performed the charset conversion
directly without loading `Encode`, so the call was undefined.

The added PerlIO unit test changed the local parallel shard layout and exposed
an existing failure in `unit/refcount/weaken_edge_cases.t`: a weak reference to
an otherwise-unbound scalar returned from a subroutine remained defined.
`RuntimeScalar.createReference()` now birth-tracks only referents with no
lexical, closure, package-global, or aggregate owner. `WeakRefRegistry` can
therefore clear that proven ephemeral referent directly, without walking the
live object graph.

## Test plan

- `make` — passes all unit-test shards
- `./jperl src/test/resources/unit/refcount/weaken_edge_cases.t` — 43/43 pass
- `./jperl src/test/resources/unit/bless_existing_scalar_ref_destroy.t` — 4/4 pass
- `prove src/test/resources/unit/perlio_encoding_loads_encode.t`
- `./jperl src/test/resources/unit/perlio_encoding_loads_encode.t`
- `./jcpan Pod::Spell` — all 8 test files and 54 tests pass; install succeeds
- 10,000 nested scalar-temporary `weaken` operations, five runs:
  fix mean 0.404s; clean parent mean 0.404s
- GitHub CI for the original commit — Ubuntu and Windows builds pass

Generated with [Codex](https://openai.com/codex)
