### PR TITLE
Fix Ormlette and File::Shuffle tooling support

### DIFF
--- a/src/main/java/org/perlonjava/app/cli/ArgumentParser.java
+++ b/src/main/java/org/perlonjava/app/cli/ArgumentParser.java
@@ -318,16 +318,16 @@ public class ArgumentParser {
             return;
         }
 
+        if (applyPerlShebangSwitches(fileContent, parsedArgs)) {
+            return;
+        }
+
         String[] lines = fileContent.split("\n", 2);
         if (lines.length == 0 || !lines[0].startsWith("#!")) {
             return;
         }
         String shebangLine = lines[0].substring(2).trim();
         if (shebangLine.isEmpty()) {
-            return;
-        }
-
-        if (processPerlShebangSwitches(shebangLine, parsedArgs)) {
             return;
         }
 
@@ -343,6 +343,25 @@ public class ArgumentParser {
         }
         List<String> cmd = buildShebangCommand(tokens);
         delegateToShebangInterpreter(args, cmd, index);
+    }
+
+    /** Apply Perl switches from an in-memory script's shebang without invoking an alternate interpreter. */
+    public static boolean applyPerlShebangSwitches(String fileContent, CompilerOptions parsedArgs) {
+        if (parsedArgs.perlShebangProcessed) {
+            return true;
+        }
+        if (fileContent == null) {
+            return false;
+        }
+        String[] lines = fileContent.split("\n", 2);
+        if (lines.length == 0 || !lines[0].startsWith("#!")) {
+            return false;
+        }
+        String shebangLine = lines[0].substring(2).trim();
+        boolean processed = !shebangLine.isEmpty()
+                && processPerlShebangSwitches(shebangLine, parsedArgs);
+        parsedArgs.perlShebangProcessed = processed;
+        return processed;
     }
 
     private static boolean processPerlShebangSwitches(String shebangLine, CompilerOptions parsedArgs) {

--- a/src/main/java/org/perlonjava/app/cli/CompilerOptions.java
+++ b/src/main/java/org/perlonjava/app/cli/CompilerOptions.java
@@ -71,6 +71,7 @@ public class CompilerOptions implements Cloneable {
     public boolean isEvalbytes = false; // Set to true for evalbytes context - treats strings as raw bytes
     public boolean isByteStringSource = false; // Set to true when parsing source that originates from a BYTE_STRING scalar (raw bytes)
     public boolean taintMode = false; // For -T
+    public boolean perlShebangProcessed = false;
     public boolean allowUnsafeOperations = false; // For -U
     public boolean runUnderDebugger = false; // For -d
     public boolean taintWarnings = false; // For -t

--- a/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
+++ b/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
@@ -1,6 +1,7 @@
 package org.perlonjava.app.scriptengine;
 
 import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.app.cli.ArgumentParser;
 import org.perlonjava.backend.bytecode.BytecodeCompiler;
 import org.perlonjava.backend.bytecode.Disassemble;
 import org.perlonjava.backend.bytecode.InterpretedCode;
@@ -57,6 +58,7 @@ public class PerlLanguageProvider {
 
     public static void resetAll() {
         globalInitialized = false;
+        GlobalContext.setThreadTaintMode(false);
         resetAllGlobals();
         DataSection.reset();
     }
@@ -85,6 +87,16 @@ public class PerlLanguageProvider {
     public static RuntimeList executePerlCode(CompilerOptions compilerOptions,
                                               boolean isTopLevelScript,
                                               int callerContext) throws Exception {
+
+        if (isTopLevelScript) {
+            ArgumentParser.applyPerlShebangSwitches(compilerOptions.code, compilerOptions);
+            GlobalContext.setThreadTaintMode(compilerOptions.taintMode);
+        } else if (compilerOptions.taintMode) {
+            // A nested require/do inherits its caller's runtime taint mode.
+            // It may enable taint explicitly, but default nested options must
+            // not disable a top-level -T program.
+            GlobalContext.setThreadTaintMode(true);
+        }
 
         // Save the current scope so we can restore it after execution.
         // This is critical because require/do should not leak their scope to the caller.
@@ -280,6 +292,10 @@ public class PerlLanguageProvider {
                                              List<LexerToken> tokens,
                                              CompilerOptions compilerOptions,
                                              int contextType) throws Exception {
+
+        if (compilerOptions.taintMode) {
+            GlobalContext.setThreadTaintMode(true);
+        }
 
         // Save the current scope so we can restore it after execution.
         ScopedSymbolTable savedCurrentScope = SpecialBlockParser.getCurrentScope();
@@ -684,6 +700,8 @@ public class PerlLanguageProvider {
      * @throws Exception if compilation fails
      */
     public static Object compilePerlCode(CompilerOptions compilerOptions) throws Exception {
+        ArgumentParser.applyPerlShebangSwitches(compilerOptions.code, compilerOptions);
+        GlobalContext.setThreadTaintMode(compilerOptions.taintMode);
         ScopedSymbolTable globalSymbolTable = new ScopedSymbolTable();
         globalSymbolTable.enterScope();
         globalSymbolTable.addVariable("this", "", null); // anon sub instance is local variable 0

--- a/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
@@ -184,6 +184,12 @@ public class EvalStringHandler {
                                              int siteStrictOptions,
                                              int siteFeatureFlags,
                                              boolean isEvalbytes) {
+        try {
+            RuntimeCode.rejectTaintedEval(codeScalar);
+        } catch (PerlCompilerException e) {
+            WarnDie.catchEval(e);
+            return new RuntimeList(new RuntimeScalar());
+        }
         return evalStringList(codeScalar.toString(), codeScalar.type, currentCode, registers,
                 sourceName, sourceLine, callContext, siteRegistry, siteStrictOptions, siteFeatureFlags, isEvalbytes);
     }

--- a/src/main/java/org/perlonjava/runtime/io/DirectoryIO.java
+++ b/src/main/java/org/perlonjava/runtime/io/DirectoryIO.java
@@ -123,11 +123,12 @@ public class DirectoryIO {
             }
             String entry = allEntries.get(currentPosition);
             currentPosition++;
-            return new RuntimeScalar(entry);
+            return new RuntimeScalar(entry).taintFromExternalInput();
         } else {
             RuntimeList result = new RuntimeList();
             while (currentPosition >= 0 && currentPosition < allEntries.size()) {
-                result.elements.add(new RuntimeScalar(allEntries.get(currentPosition)));
+                result.elements.add(new RuntimeScalar(allEntries.get(currentPosition))
+                        .taintFromExternalInput());
                 currentPosition++;
             }
             return result;

--- a/src/main/java/org/perlonjava/runtime/mro/DFS.java
+++ b/src/main/java/org/perlonjava/runtime/mro/DFS.java
@@ -93,7 +93,7 @@ public class DFS {
         visiting.add(className);
 
         // Get current @ISA array - FORCE fresh read
-        RuntimeArray isaArray = GlobalVariable.getGlobalArray(className + "::ISA");
+        RuntimeArray isaArray = InheritanceResolver.getIsaArrayForClass(className);
         List<String> parents = new ArrayList<>();
         for (RuntimeBase entity : isaArray.elements) {
             String parentName = entity.toString();

--- a/src/main/java/org/perlonjava/runtime/mro/InheritanceResolver.java
+++ b/src/main/java/org/perlonjava/runtime/mro/InheritanceResolver.java
@@ -129,7 +129,7 @@ public class InheritanceResolver {
      * Checks if the @ISA array for a class has changed since last cached.
      */
     private static boolean hasIsaChanged(String className) {
-        RuntimeArray isaArray = GlobalVariable.getGlobalArray(className + "::ISA");
+        RuntimeArray isaArray = getIsaArrayForClass(className);
         
         // Build current ISA list
         List<String> currentIsa = new ArrayList<>();
@@ -282,6 +282,21 @@ public class InheritanceResolver {
         populateIsaMapHelper(className, isaMap, new HashSet<>());
     }
 
+    /**
+     * Resolve @ISA through Perl's optional main:: package prefix.  Code may
+     * declare `package main::Foo::Bar` while objects and method calls report
+     * the same class as `Foo::Bar`; both spellings address one Perl stash.
+     */
+    static RuntimeArray getIsaArrayForClass(String className) {
+        for (String alias : packageLookupAliases(className)) {
+            String key = alias + "::ISA";
+            if (GlobalVariable.existsGlobalArray(key)) {
+                return GlobalVariable.getGlobalArray(key);
+            }
+        }
+        return GlobalVariable.getGlobalArray(className + "::ISA");
+    }
+
     private static void populateIsaMapHelper(String className,
                                              Map<String, List<String>> isaMap,
                                              Set<String> currentPath) {
@@ -297,7 +312,7 @@ public class InheritanceResolver {
         currentPath.add(className);
 
         // Retrieve @ISA array for the given class
-        RuntimeArray isaArray = GlobalVariable.getGlobalArray(className + "::ISA");
+        RuntimeArray isaArray = getIsaArrayForClass(className);
         List<String> parents = new ArrayList<>();
         for (RuntimeBase entity : isaArray.elements) {
             String parentName = entity.toString();
@@ -502,7 +517,11 @@ public class InheritanceResolver {
             aliases.add(normalized.substring(6));
         } else if (normalized.startsWith("::") && normalized.length() > 2) {
             aliases.add("main::" + normalized.substring(2));
-        } else if (!normalized.contains("::")) {
+        } else {
+            // Perl's root package prefix is optional at every nesting depth:
+            // Foo::Bar and main::Foo::Bar name the same stash.  Dynamic code
+            // generators commonly emit an explicit `package main::Foo::Bar`
+            // and later invoke it as Foo::Bar->method.
             aliases.add("main::" + normalized);
         }
 

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -1158,6 +1158,7 @@ public class IOOperator {
     private static void setByteString(RuntimeScalar target, String value) {
         RuntimeScalar tmp = new RuntimeScalar(value);
         tmp.type = RuntimeScalarType.BYTE_STRING;
+        tmp.taintFromExternalInput();
         target.set(tmp);
     }
 

--- a/src/main/java/org/perlonjava/runtime/operators/Readline.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Readline.java
@@ -103,7 +103,7 @@ public class Readline {
             if (isByteData) {
                 result.type = RuntimeScalarType.BYTE_STRING;
             }
-            return result;
+            return result.taintFromExternalInput();
         }
 
         if (rs != null && rs.isParagraphMode()) {
@@ -178,7 +178,7 @@ public class Readline {
         if (isByteMode) {
             result.type = RuntimeScalarType.BYTE_STRING;
         }
-        return result;
+        return result.taintFromExternalInput();
     }
 
     private static RuntimeScalar readFixedLength(RuntimeIO runtimeIO, int length) {
@@ -205,7 +205,7 @@ public class Readline {
         if (isByteMode) {
             rslt.type = RuntimeScalarType.BYTE_STRING;
         }
-        return rslt;
+        return rslt.taintFromExternalInput();
     }
 
     private static RuntimeScalar readUntilCharacter(RuntimeIO runtimeIO, char separator) {
@@ -236,7 +236,7 @@ public class Readline {
         if (isByteMode) {
             result.type = RuntimeScalarType.BYTE_STRING;
         }
-        return result;
+        return result.taintFromExternalInput();
     }
 
     private static RuntimeScalar readUntilString(RuntimeIO runtimeIO, String separator) {
@@ -276,7 +276,7 @@ public class Readline {
         if (isByteMode) {
             result.type = RuntimeScalarType.BYTE_STRING;
         }
-        return result;
+        return result.taintFromExternalInput();
     }
 
     /**
@@ -397,6 +397,7 @@ public class Readline {
         } else {
             scalar.set(scalarValue.toString());
         }
+        scalar.taintFromExternalInput();
 
         // Return the number of characters read
         return new RuntimeScalar(charsRead);

--- a/src/main/java/org/perlonjava/runtime/operators/StringOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/StringOperators.java
@@ -437,21 +437,23 @@ public class StringOperators {
         // b.toString() may trigger FETCH for tied vars, potentially modifying runtimeScalar.
         // Read b first so runtimeScalar.toString() reflects any FETCH side-effects,
         // matching Perl's behavior where the left SV is read after tied-var resolution.
-        String bStr = b.toString();
-        String aStr = runtimeScalar.toString();
+        RuntimeScalar bResolved = resolveTiedStringOperand(b);
+        RuntimeScalar aResolved = resolveTiedStringOperand(runtimeScalar);
+        String bStr = bResolved.toString();
+        String aStr = aResolved.toString();
 
         if (bytesHintActive()) {
-            return stringConcatBytes(aStr, bStr);
+            return propagateTaint(stringConcatBytes(aStr, bStr), aResolved, bResolved);
         }
 
         // In Perl, concatenation produces a UTF-8 string only if at least one
         // operand has the UTF-8 flag on (STRING type). Non-STRING types
         // (BYTE_STRING, INTEGER, DOUBLE, UNDEF) are all byte-compatible.
-        boolean aIsUtf8 = runtimeScalar.type == RuntimeScalarType.STRING;
-        boolean bIsUtf8 = b.type == RuntimeScalarType.STRING;
+        boolean aIsUtf8 = aResolved.type == RuntimeScalarType.STRING;
+        boolean bIsUtf8 = bResolved.type == RuntimeScalarType.STRING;
 
         if (aIsUtf8 || bIsUtf8) {
-            return new RuntimeScalar(aStr + bStr);
+            return propagateTaint(new RuntimeScalar(aStr + bStr), aResolved, bResolved);
         }
 
         // Neither operand is UTF-8 — produce BYTE_STRING result
@@ -473,10 +475,24 @@ public class StringOperators {
             byte[] out = new byte[aBytes.length + bBytes.length];
             System.arraycopy(aBytes, 0, out, 0, aBytes.length);
             System.arraycopy(bBytes, 0, out, aBytes.length, bBytes.length);
-            return new RuntimeScalar(out);
+            return propagateTaint(new RuntimeScalar(out), aResolved, bResolved);
         }
 
-        return new RuntimeScalar(aStr + bStr);
+        return propagateTaint(new RuntimeScalar(aStr + bStr), aResolved, bResolved);
+    }
+
+    private static RuntimeScalar resolveTiedStringOperand(RuntimeScalar scalar) {
+        return scalar.type == RuntimeScalarType.TIED_SCALAR ? scalar.tiedFetch() : scalar;
+    }
+
+    private static RuntimeScalar propagateTaint(RuntimeScalar result, RuntimeScalar... inputs) {
+        for (RuntimeScalar input : inputs) {
+            if (input != null && input.isTainted()) {
+                result.tainted = true;
+                break;
+            }
+        }
+        return result;
     }
 
     private static RuntimeScalar tryStringConcatOverload(RuntimeScalar runtimeScalar, RuntimeScalar b) {
@@ -512,7 +528,7 @@ public class StringOperators {
         String bStr = bResolved.toString();
 
         if (bytesHintActive()) {
-            return stringConcatBytes(aStr, bStr);
+            return propagateTaint(stringConcatBytes(aStr, bStr), aResolved, bResolved);
         }
 
         // Match stringConcat(): the UTF-8 flag propagates only from an
@@ -521,7 +537,7 @@ public class StringOperators {
         // every non-BYTE_STRING proxy as UTF-8 upgraded byte captures during
         // s///e replacement evaluation.
         if (aResolved.type == RuntimeScalarType.STRING || bResolved.type == RuntimeScalarType.STRING) {
-            return new RuntimeScalar(aStr + bStr);
+            return propagateTaint(new RuntimeScalar(aStr + bStr), aResolved, bResolved);
         }
 
         // No operand carries the UTF-8 flag.  Preserve byte semantics whenever
@@ -543,10 +559,10 @@ public class StringOperators {
             byte[] out = new byte[aBytes.length + bBytes.length];
             System.arraycopy(aBytes, 0, out, 0, aBytes.length);
             System.arraycopy(bBytes, 0, out, aBytes.length, bBytes.length);
-            return new RuntimeScalar(out);
+            return propagateTaint(new RuntimeScalar(out), aResolved, bResolved);
         }
 
-        return new RuntimeScalar(aStr + bStr);
+        return propagateTaint(new RuntimeScalar(aStr + bStr), aResolved, bResolved);
     }
 
     public static RuntimeScalar chompScalar(RuntimeScalar runtimeScalar) {
@@ -757,10 +773,12 @@ public class StringOperators {
                 WarnDie.warnWithCategory(new RuntimeScalar("Use of uninitialized value in join or string"),
                         RuntimeScalarCache.scalarEmptyString, "uninitialized");
             }
-            RuntimeScalar res = new RuntimeScalar(scalar.toString());
-            if (scalar.type != RuntimeScalarType.STRING) {
+            RuntimeScalar resolved = resolveTiedStringOperand(scalar);
+            RuntimeScalar res = new RuntimeScalar(resolved.toString());
+            if (resolved.type != RuntimeScalarType.STRING) {
                 res.type = BYTE_STRING;
             }
+            res.tainted = resolved.isTainted();
             return res;
         }
 
@@ -770,12 +788,14 @@ public class StringOperators {
                     RuntimeScalarCache.scalarEmptyString, "uninitialized");
         }
 
-        String delimiter = runtimeScalar.toString();
+        RuntimeScalar separatorResolved = resolveTiedStringOperand(runtimeScalar);
+        String delimiter = separatorResolved.toString();
 
         // In Perl, join produces a byte-string unless one of the inputs has
         // the UTF-8 flag on. Only STRING type has the flag; INTEGER, DOUBLE,
         // UNDEF, and BYTE_STRING are all byte-compatible.
-        boolean hasUtf8 = runtimeScalar.type == RuntimeScalarType.STRING;
+        boolean hasUtf8 = separatorResolved.type == RuntimeScalarType.STRING;
+        boolean tainted = separatorResolved.isTainted();
 
         // Join the elements
         StringBuilder sb = new StringBuilder();
@@ -793,15 +813,18 @@ public class StringOperators {
                         RuntimeScalarCache.scalarEmptyString, "uninitialized");
             }
 
-            if (scalar.type == RuntimeScalarType.STRING) {
+            RuntimeScalar resolved = resolveTiedStringOperand(scalar);
+            if (resolved.type == RuntimeScalarType.STRING) {
                 hasUtf8 = true;
             }
-            sb.append(scalar);
+            tainted |= resolved.isTainted();
+            sb.append(resolved);
         }
         RuntimeScalar res = new RuntimeScalar(sb.toString());
         if (!hasUtf8) {
             res.type = BYTE_STRING;
         }
+        res.tainted = tainted;
         return res;
     }
 
@@ -857,24 +880,26 @@ public class StringOperators {
      * Calls {@code toStringNoOverload()} on both operands instead of {@code toString()}.
      */
     public static RuntimeScalar stringConcatNoOverload(RuntimeScalar runtimeScalar, RuntimeScalar b) {
-        String aStr = runtimeScalar.toStringNoOverload();
-        String bStr = b.toStringNoOverload();
+        RuntimeScalar aResolved = resolveTiedStringOperand(runtimeScalar);
+        RuntimeScalar bResolved = resolveTiedStringOperand(b);
+        String aStr = aResolved.toStringNoOverload();
+        String bStr = bResolved.toStringNoOverload();
 
         if (bytesHintActive()) {
-            return stringConcatBytes(aStr, bStr);
+            return propagateTaint(stringConcatBytes(aStr, bStr), aResolved, bResolved);
         }
 
-        if (runtimeScalar.type == RuntimeScalarType.STRING || b.type == RuntimeScalarType.STRING) {
-            return new RuntimeScalar(aStr + bStr);
+        if (aResolved.type == RuntimeScalarType.STRING || bResolved.type == RuntimeScalarType.STRING) {
+            return propagateTaint(new RuntimeScalar(aStr + bStr), aResolved, bResolved);
         }
 
-        if (runtimeScalar.type == BYTE_STRING || b.type == BYTE_STRING) {
-            boolean aIsByte = runtimeScalar.type == BYTE_STRING
-                    || runtimeScalar.type == RuntimeScalarType.UNDEF
-                    || (aStr.isEmpty() && runtimeScalar.type != RuntimeScalarType.STRING);
-            boolean bIsByte = b.type == BYTE_STRING
-                    || b.type == RuntimeScalarType.UNDEF
-                    || (bStr.isEmpty() && b.type != RuntimeScalarType.STRING);
+        if (aResolved.type == BYTE_STRING || bResolved.type == BYTE_STRING) {
+            boolean aIsByte = aResolved.type == BYTE_STRING
+                    || aResolved.type == RuntimeScalarType.UNDEF
+                    || (aStr.isEmpty() && aResolved.type != RuntimeScalarType.STRING);
+            boolean bIsByte = bResolved.type == BYTE_STRING
+                    || bResolved.type == RuntimeScalarType.UNDEF
+                    || (bStr.isEmpty() && bResolved.type != RuntimeScalarType.STRING);
             if (aIsByte && bIsByte) {
                 boolean safe = true;
                 for (int i = 0; safe && i < aStr.length(); i++) {
@@ -895,12 +920,12 @@ public class StringOperators {
                     byte[] out = new byte[aBytes.length + bBytes.length];
                     System.arraycopy(aBytes, 0, out, 0, aBytes.length);
                     System.arraycopy(bBytes, 0, out, aBytes.length, bBytes.length);
-                    return new RuntimeScalar(out);
+                    return propagateTaint(new RuntimeScalar(out), aResolved, bResolved);
                 }
             }
         }
 
-        return new RuntimeScalar(aStr + bStr);
+        return propagateTaint(new RuntimeScalar(aStr + bStr), aResolved, bResolved);
     }
 
     private static RuntimeScalar stringConcatBytes(String a, String b) {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/DBI.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/DBI.java
@@ -57,6 +57,7 @@ public class DBI extends PerlModuleBase {
             dbi.registerMethod("table_info", null);
             dbi.registerMethod("column_info", null);
             dbi.registerMethod("primary_key_info", null);
+            dbi.registerMethod("primary_key", null);
             dbi.registerMethod("foreign_key_info", null);
             dbi.registerMethod("type_info", null);
             dbi.registerMethod("ping", null);
@@ -1208,8 +1209,8 @@ public class DBI extends PerlModuleBase {
             Connection conn = (Connection) dbh.get("connection").value;
             DatabaseMetaData metaData = conn.getMetaData();
 
-            String catalog = args.get(1).toString();
-            String schema = args.get(2).toString();
+            String catalog = metadataPattern(args.get(1));
+            String schema = metadataPattern(args.get(2));
             String table = args.get(3).toString();
 
             ResultSet rs = metaData.getPrimaryKeys(catalog, schema, table);
@@ -1218,6 +1219,39 @@ public class DBI extends PerlModuleBase {
             RuntimeScalar sthRef = ReferenceOperators.bless(sth.createReferenceWithTrackedElements(), new RuntimeScalar("DBI::st"));
             return sthRef.getList();
         }, dbh, "primary_key_info");
+    }
+
+    /**
+     * DBI convenience method returning only the primary-key column names.
+     * Unlike JDBC, DBI callers conventionally pass undef for catalog and
+     * schema; those values must reach DatabaseMetaData as null rather than
+     * the empty string.
+     */
+    public static RuntimeList primary_key(RuntimeArray args, int ctx) {
+        RuntimeHash dbh = args.get(0).hashDeref();
+
+        return executeWithErrorHandling(() -> {
+            if (args.size() < 4) {
+                throw new IllegalStateException("Bad number of arguments for DBI->primary_key");
+            }
+
+            Connection conn = (Connection) dbh.get("connection").value;
+            DatabaseMetaData metaData = conn.getMetaData();
+            try (ResultSet rs = metaData.getPrimaryKeys(
+                    metadataPattern(args.get(1)),
+                    metadataPattern(args.get(2)),
+                    args.get(3).toString())) {
+                RuntimeList columns = new RuntimeList();
+                while (rs.next()) {
+                    columns.add(new RuntimeScalar(rs.getString("COLUMN_NAME")));
+                }
+                return columns;
+            }
+        }, dbh, "primary_key");
+    }
+
+    private static String metadataPattern(RuntimeScalar value) {
+        return value == null || value.value == null ? null : value.toString();
     }
 
     public static RuntimeList foreign_key_info(RuntimeArray args, int ctx) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
@@ -18,10 +18,22 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeIO.initStdHandles;
  */
 public class GlobalContext {
 
+    private static final ThreadLocal<Boolean> threadTaintMode =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
+
     // Special variables internal names
     public static final String GLOBAL_PHASE = encodeSpecialVar("GLOBAL_PHASE"); // $^GLOBAL_PHASE
     public static final String OPEN = encodeSpecialVar("OPEN"); // $^OPEN
     public static final String WARNING_SCOPE = encodeSpecialVar("WARNING_SCOPE"); // ${^WARNING_SCOPE}
+
+    /** Keep command-line taint mode isolated between concurrently executing scripts. */
+    public static void setThreadTaintMode(boolean enabled) {
+        threadTaintMode.set(enabled);
+    }
+
+    public static boolean isTaintModeActive() {
+        return threadTaintMode.get();
+    }
 
     // Virtual directory names for JAR-embedded Perl resources
     // E.g., @INC contains "jar:PERL5LIB", %INC contains "jar:PERL5LIB/DBI.pm"

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -1696,6 +1696,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      */
     public static Class<?> evalStringHelper(RuntimeScalar code, String evalTag, Object[] runtimeValues) throws Exception {
 
+        rejectTaintedEval(code);
+
         // Retrieve the eval context that was saved at program compile-time
         EmitterContext ctx = RuntimeCode.evalContext.get(evalTag);
 
@@ -2212,6 +2214,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             RuntimeArray args,
             int callContext) throws Throwable {
 
+        rejectTaintedEval(code);
+
         evalTrace("evalStringWithInterpreter enter tag=" + evalTag + " ctx=" + callContext +
                 " codeType=" + code.type + " codeLen=" + (code.toString() != null ? code.toString().length() : -1));
 
@@ -2683,6 +2687,14 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
 
             // Clean up this eval's ThreadLocal stack entry.
             popEvalRuntimeContext(runtimeCtx);
+        }
+    }
+
+    /** Perl forbids compiling tainted eval STRING input while -T is active. */
+    public static void rejectTaintedEval(RuntimeScalar code) {
+        if (code != null && code.isTainted() && GlobalContext.isTaintModeActive()) {
+            throw new PerlCompilerException(
+                    "Insecure dependency in eval while running with -T switch");
         }
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -1043,6 +1043,14 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         return tainted;
     }
 
+    /** Mark a value returned by an external input source in Perl taint mode. */
+    public RuntimeScalar taintFromExternalInput() {
+        if (GlobalContext.isTaintModeActive()) {
+            tainted = true;
+        }
+        return this;
+    }
+
     // Add itself to a RuntimeArray.
     //
     // ─── WARNING: refCount accounting is intentionally asymmetric here ───

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeSubstrLvalue.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeSubstrLvalue.java
@@ -42,6 +42,7 @@ public class RuntimeSubstrLvalue extends RuntimeBaseProxy {
         this.type = (parent.type == RuntimeScalarType.BYTE_STRING)
                 ? RuntimeScalarType.BYTE_STRING : RuntimeScalarType.STRING;
         this.value = str;
+        this.tainted = parent.isTainted();
     }
 
     /**

--- a/src/main/perl/lib/App/Cpan.pm
+++ b/src/main/perl/lib/App/Cpan.pm
@@ -652,6 +652,7 @@ sub _default
 		$action->( $arg );
 
 		my $error = _cpanpm_output_indicates_failure();
+		$error ||= _cpanpm_status_indicates_failure();
 		push @errors, $error if $error;
 		}
 
@@ -763,6 +764,17 @@ sub _cpanpm_output_indicates_failure
 	return A_MODULE_FAILED_TO_INSTALL if $last_line =~ /\b(?:Cannot\s+install)\b/i;
 
 	$result || ();
+	}
+
+sub _cpanpm_status_indicates_failure
+	{
+	# CPAN already records structured phase status for every distribution in
+	# the current command, including recursively installed prerequisites.
+	# Prefer that state when App::Cpan's legacy last-output-line heuristic is
+	# fooled by trailing hints or report suggestions.
+	my @failed = CPAN::Shell->find_failed($CPAN::CurrentCommandId);
+	return A_MODULE_FAILED_TO_INSTALL if grep { $_->[5] } @failed;
+	return;
 	}
 }
 

--- a/src/main/perl/lib/CPAN/Config.pm
+++ b/src/main/perl/lib/CPAN/Config.pm
@@ -125,6 +125,7 @@ sub _bootstrap_prefs {
         'Term-ANSIColor-Markup.yml'   => 'PerlOnJava/CpanDistroprefs/Term-ANSIColor-Markup.yml',
         'LRU-Cache.yml'               => 'PerlOnJava/CpanDistroprefs/LRU-Cache.yml',
         'WWW-Form-UrlEncoded.yml'     => 'PerlOnJava/CpanDistroprefs/WWW-Form-UrlEncoded.yml',
+        'Sort-External.yml'            => 'PerlOnJava/CpanDistroprefs/Sort-External.yml',
     );
     $pref_install{'OpenAI-API.yml'} = $ENV{PERLONJAVA_OPENAI_LIVE_TESTING}
         ? 'PerlOnJava/CpanDistroprefs/OpenAI-API.live.yml'
@@ -302,6 +303,8 @@ sub _bootstrap_patches {
           'PerlOnJava/CpanPatches/LRU-Cache-1.00/PurePerl.patch' ],
         [ 'WWW-Form-UrlEncoded/PP.pm.patch',
           'PerlOnJava/CpanPatches/WWW-Form-UrlEncoded-0.26/PP.pm.patch' ],
+        [ 'Sort-External/PurePerl.patch',
+          'PerlOnJava/CpanPatches/Sort-External-0.18/PurePerl.patch' ],
     );
 
     # Like prefs, extracted patch files persist after an upgrade. These paths

--- a/src/main/perl/lib/PerlOnJava/CpanDistroprefs/Sort-External.yml
+++ b/src/main/perl/lib/PerlOnJava/CpanDistroprefs/Sort-External.yml
@@ -1,0 +1,11 @@
+---
+comment: |
+  PerlOnJava distroprefs for Sort::External.
+
+  Sort::External 0.18 keeps all object state and its temporary-file codec in
+  XS. Replace that backend with a pure-Perl implementation preserving the
+  public API, bounded external-merge behavior, binary values, and UTF-8 flags.
+match:
+  distribution: "^CREAMYG/Sort-External-"
+patches:
+  - "Sort-External/PurePerl.patch"

--- a/src/main/perl/lib/PerlOnJava/CpanPatches/Sort-External-0.18/PurePerl.patch
+++ b/src/main/perl/lib/PerlOnJava/CpanPatches/Sort-External-0.18/PurePerl.patch
@@ -1,0 +1,144 @@
+--- lib/Sort/External.pm
++++ lib/Sort/External.pm
+@@ -6,9 +6,134 @@
+ 
+ our $VERSION = '0.18';
+ 
+-use XSLoader;
+-XSLoader::load( 'Sort::External', $VERSION );
++# PerlOnJava pure-Perl backend.  The upstream implementation keeps object
++# state and its temporary-file codec in XS; this backend preserves that API
++# so the distribution remains installable on a runtime without native XS.
++
++sub _new {
++    my ($class, $working_dir, $sortsub, $cache_size, $mem_threshold,
++        $tempfile_fh) = @_;
++    return bless {
++        working_dir   => $working_dir,
++        sortsub       => $sortsub,
++        cache_size    => $cache_size,
++        mem_threshold => $mem_threshold,
++        tempfile_fh   => $tempfile_fh,
++        item_cache    => [],
++        runs          => [],
++        mem_bytes     => 0,
++        fetch_tick    => 0,
++    }, $class;
++}
++
++sub feed {
++    my $self = shift;
++    for my $item (@_) {
++        push @{$self->{item_cache}}, $item;
++        $self->{mem_bytes} += length("$item") + 32;
++    }
++
++    if (($self->{cache_size} && @{$self->{item_cache}} >= $self->{cache_size})
++        || (!$self->{cache_size}
++            && $self->{mem_bytes} > $self->{mem_threshold})) {
++        $self->_write_item_cache_to_tempfile;
++    }
++    return;
++}
++
++sub fetch {
++    my $self = shift;
++    if ($self->{fetch_tick} > $#{$self->{item_cache}}) {
++        $self->_gatekeeper;
++    }
++    return if $self->{fetch_tick} > $#{$self->{item_cache}};
++    return delete $self->{item_cache}[$self->{fetch_tick}++];
++}
++
++sub _get_sortsub     { $_[0]{sortsub} }
++sub _get_item_cache  { $_[0]{item_cache} }
++sub _get_runs        { $_[0]{runs} }
++sub _get_tempfile_fh { $_[0]{tempfile_fh} }
++sub _get_working_dir { $_[0]{working_dir} }
++sub _set_mem_bytes   { $_[0]{mem_bytes} = $_[1]; return }
++sub _set_fetch_tick  { $_[0]{fetch_tick} = $_[1]; return }
++sub _set_temp_fh     { $_[0]{tempfile_fh} = $_[1]; return }
++
++sub _print_to_sortfile {
++    my ($self, $items, $fh) = @_;
++    for my $item (@$items) {
++        die "can't handle anything other than plain scalars\n"
++            if ref($item) || ref(\$item) eq 'GLOB';
++
++        my $utf8 = utf8::is_utf8($item) ? 1 : 0;
++        my $bytes = "$item";
++        utf8::encode($bytes) if $utf8;
++        my $header = pack('N C', length($bytes), $utf8);
++
++        print $fh $header, $bytes
++            or die "PerlIO error writing external sort data: $!\n";
++    }
++    return;
++}
++
++sub _utf8_on {
++    utf8::upgrade($_[0]);
++    return;
++}
++
++package Sort::External::SortExRun;
++
++sub _new {
++    my ($class, $tempfile_fh, $start, $end) = @_;
++    return bless {
++        tempfile_fh => $tempfile_fh,
++        buffarray   => [],
++        start       => $start,
++        pos         => $start,
++        end         => $end,
++    }, $class;
++}
++
++sub _get_buffarray { $_[0]{buffarray} }
++sub _set_buffarray { $_[0]{buffarray} = $_[1]; return }
++
++sub _read_exact {
++    my ($fh, $length) = @_;
++    my $value = '';
++    while (length($value) < $length) {
++        my $read = read($fh, my $chunk, $length - length($value));
++        die "PerlIO error reading external sort data: $!\n"
++            unless defined $read;
++        die "Unexpected end of external sort data\n" unless $read;
++        $value .= $chunk;
++    }
++    return $value;
++}
+ 
++sub _refill_buffer {
++    my $self = shift;
++    my $fh = $self->{tempfile_fh};
++    my $limit = $self->{end} - $self->{pos} < 32768
++        ? $self->{end}
++        : $self->{pos} + 32768;
++    seek($fh, $self->{pos}, 0)
++        or die "PerlIO error seeking external sort data: $!\n";
++
++    my $count = 0;
++    while ($self->{pos} < $limit) {
++        my $header = _read_exact($fh, 5);
++        my ($length, $utf8) = unpack('N C', $header);
++        my $item = _read_exact($fh, $length);
++        utf8::decode($item) if $utf8;
++        push @{$self->{buffarray}}, $item;
++        $self->{pos} += 5 + $length;
++        $count++;
++    }
++    return $count;
++}
++
++package Sort::External;
++
+ use File::Temp;
+ use Fcntl qw( :DEFAULT );
+ use Carp;
+@@ -415,4 +540,3 @@
+ modified under the same terms as Perl itself.
+ 
+ =cut
+-

--- a/src/test/resources/unit/app_cpan_failure_status.t
+++ b/src/test/resources/unit/app_cpan_failure_status.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More;
+use App::Cpan ();
+
+{
+    no warnings 'redefine';
+    local *CPAN::Shell::find_failed = sub {
+        return ([ 1, 'AUTHOR/Dependency.tar.gz', 'make_test', 'NO', 0, 1 ]);
+    };
+    is(
+        App::Cpan::_cpanpm_status_indicates_failure(),
+        App::Cpan::A_MODULE_FAILED_TO_INSTALL(),
+        'mandatory prerequisite failure makes the command fail',
+    );
+}
+
+{
+    no warnings 'redefine';
+    local *CPAN::Shell::find_failed = sub {
+        return ([ 1, 'AUTHOR/Optional.tar.gz', 'make_test', 'NO', 0, 0 ]);
+    };
+    ok(
+        !App::Cpan::_cpanpm_status_indicates_failure(),
+        'optional recommendation failure does not fail the command',
+    );
+}
+
+done_testing;

--- a/src/test/resources/unit/dbi_primary_key.t
+++ b/src/test/resources/unit/dbi_primary_key.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+use Test::More;
+
+BEGIN {
+    eval { require DBI; require DBD::SQLite; 1 }
+        or plan skip_all => 'DBI and DBD::SQLite required';
+}
+
+my $dbh = DBI->connect(
+    'dbi:SQLite:dbname=:memory:',
+    '',
+    '',
+    { RaiseError => 1, PrintError => 0 },
+);
+
+$dbh->do('CREATE TABLE composite_key (payload TEXT, left_id INTEGER, right_id INTEGER, PRIMARY KEY (left_id, right_id))');
+
+is_deeply(
+    [ $dbh->primary_key(undef, undef, 'composite_key') ],
+    [ qw(left_id right_id) ],
+    'primary_key accepts undef metadata patterns and returns key columns in order',
+);
+
+my $sth = $dbh->primary_key_info(undef, undef, 'composite_key');
+my @from_info;
+while (my $row = $sth->fetchrow_hashref) {
+    push @from_info, $row->{COLUMN_NAME};
+}
+is_deeply(\@from_info, [ qw(left_id right_id) ], 'primary_key_info accepts undef metadata patterns');
+
+done_testing;

--- a/src/test/resources/unit/eval_main_nested_package_method.t
+++ b/src/test/resources/unit/eval_main_nested_package_method.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $source = <<'PERL';
+package main::Generated::Nested;
+sub answer { 42 }
+1;
+PERL
+
+my $loaded = eval $source;
+is($@, '', 'nested package source compiles through string eval');
+ok($loaded, 'nested package source returns true');
+ok(Generated::Nested->can('answer'), 'can finds method through implicit main package alias');
+is(Generated::Nested->answer, 42, 'method dispatch finds explicit main package at arbitrary depth');
+
+{
+    package Generated::Parent;
+    sub inherited { 'parent method' }
+}
+
+my $child_source = <<'PERL';
+package main::Generated::Child;
+our @ISA = ('Generated::Parent');
+1;
+PERL
+
+eval $child_source;
+is($@, '', 'dynamic child package and ISA compile through string eval');
+my $child = bless {}, 'Generated::Child';
+ok($child->isa('Generated::Parent'), 'ISA lookup follows implicit main package alias');
+is($child->inherited, 'parent method', 'inherited dispatch follows aliased ISA array');
+
+done_testing;

--- a/src/test/resources/unit/taint_external_input.t
+++ b/src/test/resources/unit/taint_external_input.t
@@ -1,0 +1,34 @@
+#!perl -T
+use strict;
+use warnings;
+use File::Temp qw(tempfile);
+use Scalar::Util qw(tainted);
+use Test::More;
+
+my ($fh, $path) = tempfile();
+print {$fh} "external input\n";
+seek $fh, 0, 0 or die "seek $path: $!";
+my $line = <$fh>;
+ok(tainted($line), 'readline marks file input as tainted under -T');
+
+seek $fh, 0, 0 or die "seek $path: $!";
+my $buffer = '';
+read($fh, $buffer, 4);
+ok(tainted($buffer), 'read marks file input as tainted under -T');
+close $fh;
+
+opendir my $dh, '.' or die "opendir .: $!";
+my $entry = readdir $dh;
+ok(tainted($entry), 'readdir marks directory input as tainted under -T');
+closedir $dh;
+
+sub perlsec_is_tainted {
+    return !eval { eval('#' . substr(join('', @_), 0, 0)); 1 };
+}
+
+ok(
+    perlsec_is_tainted($entry),
+    'tainted eval STRING is rejected using the standard perlsec idiom',
+);
+
+done_testing;


### PR DESCRIPTION
## Summary

- implement DBI `primary_key` and preserve `undef` catalog/schema metadata patterns for Ormlette
- resolve nested packages and `@ISA` through Perl's optional `main::` prefix
- propagate taint from file and directory input through string operations and reject tainted `eval STRING`
- make mandatory recursive CPAN failures affect the `jcpan` exit status
- port the XS-only Sort::External dependency to a disk-backed pure-Perl backend through PerlOnJava distroprefs

## Root causes

Ormlette depended on DBI primary-key metadata and generated explicit `main::Nested::Package` declarations that were later addressed without the root prefix. File::Shuffle's Sort::External dependency stored its complete object and temporary-file backend in XS. Its tests also exposed missing external-input taint propagation. Finally, App::Cpan's last-output-line heuristic could return success after a failed recursive dependency when CPAN printed trailing hints.

## Validation

- `make`
- `timeout 600 ./jcpan -t Ormlette` — 111 tests pass
- `timeout 600 ./jcpan -t File::Shuffle` — Sort::External and File::Shuffle pass
- patched Sort::External upstream suite under standard Perl — 59 tests pass
- new regression tests validated with standard Perl where applicable
- namespace, DBI, and taint regressions pass on JVM and interpreter backends
- `git diff --check`

Generated with [Codex](https://openai.com/codex/)
