### PR TITLE
Fix weak aggregate references in PAGI dependency chain

### DIFF
--- a/src/main/java/org/perlonjava/runtime/runtimetypes/AutovivificationArray.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/AutovivificationArray.java
@@ -39,7 +39,10 @@ public class AutovivificationArray extends ArrayList<RuntimeScalar> {
         // setting the scalar's type to ARRAYREFERENCE and its value to this array.
         if (array.elements instanceof AutovivificationArray arrayProxy) {
             array.type = RuntimeArray.PLAIN_ARRAY;
-            array.elements = new ArrayList<>();
+            // Preserve RuntimeArray's owner-aware element list. A raw
+            // ArrayList loses the aggregate ownership metadata required by
+            // weak references to scalar slots such as \$hash->{key}[-1].
+            array.resetElementsAfterAutovivification();
 
             arrayProxy.scalarToAutovivify.value = array;
             arrayProxy.scalarToAutovivify.type = RuntimeScalarType.ARRAYREFERENCE;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/AutovivificationHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/AutovivificationHash.java
@@ -42,7 +42,9 @@ public class AutovivificationHash extends HashMap<String, RuntimeScalar> {
         // setting the scalar's type to HASHREFERENCE and its value to this hash.
         if (hash.elements instanceof AutovivificationHash hashProxy) {
             hash.type = RuntimeHash.PLAIN_HASH;
-            hash.elements = new HashMap<>();
+            // Preserve RuntimeHash's owner-aware element map so references to
+            // autovivified aggregate slots retain their lvalue ownership.
+            hash.resetElementsAfterAutovivification();
 
             hashProxy.scalarToAutovivify.value = hash;
             hashProxy.scalarToAutovivify.type = HASHREFERENCE;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArray.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArray.java
@@ -71,6 +71,10 @@ public class RuntimeArray extends RuntimeBase implements RuntimeScalarReference,
         return new RuntimeArrayElementList(this);
     }
 
+    void resetElementsAfterAutovivification() {
+        elements = newElementList();
+    }
+
     private RuntimeArrayElementList newElementList(int initialCapacity) {
         return new RuntimeArrayElementList(this, initialCapacity);
     }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
@@ -64,6 +64,10 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
         return new RuntimeHashElementMap(this);
     }
 
+    void resetElementsAfterAutovivification() {
+        elements = newElementMap();
+    }
+
     private RuntimeHashElementMap newElementMap(Map<String, RuntimeScalar> values) {
         RuntimeHashElementMap map = new RuntimeHashElementMap(this);
         map.putAll(values);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -163,6 +163,12 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     boolean isStoredInRegisteredContainerOwner() {
         RuntimeBase owner = containerOwner;
         if (owner == null || !MyVarCleanupStack.isRegistered(owner)) return false;
+        return isStoredInContainerOwner();
+    }
+
+    boolean isStoredInContainerOwner() {
+        RuntimeBase owner = containerOwner;
+        if (owner == null) return false;
         if (owner instanceof RuntimeHash hash) {
             return hash.elements.containsValue(this);
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/WeakRefRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/WeakRefRegistry.java
@@ -136,10 +136,15 @@ public class WeakRefRegistry {
             base.releaseOwner(ref, "weaken");
             base.releaseActiveOwner(ref);
             if (--base.refCount == 0) {
-                if (base.localBindingExists) {
+                if (base.localBindingExists
+                        || (base instanceof RuntimeScalar scalar
+                        && scalar.isStoredInContainerOwner())) {
                     // Named container (my %hash / my @array): the local variable
-                    // slot holds a strong reference not counted in refCount.
-                    // Don't call callDestroy — the container is still alive.
+                    // slot holds a strong reference not counted in refCount. A
+                    // scalar slot inside an aggregate has the same ownership:
+                    // weakening a reference to that slot must not destroy the
+                    // slot while its container still contains it.
+                    // Don't call callDestroy — the binding is still alive.
                     // Cleanup will happen at scope exit (scopeExitCleanupHash/Array).
                 } else if (!(base instanceof RuntimeScalar scalar
                         && scalar.ephemeralScalarReferenceReferent)

--- a/src/test/resources/unit/weak_scalar_slot_cancel_link.t
+++ b/src/test/resources/unit/weak_scalar_slot_cancel_link.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+use Scalar::Util qw(isweak weaken);
+
+sub link_cancel_target {
+    my ($source, $target) = @_;
+
+    push @{ $source->{on_cancel} }, $target;
+    push @{ $target->{revoke_when_ready} },
+        my $link = [ $source, \$source->{on_cancel}[-1] ];
+    weaken($link->[0]);
+    weaken($link->[1]);
+}
+
+my $source = {};
+my $target = {};
+link_cancel_target($source, $target);
+
+ok defined($target->{revoke_when_ready}[0][1]),
+    'weak reference to a live aggregate scalar slot survives its creating scope';
+ok isweak($target->{revoke_when_ready}[0][1]),
+    'aggregate scalar-slot reference remains weak';
+
+my $slot = $target->{revoke_when_ready}[0][1];
+undef $$slot;
+
+ok !defined($source->{on_cancel}[0]),
+    'dereferencing the weak scalar-slot reference updates the aggregate';
+is scalar(@{ $source->{on_cancel} }), 1,
+    'undefining the slot preserves the aggregate shape';


### PR DESCRIPTION
## Summary

- Preserve owner-aware array and hash storage when autovivification completes.
- Keep weak references to live aggregate scalar slots valid until their owning slot is removed.
- Add a Perl-conformance regression for the cancellation-link pattern used by `Future`.

## PAGI::Server investigation

The original `./jcpan -t PAGI::Server` run failed `Future` cancellation tests because weak scalar-slot backlinks were cleared immediately. After this fix:

- `Future` passes all 778 applicable upstream tests.
- `IO::Async` passes all 665 applicable upstream tests.
- The remaining `PAGI::Server` boundary is `Future::AsyncAwait`, whose XS keyword hooks have no PerlOnJava implementation; a subsequent CPAN dependency download also encountered `java.net.ConnectException`.

## Verification

- `prove src/test/resources/unit/weak_scalar_slot_cancel_link.t` — PASS on system Perl
- `timeout 60 ./jperl src/test/resources/unit/weak_scalar_slot_cancel_link.t` — PASS
- `timeout 60 ./jperl --interpreter src/test/resources/unit/weak_scalar_slot_cancel_link.t` — PASS
- `Future` `t/02cancel-pp.t` — 38/38 PASS on JVM and interpreter backends
- `timeout 1200 make` — PASS
- `timeout 1200 ./jcpan -t PAGI::Server` — `Future` 778 PASS; `IO::Async` 665 PASS; stops at unsupported `Future::AsyncAwait` / later CPAN connection failure as noted above

Generated with [Codex](https://openai.com/codex/)
