### PR TITLE
fix: preserve qualified Class::XSAccessor usage errors

### DIFF
--- a/src/main/perl/lib/Class/XSAccessor.pm
+++ b/src/main/perl/lib/Class/XSAccessor.pm
@@ -117,7 +117,6 @@ sub _generate_method {
 
 sub _usage {
     my ($name, $args) = @_;
-    $name =~ s/^.*:://;
     croak("Usage: $name($args)");
 }
 


### PR DESCRIPTION
## Summary

- preserve fully qualified accessor names in bundled `Class::XSAccessor` usage errors
- fix the Moo-generated read-only accessor diagnostics exercised by `OAuth2::Box`

## Verification

- `make`
- focused `jperl` accessor arity check
- baseline `timeout 900 ./jcpan -t OAuth2::Box` reproduced 5 failures

The post-fix CPAN retry was blocked by CPAN connectivity after the local cache
was refreshed; the dependency tests that ran during the retry passed.
