### PR TITLE
Fix repository skill frontmatter

### DIFF
--- a/.agents/skills/debug-windows-ci/SKILL.md
+++ b/.agents/skills/debug-windows-ci/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: debug-windows-ci
+description: Debug PerlOnJava test and build failures that occur on Windows CI but pass on macOS or Linux. Use for Windows-specific path handling, shell differences, file I/O behavior, and GitHub Actions failures on windows-latest.
+---
+
 # Debug PerlOnJava Windows CI Failures
 
 ## ⚠️⚠️⚠️ CRITICAL: NEVER USE `git stash` ⚠️⚠️⚠️

--- a/.agents/skills/debugger/SKILL.md
+++ b/.agents/skills/debugger/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: debugger
+description: Implement and debug PerlOnJava's Perl debugger support, including the -d flag, DEBUG opcodes, stepping, breakpoints, source display, and debugger command behavior. Use when extending or diagnosing the bytecode interpreter's debugger implementation.
+---
+
 # Perl Debugger Implementation Skill
 
 ## ⚠️⚠️⚠️ CRITICAL: NEVER USE `git stash` ⚠️⚠️⚠️

--- a/.agents/skills/port-cpan-module/SKILL.md
+++ b/.agents/skills/port-cpan-module/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: port-cpan-module
+description: Port CPAN modules, especially distributions with XS or C components, to PerlOnJava using minimal pure-Perl adaptations and Java replacements. Use when adding a CPAN module, replacing XSLoader functionality, or implementing Perl module behavior in Java.
+---
+
 # Port CPAN Module to PerlOnJava
 
 ## ⚠️⚠️⚠️ CRITICAL: NEVER USE `git stash` ⚠️⚠️⚠️

--- a/.agents/skills/port-native-module/SKILL.md
+++ b/.agents/skills/port-native-module/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: port-native-module
+description: Port CPAN modules that require native system calls to PerlOnJava using Java's Foreign Function and Memory API. Use for modules involving POSIX functions, ioctl, terminal control, libc calls, or platform-specific native behavior, including Windows compatibility.
+---
+
 # Port Native/FFM CPAN Module to PerlOnJava
 
 ## When to Use This Skill

--- a/.agents/skills/profile-perlonjava/SKILL.md
+++ b/.agents/skills/profile-perlonjava/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: profile-perlonjava
+description: Profile and optimize PerlOnJava runtime performance with Java Flight Recorder. Use when investigating runtime bottlenecks, identifying CPU or allocation hotspots, measuring optimizations, or diagnosing performance regressions.
+---
+
 # Profile PerlOnJava
 
 ## ⚠️⚠️⚠️ CRITICAL: NEVER USE `git stash` ⚠️⚠️⚠️


### PR DESCRIPTION
## Summary

- add required YAML frontmatter to five repository skill definitions
- give each skill a directory-matching name and a concise trigger description
- restore successful discovery by Codex's skill loader

## Validation

- `quick_validate.py` passes for all five skill folders
- `git diff --check`
- `make` (`BUILD SUCCESSFUL`, 14 tasks)

Generated with [Codex](https://openai.com/codex)
