### PR TITLE
perf: reduce reference-counting overhead and DBIx::Class warnings

### DIFF
--- a/dev/architecture/weaken-destroy.md
+++ b/dev/architecture/weaken-destroy.md
@@ -974,6 +974,33 @@ the `classHasDestroy()` check at bless time, which is cached per class. Code
 that actually uses DESTROY classes pays the full tracking cost (increment/
 decrement per reference assignment), but this is by design.
 
+### Tracked-store optimization (2026-07-27)
+
+`RuntimeScalar.setLargeRefCounted()` registered each newly owned reference
+twice in `ScalarRefRegistry`. Once `weaken()` had activated the registry, each
+registration was a synchronized `WeakHashMap.put()`, so tracked stores paid for
+two monitor/map operations even though the second put replaced the same entry.
+
+The optimized path:
+
+- registers the scalar once, after DESTROY-rescue handling;
+- uses the registry without a synchronization wrapper, consistent with
+  PerlOnJava's documented single-threaded runtime model;
+- removes empty reverse weak-reference buckets during `unweaken()`;
+- includes `dev/bench/benchmark_refcount_store.pl` for repeatable measurement.
+
+Median CPU time over three fresh JVM runs of the tracked-store benchmark:
+
+| Revision | CPU time | Change |
+|----------|----------|--------|
+| `master` (`168466619`) | 2.71 s | baseline |
+| optimized branch | 2.41 s | **-11.1%** |
+
+The ordinary method benchmark was unchanged at approximately 2.35 CPU seconds,
+showing no measurable regression before weak-reference bookkeeping is active.
+Correctness validation completed with `make` and the full DBIx::Class suite:
+314 files, 13,121 tests, all successful in 679 wall-clock seconds.
+
 ### Memory Overhead
 
 - **Per-referent:** `refCount` (int, 4 bytes) and `blessId` (int, 4 bytes) on
@@ -983,7 +1010,8 @@ decrement per reference assignment), but this is by design.
   4 bytes), on `RuntimeScalar`. Always present; the JVM may pack the booleans
   into existing object-alignment padding.
 - **WeakRefRegistry:** External identity maps. Only allocated when `weaken()`
-  is called. Zero memory when no weak refs exist.
+  is called. Zero memory when no weak refs exist. Empty per-referent reverse
+  buckets are removed by overwrite, clear, and `unweaken()` paths.
 - **DestroyDispatch caches:** `BitSet` + `ConcurrentHashMap`. Negligible.
 
 ---

--- a/dev/bench/README.md
+++ b/dev/bench/README.md
@@ -23,6 +23,7 @@ under PerlOnJava (and optionally system Perl for comparison). Use them to:
 | `benchmark_memory_delta.pl` | Memory growth / leak detection |
 | `benchmark_method.pl` | Method dispatch (class, inheritance) |
 | `benchmark_regex.pl` | Regex compilation and matching |
+| `benchmark_refcount_store.pl` | Tracked reference stores after `weaken()` activates lifecycle bookkeeping |
 | `benchmark_string.pl` | String operations (concat, substr, etc.) |
 
 ## Running

--- a/dev/bench/benchmark_refcount_store.pl
+++ b/dev/bench/benchmark_refcount_store.pl
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+use Benchmark;
+use Scalar::Util qw(weaken);
+
+{
+    package RefcountStoreBench;
+
+    sub DESTROY {
+        $main::destroyed++;
+    }
+}
+
+our $destroyed = 0;
+my $object = bless { value => 1 }, 'RefcountStoreBench';
+my $weak = $object;
+weaken($weak);
+
+# Keep enough container slots active to exercise tracked overwrite ownership
+# without measuring allocation of a fresh aggregate on every iteration.
+my @slots = map { $object } 0 .. 1023;
+my $sink = 0;
+
+sub loop_refcount_stores {
+    for my $i (0 .. 999_999) {
+        $slots[$i & 1023] = $object;
+        $sink += $slots[$i & 1023]{value};
+    }
+}
+
+timethis(30, sub {
+    $sink = 0;
+    loop_refcount_stores();
+});
+
+die "tracked object destroyed during benchmark\n"
+    if $destroyed || !defined $weak;
+print "done $sink\n";

--- a/dev/modules/dbix_class.md
+++ b/dev/modules/dbix_class.md
@@ -543,9 +543,21 @@ can't ship a regression behind that flag.
 
 ---
 
-## Non-Bug Warnings (informational)
+## Environment Warning Fixes (2026-07-27)
 
-- **`Mismatch of versions '1.1' and '1.45'`** in `t/00describe_environment.t` for `Params::ValidationCompiler::Exception::Named::Required`: Not a PerlOnJava bug. `Exception::Class` deliberately sets `$INC{$subclass.pm} = __FILE__` on every generated subclass.
+- **Generated Exception::Class version mismatches**: Exception::Class 1.45
+  gives generated subclasses version 1.1 while registering
+  `Exception/Class.pm` (version 1.45) as their `%INC` source. The bundled CPAN
+  patch now aligns generated subclass versions with the registered file.
+- **Optional Getopt::Long::Descriptive base classes**: `base::import` still
+  throws the normal catchable "Base class package ... is empty" exception, but
+  no longer prints a duplicate message directly to stderr before throwing.
+- **DynaLoader and bytes version mismatches**: bundled module files now expose
+  the same versions as their Java runtime implementations.
+- Verified `t/00describe_environment.t` has none of these warnings.
+
+## Remaining Non-Bug Warnings (informational)
+
 - **`Subroutine is_bool redefined at Cpanel::JSON::XS line 2429`**: Triggered when Cpanel::JSON::XS loads through `@ISA` fallback. Cosmetic only.
 
 ---

--- a/dev/modules/moo.md
+++ b/dev/modules/moo.md
@@ -16,6 +16,22 @@ All 841/841 Moo subtests now pass across all 71 test files.
 
 ## Completed Fixes
 
+### Readonly Pad Constants Passed Through Constructors — FIXED (2026-07-27)
+
+**2 test files, 6 subtests fixed (tests 17-19 in each accessor-weaken file).**
+
+Root cause: a readonly scalar created by `\ "literal"` is strongly owned by
+the defining subroutine's pad until that subroutine is replaced. Selective
+refcounting cannot see that pad edge. When Moo passed the reference through
+its constructor and weakened the attribute, the constructor temporary reached
+zero and mortal processing cleared the weak reference immediately.
+
+Fix: detect readonly scalars present in the pad constants of currently
+installed named subroutines. Both immediate `weaken()` processing and deferred
+mortal cleanup preserve those references. Replacing the subroutine continues
+to clear them through the existing `clearPadConstantWeakRefs()` optree-reaping
+hook.
+
 ### Category C: Optree Reaping — FIXED (2025-04-09)
 
 **2 test files, 2 subtests fixed (test 19 in each accessor-weaken file).**

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Base.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Base.java
@@ -126,7 +126,6 @@ public class Base extends PerlModuleBase {
                         // Java bridge stubs for IO::Handle::_sync, or DBIC's
                         // eval-created classes).
                         if (!GlobalVariable.isPackageLoaded(baseClassName)) {
-                            System.err.println("Base class package \"" + baseClassName + "\" is empty.");
                             throw new PerlCompilerException("Base class package \"" + baseClassName + "\" is empty.");
                         }
                     } else {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/DynaLoader.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/DynaLoader.java
@@ -16,8 +16,6 @@ public class DynaLoader extends PerlModuleBase {
         DynaLoader dynaLoader = new DynaLoader();
         dynaLoader.initializeExporter();
         dynaLoader.defineExport("EXPORT", "bootstrap");
-        // Set $DynaLoader::VERSION so CPAN dependency checks are satisfied
-        GlobalVariable.getGlobalVariable("DynaLoader::VERSION").set("1.54");
         try {
             dynaLoader.registerMethod("bootstrap", null);
             dynaLoader.registerMethod("boot_DynaLoader", null);
@@ -36,7 +34,8 @@ public class DynaLoader extends PerlModuleBase {
             dynaLoader.registerMethod("dl_undef_symbols", "dl_empty", null);
             dynaLoader.registerMethod("dl_error", "dl_error", null);
 
-            // Set $DynaLoader::VERSION so CPAN dependency checking works
+            // Match the bundled DynaLoader.pm so runtime and file-based
+            // dependency/version checks report the same value.
             GlobalVariable.getGlobalVariable("DynaLoader::VERSION").set("1.56");
         } catch (NoSuchMethodException e) {
             System.err.println("Warning: Missing DynaLoader method: " + e.getMessage());

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
@@ -985,6 +985,16 @@ public class MortalList {
                 // generation is wiring Moo metadata. Clearing then makes
                 // nested dispatch call undefer_sub(undef).
                 base.refCount = 1;
+            } else if (base instanceof RuntimeScalarReadOnly
+                    && hasWeakRefs
+                    && RuntimeCode.isInstalledPadConstant(base)) {
+                // A readonly scalar referenced through \("literal") belongs to
+                // its defining subroutine's pad. Constructor/call temporaries
+                // are selectively counted, but that pad ownership is not.
+                // Preserve the weak ref while the sub remains installed;
+                // RuntimeCode.clearPadConstantWeakRefs() clears it when the
+                // sub's glob is replaced, matching Perl optree reaping.
+                base.refCount = 1;
             } else if (base.blessId == 0
                     && hasWeakRefs
                     && (ReachabilityWalker.isReachableFromLiveCodeCaptures(base)

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -891,6 +891,30 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     /**
+     * Return whether a readonly scalar is owned by the optree/pad of a
+     * currently installed named subroutine.
+     *
+     * <p>Pad constants are JVM references that selective refcounting cannot
+     * observe. This targeted lookup lets mortal processing preserve a weak
+     * reference until the owning glob is replaced, when
+     * {@link #clearPadConstantWeakRefs()} performs Perl-compatible optree
+     * reaping.</p>
+     */
+    public static boolean isInstalledPadConstant(RuntimeBase target) {
+        if (target == null) return false;
+        for (RuntimeScalar codeScalar : GlobalVariable.globalCodeRefs.values()) {
+            if (codeScalar == null || !(codeScalar.value instanceof RuntimeCode code)
+                    || code.padConstants == null) {
+                continue;
+            }
+            for (RuntimeBase constant : code.padConstants) {
+                if (constant == target) return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Release captured variable references. Called when this closure is being
      * discarded (scope exit, undef, or reassignment of the variable holding
      * this CODE ref). Decrements {@code captureCount} on each captured scalar,

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -1540,12 +1540,6 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             }
         }
 
-        // Phase B1 (refcount_alignment_52leaks_plan.md): track this
-        // scalar so the reachability walker can enumerate live lexicals.
-        if (newOwned) {
-            ScalarRefRegistry.registerRef(this);
-        }
-
         int preAssignType = this.type;
         Object preAssignValue = this.value;
 
@@ -1597,10 +1591,10 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             newOwned = true;
         }
 
-        // Phase B1 (refcount_alignment_52leaks_plan.md): register this
-        // scalar in ScalarRefRegistry so the reachability walker can
-        // enumerate live ref-holding RuntimeScalars on demand. No-op
-        // when no weaken() has ever been called.
+        // Phase B1 (refcount_alignment_52leaks_plan.md): register this scalar
+        // once, after rescue handling has had a chance to acquire ownership.
+        // This used to run both before and after the assignment, causing two
+        // WeakHashMap.put() calls for every ordinary tracked reference store.
         if (newOwned) {
             ScalarRefRegistry.registerRef(this);
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarRefRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarRefRegistry.java
@@ -1,10 +1,7 @@
 package org.perlonjava.runtime.runtimetypes;
 
 import java.lang.ref.WeakReference;
-import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.WeakHashMap;
 
 /**
@@ -31,7 +28,7 @@ public class ScalarRefRegistry {
     // hashCode/equals — RuntimeScalar uses Object's defaults, so this
     // is effectively IdentityHashMap-with-weak-keys.
     private static final Map<RuntimeScalar, Boolean> scalarRegistry =
-            Collections.synchronizedMap(new WeakHashMap<>());
+            new WeakHashMap<>();
 
     // Phase E: optional per-scalar registerRef call-site stacks.
     // Populated only when JPERL_REGISTER_STACKS=1 is set. Uses a
@@ -39,7 +36,7 @@ public class ScalarRefRegistry {
     // automatically when the scalar is JVM-GC'd. Lookup via
     // stackFor() is O(1).
     private static final Map<RuntimeScalar, Throwable> registerStacks =
-            Collections.synchronizedMap(new WeakHashMap<>());
+            new WeakHashMap<>();
 
     // Phase B1 performance toggle: when set, skip all registry
     // maintenance. Useful for benchmarks; does NOT affect correctness
@@ -109,9 +106,7 @@ public class ScalarRefRegistry {
      * unreachable entries first (e.g., freshly-exited lexical scopes).
      */
     public static java.util.List<RuntimeScalar> snapshot() {
-        synchronized (scalarRegistry) {
-            return new java.util.ArrayList<>(scalarRegistry.keySet());
-        }
+        return new java.util.ArrayList<>(scalarRegistry.keySet());
     }
 
     /**
@@ -149,8 +144,6 @@ public class ScalarRefRegistry {
      * hold? (Subject to JVM GC between calls.)
      */
     public static int approximateSize() {
-        synchronized (scalarRegistry) {
-            return scalarRegistry.size();
-        }
+        return scalarRegistry.size();
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/WeakRefRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/WeakRefRegistry.java
@@ -146,7 +146,8 @@ public class WeakRefRegistry {
                         && hasWeakRefsTo(base)
                         && (ReachabilityWalker.isReachableFromRoots(base)
                         || ReachabilityWalker.isReachableFromLiveScalarRegistry(base)
-                        || ReachabilityWalker.isReachableFromLiveCodeCaptures(base))) {
+                        || ReachabilityWalker.isReachableFromLiveCodeCaptures(base)
+                        || RuntimeCode.isInstalledPadConstant(base))) {
                     // A temporary probe can be weakened without owning the last
                     // strong Perl reference. Test::Refcount does this when it
                     // weakens a local copy before calling B::svref_2object().
@@ -170,6 +171,12 @@ public class WeakRefRegistry {
             // (new RuntimeScalar(RuntimeScalar)) is mitigated by the fact that such
             // copies don't decrement refCount on cleanup (refCountOwned=false), so
             // they can't cause false-positive refCount==0 destruction.
+        } else if (base.refCount == -1
+                && base instanceof RuntimeScalarReadOnly
+                && RuntimeCode.isInstalledPadConstant(base)) {
+            // The defining subroutine's pad is the strong owner. Its ownership
+            // is not represented in selective refCount, and glob replacement
+            // clears the weak ref explicitly via clearPadConstantWeakRefs().
         } else if (base.refCount == -1 && !(base instanceof RuntimeCode)) {
             // Untracked non-CODE object: transition to WEAKLY_TRACKED so that
             // undefine() and scopeExitCleanup() can clear weak refs

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/WeakRefRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/WeakRefRegistry.java
@@ -237,7 +237,10 @@ public class WeakRefRegistry {
         if (!weakScalars.remove(ref)) return;
         if (ref.value instanceof RuntimeBase base) {
             Set<RuntimeScalar> weakRefs = referentToWeakRefs.get(base);
-            if (weakRefs != null) weakRefs.remove(ref);
+            if (weakRefs != null) {
+                weakRefs.remove(ref);
+                if (weakRefs.isEmpty()) referentToWeakRefs.remove(base);
+            }
             if (base.refCount >= 0) {
                 base.refCount++;  // restore strong count
                 ref.refCountOwned = true;  // restore ownership

--- a/src/main/perl/lib/CPAN/Config.pm
+++ b/src/main/perl/lib/CPAN/Config.pm
@@ -197,6 +197,8 @@ sub _bootstrap_patches {
           'PerlOnJava/CpanPatches/DBI-1.647/DBI.pm.patch' ],
         [ 'DBI-1.647/PurePerl.pm.patch',
           'PerlOnJava/CpanPatches/DBI-1.647/PurePerl.pm.patch' ],
+        [ 'Exception-Class-1.45/GeneratedSubclassVersion.patch',
+          'PerlOnJava/CpanPatches/Exception-Class-1.45/GeneratedSubclassVersion.patch' ],
         [ 'Net-Server-2.018/Proto.pm.patch',
           'PerlOnJava/CpanPatches/Net-Server-2.018/Proto.pm.patch' ],
         [ 'Device-SerialPort-1.04/NoXsBitsFallback.patch',

--- a/src/main/perl/lib/DynaLoader.pm
+++ b/src/main/perl/lib/DynaLoader.pm
@@ -13,7 +13,7 @@ package DynaLoader;
 # XSLoader, so DynaLoader's bootstrap() is not needed for normal use.
 #
 
-our $VERSION = '1.54';
+our $VERSION = '1.56';
 
 # Only define bootstrap if not already registered by Java
 BEGIN {

--- a/src/main/perl/lib/PerlOnJava/CpanDistroprefs/Exception-Class.yml
+++ b/src/main/perl/lib/PerlOnJava/CpanDistroprefs/Exception-Class.yml
@@ -3,12 +3,17 @@ comment: |
   PerlOnJava distroprefs for Exception::Class.
 
   Exception::Class is pure Perl and is needed by Params::ValidationCompiler.
-  Its t/ignore.t suite has one PerlOnJava stack-frame-filter mismatch, but
-  the module otherwise builds and installs.
+  Its t/ignore.t suite has one PerlOnJava stack-frame-filter mismatch. It
+  also assigns generated exception classes version 1.1 while mapping their
+  %INC entries to Exception/Class.pm (version 1.45). This makes consumers
+  such as DBIx::Class report false module/file version mismatches. Keep the
+  generated class version aligned with the file registered in %INC.
 
   Keep the test output visible for signal, but allow CPAN to install it as
   a DateTime prerequisite.
 match:
   distribution: "^DROLSKY/Exception-Class-"
+patches:
+  - "Exception-Class-1.45/GeneratedSubclassVersion.patch"
 test:
   commandline: "PERLONJAVA_TEST_IGNORE_FAILURES"

--- a/src/main/perl/lib/PerlOnJava/CpanPatches/Exception-Class-1.45/GeneratedSubclassVersion.patch
+++ b/src/main/perl/lib/PerlOnJava/CpanPatches/Exception-Class-1.45/GeneratedSubclassVersion.patch
@@ -1,0 +1,11 @@
+--- lib/Exception/Class.pm.orig
++++ lib/Exception/Class.pm
+@@ -137,7 +137,7 @@ package $subclass;
+ 
+ use base qw($isa);
+ 
+-our \$$version_name = '1.1';
++our \$$version_name = '$VERSION';
+ 
+ 1;
+ 

--- a/src/main/perl/lib/bytes.pm
+++ b/src/main/perl/lib/bytes.pm
@@ -1,5 +1,6 @@
 package bytes;
 
+our $VERSION = '1.08';
 our $hint_bits = 0x00000008;
 
 sub import {

--- a/src/test/resources/unit/core_module_file_versions.t
+++ b/src/test/resources/unit/core_module_file_versions.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+
+use Test::More;
+use ExtUtils::MakeMaker;
+
+for my $module (qw(DynaLoader bytes)) {
+    (my $filename = "$module.pm") =~ s{::}{/}g;
+    require $filename;
+
+    my $runtime_version = $module->VERSION;
+    my $file_version = MM->parse_version($INC{$filename});
+
+    is(
+        "$runtime_version",
+        "$file_version",
+        "$module runtime version matches its module file",
+    );
+}
+
+done_testing;


### PR DESCRIPTION
## Summary

- register tracked scalar owners once after DESTROY-rescue handling instead of twice
- remove redundant synchronized wrappers from the explicitly single-threaded scalar registry
- remove empty reverse weak-reference buckets during `unweaken`
- stop caught optional `base::import` failures from printing duplicate stderr diagnostics
- align bundled DynaLoader and bytes file versions with their Java runtime versions
- patch Exception::Class 1.45 generated subclasses to match the source file registered in `%INC`
- preserve weak references to readonly constants while their defining subroutine remains installed
- add focused performance and version-consistency regression coverage

## Performance

Three fresh JVM runs of `dev/bench/benchmark_refcount_store.pl`:

| Revision | Median CPU time |
|----------|-----------------|
| master (`168466619`) | 2.71 s |
| this branch | 2.41 s |

This is an 11.1% reduction in CPU time for tracked reference stores after `weaken()` activates lifecycle bookkeeping.

The ordinary method benchmark remained approximately 2.35 CPU seconds on both revisions.

## DBIx::Class warnings

`t/00describe_environment.t` no longer reports:

- empty Getopt::Long::Descriptive base packages from caught optional-dependency probes
- Params::ValidationCompiler generated exception version mismatches
- DynaLoader or bytes runtime/file version mismatches

Exception::Class 1.45 still contains the upstream 1.1/1.45 mismatch; the CPAN distroprefs patch keeps the generated class version consistent with `Exception/Class.pm` while preserving its `%INC` registration.

## Moo weak accessors

Readonly scalars created by `\ "literal"` are strongly owned by their defining subroutine's pad, but that edge is invisible to selective refcounting. Moo passes these references through constructor temporaries before weakening an attribute, which previously let mortal processing clear the value immediately.

The runtime now recognizes readonly scalars in installed subroutine pads as strongly owned. Replacing the subroutine still clears the weak reference through the existing optree-reaping hook.

## Validation

- standard Perl: `prove src/test/resources/unit/core_module_file_versions.t`
- PerlOnJava: `./jperl src/test/resources/unit/core_module_file_versions.t`
- Exception::Class 1.45: 7 files, 86 tests, all successful
- DBIx::Class `t/00describe_environment.t`: passed with none of the targeted warnings
- `./jcpan -t Moo`: 71 files, 841 tests, all successful
- `make`: successful
- `./jcpan --jobs 8 -t DBIx::Class`
  - 314 files
  - 13,121 tests
  - 695 seconds wall time after the Moo fix
  - all tests successful

## Safety notes

Two broader reference-counting optimizations were evaluated and rejected after unit-test regressions:

- conditionally skipping temporary reachability roots
- resetting the global weak-reference mode after the last weak reference cleared

The retained performance changes preserve the existing lifecycle state machine. The warning changes retain catchable `base` exceptions and validate file/runtime version consistency with a portable test that also passes on standard Perl.

Generated with [Codex](https://openai.com/codex)
