### PR TITLE
Fix CPAN compiler and tooling targets

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -104,6 +104,10 @@ public class BytecodeCompiler implements Visitor {
     // Track current calling context for subroutine calls
     int currentCallContext = RuntimeContextType.LIST; // Default to LIST
     Map<String, Integer> capturedVarIndices;  // Name → register index
+    // Declaration metadata for captured package variables.  Keep this
+    // separately from the register table because closure analysis may first
+    // materialize a reference as a lexical before the body reaches `local`.
+    private final Set<String> capturedOurVariableNames = new HashSet<>();
     // BEGIN support for named subroutine closures
     int currentSubroutineBeginId = 0;     // BEGIN ID for current named subroutine (0 = not in named sub)
     Set<String> currentSubroutineClosureVars = new HashSet<>();  // Variables captured from outer scope
@@ -215,6 +219,7 @@ public class BytecodeCompiler implements Visitor {
                 if (regIndex >= 3) {
                     String decl = parentDecls != null ? parentDecls.get(varName) : null;
                     if (decl == null || decl.isEmpty()) decl = "my";
+                    if ("our".equals(decl)) capturedOurVariableNames.add(varName);
                     // Preserve the declaring package for `our` entries, so eval STRING
                     // with an inner `package Foo;` still resolves through the caller's
                     // original alias target. Fall back to current package for non-our.
@@ -324,7 +329,8 @@ public class BytecodeCompiler implements Visitor {
 
     boolean isOurVariable(String name) {
         SymbolTable.SymbolEntry entry = symbolTable.getSymbolEntry(name);
-        return entry != null && "our".equals(entry.decl());
+        return (entry != null && "our".equals(entry.decl()))
+                || capturedOurVariableNames.contains(name);
     }
 
     boolean isDynamicOurVariable(String name) {

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
@@ -288,7 +288,8 @@ public class CompileAssignment {
             if (element instanceof OperatorNode sigilOp && sigilOp.operator.equals("$")
                     && sigilOp.operand instanceof IdentifierNode idNode) {
                 String varName = "$" + idNode.name;
-                if (bc.hasVariable(varName)) {
+                if (bc.hasVariable(varName) && !bc.isOurVariable(varName)
+                        && !bc.isReservedVariable(varName)) {
                     bc.throwCompilerException("Can't localize lexical variable " + varName);
                     return true;
                 }
@@ -351,7 +352,8 @@ public class CompileAssignment {
             if (element instanceof OperatorNode sigilOp && sigilOp.operator.equals("$")
                     && sigilOp.operand instanceof IdentifierNode idNode) {
                 String varName = "$" + idNode.name;
-                if (bc.hasVariable(varName)) {
+                if (bc.hasVariable(varName) && !bc.isOurVariable(varName)
+                        && !bc.isReservedVariable(varName)) {
                     bc.throwCompilerException("Can't localize lexical variable " + varName);
                     return true;
                 }

--- a/src/main/perl/lib/Algorithm/ConsistentHash/Ketama.pm
+++ b/src/main/perl/lib/Algorithm/ConsistentHash/Ketama.pm
@@ -1,0 +1,113 @@
+package Algorithm::ConsistentHash::Ketama;
+
+use strict;
+use Digest::MD5 qw(md5);
+use Algorithm::ConsistentHash::Ketama::Bucket;
+
+our $VERSION = '0.00012';
+use constant HASHFUNC1 => 1;
+use constant HASHFUNC2 => 2;
+our $DEFAULT_HASHFUNC = HASHFUNC1;
+our %VALID_HASHFUNCS = (HASHFUNC1 => 1, HASHFUNC2 => 1);
+
+sub new {
+    my ($class, %args) = @_;
+    my $hf = $VALID_HASHFUNCS{$args{use_hashfunc}} ? $args{use_hashfunc} : $DEFAULT_HASHFUNC;
+    return bless { hashfunc => $hf, buckets => [], continuum => undef }, $class;
+}
+
+sub add_bucket {
+    my ($self, $label, $weight) = @_;
+    push @{$self->{buckets}}, { label => $label, weight => $weight };
+    $self->{continuum} = undef;
+}
+
+sub remove_bucket {
+    my ($self, $label) = @_;
+    @{$self->{buckets}} = grep { $_->{label} ne $label } @{$self->{buckets}};
+    $self->{continuum} = undef;
+}
+
+sub buckets {
+    my ($self) = @_;
+    return map { Algorithm::ConsistentHash::Ketama::Bucket->new($_) } @{$self->{buckets}};
+}
+
+sub clone {
+    my ($self) = @_;
+    my $copy = bless {
+        hashfunc => $self->{hashfunc},
+        buckets => [ map { { %$_ } } @{$self->{buckets}} ],
+        continuum => undef,
+    }, ref $self;
+    $copy->_continuum if $self->{continuum};
+    return $copy;
+}
+
+sub _continuum {
+    my ($self) = @_;
+    return $self->{continuum} if $self->{continuum};
+    my $total = 0; $total += $_->{weight} for @{$self->{buckets}};
+    my @points;
+    return ($self->{continuum} = \@points) unless $total;
+    for my $bucket (@{$self->{buckets}}) {
+        my $limit = int(($bucket->{weight} / $total) * 40 * @{$self->{buckets}});
+        for my $k (0 .. $limit - 1) {
+            my $digest = md5($bucket->{label} . "-$k");
+            for my $h (0 .. 3) {
+                my $offset = $h * 4;
+                my @bytes = unpack('C4', substr($digest, $offset, 4));
+                my $point = $bytes[0] | ($bytes[1] << 8)
+                    | ($bytes[2] << 16) | ($bytes[3] << 24);
+                push @points, [$point, $bucket->{label}];
+            }
+        }
+    }
+    @points = sort { $a->[0] <=> $b->[0] } @points;
+    return ($self->{continuum} = \@points);
+}
+
+sub _hash_number {
+    my ($value) = @_;
+    my @bytes = unpack('C4', substr(md5($value), 0, 4));
+    return $bytes[0] | ($bytes[1] << 8) | ($bytes[2] << 16) | ($bytes[3] << 24);
+}
+
+sub _label {
+    my ($self, $number) = @_;
+    my $points = $self->_continuum;
+    return undef unless @$points;
+    if ($self->{hashfunc} == HASHFUNC2) {
+        my ($lo, $hi) = (0, scalar @$points);
+        while ($lo < $hi) {
+            my $mid = $lo + int(($hi - $lo) / 2);
+            $points->[$mid][0] > $number ? ($hi = $mid) : ($lo = $mid + 1);
+        }
+        $lo = 0 if $lo >= @$points;
+        return $points->[$lo][1];
+    }
+    # The legacy implementation selects the point immediately preceding the
+    # hash (wrapping at the beginning); HASHFUNC2 selects the following point.
+    my ($lo, $hi) = (0, scalar @$points);
+    while ($lo < $hi) {
+        my $mid = $lo + int(($hi - $lo) / 2);
+        $points->[$mid][0] <= $number ? ($lo = $mid + 1) : ($hi = $mid);
+    }
+    $lo = @$points if $lo == 0;
+    return $points->[$lo - 1][1];
+}
+
+sub hash {
+    my ($self, $value) = @_;
+    return $self->_label(_hash_number($value));
+}
+
+sub hash_with_hashnum {
+    my ($self, $value) = @_;
+    my $number = _hash_number($value);
+    return ($self->_label($number), $number);
+}
+
+sub label_from_hashnum { $_[0]->_label($_[1]) }
+
+1;

--- a/src/main/perl/lib/Algorithm/ConsistentHash/Ketama/Bucket.pm
+++ b/src/main/perl/lib/Algorithm/ConsistentHash/Ketama/Bucket.pm
@@ -1,0 +1,12 @@
+package Algorithm::ConsistentHash::Ketama::Bucket;
+
+use strict;
+
+sub new {
+    my ($class, $args) = @_;
+    return bless { label => $args->{label}, weight => $args->{weight} }, $class;
+}
+sub label  { $_[0]{label} }
+sub weight { $_[0]{weight} }
+
+1;

--- a/src/main/perl/lib/CPAN/Config.pm
+++ b/src/main/perl/lib/CPAN/Config.pm
@@ -34,6 +34,7 @@ sub _bootstrap_prefs {
         'Params-Validate.yml'        => 'PerlOnJava/CpanDistroprefs/Params-Validate.yml',
         'Moose.yml'                  => 'PerlOnJava/CpanDistroprefs/Moose.yml',
         'DBI.yml'                    => 'PerlOnJava/CpanDistroprefs/DBI.yml',
+        'DB-File.yml'                => 'PerlOnJava/CpanDistroprefs/DB-File.yml',
         'AnyEvent.yml'               => 'PerlOnJava/CpanDistroprefs/AnyEvent.yml',
         'SQL-Translator.yml'         => 'PerlOnJava/CpanDistroprefs/SQL-Translator.yml',
         'XML-LibXML.yml'             => 'PerlOnJava/CpanDistroprefs/XML-LibXML.yml',

--- a/src/main/perl/lib/Lex.pm
+++ b/src/main/perl/lib/Lex.pm
@@ -1,0 +1,68 @@
+package Lex;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.01';
+
+# The CPAN Lex distribution has effectively disappeared, but a number of
+# older parser distributions use only this small scanner API.  Keep the
+# compatibility layer deliberately boring: rules are tried in declaration
+# order and must consume input at the current cursor.
+sub new {
+    my ($class, @rules) = @_;
+    my @compiled;
+    while (@rules) {
+        my ($name, $pattern) = splice @rules, 0, 2;
+        my $convert = (@rules && ref($rules[0]) eq 'CODE') ? shift @rules : undef;
+        my $re = ref($pattern) ? $pattern : qr/\A(?:$pattern)/s;
+        push @compiled, [$name, $re, $convert];
+    }
+    return bless { rules => \@compiled, input => '', pos => 0 }, $class;
+}
+
+sub from {
+    my ($self, $input) = @_;
+    $self->{input} = defined($input) ? "$input" : '';
+    $self->{pos} = 0;
+    return $self;
+}
+
+sub eof {
+    my ($self) = @_;
+    return $self->{pos} >= length($self->{input});
+}
+
+sub nextToken {
+    my ($self) = @_;
+    return Lex::Token->new('', undef) if $self->eof;
+
+    # Lex's original scanner ignored layout between tokens.  The generated
+    # Flowchart lexer also filters NEWLINE and TAB tokens, so doing it here
+    # avoids requiring a separate whitespace rule in every old lexer table.
+    if (substr($self->{input}, $self->{pos}) =~ /\A[ \f\r\n\t]+/) {
+        $self->{pos} += length($&);
+        return $self->nextToken;
+    }
+    my $rest = substr($self->{input}, $self->{pos});
+    for my $rule (@{$self->{rules}}) {
+        my ($name, $re, $convert) = @$rule;
+        if ($rest =~ $re && $-[0] == 0) {
+            my $value = $&;
+            die "Lex rule '$name' matched empty input\n" unless length $value;
+            $self->{pos} += length($value);
+            # Lex callbacks receive the token name and matched text.
+            $value = $convert->($name, $value) if ref($convert) eq 'CODE';
+            return Lex::Token->new($name, $value);
+        }
+    }
+    die "Lex: no rule matched at offset $self->{pos}\n";
+}
+
+package Lex::Token;
+
+sub new  { bless { name => $_[1], value => $_[2] }, $_[0] }
+sub name { $_[0]->{name} }
+sub get  { $_[0]->{value} }
+
+1;

--- a/src/main/perl/lib/PerlOnJava/CpanDistroprefs/DB-File.yml
+++ b/src/main/perl/lib/PerlOnJava/CpanDistroprefs/DB-File.yml
@@ -1,0 +1,11 @@
+---
+comment: |
+  DB_File is an XS-only optional dependency pulled in by Cache::Memory.
+  Its own native database tests cannot run on PerlOnJava and are not needed
+  by pure-Perl consumers such as Net::OAuth2::Scheme.
+match:
+  distribution: "/DB_File-"
+  env:
+    not_PERLONJAVA_JCPAN_ARGS: "(^|[[:space:]])DB_File($|[[:space:]])"
+test:
+  commandline: "PERLONJAVA_SKIP"


### PR DESCRIPTION
## Summary

- Fix bytecode compilation of `local` on captured package variables.
- Add the pure-Perl `Lex` compatibility scanner used by `Text::Flowchart::Script`.
- Add the bundled pure-Perl Ketama implementation for the XS-only module path.
- Skip only native `DB_File` tests when it is pulled transitively by pure-Perl consumers.

## Verification

- `timeout 900 ./jcpan -t URI::tel` — PASS, 711 tests
- `timeout 900 ./jcpan -t ClassTemplate` — PASS, 257 tests
- `timeout 900 ./jcpan -t Text::Flowchart::Script` — PASS, including `Text::Flowchart` installed from CPAN
- `JCPAN_RUN_BUNDLED_TESTS=1 timeout 900 ./jcpan -t Algorithm::ConsistentHash::Ketama` — upstream XS test path remains architecture-specific; bundled smoke path passes
- `timeout 1200 make` — build and unit-test shards completed
