### PR TITLE
Fix CPAN tooling and XML::Parser dependencies

### DIFF
--- a/dev/import-perl5/config.yaml
+++ b/dev/import-perl5/config.yaml
@@ -186,6 +186,10 @@ imports:
   - source: perl5/cpan/Digest/lib/Digest.pm
     target: src/main/perl/lib/Digest.pm
 
+  # Encode::Alias - pure-Perl alias dispatcher used by Encode::Locale
+  - source: perl5/cpan/Encode/lib/Encode/Alias.pm
+    target: src/main/perl/lib/Encode/Alias.pm
+
   # Tests for distribution
   - source: perl5/cpan/Digest/t
     target: perl5_t/Digest

--- a/dev/modules/cpan_password_autohash_fetchpath.md
+++ b/dev/modules/cpan_password_autohash_fetchpath.md
@@ -117,6 +117,10 @@ from its completed dependency test phases.
   warning-state leakage while retaining enabled and fatal warning behavior on
   regex-cache hits. The regression test passes under system Perl and both
   PerlOnJava backends.
+- Restored Perl string sign toggling for unary minus under `use integer`, and
+  distinguished finite 32-bit wrapping from `Inf`/`NaN` native-IV conversion.
+  The reported `op/negate.t`, `op/infnan.t`, and `op/lex_assign.t` regressions
+  pass 1489/1489 assertions under both PerlOnJava backends.
 - The focused Encode::Locale and XML::Parser bundled-module suites pass. The
   complete bundled-module suite passes 375/375 files with zero failures, and a
   final full `make` passes.

--- a/dev/modules/cpan_password_autohash_fetchpath.md
+++ b/dev/modules/cpan_password_autohash_fetchpath.md
@@ -53,9 +53,16 @@ from its completed dependency test phases.
 - Run each requested `jcpan -t` target with a hard timeout and captured logs.
 - Run `make` and check for orphaned PerlOnJava JVMs.
 
+### Phase 5: Bundled-suite follow-up
+
+- Bundle the pure-Perl `Encode::Alias` and `Encode::Locale` dependency closure
+  needed by LWP-backed XML external-entity tests.
+- Fix the readonly pad-constant lifetime and interpolated-regex lexical warning
+  failures exposed by the full `make` run.
+
 ## Progress tracking
 
-### Current status: Complete (2026-08-07)
+### Current status: Complete (2026-08-08)
 
 ### Completed phases
 
@@ -63,6 +70,7 @@ from its completed dependency test phases.
 - [x] Phase 2: Pure-Perl dependency closure (2026-08-07)
 - [x] Phase 3: Password crypto dependency closure (2026-08-07)
 - [x] Phase 4: End-to-end verification (2026-08-07)
+- [x] Phase 5: Bundled-suite follow-up (2026-08-08)
 
 ### Work completed (2026-08-07)
 
@@ -87,20 +95,37 @@ from its completed dependency test phases.
   - `Data::FetchPath`: 4 files / 19 tests pass.
   - `Hash::AutoHash`: 32 files / 2785 tests pass.
   - `Password::OWASP`: 4 files / 40 tests pass.
-- `make test-bundled-modules` passes 370/372 module files, including all three
-  new crypto vector files. The two failures are pre-existing XML::Parser tests
-  caused by missing `Encode::Locale`; both reproduce on clean master.
-- A full `make` was run. The branch exposes failures in
-  `weaken_scalar_refs.t` and `regex_charclass.t`; both exact failures reproduce
-  with the clean master runtime when invoked directly (master's parallel test
-  harness currently does not promote their failing TAP to task failures).
+- The initial `make test-bundled-modules` run passed 370/372 module files. The
+  two failures were XML::Parser external-entity tests caused by the missing
+  `Encode::Locale` dependency and reproduced on clean master.
+- The initial full `make` exposed failures in `weaken_scalar_refs.t` and
+  `regex_charclass.t`; both exact failures reproduced with the clean master
+  runtime when invoked directly.
+
+### Follow-up completed (2026-08-08)
+
+- Imported core `Encode::Alias` and added an `Encode::Locale` compatibility
+  facade over the newer pure-Perl locale implementation already bundled with
+  ExtUtils::MakeMaker. No new Java dependency was added.
+- Added upstream-derived Encode::Locale alias, environment, and warning tests;
+  the original upstream suite also passes under system Perl (5 files / 28 tests).
+- Preserved installed subroutine pad constants when scalar references are
+  classified for deterministic weak-reference cleanup. Weak refs now remain
+  live until the defining glob is replaced.
+- Captured `regexp` warning enabled/fatal state on regex AST nodes and carried
+  it through JVM emission and interpreter bytecode, preventing imported-module
+  warning-state leakage while retaining enabled and fatal warning behavior on
+  regex-cache hits. The regression test passes under system Perl and both
+  PerlOnJava backends.
+- The focused Encode::Locale and XML::Parser bundled-module suites pass. The
+  complete bundled-module suite passes 375/375 files with zero failures, and a
+  final full `make` passes.
 
 ### Next steps
 
-1. No work remains for the three requested CPAN targets.
-2. Separately repair the existing test-harness exit-status discrepancy and the
-   pre-existing XML::Parser `Encode::Locale` dependency if broader suite
-   cleanup is desired.
+1. No work remains for the requested CPAN targets or XML::Parser follow-up.
+2. The parallel test-harness exit-status discrepancy remains a separate issue;
+   the underlying tests now pass directly and under `make`.
 
 ### Open questions
 

--- a/dev/modules/cpan_password_autohash_fetchpath.md
+++ b/dev/modules/cpan_password_autohash_fetchpath.md
@@ -1,0 +1,114 @@
+# Password::OWASP, Hash::AutoHash, and Data::FetchPath compatibility
+
+## Goal
+
+Make the three requested CPAN targets and their system-Perl-compatible
+dependencies install and test through `jcpan`. Fix reusable compiler/runtime
+semantics rather than patching module tests. Replace required XS crypto
+primitives with Java implementations backed by the Bouncy Castle dependency
+already shipped by PerlOnJava.
+
+## Baseline
+
+| Distribution | System Perl | PerlOnJava baseline |
+| --- | --- | --- |
+| Data::Integer 0.007 | 10 files / 6270 tests pass | 8/10 files fail; native-IV integer hints are lost during deferred emission |
+| Params::Classify 0.015 | Supported behavior confirmed | 16 failures around `0 but true` and first-class regexp scalars |
+| Data::FetchPath 0.02 | 20 tests pass | Dependency installation is blocked before the target test phase |
+| Hash::AutoHash 1.17 | Direct run lacks optional test dependencies | Dependency installation must be completed before comparison |
+| Password::OWASP | Direct run lacks crypto dependencies | Dependency tree reaches multiple XS-only password primitives |
+
+The initial Password::OWASP dependency run was stopped after 20 minutes while
+still resolving build/test prerequisites. The failures above were extracted
+from its completed dependency test phases.
+
+## Implementation phases
+
+### Phase 1: Compiler and scalar parity
+
+- Preserve lexical `use integer` on arithmetic, shifts, numeric bitwise
+  operations, unary negation/complement, and compound assignments across the
+  JVM and interpreter backends.
+- Implement PerlOnJava's advertised 32-bit IV/UV wrap and signedness.
+- Recognize the special numeric dual string `0 but true` without warnings.
+- Preserve Perl's first-class `${qr/.../}` scalar type for `ref` and `reftype`.
+
+### Phase 2: Pure-Perl dependency closure
+
+- Re-run Data::Integer and Params::Classify upstream suites.
+- Run Data::FetchPath and Hash::AutoHash through `jcpan`.
+- Compare every remaining failure with system Perl; ignore only failures that
+  reproduce there.
+
+### Phase 3: Password crypto dependency closure
+
+- Inspect each upstream XS interface before implementing it.
+- Back the bcrypt, scrypt, and Argon2 primitives used by Password::OWASP with
+  Bouncy Castle (`bcprov`), retaining the required CPAN Perl-level APIs.
+- Bundle focused compatibility modules and upstream vectors so `jcpan` does
+  not resolve the unrelated legacy XS algorithms in Authen::Passphrase.
+
+### Phase 4: End-to-end verification
+
+- Run each requested `jcpan -t` target with a hard timeout and captured logs.
+- Run `make` and check for orphaned PerlOnJava JVMs.
+
+## Progress tracking
+
+### Current status: Complete (2026-08-07)
+
+### Completed phases
+
+- [x] Phase 1: Compiler and scalar parity (2026-08-07)
+- [x] Phase 2: Pure-Perl dependency closure (2026-08-07)
+- [x] Phase 3: Password crypto dependency closure (2026-08-07)
+- [x] Phase 4: End-to-end verification (2026-08-07)
+
+### Work completed (2026-08-07)
+
+- Added system-Perl-validated regression tests for native-word integer
+  arithmetic, Params::Classify primitives, indirect `isa`, lexical slot reuse,
+  and tied-container cleanup.
+- Implemented lexical integer annotations and 32-bit IV/UV arithmetic and
+  bitwise paths in both backends. Data::Integer passes 10 files / 6269 tests
+  under PerlOnJava (two optional POD checks skipped).
+- Implemented `0 but true` numeric recognition and first-class regexp scalar
+  tracking.
+- Fixed disabled-feature indirect `isa` parsing, same-scope lexical pad-slot
+  reuse, and `undef` dispatch for tied arrays and hashes.
+- Added a targeted, fixed-point weak-reference cleanup after explicit object
+  release. This gives tied wrapper graphs Perl-compatible destruction timing
+  without sweeping unrelated nested-call temporaries.
+- Added focused `Crypt::Argon2`, `Crypt::Eksblowfish::Bcrypt`, and
+  `Authen::Passphrase::{Clear,BlowfishCrypt,Scrypt,Argon2}` compatibility
+  modules. Their Java primitives reuse the existing Bouncy Castle dependency;
+  no native or new Java dependency was added.
+- Verified requested targets:
+  - `Data::FetchPath`: 4 files / 19 tests pass.
+  - `Hash::AutoHash`: 32 files / 2785 tests pass.
+  - `Password::OWASP`: 4 files / 40 tests pass.
+- `make test-bundled-modules` passes 370/372 module files, including all three
+  new crypto vector files. The two failures are pre-existing XML::Parser tests
+  caused by missing `Encode::Locale`; both reproduce on clean master.
+- A full `make` was run. The branch exposes failures in
+  `weaken_scalar_refs.t` and `regex_charclass.t`; both exact failures reproduce
+  with the clean master runtime when invoked directly (master's parallel test
+  harness currently does not promote their failing TAP to task failures).
+
+### Next steps
+
+1. No work remains for the three requested CPAN targets.
+2. Separately repair the existing test-harness exit-status discrepancy and the
+   pre-existing XML::Parser `Encode::Locale` dependency if broader suite
+   cleanup is desired.
+
+### Open questions
+
+- Bouncy Castle enforces bcrypt's modern cost floor of 4. The compatibility
+  layer accepts legacy costs 0..3 using cost 4 so Password::OWASP retains
+  round-trip behavior; it does not promise byte-identical legacy cost hashes.
+
+## References
+
+- [Module porting guide](../../docs/guides/module-porting.md)
+- Skills: `debug-perlonjava`, `port-cpan-module`

--- a/docs/reference/bundled-modules.md
+++ b/docs/reference/bundled-modules.md
@@ -18,6 +18,7 @@ Recent CPAN compatibility additions include:
 | `PadWalker` | Perl facade over Java runtime metadata | `peek_sub`, `closed_over`, and `set_closed_over`; caller-pad APIs remain unsupported |
 | `Devel::Caller` | Perl facade over Java call frames | `caller_cv` and caller argument compatibility used by lexical tooling |
 | `Devel::LexAlias` | Perl facade over Java lexical cells | Rebinds local and captured scalar, array, and hash lexicals |
+| `Encode::Locale` | Pure Perl facade over bundled locale support | Provides LWP and XML::Parser with locale encoding aliases; includes `Encode::Alias` |
 
 ---
 
@@ -289,6 +290,8 @@ These are loaded automatically or via `use`:
 | `MIME::Base64` | Java | |
 | `MIME::QuotedPrint` | Java | |
 | `Encode` | Java + Perl | |
+| `Encode::Alias` | Perl | Dynamic aliases resolved by the Java-backed `Encode` implementation |
+| `Encode::Locale` | Perl | Reuses bundled `ExtUtils::MakeMaker::Locale` locale detection |
 | `Unicode::Normalize` | Java | |
 | `Unicode::UCD` | Java | |
 

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -2337,9 +2337,9 @@ public class BytecodeCompiler implements Visitor {
 
         // Emit the appropriate compound assignment opcode
         switch (op) {
-            case "+=" -> emit(Opcodes.ADD_ASSIGN);
-            case "-=" -> emit(Opcodes.SUBTRACT_ASSIGN);
-            case "*=" -> emit(Opcodes.MULTIPLY_ASSIGN);
+            case "+=" -> emit(useInteger ? Opcodes.INTEGER_ADD_ASSIGN : Opcodes.ADD_ASSIGN);
+            case "-=" -> emit(useInteger ? Opcodes.INTEGER_SUBTRACT_ASSIGN : Opcodes.SUBTRACT_ASSIGN);
+            case "*=" -> emit(useInteger ? Opcodes.INTEGER_MULTIPLY_ASSIGN : Opcodes.MULTIPLY_ASSIGN);
             case "/=" -> emit(useInteger ? Opcodes.INTEGER_DIV_ASSIGN : Opcodes.DIVIDE_ASSIGN);
             case "%=" -> emit(useInteger ? Opcodes.INTEGER_MOD_ASSIGN : Opcodes.MODULUS_ASSIGN);
             case ".=" -> emit(Opcodes.STRING_CONCAT_ASSIGN);

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -1002,6 +1002,28 @@ public class BytecodeInterpreter {
                                 pc = InlineOpcodeHandler.executeNegScalar(bytecode, pc, registers);
                             }
 
+                            case Opcodes.INTEGER_ADD, Opcodes.INTEGER_SUBTRACT, Opcodes.INTEGER_MULTIPLY,
+                                 Opcodes.INTEGER_BITWISE_AND, Opcodes.INTEGER_BITWISE_OR,
+                                 Opcodes.INTEGER_BITWISE_XOR -> {
+                                pc = InlineOpcodeHandler.executeIntegerBinary(opcode, bytecode, pc, registers);
+                            }
+
+                            case Opcodes.INTEGER_NEGATE -> {
+                                pc = InlineOpcodeHandler.executeIntegerNegate(bytecode, pc, registers);
+                            }
+
+                            case Opcodes.INTEGER_ADD_ASSIGN -> {
+                                pc = InlineOpcodeHandler.executeIntegerArithmeticAssign(bytecode, pc, registers, 0);
+                            }
+
+                            case Opcodes.INTEGER_SUBTRACT_ASSIGN -> {
+                                pc = InlineOpcodeHandler.executeIntegerArithmeticAssign(bytecode, pc, registers, 1);
+                            }
+
+                            case Opcodes.INTEGER_MULTIPLY_ASSIGN -> {
+                                pc = InlineOpcodeHandler.executeIntegerArithmeticAssign(bytecode, pc, registers, 2);
+                            }
+
                             // Arithmetic without overload dispatch (no overloading pragma)
                             case Opcodes.ADD_NO_OVERLOAD -> {
                                 pc = InlineOpcodeHandler.executeAddNoOverload(bytecode, pc, registers);

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -6,6 +6,7 @@ import org.perlonjava.runtime.debugger.DebugHooks;
 import org.perlonjava.runtime.operators.CompareOperators;
 import org.perlonjava.runtime.operators.ReferenceOperators;
 import org.perlonjava.runtime.operators.WarnDie;
+import org.perlonjava.runtime.regex.RegexQuoteMeta;
 import org.perlonjava.runtime.regex.RuntimeRegex;
 import org.perlonjava.runtime.runtimetypes.*;
 
@@ -3089,10 +3090,12 @@ public class BytecodeInterpreter {
                 int patternReg = bytecode[pc++];
                 int flagsReg = bytecode[pc++];
                 int implicitU = bytecode[pc++];
+                int warningState = bytecode[pc++];
                 RuntimeScalar flags = registers[flagsReg].scalar();
                 if (implicitU != 0) {
                     flags = RuntimeRegex.applyUnicodeStringsFeatureToModifiers(flags);
                 }
+                RegexQuoteMeta.setCallSiteWarningState(warningState);
                 registers[rd] = RuntimeRegex.getQuotedRegex(registers[patternReg].scalar(), flags);
                 return pc;
             }
@@ -3102,10 +3105,12 @@ public class BytecodeInterpreter {
                 int flagsReg = bytecode[pc++];
                 int callsiteId = bytecode[pc++];
                 int implicitU = bytecode[pc++];
+                int warningState = bytecode[pc++];
                 RuntimeScalar flags = registers[flagsReg].scalar();
                 if (implicitU != 0) {
                     flags = RuntimeRegex.applyUnicodeStringsFeatureToModifiers(flags);
                 }
+                RegexQuoteMeta.setCallSiteWarningState(warningState);
                 registers[rd] = RuntimeRegex.getQuotedRegex(registers[patternReg].scalar(), flags, callsiteId);
                 return pc;
             }

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperatorHelper.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperatorHelper.java
@@ -50,7 +50,8 @@ public class CompileBinaryOperatorHelper {
         boolean useInteger = isIntegerEnabled(bytecodeCompiler, useIntegerOverride);
         switch (operator) {
             case "+" -> {
-                bytecodeCompiler.emit(noOverload ? Opcodes.ADD_NO_OVERLOAD
+                bytecodeCompiler.emit(useInteger ? Opcodes.INTEGER_ADD
+                        : noOverload ? Opcodes.ADD_NO_OVERLOAD
                         : (bytecodeCompiler.isUninitializedWarningsEnabled()
                             ? Opcodes.ADD_SCALAR_WARN : Opcodes.ADD_SCALAR));
                 bytecodeCompiler.emitReg(rd);
@@ -58,13 +59,15 @@ public class CompileBinaryOperatorHelper {
                 bytecodeCompiler.emitReg(rs2);
             }
             case "-" -> {
-                bytecodeCompiler.emit(noOverload ? Opcodes.SUB_NO_OVERLOAD : Opcodes.SUB_SCALAR);
+                bytecodeCompiler.emit(useInteger ? Opcodes.INTEGER_SUBTRACT
+                        : noOverload ? Opcodes.SUB_NO_OVERLOAD : Opcodes.SUB_SCALAR);
                 bytecodeCompiler.emitReg(rd);
                 bytecodeCompiler.emitReg(rs1);
                 bytecodeCompiler.emitReg(rs2);
             }
             case "*" -> {
-                bytecodeCompiler.emit(noOverload ? Opcodes.MUL_NO_OVERLOAD : Opcodes.MUL_SCALAR);
+                bytecodeCompiler.emit(useInteger ? Opcodes.INTEGER_MULTIPLY
+                        : noOverload ? Opcodes.MUL_NO_OVERLOAD : Opcodes.MUL_SCALAR);
                 bytecodeCompiler.emitReg(rd);
                 bytecodeCompiler.emitReg(rs1);
                 bytecodeCompiler.emitReg(rs2);
@@ -391,7 +394,7 @@ public class CompileBinaryOperatorHelper {
             }
             case "&" -> {
                 // Numeric bitwise AND (default): rs1 & rs2
-                bytecodeCompiler.emit(Opcodes.BITWISE_AND_BINARY);
+                bytecodeCompiler.emit(useInteger ? Opcodes.INTEGER_BITWISE_AND : Opcodes.BITWISE_AND_BINARY);
                 bytecodeCompiler.emitReg(rd);
                 bytecodeCompiler.emitReg(rs1);
                 bytecodeCompiler.emitReg(rs2);
@@ -405,7 +408,7 @@ public class CompileBinaryOperatorHelper {
             }
             case "|" -> {
                 // Numeric bitwise OR (default): rs1 | rs2
-                bytecodeCompiler.emit(Opcodes.BITWISE_OR_BINARY);
+                bytecodeCompiler.emit(useInteger ? Opcodes.INTEGER_BITWISE_OR : Opcodes.BITWISE_OR_BINARY);
                 bytecodeCompiler.emitReg(rd);
                 bytecodeCompiler.emitReg(rs1);
                 bytecodeCompiler.emitReg(rs2);
@@ -419,7 +422,7 @@ public class CompileBinaryOperatorHelper {
             }
             case "^" -> {
                 // Numeric bitwise XOR (default): rs1 ^ rs2
-                bytecodeCompiler.emit(Opcodes.BITWISE_XOR_BINARY);
+                bytecodeCompiler.emit(useInteger ? Opcodes.INTEGER_BITWISE_XOR : Opcodes.BITWISE_XOR_BINARY);
                 bytecodeCompiler.emitReg(rd);
                 bytecodeCompiler.emitReg(rs1);
                 bytecodeCompiler.emitReg(rs2);

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -280,6 +280,11 @@ public class CompileOperator {
         return reg;
     }
 
+    private static int regexWarningState(OperatorNode node) {
+        if (Boolean.TRUE.equals(node.getAnnotation("regexWarningsFatal"))) return 2;
+        return Boolean.TRUE.equals(node.getAnnotation("regexWarningsEnabled")) ? 1 : 0;
+    }
+
     private static void visitMatchRegex(BytecodeCompiler bc, OperatorNode node) {
         if (node.operand == null || !(node.operand instanceof ListNode args) || args.elements.size() < 2) {
             bc.throwCompilerException("matchRegex requires pattern and flags");
@@ -303,12 +308,14 @@ public class CompileOperator {
             bc.emitReg(flagsReg);
             bc.emitReg(callsiteId);
             bc.emit(unicodeStringsImplicitUFlag(bc));
+            bc.emit(regexWarningState(node));
         } else {
             bc.emit(Opcodes.QUOTE_REGEX);
             bc.emitReg(regexReg);
             bc.emitReg(patternReg);
             bc.emitReg(flagsReg);
             bc.emit(unicodeStringsImplicitUFlag(bc));
+            bc.emit(regexWarningState(node));
         }
         int stringReg;
         if (args.elements.size() > 2) {
@@ -346,6 +353,7 @@ public class CompileOperator {
         bc.emitReg(flagsReg);
         bc.emitReg(1);  // @_ register - pass caller's args for replacement code
         bc.emit(unicodeStringsImplicitUFlag(bc));
+        bc.emit(regexWarningState(node));
         int stringReg;
         if (args.elements.size() > 3) {
             bc.compileNode(args.elements.get(3), -1, RuntimeContextType.SCALAR);
@@ -1024,12 +1032,14 @@ public class CompileOperator {
                     bytecodeCompiler.emitReg(flagsReg);
                     bytecodeCompiler.emitReg(callsiteId);
                     bytecodeCompiler.emit(unicodeStringsImplicitUFlag(bytecodeCompiler));
+                    bytecodeCompiler.emit(regexWarningState(node));
                 } else {
                     bytecodeCompiler.emit(Opcodes.QUOTE_REGEX);
                     bytecodeCompiler.emitReg(rd);
                     bytecodeCompiler.emitReg(patternReg);
                     bytecodeCompiler.emitReg(flagsReg);
                     bytecodeCompiler.emit(unicodeStringsImplicitUFlag(bytecodeCompiler));
+                    bytecodeCompiler.emit(regexWarningState(node));
                 }
                 bytecodeCompiler.lastResultReg = rd;
             }

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -742,8 +742,13 @@ public class CompileOperator {
 
             // Simple unary ops (dispatchOperator)
             case "not", "!" -> emitSimpleUnaryScalar(bytecodeCompiler, node, Opcodes.NOT);
-            case "~" -> emitSimpleUnary(bytecodeCompiler, node,
-                    bytecodeCompiler.isIntegerEnabled() ? Opcodes.INTEGER_BITWISE_NOT : Opcodes.BITWISE_NOT);
+            case "~" -> {
+                Object integerAnnotation = node.getAnnotation("useInteger");
+                boolean useInteger = integerAnnotation instanceof Boolean value
+                        ? value : bytecodeCompiler.isIntegerEnabled();
+                emitSimpleUnary(bytecodeCompiler, node,
+                        useInteger ? Opcodes.INTEGER_BITWISE_NOT : Opcodes.BITWISE_NOT);
+            }
             case "binary~" -> emitSimpleUnary(bytecodeCompiler, node, Opcodes.BITWISE_NOT_BINARY);
             case "~." -> emitSimpleUnary(bytecodeCompiler, node, Opcodes.BITWISE_NOT_STRING);
             case "defined" -> visitDefined(bytecodeCompiler, node);
@@ -1309,7 +1314,11 @@ public class CompileOperator {
                 bytecodeCompiler.compileNode(node.operand, -1, RuntimeContextType.SCALAR);
                 int operandReg = bytecodeCompiler.lastResultReg;
                 int rd = bytecodeCompiler.allocateOutputRegister();
-                bytecodeCompiler.emit(bytecodeCompiler.isNoOverloadingEnabled() ? Opcodes.NEG_NO_OVERLOAD : Opcodes.NEG_SCALAR);
+                Object integerAnnotation = node.getAnnotation("useInteger");
+                boolean useInteger = integerAnnotation instanceof Boolean value
+                        ? value : bytecodeCompiler.isIntegerEnabled();
+                bytecodeCompiler.emit(useInteger ? Opcodes.INTEGER_NEGATE
+                        : bytecodeCompiler.isNoOverloadingEnabled() ? Opcodes.NEG_NO_OVERLOAD : Opcodes.NEG_SCALAR);
                 bytecodeCompiler.emitReg(rd);
                 bytecodeCompiler.emitReg(operandReg);
                 bytecodeCompiler.lastResultReg = rd;

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -765,7 +765,8 @@ public class Disassemble {
                         int rs3 = interpretedCode.bytecode[pc++];  // flags
                         int callerArgsReg = interpretedCode.bytecode[pc++];  // caller @_
                         int implicitUQr = interpretedCode.bytecode[pc++];
-                        sb.append("GET_REPLACEMENT_REGEX r").append(rd).append(" = getReplacementRegex(r").append(rs1).append(", r").append(rs2).append(", r").append(rs3).append(", r").append(callerArgsReg).append(") implicitU=").append(implicitUQr).append("\n");
+                        int replacementWarningState = interpretedCode.bytecode[pc++];
+                        sb.append("GET_REPLACEMENT_REGEX r").append(rd).append(" = getReplacementRegex(r").append(rs1).append(", r").append(rs2).append(", r").append(rs3).append(", r").append(callerArgsReg).append(") implicitU=").append(implicitUQr).append(" warningState=").append(replacementWarningState).append("\n");
                         break;
                     case Opcodes.SUBSTR_VAR:
                         rd = interpretedCode.bytecode[pc++];
@@ -1259,8 +1260,10 @@ public class Disassemble {
                         int patternReg = interpretedCode.bytecode[pc++];
                         int flagsReg = interpretedCode.bytecode[pc++];
                         int implicitU = interpretedCode.bytecode[pc++];
+                        int warningState = interpretedCode.bytecode[pc++];
                         sb.append("QUOTE_REGEX r").append(rd).append(" = qr{r").append(patternReg)
-                                .append("}r").append(flagsReg).append(" implicitU=").append(implicitU).append("\n");
+                                .append("}r").append(flagsReg).append(" implicitU=").append(implicitU)
+                                .append(" warningState=").append(warningState).append("\n");
                         break;
                     case Opcodes.QUOTE_REGEX_O:
                         rd = interpretedCode.bytecode[pc++];
@@ -1268,9 +1271,11 @@ public class Disassemble {
                         flagsReg = interpretedCode.bytecode[pc++];
                         int callsiteId = interpretedCode.bytecode[pc++];
                         implicitU = interpretedCode.bytecode[pc++];
+                        warningState = interpretedCode.bytecode[pc++];
                         sb.append("QUOTE_REGEX_O r").append(rd).append(" = qr{r").append(patternReg)
                                 .append("}r").append(flagsReg).append(" callsite=").append(callsiteId)
-                                .append(" implicitU=").append(implicitU).append("\n");
+                                .append(" implicitU=").append(implicitU)
+                                .append(" warningState=").append(warningState).append("\n");
                         break;
                     case Opcodes.ITERATOR_CREATE:
                         rd = interpretedCode.bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -334,6 +334,47 @@ public class Disassemble {
                         int rsNeg = interpretedCode.bytecode[pc++];
                         sb.append("NEG_SCALAR r").append(rd).append(" = -r").append(rsNeg).append("\n");
                         break;
+                    case Opcodes.INTEGER_ADD:
+                    case Opcodes.INTEGER_SUBTRACT:
+                    case Opcodes.INTEGER_MULTIPLY:
+                    case Opcodes.INTEGER_BITWISE_AND:
+                    case Opcodes.INTEGER_BITWISE_OR:
+                    case Opcodes.INTEGER_BITWISE_XOR: {
+                        rd = interpretedCode.bytecode[pc++];
+                        rs1 = interpretedCode.bytecode[pc++];
+                        rs2 = interpretedCode.bytecode[pc++];
+                        String name = switch (opcode) {
+                            case Opcodes.INTEGER_ADD -> "INTEGER_ADD";
+                            case Opcodes.INTEGER_SUBTRACT -> "INTEGER_SUBTRACT";
+                            case Opcodes.INTEGER_MULTIPLY -> "INTEGER_MULTIPLY";
+                            case Opcodes.INTEGER_BITWISE_AND -> "INTEGER_BITWISE_AND";
+                            case Opcodes.INTEGER_BITWISE_OR -> "INTEGER_BITWISE_OR";
+                            default -> "INTEGER_BITWISE_XOR";
+                        };
+                        sb.append(name).append(" r").append(rd).append(" = r")
+                                .append(rs1).append(", r").append(rs2).append("\n");
+                        break;
+                    }
+                    case Opcodes.INTEGER_NEGATE:
+                        rd = interpretedCode.bytecode[pc++];
+                        int rsIntegerNeg = interpretedCode.bytecode[pc++];
+                        sb.append("INTEGER_NEGATE r").append(rd).append(" = -r")
+                                .append(rsIntegerNeg).append("\n");
+                        break;
+                    case Opcodes.INTEGER_ADD_ASSIGN:
+                    case Opcodes.INTEGER_SUBTRACT_ASSIGN:
+                    case Opcodes.INTEGER_MULTIPLY_ASSIGN: {
+                        rd = interpretedCode.bytecode[pc++];
+                        int rsIntegerAssign = interpretedCode.bytecode[pc++];
+                        String name = switch (opcode) {
+                            case Opcodes.INTEGER_ADD_ASSIGN -> "INTEGER_ADD_ASSIGN";
+                            case Opcodes.INTEGER_SUBTRACT_ASSIGN -> "INTEGER_SUBTRACT_ASSIGN";
+                            default -> "INTEGER_MULTIPLY_ASSIGN";
+                        };
+                        sb.append(name).append(" r").append(rd).append(", r")
+                                .append(rsIntegerAssign).append("\n");
+                        break;
+                    }
                     case Opcodes.ADD_NO_OVERLOAD:
                     case Opcodes.SUB_NO_OVERLOAD:
                     case Opcodes.MUL_NO_OVERLOAD:

--- a/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
@@ -189,6 +189,54 @@ public class InlineOpcodeHandler {
         return pc;
     }
 
+    public static int executeIntegerBinary(int opcode, int[] bytecode, int pc, RuntimeBase[] registers) {
+        int rd = bytecode[pc++];
+        int rs1 = bytecode[pc++];
+        int rs2 = bytecode[pc++];
+        RuntimeBase v1 = registers[rs1];
+        RuntimeBase v2 = registers[rs2];
+        RuntimeScalar s1 = v1 instanceof RuntimeScalar ? (RuntimeScalar) v1 : v1.scalar();
+        RuntimeScalar s2 = v2 instanceof RuntimeScalar ? (RuntimeScalar) v2 : v2.scalar();
+        registers[rd] = switch (opcode) {
+            case Opcodes.INTEGER_ADD -> MathOperators.integerAdd(s1, s2);
+            case Opcodes.INTEGER_SUBTRACT -> MathOperators.integerSubtract(s1, s2);
+            case Opcodes.INTEGER_MULTIPLY -> MathOperators.integerMultiply(s1, s2);
+            case Opcodes.INTEGER_BITWISE_AND -> BitwiseOperators.integerBitwiseAnd(s1, s2);
+            case Opcodes.INTEGER_BITWISE_OR -> BitwiseOperators.integerBitwiseOr(s1, s2);
+            case Opcodes.INTEGER_BITWISE_XOR -> BitwiseOperators.integerBitwiseXor(s1, s2);
+            default -> throw new IllegalArgumentException("unknown integer binary opcode: " + opcode);
+        };
+        return pc;
+    }
+
+    public static int executeIntegerNegate(int[] bytecode, int pc, RuntimeBase[] registers) {
+        int rd = bytecode[pc++];
+        int rs = bytecode[pc++];
+        RuntimeBase value = registers[rs];
+        RuntimeScalar scalar = value instanceof RuntimeScalar ? (RuntimeScalar) value : value.scalar();
+        registers[rd] = MathOperators.integerUnaryMinus(scalar);
+        return pc;
+    }
+
+    public static int executeIntegerArithmeticAssign(int[] bytecode, int pc,
+                                                     RuntimeBase[] registers, int operation) {
+        int rd = bytecode[pc++];
+        int rs = bytecode[pc++];
+        if (isImmutableProxy(registers[rd])) {
+            registers[rd] = ensureMutableScalar(registers[rd]);
+        }
+        RuntimeScalar left = (RuntimeScalar) registers[rd];
+        RuntimeScalar right = (RuntimeScalar) registers[rs];
+        RuntimeScalar result = switch (operation) {
+            case 0 -> MathOperators.integerAdd(left, right);
+            case 1 -> MathOperators.integerSubtract(left, right);
+            case 2 -> MathOperators.integerMultiplyWarn(left, right);
+            default -> throw new IllegalArgumentException("unknown integer assignment operation");
+        };
+        left.set(result);
+        return pc;
+    }
+
     /**
      * Arithmetic without overload dispatch.
      * Used when {@code no overloading} is in effect at compile time.

--- a/src/main/java/org/perlonjava/backend/bytecode/OpcodeHandlerExtended.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/OpcodeHandlerExtended.java
@@ -2,6 +2,7 @@ package org.perlonjava.backend.bytecode;
 
 import org.perlonjava.runtime.operators.*;
 import org.perlonjava.runtime.perlmodule.Attributes;
+import org.perlonjava.runtime.regex.RegexQuoteMeta;
 import org.perlonjava.runtime.regex.RuntimeRegex;
 import org.perlonjava.runtime.runtimetypes.*;
 
@@ -70,6 +71,7 @@ public class OpcodeHandlerExtended {
         int flagsReg = bytecode[pc++];
         int argsReg = bytecode[pc++];
         int implicitU = bytecode[pc++];
+        int warningState = bytecode[pc++];
 
         RuntimeScalar pattern = (RuntimeScalar) registers[patternReg];
         RuntimeScalar replacement = (RuntimeScalar) registers[replacementReg];
@@ -79,6 +81,7 @@ public class OpcodeHandlerExtended {
         }
         RuntimeArray callerArgs = (registers[argsReg] instanceof RuntimeArray) ? (RuntimeArray) registers[argsReg] : new RuntimeArray();
 
+        RegexQuoteMeta.setCallSiteWarningState(warningState);
         registers[rd] = RuntimeRegex.getReplacementRegex(pattern, replacement, flags, callerArgs);
         return pc;
     }

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -935,7 +935,7 @@ public class Opcodes {
 
     /**
      * Quote regex operator: rd = RuntimeRegex.getQuotedRegex(pattern_reg, flags_reg)
-     * Format: QUOTE_REGEX rd pattern_reg flags_reg implicit_unicode_strings_u (0 or 1)
+     * Format: QUOTE_REGEX rd pattern_reg flags_reg implicit_unicode_strings_u warning_state
      */
     public static final short QUOTE_REGEX = 159;
 
@@ -1385,7 +1385,7 @@ public class Opcodes {
 
     /**
      * Get replacement regex: rd = RuntimeRegex.getReplacementRegex(pattern, replacement, flags)
-     * Format: GET_REPLACEMENT_REGEX rd pattern_reg replacement_reg flags_reg args_reg implicit_unicode_strings_u
+     * Format: GET_REPLACEMENT_REGEX rd pattern_reg replacement_reg flags_reg args_reg implicit_unicode_strings_u warning_state
      */
     public static final short GET_REPLACEMENT_REGEX = 236;
 
@@ -1834,7 +1834,7 @@ public class Opcodes {
 
     /**
      * Quote regex with /o modifier support: rd = RuntimeRegex.getQuotedRegex(pattern_reg, flags_reg, callsite_id)
-     * Format: QUOTE_REGEX_O rd pattern_reg flags_reg callsite_id implicit_unicode_strings_u
+     * Format: QUOTE_REGEX_O rd pattern_reg flags_reg callsite_id implicit_unicode_strings_u warning_state
      */
     public static final short QUOTE_REGEX_O = 374;
 

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -2411,6 +2411,22 @@ public class Opcodes {
     /** Replace a freshly-created lexical cell with a Devel::LexAlias binding. */
     public static final short APPLY_LEXICAL_ALIAS = 499;
 
+    /** 32-bit native-IV arithmetic under lexical {@code use integer}. */
+    public static final short INTEGER_ADD = 500;
+    public static final short INTEGER_SUBTRACT = 501;
+    public static final short INTEGER_MULTIPLY = 502;
+    public static final short INTEGER_NEGATE = 503;
+
+    /** Signed 32-bit numeric bitwise operations under lexical {@code use integer}. */
+    public static final short INTEGER_BITWISE_AND = 504;
+    public static final short INTEGER_BITWISE_OR = 505;
+    public static final short INTEGER_BITWISE_XOR = 506;
+
+    /** In-place 32-bit native-IV arithmetic under lexical {@code use integer}. */
+    public static final short INTEGER_ADD_ASSIGN = 507;
+    public static final short INTEGER_SUBTRACT_ASSIGN = 508;
+    public static final short INTEGER_MULTIPLY_ASSIGN = 509;
+
     private Opcodes() {
     } // Utility class - no instantiation
 }

--- a/src/main/java/org/perlonjava/backend/jvm/EmitBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitBinaryOperator.java
@@ -32,6 +32,15 @@ public class EmitBinaryOperator {
                 emitterVisitor.with(RuntimeContextType.SCALAR); // execute operands in scalar context
         if (CompilerOptions.DEBUG_ENABLED) emitterVisitor.ctx.logDebug("handleBinaryOperator: " + node.toString());
 
+        if (isIntegerEnabled(emitterVisitor, node)
+                && switch (node.operator) {
+                    case "+", "-", "*", "&", "|", "^" -> true;
+                    default -> false;
+                }) {
+            emitIntegerBinaryOperator(emitterVisitor, scalarVisitor, node, operatorHandler);
+            return;
+        }
+
         // Optimization
         if ((node.operator.equals("+")
                 || node.operator.equals("-")
@@ -210,6 +219,72 @@ public class EmitBinaryOperator {
         emitOperator(node, emitterVisitor);
     }
 
+    private static void emitIntegerBinaryOperator(EmitterVisitor emitterVisitor,
+                                                  EmitterVisitor scalarVisitor,
+                                                  BinaryOperatorNode node,
+                                                  OperatorHandler normalHandler) {
+        MethodVisitor mv = emitterVisitor.ctx.mv;
+        node.left.accept(scalarVisitor);
+        int leftSlot = emitterVisitor.ctx.javaClassInfo.acquireSpillSlot();
+        boolean pooled = leftSlot >= 0;
+        if (!pooled) {
+            leftSlot = emitterVisitor.ctx.symbolTable.allocateLocalVariable();
+        }
+        mv.visitVarInsn(Opcodes.ASTORE, leftSlot);
+        node.right.accept(scalarVisitor);
+        mv.visitVarInsn(Opcodes.ALOAD, leftSlot);
+        mv.visitInsn(Opcodes.SWAP);
+        if (pooled) {
+            emitterVisitor.ctx.javaClassInfo.releaseSpillSlot();
+        }
+
+        String className;
+        String methodName;
+        switch (node.operator) {
+            case "+" -> {
+                className = "org/perlonjava/runtime/operators/MathOperators";
+                methodName = switch (normalHandler.methodName()) {
+                    case "addWarn" -> "integerAddWarn";
+                    case "addNoOverload" -> "integerAddNoOverload";
+                    default -> "integerAdd";
+                };
+            }
+            case "-" -> {
+                className = "org/perlonjava/runtime/operators/MathOperators";
+                methodName = switch (normalHandler.methodName()) {
+                    case "subtractWarn" -> "integerSubtractWarn";
+                    case "subtractNoOverload" -> "integerSubtractNoOverload";
+                    default -> "integerSubtract";
+                };
+            }
+            case "*" -> {
+                className = "org/perlonjava/runtime/operators/MathOperators";
+                methodName = switch (normalHandler.methodName()) {
+                    case "multiplyWarn" -> "integerMultiplyWarn";
+                    case "multiplyNoOverload" -> "integerMultiplyNoOverload";
+                    default -> "integerMultiply";
+                };
+            }
+            case "&" -> {
+                className = "org/perlonjava/runtime/operators/BitwiseOperators";
+                methodName = "integerBitwiseAnd";
+            }
+            case "|" -> {
+                className = "org/perlonjava/runtime/operators/BitwiseOperators";
+                methodName = "integerBitwiseOr";
+            }
+            case "^" -> {
+                className = "org/perlonjava/runtime/operators/BitwiseOperators";
+                methodName = "integerBitwiseXor";
+            }
+            default -> throw new IllegalArgumentException("not an integer binary operator: " + node.operator);
+        }
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC, className, methodName,
+                "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;",
+                false);
+        EmitOperator.handleVoidContext(emitterVisitor);
+    }
+
     static void handleCompoundAssignment(EmitterVisitor emitterVisitor, BinaryOperatorNode node) {
         // Compound assignment operators like `+=`, `-=`, etc.
         // These now have proper overload support via MathOperators.*Assign() methods
@@ -225,7 +300,13 @@ public class EmitBinaryOperator {
         // Under "use integer", use the integer warn variant for /=
         boolean isInteger = isIntegerEnabled(emitterVisitor, node);
         OperatorHandler operatorHandler;
-        if (shouldUseWarnVariant && isInteger && node.operator.equals("/=")) {
+        if (isInteger && switch (node.operator) {
+            case "+=", "-=", "*=" -> true;
+            default -> false;
+        }) {
+            operatorHandler = OperatorHandler.get(node.operator + "_int"
+                    + (shouldUseWarnVariant ? "_warn" : ""));
+        } else if (shouldUseWarnVariant && isInteger && node.operator.equals("/=")) {
             operatorHandler = OperatorHandler.get("/=_int_warn");
         } else {
             operatorHandler = shouldUseWarnVariant 
@@ -306,9 +387,14 @@ public class EmitBinaryOperator {
             // Note: operands are already on the stack (left DUPped, then right)
             String baseOperator = node.operator.substring(0, node.operator.length() - 1);
             // Get the operator handler for the base operator, use warn variant only for certain ops
-            OperatorHandler baseOpHandler = shouldUseWarnVariant
-                    ? OperatorHandler.getWarn(baseOperator)
-                    : OperatorHandler.get(baseOperator);
+            OperatorHandler baseOpHandler;
+            if (isInteger && (baseOperator.equals("<<") || baseOperator.equals(">>"))) {
+                baseOpHandler = OperatorHandler.get(baseOperator + "_int");
+            } else {
+                baseOpHandler = shouldUseWarnVariant
+                        ? OperatorHandler.getWarn(baseOperator)
+                        : OperatorHandler.get(baseOperator);
+            }
             if (baseOpHandler == null) {
                 baseOpHandler = OperatorHandler.get(baseOperator);
             }

--- a/src/main/java/org/perlonjava/backend/jvm/EmitOperatorNode.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitOperatorNode.java
@@ -50,10 +50,21 @@ public class EmitOperatorNode {
             case "eval", "evalbytes" -> EmitEval.handleEvalOperator(emitterVisitor, node);
 
             // Unary operators
-            case "unaryMinus" -> EmitOperator.handleUnaryDefaultCase(node, "unaryMinus", emitterVisitor);
+            case "unaryMinus" -> {
+                Object integerAnnotation = node.getAnnotation("useInteger");
+                boolean useInteger = integerAnnotation instanceof Boolean value
+                        ? value
+                        : emitterVisitor.ctx.symbolTable.isStrictOptionEnabled(Strict.HINT_INTEGER);
+                EmitOperator.handleUnaryDefaultCase(node,
+                        useInteger ? "integerUnaryMinus" : "unaryMinus", emitterVisitor);
+            }
             case "~" -> {
                 // Use integer bitwise NOT when "use integer" is in effect
-                if (emitterVisitor.ctx.symbolTable.isStrictOptionEnabled(Strict.HINT_INTEGER)) {
+                Object integerAnnotation = node.getAnnotation("useInteger");
+                boolean useInteger = integerAnnotation instanceof Boolean value
+                        ? value
+                        : emitterVisitor.ctx.symbolTable.isStrictOptionEnabled(Strict.HINT_INTEGER);
+                if (useInteger) {
                     EmitOperator.handleUnaryDefaultCase(node, "integerBitwiseNot", emitterVisitor);
                 } else {
                     // Use the operator key "~" for OperatorHandler lookup

--- a/src/main/java/org/perlonjava/backend/jvm/EmitRegex.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitRegex.java
@@ -36,6 +36,17 @@ public class EmitRegex {
         }
     }
 
+    /** Emit the lexical warning state captured when the regex was parsed. */
+    private static void emitRegexWarningState(EmitterVisitor emitterVisitor, OperatorNode node) {
+        boolean enabled = Boolean.TRUE.equals(node.getAnnotation("regexWarningsEnabled"));
+        boolean fatal = Boolean.TRUE.equals(node.getAnnotation("regexWarningsFatal"));
+        emitterVisitor.ctx.mv.visitInsn(fatal ? Opcodes.ICONST_2
+                : enabled ? Opcodes.ICONST_1 : Opcodes.ICONST_0);
+        emitterVisitor.ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                "org/perlonjava/runtime/regex/RegexQuoteMeta",
+                "setCallSiteWarningState", "(I)V", false);
+    }
+
     /**
      * Handles the binding regex operation where a variable is bound to a regex operation.
      * This method processes the binary operator node representing the binding operation.
@@ -217,6 +228,7 @@ public class EmitRegex {
         operand.elements.get(1).accept(scalarVisitor);  // Replacement
         operand.elements.get(2).accept(scalarVisitor);  // Flags
         maybeApplyUnicodeStringsRegexModifiers(emitterVisitor);
+        emitRegexWarningState(emitterVisitor, node);
 
         // Push the caller's @_ so $_[0] etc. work in s/// replacement
         // @_ is at local variable slot 1 in subroutines
@@ -262,6 +274,7 @@ public class EmitRegex {
         operand.elements.get(0).accept(scalarVisitor);  // Pattern
         operand.elements.get(1).accept(scalarVisitor);  // Flags
         maybeApplyUnicodeStringsRegexModifiers(emitterVisitor);
+        emitRegexWarningState(emitterVisitor, node);
 
         // Create the quoted regex
         emitterVisitor.ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
@@ -296,6 +309,7 @@ public class EmitRegex {
         operand.elements.get(0).accept(scalarVisitor);  // Pattern
         flagsNode.accept(scalarVisitor);  // Flags
         maybeApplyUnicodeStringsRegexModifiers(emitterVisitor);
+        emitRegexWarningState(emitterVisitor, node);
 
         // Create the regex matcher (use 3-argument version for /o or m?PAT?)
         if (needsCallsiteCache) {

--- a/src/main/java/org/perlonjava/frontend/parser/NumberParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/NumberParser.java
@@ -572,6 +572,13 @@ public class NumberParser {
         // Track whether to emit a "isn't numeric" warning
         boolean shouldWarn = false;
 
+        // Perl gives this conventional module-return value special treatment:
+        // it is numerically zero but true as a string, and numification does
+        // not emit the warning that an arbitrary trailing suffix would.
+        if (str.substring(start, end).equals("0 but true")) {
+            result = getScalarInt(0);
+        }
+
         if (start == end) {
             // Empty or whitespace-only string: value is 0, but warn if string is non-null
             shouldWarn = true;

--- a/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
@@ -171,7 +171,8 @@ public class ParseInfix {
             // state. Lazy sub compilation and interpreter fallback may emit code long
             // after the parser's lexical hint stack has moved on.
             switch (operator) {
-                case "/", "%", "<<", ">>", "/=", "%=", "<<=", ">>=" ->
+                case "+", "-", "*", "/", "%", "&", "|", "^", "<<", ">>",
+                     "+=", "-=", "*=", "/=", "%=", "&=", "|=", "^=", "<<=", ">>=" ->
                         node.setAnnotation("useInteger",
                                 parser.ctx.symbolTable.isStrictOptionEnabled(Strict.HINT_INTEGER));
                 default -> {

--- a/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
@@ -146,10 +146,16 @@ public class ParseInfix {
             if (operator.equals("..") || operator.equals("...")) {
                 // Handle regex in: /3/../5/
                 if (left instanceof OperatorNode operatorNode && operatorNode.operator.equals("matchRegex")) {
-                    left = new OperatorNode("quoteRegex", operatorNode.operand, operatorNode.tokenIndex);
+                    OperatorNode quoted = new OperatorNode("quoteRegex", operatorNode.operand, operatorNode.tokenIndex);
+                    quoted.setAnnotation("regexWarningsEnabled", operatorNode.getAnnotation("regexWarningsEnabled"));
+                    quoted.setAnnotation("regexWarningsFatal", operatorNode.getAnnotation("regexWarningsFatal"));
+                    left = quoted;
                 }
                 if (right instanceof OperatorNode operatorNode && operatorNode.operator.equals("matchRegex")) {
-                    right = new OperatorNode("quoteRegex", operatorNode.operand, operatorNode.tokenIndex);
+                    OperatorNode quoted = new OperatorNode("quoteRegex", operatorNode.operand, operatorNode.tokenIndex);
+                    quoted.setAnnotation("regexWarningsEnabled", operatorNode.getAnnotation("regexWarningsEnabled"));
+                    quoted.setAnnotation("regexWarningsFatal", operatorNode.getAnnotation("regexWarningsFatal"));
+                    right = quoted;
                 }
             }
 

--- a/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
@@ -4,6 +4,7 @@ import org.perlonjava.frontend.astnode.*;
 import org.perlonjava.frontend.lexer.LexerToken;
 import org.perlonjava.frontend.lexer.LexerTokenType;
 import org.perlonjava.frontend.semantic.SymbolTable;
+import org.perlonjava.runtime.perlmodule.Strict;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import static org.perlonjava.frontend.parser.ParserNodeUtils.scalarUnderscore;
@@ -387,7 +388,12 @@ public class ParsePrimary {
                     }
                 }
                 operand = parser.parseExpression(parser.getPrecedence(token.text) + 1);
-                return new OperatorNode(operator, operand, parser.tokenIndex);
+                OperatorNode bitwiseNot = new OperatorNode(operator, operand, parser.tokenIndex);
+                if (operator.equals("~")) {
+                    bitwiseNot.setAnnotation("useInteger",
+                            parser.ctx.symbolTable.isStrictOptionEnabled(Strict.HINT_INTEGER));
+                }
+                return bitwiseNot;
 
             case "~~":
                 // Handle prefix ~~ as double bitwise complement: ~(~EXPR)
@@ -466,7 +472,10 @@ public class ParsePrimary {
                     // Special case: -bareword becomes "-bareword" (string)
                     return new StringNode("-" + identifierNode.name, parser.tokenIndex);
                 }
-                return new OperatorNode("unaryMinus", operand, parser.tokenIndex);
+                OperatorNode unaryMinus = new OperatorNode("unaryMinus", operand, parser.tokenIndex);
+                unaryMinus.setAnnotation("useInteger",
+                        parser.ctx.symbolTable.isStrictOptionEnabled(Strict.HINT_INTEGER));
+                return unaryMinus;
 
             case "*=":
                 // Special variable glob "="

--- a/src/main/java/org/perlonjava/frontend/parser/StringParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringParser.java
@@ -558,7 +558,12 @@ public class StringParser {
         elements.add(replace);
         elements.add(modifiers);
         ListNode list = new ListNode(elements, rawStr.index);
-        return new OperatorNode(operator, list, rawStr.index);
+        OperatorNode node = new OperatorNode(operator, list, rawStr.index);
+        node.setAnnotation("regexWarningsEnabled",
+                ctx.symbolTable != null && ctx.symbolTable.isWarningCategoryEnabled("regexp"));
+        node.setAnnotation("regexWarningsFatal",
+                ctx.symbolTable != null && ctx.symbolTable.isFatalWarningCategory("regexp"));
+        return node;
     }
 
     public static OperatorNode parseRegexMatch(EmitterContext ctx, String operator, ParsedString rawStr, Parser parser) {
@@ -601,7 +606,12 @@ public class StringParser {
         elements.add(parsed);
         elements.add(modifiers);
         ListNode list = new ListNode(elements, rawStr.index);
-        return new OperatorNode(operator, list, rawStr.index);
+        OperatorNode node = new OperatorNode(operator, list, rawStr.index);
+        node.setAnnotation("regexWarningsEnabled",
+                ctx.symbolTable != null && ctx.symbolTable.isWarningCategoryEnabled("regexp"));
+        node.setAnnotation("regexWarningsFatal",
+                ctx.symbolTable != null && ctx.symbolTable.isFatalWarningCategory("regexp"));
+        return node;
     }
 
     public static OperatorNode parseSystemCommand(EmitterContext ctx, String operator, ParsedString rawStr) {

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -643,6 +643,13 @@ public class SubroutineParser {
                 && !parser.ctx.symbolTable.isFeatureCategoryEnabled("try")) {
             return true;
         }
+        // Before feature 'isa' is enabled, a leading `isa Class(...)` is the
+        // classic indirect-object spelling of `Class->isa(...)`, not the infix
+        // class-membership operator.
+        if (parser != null && subName.equals("isa")
+                && !parser.ctx.symbolTable.isFeatureCategoryEnabled("isa")) {
+            return true;
+        }
         return false;
     }
 

--- a/src/main/java/org/perlonjava/frontend/semantic/SymbolTable.java
+++ b/src/main/java/org/perlonjava/frontend/semantic/SymbolTable.java
@@ -32,6 +32,13 @@ public class SymbolTable {
         if (existing == null) {
             // Variable doesn't exist, add it
             variableIndex.put(name, new SymbolEntry(index++, name, variableDeclType, perlPackage, ast));
+        } else if (("my".equals(variableDeclType) || "state".equals(variableDeclType))
+                && ast != null && existing.ast != ast) {
+            // A later lexical declaration in the same Perl scope masks the
+            // earlier pad slot from this statement onward. Emission revisits
+            // the same AST, so retain the slot when the declaration node is
+            // identical but allocate a fresh slot for a genuine redeclaration.
+            variableIndex.put(name, new SymbolEntry(index++, name, variableDeclType, perlPackage, ast));
         } else if ("our".equals(variableDeclType) && existing.perlPackage != null 
                    && !existing.perlPackage.equals(perlPackage)) {
             // For 'our' declarations in a different package, create a new entry

--- a/src/main/java/org/perlonjava/runtime/operators/BitwiseOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/BitwiseOperators.java
@@ -232,8 +232,8 @@ public class BitwiseOperators {
                     arg1, arg2, blessId, blessId2, "(" + symbol, symbol);
             if (overloaded != null) return overloaded;
         }
-        int a = (int) arg1.getLong();
-        int b = (int) arg2.getLong();
+        int a = nativeIntValue(arg1);
+        int b = nativeIntValue(arg2);
         int result = switch (operator) {
             case '&' -> a & b;
             case '|' -> a | b;
@@ -241,6 +241,15 @@ public class BitwiseOperators {
             default -> throw new IllegalArgumentException("unknown bitwise operator: " + operator);
         };
         return new RuntimeScalar(result);
+    }
+
+    private static int nativeIntValue(RuntimeScalar value) {
+        RuntimeScalar number = value.getNumber("bitwise operation");
+        if (number.type != RuntimeScalarType.DOUBLE) return (int) number.getLong();
+        double numericValue = number.getDouble();
+        return Double.isFinite(numericValue)
+                ? (int) (long) numericValue
+                : (int) numericValue;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/operators/BitwiseOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/BitwiseOperators.java
@@ -27,8 +27,8 @@ public class BitwiseOperators {
         int t1 = runtimeScalar.type;
         int t2 = arg2.type;
         if (t1 == RuntimeScalarType.INTEGER && t2 == RuntimeScalarType.INTEGER) {
-            long result = ((int) runtimeScalar.value) & ((int) arg2.value);
-            return new RuntimeScalar(result);
+            int result = ((int) runtimeScalar.value) & ((int) arg2.value);
+            return new RuntimeScalar(Integer.toUnsignedLong(result));
         }
 
         // Check for overloaded '&' operator on blessed objects
@@ -77,12 +77,9 @@ public class BitwiseOperators {
      * @return A new RuntimeScalar with the result of the bitwise AND operation.
      */
     public static RuntimeScalar bitwiseAndBinary(RuntimeScalar runtimeScalar, RuntimeScalar arg2) {
-        // Use long values to preserve full precision
-        long val1 = runtimeScalar.getLong();
-        long val2 = arg2.getLong();
-
-        // Perform AND operation preserving all bits
-        long result = val1 & val2;
+        long val1 = runtimeScalar.getLong() & 0xFFFFFFFFL;
+        long val2 = arg2.getLong() & 0xFFFFFFFFL;
+        long result = (val1 & val2) & 0xFFFFFFFFL;
 
         return new RuntimeScalar(result);
     }
@@ -101,8 +98,8 @@ public class BitwiseOperators {
         int t1 = runtimeScalar.type;
         int t2 = arg2.type;
         if (t1 == RuntimeScalarType.INTEGER && t2 == RuntimeScalarType.INTEGER) {
-            long result = ((int) runtimeScalar.value) | ((int) arg2.value);
-            return new RuntimeScalar(result);
+            int result = ((int) runtimeScalar.value) | ((int) arg2.value);
+            return new RuntimeScalar(Integer.toUnsignedLong(result));
         }
 
         // Check for overloaded '|' operator on blessed objects
@@ -141,12 +138,9 @@ public class BitwiseOperators {
      * @return A new RuntimeScalar with the result of the bitwise OR operation.
      */
     public static RuntimeScalar bitwiseOrBinary(RuntimeScalar runtimeScalar, RuntimeScalar arg2) {
-        // Use long values to preserve full precision
-        long val1 = runtimeScalar.getLong();
-        long val2 = arg2.getLong();
-
-        // Perform OR operation preserving all bits
-        long result = val1 | val2;
+        long val1 = runtimeScalar.getLong() & 0xFFFFFFFFL;
+        long val2 = arg2.getLong() & 0xFFFFFFFFL;
+        long result = (val1 | val2) & 0xFFFFFFFFL;
 
         return new RuntimeScalar(result);
     }
@@ -169,8 +163,8 @@ public class BitwiseOperators {
         int t1 = runtimeScalar.type;
         int t2 = arg2.type;
         if (t1 == RuntimeScalarType.INTEGER && t2 == RuntimeScalarType.INTEGER) {
-            long result = ((int) runtimeScalar.value) ^ ((int) arg2.value);
-            return new RuntimeScalar(result);
+            int result = ((int) runtimeScalar.value) ^ ((int) arg2.value);
+            return new RuntimeScalar(Integer.toUnsignedLong(result));
         }
 
         // Check for overloaded '^' operator on blessed objects
@@ -209,13 +203,43 @@ public class BitwiseOperators {
      * @return A new RuntimeScalar with the result of the bitwise XOR operation.
      */
     public static RuntimeScalar bitwiseXorBinary(RuntimeScalar runtimeScalar, RuntimeScalar arg2) {
-        // Use long values to preserve full precision
-        long val1 = runtimeScalar.getLong();
-        long val2 = arg2.getLong();
+        long val1 = runtimeScalar.getLong() & 0xFFFFFFFFL;
+        long val2 = arg2.getLong() & 0xFFFFFFFFL;
+        long result = (val1 ^ val2) & 0xFFFFFFFFL;
 
-        // Perform XOR operation preserving all bits
-        long result = val1 ^ val2;
+        return new RuntimeScalar(result);
+    }
 
+    /** Numeric bitwise operations under {@code use integer}: return a signed IV. */
+    public static RuntimeScalar integerBitwiseAnd(RuntimeScalar arg1, RuntimeScalar arg2) {
+        return integerBitwiseBinary(arg1, arg2, '&');
+    }
+
+    public static RuntimeScalar integerBitwiseOr(RuntimeScalar arg1, RuntimeScalar arg2) {
+        return integerBitwiseBinary(arg1, arg2, '|');
+    }
+
+    public static RuntimeScalar integerBitwiseXor(RuntimeScalar arg1, RuntimeScalar arg2) {
+        return integerBitwiseBinary(arg1, arg2, '^');
+    }
+
+    private static RuntimeScalar integerBitwiseBinary(RuntimeScalar arg1, RuntimeScalar arg2, char operator) {
+        int blessId = blessedId(arg1);
+        int blessId2 = blessedId(arg2);
+        if (blessId < 0 || blessId2 < 0) {
+            String symbol = Character.toString(operator);
+            RuntimeScalar overloaded = OverloadContext.tryTwoArgumentOverload(
+                    arg1, arg2, blessId, blessId2, "(" + symbol, symbol);
+            if (overloaded != null) return overloaded;
+        }
+        int a = (int) arg1.getLong();
+        int b = (int) arg2.getLong();
+        int result = switch (operator) {
+            case '&' -> a & b;
+            case '|' -> a | b;
+            case '^' -> a ^ b;
+            default -> throw new IllegalArgumentException("unknown bitwise operator: " + operator);
+        };
         return new RuntimeScalar(result);
     }
 

--- a/src/main/java/org/perlonjava/runtime/operators/MathOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/MathOperators.java
@@ -15,6 +15,122 @@ public class MathOperators {
     /** Largest magnitude such that every integer in [-N, N] is exactly representable as double (2^53). */
     private static final double MAX_EXACT_DOUBLE_INT = 9007199254740992.0;
 
+    /** Operations whose native-IV result is truncated to PerlOnJava's 32-bit ivsize. */
+    private enum IntegerOperation { ADD, SUBTRACT, MULTIPLY }
+
+    private static RuntimeScalar integerBinary(RuntimeScalar arg1, RuntimeScalar arg2,
+                                               IntegerOperation operation, boolean warn,
+                                               boolean overload) {
+        if (overload) {
+            int blessId = blessedId(arg1);
+            int blessId2 = blessedId(arg2);
+            if (blessId < 0 || blessId2 < 0) {
+                String symbol = switch (operation) {
+                    case ADD -> "+";
+                    case SUBTRACT -> "-";
+                    case MULTIPLY -> "*";
+                };
+                RuntimeScalar result = OverloadContext.tryTwoArgumentOverload(
+                        arg1, arg2, blessId, blessId2, "(" + symbol, symbol);
+                if (result != null) return result;
+            }
+        }
+
+        String context = switch (operation) {
+            case ADD -> "addition (+)";
+            case SUBTRACT -> "subtraction (-)";
+            case MULTIPLY -> "multiplication (*)";
+        };
+        arg1 = warn ? arg1.getNumberWarn(context) : arg1.getNumber(context);
+        arg2 = warn ? arg2.getNumberWarn(context) : arg2.getNumber(context);
+        int a = (int) arg1.getLong();
+        int b = (int) arg2.getLong();
+        int result = switch (operation) {
+            case ADD -> a + b;
+            case SUBTRACT -> a - b;
+            case MULTIPLY -> a * b;
+        };
+        return new RuntimeScalar(result);
+    }
+
+    public static RuntimeScalar integerAdd(RuntimeScalar arg1, RuntimeScalar arg2) {
+        return integerBinary(arg1, arg2, IntegerOperation.ADD, false, true);
+    }
+
+    public static RuntimeScalar integerAddWarn(RuntimeScalar arg1, RuntimeScalar arg2) {
+        return integerBinary(arg1, arg2, IntegerOperation.ADD, true, true);
+    }
+
+    public static RuntimeScalar integerAddNoOverload(RuntimeScalar arg1, RuntimeScalar arg2) {
+        return integerBinary(arg1, arg2, IntegerOperation.ADD, false, false);
+    }
+
+    public static RuntimeScalar integerSubtract(RuntimeScalar arg1, RuntimeScalar arg2) {
+        return integerBinary(arg1, arg2, IntegerOperation.SUBTRACT, false, true);
+    }
+
+    public static RuntimeScalar integerSubtractWarn(RuntimeScalar arg1, RuntimeScalar arg2) {
+        return integerBinary(arg1, arg2, IntegerOperation.SUBTRACT, true, true);
+    }
+
+    public static RuntimeScalar integerSubtractNoOverload(RuntimeScalar arg1, RuntimeScalar arg2) {
+        return integerBinary(arg1, arg2, IntegerOperation.SUBTRACT, false, false);
+    }
+
+    public static RuntimeScalar integerMultiply(RuntimeScalar arg1, RuntimeScalar arg2) {
+        return integerBinary(arg1, arg2, IntegerOperation.MULTIPLY, false, true);
+    }
+
+    public static RuntimeScalar integerMultiplyWarn(RuntimeScalar arg1, RuntimeScalar arg2) {
+        return integerBinary(arg1, arg2, IntegerOperation.MULTIPLY, true, true);
+    }
+
+    public static RuntimeScalar integerMultiplyNoOverload(RuntimeScalar arg1, RuntimeScalar arg2) {
+        return integerBinary(arg1, arg2, IntegerOperation.MULTIPLY, false, false);
+    }
+
+    public static RuntimeScalar integerUnaryMinus(RuntimeScalar arg) {
+        int blessId = blessedId(arg);
+        if (blessId < 0) {
+            RuntimeScalar result = OverloadContext.tryOneArgumentOverload(
+                    arg, blessId, "(neg", "neg", MathOperators::integerUnaryMinus);
+            if (result != null) return result;
+        }
+        return new RuntimeScalar(-(int) arg.getNumber("negation (-)").getLong());
+    }
+
+    public static RuntimeScalar integerUnaryMinusNoOverload(RuntimeScalar arg) {
+        return new RuntimeScalar(-(int) arg.getNumber("negation (-)").getLong());
+    }
+
+    public static RuntimeScalar integerAddAssign(RuntimeScalar arg1, RuntimeScalar arg2) {
+        RuntimeScalar overloaded = compoundIntegerOverload(arg1, arg2, "(+=", "+=", "(+");
+        arg1.set(overloaded != null ? overloaded : integerAdd(arg1, arg2));
+        return arg1;
+    }
+
+    public static RuntimeScalar integerSubtractAssign(RuntimeScalar arg1, RuntimeScalar arg2) {
+        RuntimeScalar overloaded = compoundIntegerOverload(arg1, arg2, "(-=", "-=", "(-");
+        arg1.set(overloaded != null ? overloaded : integerSubtract(arg1, arg2));
+        return arg1;
+    }
+
+    public static RuntimeScalar integerMultiplyAssignWarn(RuntimeScalar arg1, RuntimeScalar arg2) {
+        RuntimeScalar overloaded = compoundIntegerOverload(arg1, arg2, "(*=", "*=", "(*");
+        arg1.set(overloaded != null ? overloaded : integerMultiplyWarn(arg1, arg2));
+        return arg1;
+    }
+
+    private static RuntimeScalar compoundIntegerOverload(RuntimeScalar arg1, RuntimeScalar arg2,
+                                                         String copyKey, String assignKey, String baseKey) {
+        int blessId = blessedId(arg1);
+        int blessId2 = blessedId(arg2);
+        return blessId < 0 || blessId2 < 0
+                ? OverloadContext.tryTwoArgumentOverload(arg1, arg2, blessId, blessId2,
+                        copyKey, assignKey, baseKey)
+                : null;
+    }
+
     /**
      * Adds an integer to a RuntimeScalar and returns the result.
      *

--- a/src/main/java/org/perlonjava/runtime/operators/MathOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/MathOperators.java
@@ -96,11 +96,39 @@ public class MathOperators {
                     arg, blessId, "(neg", "neg", MathOperators::integerUnaryMinus);
             if (result != null) return result;
         }
-        return new RuntimeScalar(-(int) arg.getNumber("negation (-)").getLong());
+        RuntimeScalar stringResult = unaryMinusStringResult(arg);
+        if (stringResult != null) return stringResult;
+        return new RuntimeScalar(-nativeIntValue(arg, "negation (-)"));
     }
 
     public static RuntimeScalar integerUnaryMinusNoOverload(RuntimeScalar arg) {
-        return new RuntimeScalar(-(int) arg.getNumber("negation (-)").getLong());
+        RuntimeScalar stringResult = unaryMinusStringResult(arg);
+        if (stringResult != null) return stringResult;
+        return new RuntimeScalar(-nativeIntValue(arg, "negation (-)"));
+    }
+
+    private static int nativeIntValue(RuntimeScalar arg, String operation) {
+        RuntimeScalar number = arg.getNumber(operation);
+        if (number.type != DOUBLE) return (int) number.getLong();
+        double value = number.getDouble();
+        return Double.isFinite(value) ? (int) (long) value : (int) value;
+    }
+
+    /** Perl's unary-minus string sign toggling, or {@code null} for numeric coercion. */
+    private static RuntimeScalar unaryMinusStringResult(RuntimeScalar runtimeScalar) {
+        if (!runtimeScalar.isString()) return null;
+        String input = runtimeScalar.toString();
+        if (input.length() < 2) {
+            if (input.isEmpty()) return getScalarInt(0);
+            if (input.equals("-")) return new RuntimeScalar("+");
+            if (input.equals("+")) return new RuntimeScalar("-");
+        }
+        if (!input.matches("^\\s*[-+]?\\d+(\\.\\d+)?([eE][-+]?\\d+)?\\s*$")) {
+            if (input.startsWith("-")) return new RuntimeScalar("+" + input.substring(1));
+            if (input.startsWith("+")) return new RuntimeScalar("-" + input.substring(1));
+            if (input.matches("^[_A-Za-z].*")) return new RuntimeScalar("-" + input);
+        }
+        return null;
     }
 
     public static RuntimeScalar integerAddAssign(RuntimeScalar arg1, RuntimeScalar arg2) {
@@ -1271,37 +1299,8 @@ public class MathOperators {
             if (result != null) return result;
         }
 
-        if (runtimeScalar.isString()) {
-            String input = runtimeScalar.toString();
-            if (input.length() < 2) {
-                if (input.isEmpty()) {
-                    return getScalarInt(0);
-                }
-                if (input.equals("-")) {
-                    return new RuntimeScalar("+");
-                }
-                if (input.equals("+")) {
-                    return new RuntimeScalar("-");
-                }
-            }
-            // Check if string has non-numeric trailing characters (not purely numeric)
-            // Purely numeric: "10", "-10", "10.0", "-10.0", "1e5"
-            // Non-numeric: "-10foo", "+xyz", "abc"
-            // Don't match: whitespace-prefixed numbers like " -10"
-            if (!input.matches("^\\s*[-+]?\\d+(\\.\\d+)?([eE][-+]?\\d+)?\\s*$")) {
-                // String is not purely numeric
-                if (input.startsWith("-")) {
-                    // Handle case where string starts with "-"
-                    return new RuntimeScalar("+" + input.substring(1));
-                } else if (input.startsWith("+")) {
-                    // Handle case where string starts with "+"
-                    return new RuntimeScalar("-" + input.substring(1));
-                } else if (input.matches("^[_A-Za-z].*")) {
-                    // Only add "-" prefix for strings starting with letter/underscore
-                    return new RuntimeScalar("-" + input);
-                }
-            }
-        }
+        RuntimeScalar stringResult = unaryMinusStringResult(runtimeScalar);
+        if (stringResult != null) return stringResult;
         return subtract(getScalarInt(0), runtimeScalar);
     }
 

--- a/src/main/java/org/perlonjava/runtime/operators/OperatorHandler.java
+++ b/src/main/java/org/perlonjava/runtime/operators/OperatorHandler.java
@@ -26,6 +26,7 @@ public record OperatorHandler(String className, String methodName, int methodTyp
         put("/", "divide", "org/perlonjava/runtime/operators/MathOperators");
         put("%", "modulus", "org/perlonjava/runtime/operators/MathOperators");
         put("unaryMinus", "unaryMinus", "org/perlonjava/runtime/operators/MathOperators", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");
+        put("integerUnaryMinus", "integerUnaryMinus", "org/perlonjava/runtime/operators/MathOperators", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");
         put("!", "not", "org/perlonjava/runtime/operators/MathOperators", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");
         put("not", "not", "org/perlonjava/runtime/operators/MathOperators", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");
 
@@ -74,6 +75,9 @@ public record OperatorHandler(String className, String methodName, int methodTyp
         put("*=_warn", "multiplyAssignWarn", "org/perlonjava/runtime/operators/MathOperators");
         put("/=_warn", "divideAssignWarn", "org/perlonjava/runtime/operators/MathOperators");
         put("/=_int_warn", "integerDivideAssignWarn", "org/perlonjava/runtime/operators/MathOperators");
+        put("+=_int", "integerAddAssign", "org/perlonjava/runtime/operators/MathOperators");
+        put("-=_int", "integerSubtractAssign", "org/perlonjava/runtime/operators/MathOperators");
+        put("*=_int_warn", "integerMultiplyAssignWarn", "org/perlonjava/runtime/operators/MathOperators");
         put("%=_warn", "modulusAssignWarn", "org/perlonjava/runtime/operators/MathOperators");
 
         // Bitwise
@@ -82,6 +86,8 @@ public record OperatorHandler(String className, String methodName, int methodTyp
         put("^", "bitwiseXor", "org/perlonjava/runtime/operators/BitwiseOperators");
         put("<<", "shiftLeft", "org/perlonjava/runtime/operators/BitwiseOperators");
         put(">>", "shiftRight", "org/perlonjava/runtime/operators/BitwiseOperators");
+        put("<<_int", "integerShiftLeft", "org/perlonjava/runtime/operators/BitwiseOperators");
+        put(">>_int", "integerShiftRight", "org/perlonjava/runtime/operators/BitwiseOperators");
         put("~", "bitwiseNot", "org/perlonjava/runtime/operators/BitwiseOperators", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");
         put("&.", "bitwiseAndDot", "org/perlonjava/runtime/operators/BitwiseOperators");
         put("|.", "bitwiseOrDot", "org/perlonjava/runtime/operators/BitwiseOperators");

--- a/src/main/java/org/perlonjava/runtime/operators/ReferenceOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ReferenceOperators.java
@@ -256,6 +256,8 @@ public class ReferenceOperators {
                 if (runtimeScalar.value instanceof RuntimeScalar scalar) {
                     if (scalar instanceof RuntimeSubstrLvalue) {
                         ref = "LVALUE";
+                    } else if (scalar.firstClassRegexScalar) {
+                        ref = "REGEXP";
                     } else {
                         ref = switch (scalar.type) {
                             case VSTRING -> "VSTRING";

--- a/src/main/java/org/perlonjava/runtime/perlmodule/AuthenPassphraseScrypt.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/AuthenPassphraseScrypt.java
@@ -1,0 +1,49 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.bouncycastle.crypto.generators.SCrypt;
+import org.perlonjava.runtime.runtimetypes.*;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+
+/** Authen::Passphrase::Scrypt's single XS primitive, backed by Bouncy Castle. */
+public class AuthenPassphraseScrypt extends PerlModuleBase {
+    private static final SecureRandom RANDOM = new SecureRandom();
+    public AuthenPassphraseScrypt() {
+        super("Authen::Passphrase::Scrypt", false);
+    }
+
+    public static void initialize() {
+        AuthenPassphraseScrypt mod = new AuthenPassphraseScrypt();
+        GlobalVariable.getGlobalVariable("Authen::Passphrase::Scrypt::VERSION").set(new RuntimeScalar("0.002"));
+        try {
+            mod.registerMethod("crypto_scrypt", null);
+            mod.registerMethod("_scrypt_random_bytes", null);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Authen::Passphrase::Scrypt Java binding is incomplete", e);
+        }
+    }
+
+    public static RuntimeList crypto_scrypt(RuntimeArray args, int ctx) {
+        if (args.size() < 6) throw new PerlCompilerException(
+                "Usage: Authen::Passphrase::Scrypt::crypto_scrypt(password, salt, N, r, p, length)");
+        try {
+            byte[] result = SCrypt.generate(bytes(args.get(0)), bytes(args.get(1)),
+                    args.get(2).getInt(), args.get(3).getInt(), args.get(4).getInt(), args.get(5).getInt());
+            return new RuntimeScalar(new String(result, StandardCharsets.ISO_8859_1)).getList();
+        } catch (RuntimeException e) {
+            throw new PerlCompilerException("Error in crypto_scrypt: " + e.getMessage());
+        }
+    }
+
+    public static RuntimeList _scrypt_random_bytes(RuntimeArray args, int ctx) {
+        int length = args.isEmpty() ? 32 : args.get(0).getInt();
+        byte[] output = new byte[Math.max(0, length)];
+        RANDOM.nextBytes(output);
+        return new RuntimeScalar(new String(output, StandardCharsets.ISO_8859_1)).getList();
+    }
+
+    private static byte[] bytes(RuntimeScalar scalar) {
+        return scalar.toString().getBytes(StandardCharsets.ISO_8859_1);
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/CryptArgon2.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/CryptArgon2.java
@@ -1,0 +1,170 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
+import org.bouncycastle.crypto.params.Argon2Parameters;
+import org.perlonjava.runtime.runtimetypes.*;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Crypt::Argon2's XS primitives, backed by the bundled Bouncy Castle provider. */
+public class CryptArgon2 extends PerlModuleBase {
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final Pattern ENCODED = Pattern.compile(
+            "^\\$(argon2(?:id|i|d))\\$v=(\\d+)\\$m=(\\d+),t=(\\d+),p=(\\d+)\\$([^$]+)\\$(.*)$");
+
+    public CryptArgon2() {
+        super("Crypt::Argon2", false);
+    }
+
+    public static void initialize() {
+        CryptArgon2 mod = new CryptArgon2();
+        GlobalVariable.getGlobalVariable("Crypt::Argon2::VERSION").set(new RuntimeScalar("0.032"));
+        try {
+            for (String method : new String[]{
+                    "argon2_pass", "argon2_raw", "argon2_verify",
+                    "argon2id_pass", "argon2id_raw", "argon2id_verify",
+                    "argon2i_pass", "argon2i_raw", "argon2i_verify",
+                    "argon2d_pass", "argon2d_raw", "argon2d_verify",
+                    "argon2_implementation", "_argon2_random_bytes"}) {
+                mod.registerMethod(method, null);
+            }
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Crypt::Argon2 Java binding is incomplete", e);
+        }
+    }
+
+    public static RuntimeList argon2_pass(RuntimeArray args, int ctx) {
+        requireArgs(args, 7, "argon2_pass");
+        return pass(args.get(0).toString(), args, 1).getList();
+    }
+
+    public static RuntimeList argon2_raw(RuntimeArray args, int ctx) {
+        requireArgs(args, 7, "argon2_raw");
+        return raw(args.get(0).toString(), args, 1).getList();
+    }
+
+    public static RuntimeList argon2id_pass(RuntimeArray args, int ctx) { return pass("argon2id", args, 0).getList(); }
+    public static RuntimeList argon2i_pass(RuntimeArray args, int ctx) { return pass("argon2i", args, 0).getList(); }
+    public static RuntimeList argon2d_pass(RuntimeArray args, int ctx) { return pass("argon2d", args, 0).getList(); }
+    public static RuntimeList argon2id_raw(RuntimeArray args, int ctx) { return raw("argon2id", args, 0).getList(); }
+    public static RuntimeList argon2i_raw(RuntimeArray args, int ctx) { return raw("argon2i", args, 0).getList(); }
+    public static RuntimeList argon2d_raw(RuntimeArray args, int ctx) { return raw("argon2d", args, 0).getList(); }
+
+    public static RuntimeList argon2_verify(RuntimeArray args, int ctx) { return verify(null, args).getList(); }
+    public static RuntimeList argon2id_verify(RuntimeArray args, int ctx) { return verify("argon2id", args).getList(); }
+    public static RuntimeList argon2i_verify(RuntimeArray args, int ctx) { return verify("argon2i", args).getList(); }
+    public static RuntimeList argon2d_verify(RuntimeArray args, int ctx) { return verify("argon2d", args).getList(); }
+
+    public static RuntimeList argon2_implementation(RuntimeArray args, int ctx) {
+        return new RuntimeScalar("bouncycastle").getList();
+    }
+
+    public static RuntimeList _argon2_random_bytes(RuntimeArray args, int ctx) {
+        int length = args.isEmpty() ? 16 : args.get(0).getInt();
+        byte[] output = new byte[Math.max(0, length)];
+        RANDOM.nextBytes(output);
+        return new RuntimeScalar(new String(output, StandardCharsets.ISO_8859_1)).getList();
+    }
+
+    private static RuntimeScalar pass(String type, RuntimeArray args, int offset) {
+        requireArgs(args, offset + 6, type + "_pass");
+        byte[] salt = bytes(args.get(offset + 1));
+        int t = args.get(offset + 2).getInt();
+        int memory = memoryKiB(args.get(offset + 3).toString(), type);
+        int lanes = args.get(offset + 4).getInt();
+        byte[] tag = derive(type, bytes(args.get(offset)), salt, t, memory, lanes,
+                args.get(offset + 5).getInt());
+        Base64.Encoder b64 = Base64.getEncoder().withoutPadding();
+        String encoded = "$" + type + "$v=19$m=" + memory + ",t=" + t + ",p=" + lanes
+                + "$" + b64.encodeToString(salt) + "$" + b64.encodeToString(tag);
+        return new RuntimeScalar(encoded);
+    }
+
+    private static RuntimeScalar raw(String type, RuntimeArray args, int offset) {
+        requireArgs(args, offset + 6, type + "_raw");
+        byte[] tag = derive(type, bytes(args.get(offset)), bytes(args.get(offset + 1)),
+                args.get(offset + 2).getInt(), memoryKiB(args.get(offset + 3).toString(), type),
+                args.get(offset + 4).getInt(), args.get(offset + 5).getInt());
+        return new RuntimeScalar(new String(tag, StandardCharsets.ISO_8859_1));
+    }
+
+    private static RuntimeScalar verify(String requiredType, RuntimeArray args) {
+        requireArgs(args, 2, "argon2_verify");
+        Matcher match = ENCODED.matcher(args.get(0).toString());
+        if (!match.matches()) {
+            throw new PerlCompilerException("Could not detect argon2 type: missing '$' separator");
+        }
+        String type = match.group(1);
+        if (requiredType != null && !requiredType.equals(type)) return new RuntimeScalar(0);
+        try {
+            byte[] salt = Base64.getDecoder().decode(padBase64(match.group(6)));
+            byte[] expected = Base64.getDecoder().decode(padBase64(match.group(7)));
+            byte[] actual = derive(type, bytes(args.get(1)), salt,
+                    Integer.parseInt(match.group(4)), Integer.parseInt(match.group(3)),
+                    Integer.parseInt(match.group(5)), expected.length);
+            return new RuntimeScalar(MessageDigest.isEqual(expected, actual) ? 1 : 0);
+        } catch (IllegalArgumentException e) {
+            throw new PerlCompilerException("Could not verify " + type + " tag: decoding failed");
+        }
+    }
+
+    private static byte[] derive(String type, byte[] password, byte[] salt,
+                                 int iterations, int memory, int lanes, int size) {
+        int bcType = switch (type) {
+            case "argon2i" -> Argon2Parameters.ARGON2_i;
+            case "argon2d" -> Argon2Parameters.ARGON2_d;
+            case "argon2id" -> Argon2Parameters.ARGON2_id;
+            default -> throw new PerlCompilerException("No such argon2 type " + type);
+        };
+        try {
+            Argon2Parameters params = new Argon2Parameters.Builder(bcType)
+                    .withVersion(Argon2Parameters.ARGON2_VERSION_13)
+                    .withSalt(salt).withIterations(iterations).withMemoryAsKB(memory)
+                    .withParallelism(lanes).build();
+            Argon2BytesGenerator generator = new Argon2BytesGenerator();
+            generator.init(params);
+            byte[] output = new byte[size];
+            generator.generateBytes(password, output);
+            return output;
+        } catch (RuntimeException e) {
+            throw new PerlCompilerException("Couldn't compute " + type + " tag: " + e.getMessage());
+        }
+    }
+
+    private static int memoryKiB(String text, String type) {
+        Matcher matcher = Pattern.compile("^(\\d+)([kMG]?)$").matcher(text);
+        if (!matcher.matches()) {
+            throw new PerlCompilerException("Couldn't compute " + type + " tag: memory cost doesn't contain anything numeric");
+        }
+        long value = Long.parseLong(matcher.group(1));
+        value = switch (matcher.group(2)) {
+            case "k" -> value;
+            case "M" -> value * 1024L;
+            case "G" -> value * 1024L * 1024L;
+            default -> {
+                if (value <= 1024) throw new PerlCompilerException(
+                        "Couldn't compute " + type + " tag: Memory size must be at least a kilobyte");
+                yield value / 1024L;
+            }
+        };
+        if (value > Integer.MAX_VALUE) throw new PerlCompilerException("Couldn't compute " + type + " tag: memory cost too large");
+        return (int) value;
+    }
+
+    private static byte[] bytes(RuntimeScalar scalar) {
+        return scalar.toString().getBytes(StandardCharsets.ISO_8859_1);
+    }
+
+    private static String padBase64(String input) {
+        return input + "=".repeat((4 - input.length() % 4) % 4);
+    }
+
+    private static void requireArgs(RuntimeArray args, int count, String name) {
+        if (args.size() < count) throw new PerlCompilerException("Usage: Crypt::Argon2::" + name);
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/CryptEksblowfishBcrypt.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/CryptEksblowfishBcrypt.java
@@ -1,0 +1,61 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.bouncycastle.crypto.generators.BCrypt;
+import org.perlonjava.runtime.runtimetypes.*;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+/** Focused bcrypt primitive used by Crypt::Eksblowfish::Bcrypt. */
+public class CryptEksblowfishBcrypt extends PerlModuleBase {
+    private static final SecureRandom RANDOM = new SecureRandom();
+    public CryptEksblowfishBcrypt() {
+        super("Crypt::Eksblowfish::Bcrypt", false);
+    }
+
+    public static void initialize() {
+        CryptEksblowfishBcrypt mod = new CryptEksblowfishBcrypt();
+        try {
+            mod.registerMethod("_bcrypt_hash_java", "bcryptHash", null);
+            mod.registerMethod("_bcrypt_random_bytes", null);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Crypt::Eksblowfish::Bcrypt Java binding is incomplete", e);
+        }
+    }
+
+    public static RuntimeList bcryptHash(RuntimeArray args, int ctx) {
+        if (args.size() < 4) throw new PerlCompilerException(
+                "Usage: Crypt::Eksblowfish::Bcrypt::_bcrypt_hash_java(key_nul, cost, salt, password)");
+        boolean keyNul = args.get(0).getBoolean();
+        int cost = args.get(1).getInt();
+        byte[] salt = bytes(args.get(2));
+        byte[] password = bytes(args.get(3));
+        if (salt.length != 16) throw new PerlCompilerException("bcrypt salt must be 16 octets");
+        if (password.length > 72) password = Arrays.copyOf(password, 72);
+        if (keyNul || password.length == 0) {
+            int length = Math.min(password.length + 1, 72);
+            password = Arrays.copyOf(password, length);
+        }
+        try {
+            // Bouncy Castle enforces bcrypt's modern cost floor of four.  The
+            // older Crypt::Eksblowfish API also accepts 0..3; retain its
+            // round-trip behavior for those legacy settings using the floor.
+            byte[] result = BCrypt.generate(password, salt, Math.max(4, cost), false);
+            return new RuntimeScalar(new String(Arrays.copyOf(result, 23), StandardCharsets.ISO_8859_1)).getList();
+        } catch (RuntimeException e) {
+            throw new PerlCompilerException("bcrypt failed: " + e.getMessage());
+        }
+    }
+
+    public static RuntimeList _bcrypt_random_bytes(RuntimeArray args, int ctx) {
+        int length = args.isEmpty() ? 16 : args.get(0).getInt();
+        byte[] output = new byte[Math.max(0, length)];
+        RANDOM.nextBytes(output);
+        return new RuntimeScalar(new String(output, StandardCharsets.ISO_8859_1)).getList();
+    }
+
+    private static byte[] bytes(RuntimeScalar scalar) {
+        return scalar.toString().getBytes(StandardCharsets.ISO_8859_1);
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/ScalarUtil.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/ScalarUtil.java
@@ -158,6 +158,7 @@ public class ScalarUtil extends PerlModuleBase {
                 if (scalar.value instanceof RuntimeScalar inner) {
                     if (inner.type == READONLY_SCALAR) inner = (RuntimeScalar) inner.value;
                     if (inner instanceof RuntimeSubstrLvalue) yield "LVALUE";
+                    if (inner.firstClassRegexScalar) yield "REGEXP";
                     yield switch (inner.type) {
                         case VSTRING -> "VSTRING";
                         case REGEX, ARRAYREFERENCE, HASHREFERENCE, CODE, GLOBREFERENCE, REFERENCE -> "REF";

--- a/src/main/java/org/perlonjava/runtime/regex/RegexQuoteMeta.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexQuoteMeta.java
@@ -8,6 +8,11 @@ import java.util.List;
 
 public class RegexQuoteMeta {
     private static final ThreadLocal<List<String>> WARNINGS_ON_USE = ThreadLocal.withInitial(ArrayList::new);
+    private static final ThreadLocal<Integer> CALL_SITE_WARNING_STATE = new ThreadLocal<>();
+
+    public static void setCallSiteWarningState(int state) {
+        CALL_SITE_WARNING_STATE.set(state);
+    }
 
     public static String escapeQ(String s) {
         WARNINGS_ON_USE.get().clear();
@@ -101,7 +106,21 @@ public class RegexQuoteMeta {
 
     private static void warnUnrecognizedCharClassEscape(char c) {
         String message = "Unrecognized escape \\" + c + " in character class passed through in regex";
-        WARNINGS_ON_USE.get().add(message);
-        WarnDie.warnWithCategory(new RuntimeScalar(message), new RuntimeScalar(""), "regexp");
+        // This warning belongs to construction of the interpolated pattern.
+        // Retaining it on the cached RuntimeRegex re-emits it for every match
+        // and can leak a warning-enabled compilation into a no-warnings use.
+        Integer state = CALL_SITE_WARNING_STATE.get();
+        if (state != null && state == 0) {
+            return;
+        }
+        RuntimeScalar warning = new RuntimeScalar(message);
+        RuntimeScalar where = new RuntimeScalar("");
+        if (state != null && state == 2) {
+            WarnDie.die(warning, where);
+        } else if (state != null) {
+            WarnDie.warn(warning, where);
+        } else {
+            WarnDie.warnWithCategory(warning, where, "regexp");
+        }
     }
 }

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -281,7 +281,17 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             System.err.println("  caller stack: " + Thread.currentThread().getStackTrace()[2]);
         }
 
-        String cacheKey = patternString + "/" + modifiers;
+        String originalPatternString = patternString;
+        String compilePatternString = patternString;
+        List<String> quoteMetaWarningsOnUse = new ArrayList<>();
+        if (compilePatternString != null && compilePatternString.contains("\\Q")) {
+            // Interpolated-pattern warnings are lexical diagnostics for each
+            // construction, even when the compiled regex itself is cached.
+            compilePatternString = escapeQ(compilePatternString);
+            quoteMetaWarningsOnUse = RegexQuoteMeta.getWarningsOnUse();
+        }
+
+        String cacheKey = originalPatternString + "/" + modifiers;
 
         // Check if the regex is already cached
         RuntimeRegex regex = regexCache.get(cacheKey);
@@ -290,14 +300,6 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 System.err.println("  cache miss, compiling new regex");
             }
             regex = new RuntimeRegex();
-
-            String originalPatternString = patternString;
-            String compilePatternString = patternString;
-            List<String> quoteMetaWarningsOnUse = new ArrayList<>();
-            if (compilePatternString != null && compilePatternString.contains("\\Q")) {
-                compilePatternString = escapeQ(compilePatternString);
-                quoteMetaWarningsOnUse = RegexQuoteMeta.getWarningsOnUse();
-            }
 
             // Note: flags /e /ee are processed at parse time, in parseRegexReplace()
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
@@ -901,8 +901,22 @@ public class MortalList {
     private static boolean inAutoSweep = false;
     private static boolean immediateWeakSweepRequested = false;
 
+    // Objects explicitly released by undef while JVM statement temporaries may
+    // still make them appear reachable. Recheck only these referents at the
+    // next Perl statement boundary; a full nested-call sweep can invalidate
+    // unrelated weak callback graphs whose caller-owned return values have not
+    // reached a walker-visible lexical yet.
+    private static final Set<RuntimeBase> targetedWeakSweepReferents =
+            Collections.newSetFromMap(new IdentityHashMap<>());
+
     public static void requestImmediateWeakSweep() {
         immediateWeakSweepRequested = true;
+    }
+
+    public static void requestTargetedWeakSweep(RuntimeBase referent) {
+        if (referent != null) {
+            targetedWeakSweepReferents.add(referent);
+        }
     }
 
     // D-W6.18 perf: cached reachable-set, valid for the duration of a
@@ -1132,6 +1146,12 @@ public class MortalList {
     }
 
     private static void maybeAutoSweepAtStatementBoundary(boolean topLevel) {
+        if (!targetedWeakSweepReferents.isEmpty()) {
+            Set<RuntimeBase> targets = Collections.newSetFromMap(new IdentityHashMap<>());
+            targets.addAll(targetedWeakSweepReferents);
+            targetedWeakSweepReferents.clear();
+            ReachabilityWalker.sweepReleasedWeakReferents(targets);
+        }
         if (topLevel) {
             maybeAutoSweep();
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ReachabilityWalker.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ReachabilityWalker.java
@@ -1480,6 +1480,58 @@ public class ReachabilityWalker {
     }
 
     /**
+     * Reconsider only referents explicitly released by {@code undef}. This is
+     * safe to run at a nested statement boundary because it cannot clear weak
+     * references belonging to unrelated in-flight return values.
+     */
+    public static int sweepReleasedWeakReferents(Set<RuntimeBase> referents) {
+        if (referents == null || referents.isEmpty()) return 0;
+        Set<RuntimeBase> live = new ReachabilityWalker().walk();
+        int cleared = 0;
+        boolean releasedObjectNeedsCascade = false;
+        for (RuntimeBase referent : referents) {
+            if (referent == null || referent.currentlyDestroying) {
+                continue;
+            }
+            if (referent.destroyFired || referent.refCount == Integer.MIN_VALUE) {
+                // An eager sweep in RuntimeScalar.undefine() may already have
+                // destroyed this wrapper using a liveness snapshot taken
+                // before its tied/container edges were released. Re-walk
+                // below so newly unreachable dependants are collected too.
+                releasedObjectNeedsCascade = true;
+                continue;
+            }
+            if (live.contains(referent)) continue;
+            if ((referent instanceof RuntimeHash || referent instanceof RuntimeArray)
+                    && referent.localBindingExists) {
+                continue;
+            }
+            if (referent.blessId != 0) {
+                referent.refCount = Integer.MIN_VALUE;
+                DestroyDispatch.callDestroy(referent);
+            } else {
+                WeakRefRegistry.clearWeakRefsTo(referent);
+                referent.refCount = Integer.MIN_VALUE;
+            }
+            cleared++;
+            releasedObjectNeedsCascade = true;
+        }
+
+        // Destruction can remove the last strong edge to another weakly
+        // observed object (a tied hash wrapper -> handler -> external hash is
+        // one example). Reachability snapshots are intentionally immutable,
+        // so iterate to a fixed point after this explicit release.
+        if (releasedObjectNeedsCascade) {
+            for (int pass = 0; pass < 8; pass++) {
+                int passCleared = sweepWeakRefs(false, false);
+                cleared += passCleared;
+                if (passCleared == 0) break;
+            }
+        }
+        return cleared;
+    }
+
+    /**
      * Sweep only objects registered by {@link DestroyDispatch} as needing
      * deterministic DESTROY side effects even when they are not weak-ref
      * referents. This is intentionally narrower than {@link #sweepWeakRefs}:

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArray.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArray.java
@@ -1599,6 +1599,10 @@ public class RuntimeArray extends RuntimeBase implements RuntimeScalarReference,
      * @return The updated RuntimeArray after undefining.
      */
     public RuntimeArray undefine() {
+        if (this.type == TIED_ARRAY) {
+            TieArray.tiedClear(this);
+            return this;
+        }
         notePackageRootMutation();
         MortalList.deferDestroyForContainerClear(this.elements);
         this.elements.clear();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
@@ -1282,6 +1282,11 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
      * @return The current RuntimeHash instance after undefining its elements.
      */
     public RuntimeHash undefine() {
+        if (this.type == TIED_HASH) {
+            TieHash.tiedClear(this);
+            hashIterator = null;
+            return this;
+        }
         notePackageRootClear(this.elements.values());
         // Fast path: if no value could possibly fire a DESTROY, use the
         // old one-shot path (one flush total instead of N flushes). The

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -80,6 +80,9 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
      */
     public String numericLiteralText;
 
+    /** True for the non-reference scalar produced by dereferencing a qr// value. */
+    public boolean firstClassRegexScalar;
+
     /**
      * True once a string scalar has been used in numeric context. Perl keeps a
      * numeric slot alongside the string slot on the same SV; this lightweight
@@ -361,6 +364,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.tainted = scalar.tainted;
         this.numericLiteralText = scalar.numericLiteralText;
         this.numericContextSeen = scalar.numericContextSeen;
+        this.firstClassRegexScalar = scalar.firstClassRegexScalar;
         if (this.type == GLOBREFERENCE && this.value instanceof RuntimeGlob glob
                 && glob.globName == null) {
             glob.ioHolderCount++;
@@ -440,6 +444,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 this.tainted = scalar.tainted;
                 this.numericLiteralText = scalar.numericLiteralText;
                 this.numericContextSeen = scalar.numericContextSeen;
+                this.firstClassRegexScalar = scalar.firstClassRegexScalar;
             }
             case Long longValue -> initializeWithLong(longValue);
             default -> {
@@ -547,6 +552,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     private void initializeWithLong(Long value) {
         this.tainted = false;
         this.numericContextSeen = false;
+        this.firstClassRegexScalar = false;
         if (value > Integer.MAX_VALUE || value < Integer.MIN_VALUE) {
             // Java double can only exactly represent integers up to 2^53.
             // Beyond that, storing as DOUBLE loses precision and breaks exact pack/unpack
@@ -1296,6 +1302,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 this.tainted = value.tainted;
                 this.numericLiteralText = value.numericLiteralText;
                 this.numericContextSeen = value.numericContextSeen;
+                this.firstClassRegexScalar = value.firstClassRegexScalar;
                 RuntimePosLvalue.invalidatePos(this);
             } else {
                 this.type = value.type;
@@ -1304,6 +1311,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 this.tainted = value.tainted;
                 this.numericLiteralText = value.numericLiteralText;
                 this.numericContextSeen = value.numericContextSeen;
+                this.firstClassRegexScalar = value.firstClassRegexScalar;
             }
             return this;
         }
@@ -1357,6 +1365,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             this.tainted = false;
             this.numericLiteralText = null;
             this.numericContextSeen = false;
+            this.firstClassRegexScalar = false;
             return this;
         }
         // Unwrap source special types via switch dispatcher
@@ -1397,6 +1406,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.tainted = value.tainted;
         this.numericLiteralText = value.numericLiteralText;
         this.numericContextSeen = value.numericContextSeen;
+        this.firstClassRegexScalar = value.firstClassRegexScalar;
         return this;
     }
 
@@ -1558,6 +1568,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.tainted = value.tainted;
         this.numericLiteralText = value.numericLiteralText;
         this.numericContextSeen = value.numericContextSeen;
+        this.firstClassRegexScalar = value.firstClassRegexScalar;
         if (this.globalCodeRefFqn != null && this.value instanceof RuntimeCode code) {
             code.hadStashRef = true;
         }
@@ -1711,7 +1722,10 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         if (oldBase != null
                 && oldBase.refCount == WeakRefRegistry.WEAKLY_TRACKED
                 && value.type == UNDEF) {
-            MortalList.requestImmediateWeakSweep();
+            MortalList.requestTargetedWeakSweep(oldBase);
+        }
+        if (undefAssignmentOfDestroyableRef && !ModuleInitGuard.inModuleInit()) {
+            MortalList.requestTargetedWeakSweep(oldBase);
         }
 
         // Update ownership: this scalar now owns a refCount iff we incremented.
@@ -1780,6 +1794,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.tainted = false;
         this.numericLiteralText = null;
         this.numericContextSeen = false;
+        this.firstClassRegexScalar = false;
         return this;
     }
 
@@ -1794,6 +1809,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.tainted = false;
         this.numericLiteralText = null;
         this.numericContextSeen = false;
+        this.firstClassRegexScalar = false;
         return this;
     }
 
@@ -1833,6 +1849,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.tainted = false;
         this.numericLiteralText = null;
         this.numericContextSeen = false;
+        this.firstClassRegexScalar = false;
         return this;
     }
 
@@ -1848,6 +1865,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.tainted = false;
         this.numericLiteralText = null;
         this.numericContextSeen = false;
+        this.firstClassRegexScalar = false;
         return this;
     }
 
@@ -1868,6 +1886,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.tainted = false;
         this.numericLiteralText = null;
         this.numericContextSeen = false;
+        this.firstClassRegexScalar = false;
         return this;
     }
 
@@ -2374,15 +2393,18 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 this.type = RuntimeScalarType.REFERENCE;
                 this.numericLiteralText = null;
                 this.numericContextSeen = false;
+                this.firstClassRegexScalar = false;
                 yield newScalar;
             }
             case REFERENCE -> (RuntimeScalar) value;
             case REGEX -> {
-                // Dereferencing a Regexp (qr//) returns its stringified form
-                // In Perl, ${qr/foo/} returns "(?^:foo)"
+                // Dereferencing qr// produces a non-reference scalar whose
+                // string value is the compiled pattern, but whose referent type
+                // remains REGEXP (reftype(\${qr/foo/}) eq "REGEXP").
                 RuntimeScalar result = new RuntimeScalar();
                 result.type = RuntimeScalarType.STRING;
                 result.value = this.value.toString();
+                result.firstClassRegexScalar = true;
                 yield result;
             }
             case GLOB -> {
@@ -2874,6 +2896,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             this.tainted = false;
             this.numericLiteralText = null;
             this.numericContextSeen = false;
+            this.firstClassRegexScalar = false;
             // Invalidate the method resolution cache
             InheritanceResolver.invalidateCache();
             if (releasedCode && WeakRefRegistry.weakRefsExist && !ModuleInitGuard.inModuleInit()) {
@@ -2902,6 +2925,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.tainted = false;
         this.numericLiteralText = null;
         this.numericContextSeen = false;
+        this.firstClassRegexScalar = false;
 
         // Decrement AFTER clearing (Perl 5 semantics: DESTROY sees the new state)
         boolean undefOnBlessedWithDestroy = false;
@@ -2962,6 +2986,18 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             }
         }
 
+        // An explicitly released blessed wrapper may have no DESTROY method
+        // of its own while still owning a tied container whose handler does.
+        // If the wrapper itself is being observed weakly, let the reachability
+        // walker decide immediately whether this was its last strong owner.
+        // Hash::AutoHash's wraptie constructor has exactly this shape.
+        if (!undefOnBlessedWithDestroy
+                && oldBase != null
+                && oldBase.blessId != 0
+                && WeakRefRegistry.hasWeakRefsTo(oldBase)) {
+            undefOnBlessedWithDestroy = true;
+        }
+
         // Flush deferred mortal decrements. Without this, pending DECs from
         // scope exit of locals (e.g., `my ($a,$b) = @_` inside a sub) would
         // not be processed until the next setLarge/apply, making the refCount
@@ -2977,6 +3013,10 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         // check. Skips when we're in module-init to avoid clearing weak refs
         // that require/use chains still depend on.
         if (undefOnBlessedWithDestroy && !ModuleInitGuard.inModuleInit()) {
+            // The current undef call can still have JVM temporaries that make
+            // the just-released wrapper appear live.  Also arm the next Perl
+            // statement boundary, after those temporaries have disappeared.
+            MortalList.requestTargetedWeakSweep(oldBase);
             if (System.getenv("JPERL_PHASE_D_DBG") != null) {
                 System.err.println("DBG Phase D undef-of-blessed trigger for " +
                         (oldBase != null ? org.perlonjava.runtime.runtimetypes.NameNormalizer.getBlessStr(oldBase.blessId) : "?") +
@@ -3250,6 +3290,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     public RuntimeScalar preAutoIncrement() {
         this.numericLiteralText = null;
         this.numericContextSeen = false;
+        this.firstClassRegexScalar = false;
         // Cases 0-11 are listed in order from RuntimeScalarType, and compile to fast tableswitch
         switch (type) {
             case INTEGER -> { // 0
@@ -3370,6 +3411,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 new RuntimeScalar(0) : new RuntimeScalar(this);
         this.numericLiteralText = null;
         this.numericContextSeen = false;
+        this.firstClassRegexScalar = false;
 
         // Cases 0-11 are listed in order from RuntimeScalarType, and compile to fast tableswitch
         switch (type) {
@@ -3471,6 +3513,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     public RuntimeScalar preAutoDecrement() {
         this.numericLiteralText = null;
         this.numericContextSeen = false;
+        this.firstClassRegexScalar = false;
         // Cases 0-11 are listed in order from RuntimeScalarType, and compile to fast tableswitch
         switch (type) {
             case INTEGER -> // 0
@@ -3575,6 +3618,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         RuntimeScalar old = new RuntimeScalar(this);
         this.numericLiteralText = null;
         this.numericContextSeen = false;
+        this.firstClassRegexScalar = false;
 
         // Cases 0-11 are listed in order from RuntimeScalarType, and compile to fast tableswitch
         switch (type) {
@@ -3723,6 +3767,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         currentState.tainted = this.tainted;
         currentState.numericLiteralText = this.numericLiteralText;
         currentState.numericContextSeen = this.numericContextSeen;
+        currentState.firstClassRegexScalar = this.firstClassRegexScalar;
         // Push the current state onto the stack
         dynamicStateStack.push(currentState);
         // Clear the current type and value
@@ -3733,6 +3778,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.tainted = false;
         this.numericLiteralText = null;
         this.numericContextSeen = false;
+        this.firstClassRegexScalar = false;
     }
 
     /**
@@ -3765,6 +3811,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             this.tainted = previousState.tainted;
             this.numericLiteralText = previousState.numericLiteralText;
             this.numericContextSeen = previousState.numericContextSeen;
+            this.firstClassRegexScalar = previousState.firstClassRegexScalar;
 
             releaseScalarReferenceContents(scalarReferenceContents);
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -2851,12 +2851,14 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 && !isRegisteredLexical
                 && captureCount == 0
                 && !isPackageGlobalRoot
-                && containerOwner == null) {
+                && containerOwner == null
+                && !RuntimeCode.isInstalledPadConstant(this)) {
             // An unbound scalar value returned from a subroutine is an
             // ephemeral Perl SV. Birth-track it so weaken(\(sub_return()))
             // consumes its sole owner immediately. Bound lexicals, closure
-            // captures, globals, aggregate elements, and active @_ arguments
-            // retain the established untracked/WEAKLY_TRACKED behavior.
+            // captures, globals, aggregate elements, active @_ arguments, and
+            // constants owned by an installed subroutine's optree retain the
+            // established untracked/WEAKLY_TRACKED behavior.
             this.refCount = 0;
             this.ephemeralScalarReferenceReferent = true;
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarUtils.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarUtils.java
@@ -152,6 +152,12 @@ public class ScalarUtils {
             if (str.isEmpty()) {
                 return false;
             }
+            // This is Perl's canonical true-but-zero value.  The core numeric
+            // parser accepts it without warning even though the suffix would be
+            // non-numeric for every other string.
+            if (str.equals("0 but true")) {
+                return true;
+            }
             // Check for Inf and NaN (with optional sign prefix)
             String check = str;
             if ((str.charAt(0) == '+' || str.charAt(0) == '-') && str.length() > 1) {

--- a/src/main/perl/lib/Authen/Passphrase.pm
+++ b/src/main/perl/lib/Authen/Passphrase.pm
@@ -1,0 +1,36 @@
+package Authen::Passphrase;
+use strict;
+use warnings;
+use Carp qw(croak);
+
+our $VERSION = '0.009';
+
+sub from_crypt {
+    my ($class, $value) = @_;
+    croak "from_crypt called on subclass $class" unless $class eq __PACKAGE__;
+    if ($value =~ /^\$2a?\$/) {
+        require Authen::Passphrase::BlowfishCrypt;
+        return Authen::Passphrase::BlowfishCrypt->from_crypt($value);
+    }
+    croak "unrecognised crypt scheme in $value";
+}
+
+sub from_rfc2307 {
+    my ($class, $value) = @_;
+    if ($value =~ /^\{(?:CRYPT|WM-CRY)\}(.*)$/i) {
+        return $class->from_crypt($1);
+    }
+    croak "RFC 2307 string not supported for $class" unless $class eq __PACKAGE__;
+    if ($value =~ /^\{CLEARTEXT\}/i) {
+        require Authen::Passphrase::Clear;
+        return Authen::Passphrase::Clear->from_rfc2307($value);
+    }
+    croak "unrecognised RFC 2307 scheme";
+}
+
+sub as_rfc2307 { '{CRYPT}' . $_[0]->as_crypt }
+sub match { croak 'abstract match method' }
+sub passphrase { croak 'passphrase cannot be recovered' }
+sub as_crypt { croak 'passphrase cannot be expressed as a crypt string' }
+
+1;

--- a/src/main/perl/lib/Authen/Passphrase/Argon2.pm
+++ b/src/main/perl/lib/Authen/Passphrase/Argon2.pm
@@ -1,0 +1,40 @@
+package Authen::Passphrase::Argon2;
+use 5.014;
+use strict;
+use warnings;
+use Carp qw(croak);
+use parent 'Authen::Passphrase';
+use Crypt::Argon2 qw(argon2id_pass argon2id_verify);
+
+our $VERSION = '1.01';
+
+sub new {
+    my ($class, @input) = @_;
+    @input = %{$input[0]} if @input == 1 && ref($input[0]) eq 'HASH';
+    my %args = @input;
+    my $salt = exists $args{salt} ? $args{salt}
+        : exists $args{salt_random} ? Crypt::Argon2::_argon2_random_bytes(16)
+        : croak 'salt not set';
+    my $self = bless {
+        algorithm => 'Argon2', salt => $salt, cost => ($args{cost} || 3),
+        factor => ($args{factor} || '32M'), parallelism => ($args{parallelism} || 1),
+        size => ($args{size} || 16),
+    }, $class;
+    my $value = $args{passphrase};
+    $value = $args{hash} if exists $args{hash};
+    croak 'hash or passphrase not set' unless defined $value;
+    $self->{crypt} = $value =~ /^\$argon2/ ? $value : $self->_hash_of($value);
+    return $self;
+}
+
+sub _hash_of { argon2id_pass($_[1], $_[0]->{salt}, $_[0]->{cost}, $_[0]->{factor}, $_[0]->{parallelism}, $_[0]->{size}) }
+sub match { argon2id_verify($_[0]->{crypt}, $_[1]) }
+sub from_crypt { my ($class, $value) = @_; $value =~ /^\$argon2id/ or croak 'not a valid raw hash'; return bless {crypt => $value, algorithm => 'Argon2'}, $class }
+sub from_rfc2307 { my ($class, $value) = @_; $value =~ /^\{ARGON2\}(.*)$/ or croak 'invalid Argon2 RFC2307 format'; return $class->from_crypt($1) }
+sub as_crypt { $_[0]->{crypt} = $_[1] if defined $_[1]; $_[0]->{crypt} }
+sub as_rfc2307 { '{ARGON2}' . $_[0]->as_crypt }
+sub algorithm { $_[0]->{algorithm} }
+sub salt { $_[0]->{salt} }
+sub hash { $_[0]->{crypt} }
+
+1;

--- a/src/main/perl/lib/Authen/Passphrase/BlowfishCrypt.pm
+++ b/src/main/perl/lib/Authen/Passphrase/BlowfishCrypt.pm
@@ -1,0 +1,59 @@
+package Authen::Passphrase::BlowfishCrypt;
+use strict;
+use warnings;
+use Carp qw(croak);
+use parent 'Authen::Passphrase';
+use Crypt::Eksblowfish::Bcrypt 0.008 qw(bcrypt_hash en_base64 de_base64);
+
+our $VERSION = '0.009';
+
+sub new {
+    my $class = shift;
+    my ($passphrase, %self);
+    while (@_) {
+        my ($key, $value) = (shift, shift);
+        if ($key eq 'key_nul') { croak 'key_nul specified redundantly' if exists $self{key_nul}; $self{key_nul} = !!$value }
+        elsif ($key eq 'cost' || $key eq 'keying_nrounds_log2') { croak 'cost specified redundantly' if exists $self{cost}; $self{cost} = 0 + $value }
+        elsif ($key eq 'salt') { croak 'salt specified redundantly' if exists $self{salt}; $self{salt} = "$value" }
+        elsif ($key eq 'salt_base64') { croak 'salt specified redundantly' if exists $self{salt}; $self{salt} = de_base64($value) }
+        elsif ($key eq 'salt_random') { croak 'salt specified redundantly' if exists $self{salt}; $self{salt} = Crypt::Eksblowfish::Bcrypt::_bcrypt_random_bytes(16) }
+        elsif ($key eq 'hash') { croak 'hash specified redundantly' if exists $self{hash} || defined $passphrase; $self{hash} = "$value" }
+        elsif ($key eq 'hash_base64') { croak 'hash specified redundantly' if exists $self{hash} || defined $passphrase; $self{hash} = de_base64($value) }
+        elsif ($key eq 'passphrase') { croak 'passphrase specified redundantly' if exists $self{hash} || defined $passphrase; $passphrase = $value }
+        else { croak "unrecognised attribute `$key'" }
+    }
+    $self{key_nul} = 1 unless exists $self{key_nul};
+    croak 'cost not specified' unless exists $self{cost};
+    croak 'salt not specified' unless length($self{salt}) == 16;
+    my $self = bless \%self, $class;
+    $self->{hash} = $self->_hash_of($passphrase) if defined $passphrase;
+    croak 'hash not specified' unless length($self->{hash}) == 23;
+    return $self;
+}
+
+sub from_crypt {
+    my ($class, $value) = @_;
+    $value =~ /^\$2(a?)\$([0-9]{2})\$([.\/A-Za-z0-9]{22})([.\/A-Za-z0-9]{31})$/
+        or return $class->SUPER::from_crypt($value);
+    return $class->new(key_nul => !!$1, cost => $2,
+        salt_base64 => $3, hash_base64 => $4);
+}
+
+sub from_rfc2307 {
+    my ($class, $value) = @_;
+    $value =~ /^\{CRYPT\}(.*)$/i or return $class->SUPER::from_rfc2307($value);
+    return $class->from_crypt($1);
+}
+
+sub key_nul { $_[0]->{key_nul} }
+sub cost { $_[0]->{cost} }
+*keying_nrounds_log2 = \&cost;
+sub salt { $_[0]->{salt} }
+sub salt_base64 { en_base64($_[0]->{salt}) }
+sub hash { $_[0]->{hash} }
+sub hash_base64 { en_base64($_[0]->{hash}) }
+sub _hash_of { bcrypt_hash({key_nul => $_[0]->{key_nul}, cost => $_[0]->{cost}, salt => $_[0]->{salt}}, $_[1]) }
+sub match { $_[0]->_hash_of($_[1]) eq $_[0]->{hash} }
+sub as_crypt { sprintf("\$2%s\$%02d\$%s%s", $_[0]->key_nul ? 'a' : '', $_[0]->cost, $_[0]->salt_base64, $_[0]->hash_base64) }
+
+1;

--- a/src/main/perl/lib/Authen/Passphrase/Clear.pm
+++ b/src/main/perl/lib/Authen/Passphrase/Clear.pm
@@ -1,0 +1,28 @@
+package Authen::Passphrase::Clear;
+use strict;
+use warnings;
+use Carp qw(croak);
+use parent 'Authen::Passphrase';
+
+our $VERSION = '0.009';
+
+sub new {
+    my ($class, $passphrase) = @_;
+    $passphrase = "$passphrase";
+    return bless \$passphrase, $class;
+}
+
+sub from_rfc2307 {
+    my ($class, $value) = @_;
+    $value =~ /^\{CLEARTEXT\}([!-~]*)$/i or croak 'malformed {CLEARTEXT} data';
+    return $class->new($1);
+}
+
+sub match { $_[1] eq ${$_[0]} }
+sub passphrase { ${$_[0]} }
+sub as_rfc2307 {
+    croak "can't put this passphrase into an RFC 2307 string" if ${$_[0]} =~ /[^!-~]/;
+    return '{CLEARTEXT}' . ${$_[0]};
+}
+
+1;

--- a/src/main/perl/lib/Authen/Passphrase/Scrypt.pm
+++ b/src/main/perl/lib/Authen/Passphrase/Scrypt.pm
@@ -1,0 +1,57 @@
+package Authen::Passphrase::Scrypt;
+use 5.014;
+use strict;
+use warnings;
+use Carp qw(croak);
+use parent qw(Exporter Authen::Passphrase);
+use Digest::SHA qw(sha256 hmac_sha256);
+use MIME::Base64 qw(encode_base64 decode_base64);
+
+our $VERSION = '0.002';
+our @EXPORT = qw(crypto_scrypt);
+our @EXPORT_OK = @EXPORT;
+
+use XSLoader;
+XSLoader::load(__PACKAGE__, $VERSION);
+
+sub compute_hash { crypto_scrypt($_[1], $_[0]->{salt}, 1 << $_[0]->{logN}, $_[0]->{r}, $_[0]->{p}, 64) }
+sub truncated_sha256 { substr sha256($_[0]), 0, 16 }
+sub truncate_hash { substr $_[0], 32 }
+
+sub new {
+    my ($class, @args) = @_;
+    @args = %{$args[0]} if @args == 1 && ref($args[0]) eq 'HASH';
+    my %args = (logN => 14, r => 16, p => 1, @args);
+    $args{salt} = _scrypt_random_bytes(32) unless exists $args{salt};
+    croak 'passphrase not set' unless defined $args{passphrase};
+    my $self = bless \%args, $class;
+    my $data = "scrypt\0" . pack('CNNa32', @args{qw(logN r p salt)});
+    $data .= truncated_sha256($data);
+    $self->{data} = $data;
+    $self->{hmac} = hmac_sha256($data, truncate_hash($self->compute_hash($self->{passphrase})));
+    return $self;
+}
+
+sub from_rfc2307 {
+    my ($class, $value) = @_;
+    $value =~ /^\{SCRYPT\}([A-Za-z0-9+\/]{128})$/ or croak 'Invalid Scrypt RFC2307';
+    my $data = decode_base64($1);
+    my ($name, $logN, $r, $p, $salt, $checksum, $hmac) = unpack('Z7CNNa32a16a32', $data);
+    croak 'Invalid Scrypt hash: should start with "scrypt"' unless $name eq 'scrypt';
+    croak 'Invalid Scrypt hash: bad checksum' unless $checksum eq truncated_sha256(substr($data, 0, 48));
+    return bless {data => substr($data, 0, 64), logN => $logN, r => $r, p => $p, salt => $salt, hmac => $hmac}, $class;
+}
+
+sub match { $_[0]->{hmac} eq hmac_sha256($_[0]->{data}, truncate_hash($_[0]->compute_hash($_[1]))) }
+sub as_rfc2307 { '{SCRYPT}' . encode_base64($_[0]->{data} . $_[0]->{hmac}, '') }
+sub from_crypt { croak __PACKAGE__ . ' does not support crypt strings, use from_rfc2307 instead' }
+sub as_crypt { croak __PACKAGE__ . ' does not support crypt strings, use as_rfc2307 instead' }
+sub data { $_[0]->{data} }
+sub logN { $_[0]->{logN} }
+sub r { $_[0]->{r} }
+sub p { $_[0]->{p} }
+sub salt { $_[0]->{salt} }
+sub hmac { $_[0]->{hmac} }
+sub passphrase { $_[0]->{passphrase} }
+
+1;

--- a/src/main/perl/lib/Crypt/Argon2.pm
+++ b/src/main/perl/lib/Crypt/Argon2.pm
@@ -1,0 +1,36 @@
+package Crypt::Argon2;
+use strict;
+use warnings;
+use Exporter 5.57 'import';
+
+our $VERSION = '0.032';
+our @EXPORT_OK = qw(
+    argon2_raw argon2_pass argon2_verify
+    argon2id_raw argon2id_pass argon2id_verify
+    argon2i_raw argon2i_pass argon2i_verify
+    argon2d_raw argon2d_pass argon2d_verify
+    argon2_needs_rehash argon2_types argon2_implementation
+);
+
+use XSLoader;
+XSLoader::load(__PACKAGE__, $VERSION);
+
+my %multiplier = (k => 1, M => 1024, G => 1024 * 1024);
+my $encoded = qr/ ^ \$ (argon2(?:i|d|id)) \$ v=(\d+) \$ m=(\d+),t=(\d+),p=(\d+) \$ ([^\$]+) \$ (.*) $ /x;
+
+sub argon2_needs_rehash {
+    my ($value, $type, $time, $memory, $parallel, $output_length, $salt_length) = @_;
+    $memory =~ s/ \A (\d+) ([kMG]) \z / $1 * $multiplier{$2} * 1024 /xmse;
+    $memory /= 1024;
+    my ($got_type, $version, $got_memory, $got_time, $got_parallel, $salt, $hash) =
+        $value =~ $encoded or return 1;
+    return 1 if $got_type ne $type || $version != 19 || $got_memory != $memory
+        || $got_time != $time || $got_parallel != $parallel;
+    return 1 if int(3 / 4 * length($salt)) != $salt_length
+        || int(3 / 4 * length($hash)) != $output_length;
+    return 0;
+}
+
+sub argon2_types { qw(argon2id argon2i argon2d) }
+
+1;

--- a/src/main/perl/lib/Crypt/Eksblowfish/Bcrypt.pm
+++ b/src/main/perl/lib/Crypt/Eksblowfish/Bcrypt.pm
@@ -1,0 +1,42 @@
+package Crypt::Eksblowfish::Bcrypt;
+use strict;
+use warnings;
+use Carp qw(croak);
+use Exporter 'import';
+use MIME::Base64 2.21 qw(encode_base64 decode_base64);
+
+our $VERSION = '0.009';
+our @EXPORT_OK = qw(bcrypt_hash en_base64 de_base64 bcrypt);
+
+use XSLoader;
+XSLoader::load(__PACKAGE__, $VERSION);
+
+sub bcrypt_hash($$) {
+    my ($settings, $password) = @_;
+    return _bcrypt_hash_java(!!$settings->{key_nul}, $settings->{cost},
+        $settings->{salt}, $password);
+}
+
+sub en_base64($) {
+    my $text = encode_base64($_[0], '');
+    $text =~ tr#A-Za-z0-9+/=#./A-Za-z0-9#d;
+    return $text;
+}
+
+sub de_base64($) {
+    my $text = $_[0];
+    croak 'bad base64 encoding' unless $text =~ m#\A(?>(?:[./A-Za-z0-9]{4})*)(?:|[./A-Za-z0-9]{2}[.CGKOSWaeimquy26]|[./A-Za-z0-9][.Oeu])\z#x;
+    $text =~ tr#./A-Za-z0-9#A-Za-z0-9+/#;
+    $text .= '=' x (3 - (length($text) + 3) % 4);
+    return decode_base64($text);
+}
+
+sub bcrypt($$) {
+    my ($password, $settings) = @_;
+    croak 'bad bcrypt settings' unless $settings =~ m#\A\$2(a?)\$([0-9]{2})\$([./A-Za-z0-9]{22})#;
+    my ($key_nul, $cost, $salt64) = ($1, $2, $3);
+    my $hash = bcrypt_hash({key_nul => $key_nul, cost => $cost, salt => de_base64($salt64)}, $password);
+    return "\$2${key_nul}\$${cost}\$${salt64}" . en_base64($hash);
+}
+
+1;

--- a/src/main/perl/lib/Encode/Alias.pm
+++ b/src/main/perl/lib/Encode/Alias.pm
@@ -1,0 +1,399 @@
+package Encode::Alias;
+use strict;
+use warnings;
+our $VERSION = do { my @r = ( q$Revision: 2.25 $ =~ /\d+/g ); sprintf "%d." . "%02d" x $#r, @r };
+use constant DEBUG => !!$ENV{PERL_ENCODE_DEBUG};
+
+use Exporter 'import';
+
+# Public, encouraged API is exported by default
+
+our @EXPORT =
+  qw (
+  define_alias
+  find_alias
+);
+
+our @Alias;    # ordered matching list
+our %Alias;    # cached known aliases
+
+sub find_alias {
+    my $class = shift;
+    my $find  = shift;
+    unless ( exists $Alias{$find} ) {
+        $Alias{$find} = undef;    # Recursion guard
+        for ( my $i = 0 ; $i < @Alias ; $i += 2 ) {
+            my $alias = $Alias[$i];
+            my $val   = $Alias[ $i + 1 ];
+            my $new;
+            if ( ref($alias) eq 'Regexp' && $find =~ $alias ) {
+                DEBUG and warn "eval $val";
+                $new = eval $val;
+                DEBUG and $@ and warn "$val, $@";
+            }
+            elsif ( ref($alias) eq 'CODE' ) {
+                DEBUG and warn "$alias", "->", "($find)";
+                $new = $alias->($find);
+            }
+            elsif ( lc($find) eq lc($alias) ) {
+                $new = $val;
+            }
+            if ( defined($new) ) {
+                next if $new eq $find;    # avoid (direct) recursion on bugs
+                DEBUG and warn "$alias, $new";
+                my $enc =
+                  ( ref($new) ) ? $new : Encode::find_encoding($new);
+                if ($enc) {
+                    $Alias{$find} = $enc;
+                    last;
+                }
+            }
+        }
+
+        # case insensitive search when canonical is not in all lowercase
+        # RT ticket #7835
+        unless ( $Alias{$find} ) {
+            my $lcfind = lc($find);
+            for my $name ( keys %Encode::Encoding, keys %Encode::ExtModule )
+            {
+                $lcfind eq lc($name) or next;
+                $Alias{$find} = Encode::find_encoding($name);
+                DEBUG and warn "$find => $name";
+            }
+        }
+    }
+    if (DEBUG) {
+        my $name;
+        if ( my $e = $Alias{$find} ) {
+            $name = $e->name;
+        }
+        else {
+            $name = "";
+        }
+        warn "find_alias($class, $find)->name = $name";
+    }
+    return $Alias{$find};
+}
+
+sub define_alias {
+    while (@_) {
+        my $alias = shift;
+        my $name = shift;
+        unshift( @Alias, $alias => $name )    # newer one has precedence
+            if defined $alias;
+        if ( ref($alias) ) {
+
+            # clear %Alias cache to allow overrides
+            my @a = keys %Alias;
+            for my $k (@a) {
+                if ( ref($alias) eq 'Regexp' && $k =~ $alias ) {
+                    DEBUG and warn "delete \$Alias\{$k\}";
+                    delete $Alias{$k};
+                }
+                elsif ( ref($alias) eq 'CODE' && $alias->($k) ) {
+                    DEBUG and warn "delete \$Alias\{$k\}";
+                    delete $Alias{$k};
+                }
+            }
+        }
+        elsif (defined $alias) {
+            DEBUG and warn "delete \$Alias\{$alias\}";
+            delete $Alias{$alias};
+        }
+        elsif (DEBUG) {
+            require Carp;
+            Carp::croak("undef \$alias");
+        }
+    }
+}
+
+# HACK: Encode must be used after define_alias is declarated as Encode calls define_alias
+use Encode ();
+
+# Allow latin-1 style names as well
+# 0  1  2  3  4  5   6   7   8   9  10
+our @Latin2iso = ( 0, 1, 2, 3, 4, 9, 10, 13, 14, 15, 16 );
+
+# Allow winlatin1 style names as well
+our %Winlatin2cp = (
+    'latin1'     => 1252,
+    'latin2'     => 1250,
+    'cyrillic'   => 1251,
+    'greek'      => 1253,
+    'turkish'    => 1254,
+    'hebrew'     => 1255,
+    'arabic'     => 1256,
+    'baltic'     => 1257,
+    'vietnamese' => 1258,
+);
+
+init_aliases();
+
+sub undef_aliases {
+    @Alias = ();
+    %Alias = ();
+}
+
+sub init_aliases {
+    undef_aliases();
+
+    # Try all-lower-case version should all else fails
+    define_alias( qr/^(.*)$/ => '"\L$1"' );
+
+    # UTF/UCS stuff
+    define_alias( qr/^(unicode-1-1-)?UTF-?7$/i     => '"UTF-7"' );
+    define_alias( qr/^UCS-?2-?LE$/i => '"UCS-2LE"' );
+    define_alias(
+        qr/^UCS-?2-?(BE)?$/i    => '"UCS-2BE"',
+        qr/^UCS-?4-?(BE|LE|)?$/i => 'uc("UTF-32$1")',
+        qr/^iso-10646-1$/i      => '"UCS-2BE"'
+    );
+    define_alias(
+        qr/^UTF-?(16|32)-?BE$/i => '"UTF-$1BE"',
+        qr/^UTF-?(16|32)-?LE$/i => '"UTF-$1LE"',
+        qr/^UTF-?(16|32)$/i     => '"UTF-$1"',
+    );
+
+    # ASCII
+    define_alias( qr/^(?:US-?)ascii$/i       => '"ascii"' );
+    define_alias( 'C'                        => 'ascii' );
+    define_alias( qr/\b(?:ISO[-_]?)?646(?:[-_]?US)?$/i => '"ascii"' );
+
+    # Allow variants of iso-8859-1 etc.
+    define_alias( qr/\biso[-_]?(\d+)[-_](\d+)$/i => '"iso-$1-$2"' );
+
+    # ISO-8859-8-I => ISO-8859-8
+    # https://en.wikipedia.org/wiki/ISO-8859-8-I
+    define_alias( qr/\biso[-_]8859[-_]8[-_]I$/i => '"iso-8859-8"' );
+
+    # At least HP-UX has these.
+    define_alias( qr/\biso8859(\d+)$/i => '"iso-8859-$1"' );
+
+    # More HP stuff.
+    define_alias(
+        qr/\b(?:hp-)?(arabic|greek|hebrew|kana|roman|thai|turkish)8$/i =>
+          '"${1}8"' );
+
+    # The Official name of ASCII.
+    define_alias( qr/\bANSI[-_]?X3\.4[-_]?1968$/i => '"ascii"' );
+
+    # This is a font issue, not an encoding issue.
+    # (The currency symbol of the Latin 1 upper half
+    #  has been redefined as the euro symbol.)
+    define_alias( qr/^(.+)\@euro$/i => '"$1"' );
+
+    define_alias( qr/\b(?:iso[-_]?)?latin[-_]?(\d+)$/i =>
+'defined $Encode::Alias::Latin2iso[$1] ? "iso-8859-$Encode::Alias::Latin2iso[$1]" : undef'
+    );
+
+    define_alias(
+        qr/\bwin(latin[12]|cyrillic|baltic|greek|turkish|
+             hebrew|arabic|baltic|vietnamese)$/ix =>
+          '"cp" . $Encode::Alias::Winlatin2cp{lc($1)}'
+    );
+
+    # Common names for non-latin preferred MIME names
+    define_alias(
+        'ascii'    => 'US-ascii',
+        'cyrillic' => 'iso-8859-5',
+        'arabic'   => 'iso-8859-6',
+        'greek'    => 'iso-8859-7',
+        'hebrew'   => 'iso-8859-8',
+        'thai'     => 'iso-8859-11',
+    );
+    # RT #20781
+    define_alias(qr/\btis-?620\b/i  => '"iso-8859-11"');
+
+    # At least AIX has IBM-NNN (surprisingly...) instead of cpNNN.
+    # And Microsoft has their own naming (again, surprisingly).
+    # And windows-* is registered in IANA!
+    define_alias(
+        qr/\b(?:cp|ibm|ms|windows)[-_ ]?(\d{2,4})$/i => '"cp$1"' );
+
+    # Sometimes seen with a leading zero.
+    # define_alias( qr/\bcp037\b/i => '"cp37"');
+
+    # Mac Mappings
+    # predefined in *.ucm; unneeded
+    # define_alias( qr/\bmacIcelandic$/i => '"macIceland"');
+    define_alias( qr/^(?:x[_-])?mac[_-](.*)$/i => '"mac$1"' );
+    # http://rt.cpan.org/Ticket/Display.html?id=36326
+    define_alias( qr/^macintosh$/i => '"MacRoman"' );
+    # https://rt.cpan.org/Ticket/Display.html?id=78125
+    define_alias( qr/^macce$/i => '"MacCentralEurRoman"' );
+    # Ououououou. gone.  They are different!
+    # define_alias( qr/\bmacRomanian$/i => '"macRumanian"');
+
+    # Standardize on the dashed versions.
+    define_alias( qr/\bkoi8[\s\-_]*([ru])$/i => '"koi8-$1"' );
+
+    unless ($Encode::ON_EBCDIC) {
+
+        # for Encode::CN
+        define_alias( qr/\beuc.*cn$/i => '"euc-cn"' );
+        define_alias( qr/\bcn.*euc$/i => '"euc-cn"' );
+
+        # define_alias( qr/\bGB[- ]?(\d+)$/i => '"euc-cn"' )
+        # CP936 doesn't have vendor-addon for GBK, so they're identical.
+        define_alias( qr/^gbk$/i => '"cp936"' );
+
+        # This fixes gb2312 vs. euc-cn confusion, practically
+        define_alias( qr/\bGB[-_ ]?2312(?!-?raw)/i => '"euc-cn"' );
+
+        # for Encode::JP
+        define_alias( qr/\bjis$/i         => '"7bit-jis"' );
+        define_alias( qr/\beuc.*jp$/i     => '"euc-jp"' );
+        define_alias( qr/\bjp.*euc$/i     => '"euc-jp"' );
+        define_alias( qr/\bujis$/i        => '"euc-jp"' );
+        define_alias( qr/\bshift.*jis$/i  => '"shiftjis"' );
+        define_alias( qr/\bsjis$/i        => '"shiftjis"' );
+        define_alias( qr/\bwindows-31j$/i => '"cp932"' );
+
+        # for Encode::KR
+        define_alias( qr/\beuc.*kr$/i => '"euc-kr"' );
+        define_alias( qr/\bkr.*euc$/i => '"euc-kr"' );
+
+        # This fixes ksc5601 vs. euc-kr confusion, practically
+        define_alias( qr/(?:x-)?uhc$/i         => '"cp949"' );
+        define_alias( qr/(?:x-)?windows-949$/i => '"cp949"' );
+        define_alias( qr/\bks_c_5601-1987$/i   => '"cp949"' );
+
+        # for Encode::TW
+        define_alias( qr/\bbig-?5$/i              => '"big5-eten"' );
+        define_alias( qr/\bbig5-?et(?:en)?$/i     => '"big5-eten"' );
+        define_alias( qr/\btca[-_]?big5$/i        => '"big5-eten"' );
+        define_alias( qr/\bbig5-?hk(?:scs)?$/i    => '"big5-hkscs"' );
+        define_alias( qr/\bhk(?:scs)?[-_]?big5$/i => '"big5-hkscs"' );
+    }
+
+    # https://github.com/dankogai/p5-encode/issues/37
+    define_alias(qr/cp65000/i => '"UTF-7"');
+    define_alias(qr/cp65001/i => '"utf-8-strict"');
+
+    # utf8 is blessed :)
+    define_alias( qr/\bUTF-8$/i => '"utf-8-strict"' );
+
+    # At last, Map white space and _ to '-'
+    define_alias( qr/^([^\s_]+)[\s_]+([^\s_]*)$/i => '"$1-$2"' );
+}
+
+1;
+__END__
+
+# TODO: HP-UX '8' encodings arabic8 greek8 hebrew8 kana8 thai8 turkish8
+# TODO: HP-UX '15' encodings japanese15 korean15 roi15
+# TODO: Cyrillic encoding ISO-IR-111 (useful?)
+# TODO: Armenian encoding ARMSCII-8
+# TODO: Hebrew encoding ISO-8859-8-1
+# TODO: Thai encoding TCVN
+# TODO: Vietnamese encodings VPS
+# TODO: Mac Asian+African encodings: Arabic Armenian Bengali Burmese
+#       ChineseSimp ChineseTrad Devanagari Ethiopic ExtArabic
+#       Farsi Georgian Gujarati Gurmukhi Hebrew Japanese
+#       Kannada Khmer Korean Laotian Malayalam Mongolian
+#       Oriya Sinhalese Symbol Tamil Telugu Tibetan Vietnamese
+
+=head1 NAME
+
+Encode::Alias - alias definitions to encodings
+
+=head1 SYNOPSIS
+
+  use Encode;
+  use Encode::Alias;
+  define_alias( "newName" => ENCODING);
+  define_alias( qr/.../ => ENCODING);
+  define_alias( sub { return ENCODING if ...; } );
+
+=head1 DESCRIPTION
+
+Allows newName to be used as an alias for ENCODING. ENCODING may be
+either the name of an encoding or an encoding object (as described 
+in L<Encode>).
+
+Currently the first argument to define_alias() can be specified in the
+following ways:
+
+=over 4
+
+=item As a simple string.
+
+=item As a qr// compiled regular expression, e.g.:
+
+  define_alias( qr/^iso8859-(\d+)$/i => '"iso-8859-$1"' );
+
+In this case, if I<ENCODING> is not a reference, it is C<eval>-ed
+in order to allow C<$1> etc. to be substituted.  The example is one
+way to alias names as used in X11 fonts to the MIME names for the
+iso-8859-* family.  Note the double quotes inside the single quotes.
+
+(or, you don't have to do this yourself because this example is predefined)
+
+If you are using a regex here, you have to use the quotes as shown or
+it won't work.  Also note that regex handling is tricky even for the
+experienced.  Use this feature with caution.
+
+=item As a code reference, e.g.:
+
+  define_alias( sub {shift =~ /^iso8859-(\d+)$/i ? "iso-8859-$1" : undef } );
+
+The same effect as the example above in a different way.  The coderef
+takes the alias name as an argument and returns a canonical name on
+success or undef if not.  Note the second argument is ignored if provided.
+Use this with even more caution than the regex version.
+
+=back
+
+=head3 Changes in code reference aliasing
+
+As of Encode 1.87, the older form
+
+  define_alias( sub { return  /^iso8859-(\d+)$/i ? "iso-8859-$1" : undef } );
+
+no longer works. 
+
+Encode up to 1.86 internally used "local $_" to implement this older
+form.  But consider the code below;
+
+  use Encode;
+  $_ = "eeeee" ;
+  while (/(e)/g) {
+    my $utf = decode('aliased-encoding-name', $1);
+    print "position:",pos,"\n";
+  }
+
+Prior to Encode 1.86 this fails because of "local $_".
+
+=head2 Alias overloading
+
+You can override predefined aliases by simply applying define_alias().
+The new alias is always evaluated first, and when necessary,
+define_alias() flushes the internal cache to make the new definition
+available.
+
+  # redirect SHIFT_JIS to MS/IBM Code Page 932, which is a
+  # superset of SHIFT_JIS
+
+  define_alias( qr/shift.*jis$/i  => '"cp932"' );
+  define_alias( qr/sjis$/i        => '"cp932"' );
+
+If you want to zap all predefined aliases, you can use
+
+  Encode::Alias->undef_aliases;
+
+to do so.  And
+
+  Encode::Alias->init_aliases;
+
+gets the factory settings back.
+
+Note that define_alias() will not be able to override the canonical name
+of encodings. Encodings are first looked up by canonical name before
+potential aliases are tried.
+
+=head1 SEE ALSO
+
+L<Encode>, L<Encode::Supported>
+
+=cut
+

--- a/src/main/perl/lib/Encode/Locale.pm
+++ b/src/main/perl/lib/Encode/Locale.pm
@@ -1,0 +1,54 @@
+package Encode::Locale;
+
+use strict;
+our $VERSION = "1.05";
+
+use base 'Exporter';
+our @EXPORT_OK = qw(
+    decode_argv env
+    $ENCODING_LOCALE $ENCODING_LOCALE_FS
+    $ENCODING_CONSOLE_IN $ENCODING_CONSOLE_OUT
+);
+
+# ExtUtils::MakeMaker ships a maintained derivative of Encode::Locale.  Reuse
+# that bundled pure-Perl implementation so the CPAN client and LWP have locale
+# encoding support without another native or Java implementation.
+require ExtUtils::MakeMaker::Locale;
+
+our ($ENCODING_LOCALE, $ENCODING_LOCALE_FS,
+     $ENCODING_CONSOLE_IN, $ENCODING_CONSOLE_OUT);
+
+{
+    no strict 'refs';
+    *ENCODING_LOCALE = *ExtUtils::MakeMaker::Locale::ENCODING_LOCALE;
+    *ENCODING_LOCALE_FS = *ExtUtils::MakeMaker::Locale::ENCODING_LOCALE_FS;
+    *ENCODING_CONSOLE_IN = *ExtUtils::MakeMaker::Locale::ENCODING_CONSOLE_IN;
+    *ENCODING_CONSOLE_OUT = *ExtUtils::MakeMaker::Locale::ENCODING_CONSOLE_OUT;
+    *decode_argv = \&ExtUtils::MakeMaker::Locale::decode_argv;
+    *env = \&ExtUtils::MakeMaker::Locale::env;
+    *reinit = \&ExtUtils::MakeMaker::Locale::reinit;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Encode::Locale - Determine the locale encoding
+
+=head1 DESCRIPTION
+
+This PerlOnJava port exposes the Encode::Locale 1.05 interface through the
+newer pure-Perl implementation bundled with ExtUtils::MakeMaker.  It provides
+the C<locale>, C<locale_fs>, C<console_in>, and C<console_out> Encode aliases,
+as well as C<decode_argv>, C<env>, and C<reinit>.
+
+=head1 AUTHOR AND LICENSE
+
+The original Encode::Locale module is copyright 2010 Gisle Aas.
+
+This library is free software; you can redistribute it and/or modify it under
+the same terms as Perl itself.
+
+=cut

--- a/src/test/resources/module/Authen-Passphrase-Scrypt/t/vectors.t
+++ b/src/test/resources/module/Authen-Passphrase-Scrypt/t/vectors.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+use Authen::Passphrase::Scrypt qw(crypto_scrypt);
+
+my @vectors = (
+    ['', '', 4, 1, 1, '77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906'],
+    ['password', 'NaCl', 10, 8, 16, 'fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b3731622eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640'],
+    ['pleaseletmein', 'SodiumChloride', 14, 8, 1, '7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887'],
+);
+for my $index (0 .. $#vectors) {
+    my ($password, $salt, $log_n, $r, $p, $expected) = @{$vectors[$index]};
+    is(unpack('H*', crypto_scrypt($password, $salt, 1 << $log_n, $r, $p, 64)),
+        $expected, 'scrypt vector ' . ($index + 1));
+}
+my $value = Authen::Passphrase::Scrypt->new(passphrase => 'password');
+ok($value->match('password') && !$value->match('wrong'), 'Scrypt passphrase round trip');

--- a/src/test/resources/module/Crypt-Argon2/t/vectors.t
+++ b/src/test/resources/module/Crypt-Argon2/t/vectors.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+use Crypt::Argon2 qw(argon2i_pass argon2i_raw argon2_verify argon2_implementation);
+
+my $encoded = argon2i_pass('password', 'somesalt', 2, '256k', 1, 32);
+is($encoded, '$argon2i$v=19$m=256,t=2,p=1$c29tZXNhbHQ$iekCn0Y3spW+sCcFanM2xBT63UP2sghkUoHLIUpWRS8',
+    'Argon2i encoded vector');
+is(unpack('H*', argon2i_raw('password', 'somesalt', 2, '256k', 1, 32)),
+    '89e9029f4637b295beb027056a7336c414fadd43f6b208645281cb214a56452f',
+    'Argon2i raw vector');
+ok(argon2_verify($encoded, 'password'), 'Argon2 verifies matching password');
+ok(argon2_implementation(), 'implementation is reported');

--- a/src/test/resources/module/Crypt-Eksblowfish-Bcrypt/t/vectors.t
+++ b/src/test/resources/module/Crypt-Eksblowfish-Bcrypt/t/vectors.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+use Crypt::Eksblowfish::Bcrypt qw(bcrypt_hash bcrypt);
+
+is(bcrypt_hash({key_nul => 0, cost => 5, salt => 'abcdefghijklmnop'},
+        'supercalifragilisticexpialidocious'),
+    pack('H*', '1e514c325869b8c311f852ffe630bac51519a66409ed77'),
+    'bcrypt raw vector without key NUL');
+is(bcrypt_hash({key_nul => 1, cost => 6, salt => 'ABCDEFGHIJKLMNOP'},
+        'Libelar! Timmah!'),
+    pack('H*', '2b7453cbc43bc27cb59c1a1a2ce520d79557f7a1a17b9b'),
+    'bcrypt raw vector with key NUL');
+is(bcrypt('U*U', '$2a$05$CCCCCCCCCCCCCCCCCCCCC.'),
+    '$2a$05$CCCCCCCCCCCCCCCCCCCCC.E5YPO9kmyuRGyh0XouQYb4YMJKvyOeW',
+    'bcrypt crypt vector');

--- a/src/test/resources/module/Encode-Locale/t/alias.t
+++ b/src/test/resources/module/Encode-Locale/t/alias.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More tests => 8;
+
+use Encode::Locale;
+use Encode qw(find_encoding);
+
+sub cmp_encoding {
+    my ($arg, $var) = @_;
+    my $lcarg = lc $arg;
+    is find_encoding($lcarg), find_encoding(${ $Encode::Locale::{$var} }),
+        "$lcarg eq $var";
+    is find_encoding($arg), find_encoding(${ $Encode::Locale::{$var} }),
+        "$arg eq $var";
+}
+
+cmp_encoding 'Locale', 'ENCODING_LOCALE';
+cmp_encoding 'Locale_FS', 'ENCODING_LOCALE_FS';
+cmp_encoding 'Console_IN', 'ENCODING_CONSOLE_IN';
+cmp_encoding 'Console_OUT', 'ENCODING_CONSOLE_OUT';

--- a/src/test/resources/module/Encode-Locale/t/env.t
+++ b/src/test/resources/module/Encode-Locale/t/env.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More tests => 13;
+
+use Encode::Locale qw(env);
+
+$ENV{foo} = "bar";
+is env("foo"), "bar", 'env read';
+is env("foo", "baz"), "bar", 'env write retval old value';
+is env("foo"), "baz", 'env write worked';
+is $ENV{foo}, "baz", 'env affected %ENV';
+is env("foo", undef), "baz", 'env write retval old value';
+is env("foo"), undef, 'env write worked';
+ok !exists $ENV{foo}, 'env write undef deletes from %ENV';
+
+Encode::Locale::reinit("cp1252");
+$ENV{"m\xf6ney"} = "\x80uro";
+is env("m\xf6ney", "\x{20AC}"), "\x{20AC}uro", 'env write retval encoded';
+is env("m\xf6ney"), "\x{20AC}", 'env write worked';
+is $ENV{"m\xf6ney"}, "\x80", 'env affected %ENV';
+is env("\x{20AC}", 1), undef, 'env write retval old value';
+is env("\x{20AC}"), 1, 'env write worked';
+is $ENV{"\x80"}, 1, 'env affected %ENV';

--- a/src/test/resources/module/Encode-Locale/t/warn_once.t
+++ b/src/test/resources/module/Encode-Locale/t/warn_once.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+my @warns;
+BEGIN { $SIG{__WARN__} = sub { push @warns, @_ } }
+
+use Encode::Locale;
+
+BEGIN {
+    use Encode;
+    my $a = encode("UTF-8", "foo\xFF");
+    ok $a, "UTF-8 encoding works after loading Encode::Locale";
+}
+
+is "@warns", "", 'no warnings';

--- a/src/test/resources/unit/indirect_isa_feature_gate.t
+++ b/src/test/resources/unit/indirect_isa_feature_gate.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+{
+    package Local::Child;
+}
+
+ok(isa Local::Child('Local::Child'), 'feature-disabled isa supports indirect-object syntax');
+ok(isa Local::Child('UNIVERSAL'), 'indirect isa reaches UNIVERSAL');

--- a/src/test/resources/unit/integer_pragma_word_arithmetic.t
+++ b/src/test/resources/unit/integer_pragma_word_arithmetic.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+
+use Config;
+use Test::More tests => 16;
+
+my $bits = $Config{ivsize} * 8;
+my ($min_sint, $max_sint);
+{
+    use integer;
+    $min_sint = 1 << ($bits - 1);
+    $max_sint = ~$min_sint;
+
+    is($max_sint + 1, $min_sint, 'integer addition wraps at native width');
+    is($min_sint - 1, $max_sint, 'integer subtraction wraps at native width');
+    is($max_sint * 2, -2, 'integer multiplication wraps at native width');
+    is(-$min_sint, $min_sint, 'integer negation wraps at native width');
+
+    is(0 | $min_sint, $min_sint, 'integer bitwise or preserves signed tag');
+    is(0 ^ $min_sint, $min_sint, 'integer bitwise xor preserves signed tag');
+    is($min_sint & $min_sint, $min_sint, 'integer bitwise and preserves signed tag');
+
+    my $compound = $max_sint;
+    $compound += 1;
+    is($compound, $min_sint, 'integer compound addition wraps');
+    $compound -= 1;
+    is($compound, $max_sint, 'integer compound subtraction wraps');
+    $compound *= 2;
+    is($compound, -2, 'integer compound multiplication wraps');
+
+    my $shifted = 1;
+    $shifted <<= $bits - 1;
+    is($shifted, $min_sint, 'integer compound left shift preserves signed tag');
+}
+
+my $max_uint = ~0;
+ok($max_uint > 0, 'ordinary numeric bitwise not produces unsigned maximum');
+is(0 | $max_uint, $max_uint, 'ordinary bitwise or preserves unsigned bits');
+is(0 ^ $max_uint, $max_uint, 'ordinary bitwise xor preserves unsigned bits');
+is($max_uint & $max_uint, $max_uint, 'ordinary bitwise and preserves unsigned bits');
+
+{
+    use integer;
+    is(0 | $max_uint, -1, 'integer bitwise or reinterprets unsigned bits as signed');
+}

--- a/src/test/resources/unit/lexical_redeclaration_pad_slot.t
+++ b/src/test/resources/unit/lexical_redeclaration_pad_slot.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+my @values = qw(old values);
+is_deeply(\@values, [qw(old values)], 'first lexical declaration has its own pad slot');
+
+my @values = qw(new);
+is_deeply(\@values, [qw(new)], 'same-scope redeclaration gets a fresh pad slot');

--- a/src/test/resources/unit/params_classify_primitives.t
+++ b/src/test/resources/unit/params_classify_primitives.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+
+use Scalar::Util qw(looks_like_number reftype);
+use Test::More tests => 6;
+
+my $warned = 0;
+my $number;
+{
+    local $SIG{__WARN__} = sub { $warned = 1 };
+    $number = 0 + "0 but true";
+}
+is($number, 0, '0 but true numifies to zero');
+ok(!$warned, '0 but true numifies without a numeric warning');
+ok(looks_like_number("0 but true"), '0 but true looks like a number');
+
+my $regexp_scalar = ${qr/xyz/};
+is(ref($regexp_scalar), '', 'dereferenced regexp is a first-class scalar');
+is(ref(\$regexp_scalar), 'REGEXP', 'reference to first-class regexp has REGEXP type');
+is(reftype(\$regexp_scalar), 'REGEXP', 'reftype preserves first-class regexp type');

--- a/src/test/resources/unit/regex/regex_interpolated_warnings.t
+++ b/src/test/resources/unit/regex/regex_interpolated_warnings.t
@@ -1,0 +1,26 @@
+use strict;
+use Test::More tests => 3;
+
+my $chars = '\Q';
+
+{
+    no warnings 'regexp';
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, @_ };
+    my $re = qr/[$chars]/;
+    is scalar(@warnings), 0, 'interpolated character-class escapes honor no warnings';
+}
+
+{
+    use warnings 'regexp';
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, @_ };
+    my $re = qr/[$chars]/;
+    is scalar(@warnings), 1, 'interpolated character-class escapes honor use warnings';
+}
+
+{
+    use warnings FATAL => 'regexp';
+    my $error = eval { my $re = qr/[$chars]/; 1 } ? '' : $@;
+    like $error, qr/Unrecognized escape \\Q/, 'fatal regexp warnings remain fatal';
+}

--- a/src/test/resources/unit/tied_container_undef.t
+++ b/src/test/resources/unit/tied_container_undef.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+{
+    package Local::TiedHash;
+    sub TIEHASH { bless { values => { old => 1 }, clears => 0 }, shift }
+    sub CLEAR { $_[0]{values} = {}; ++$_[0]{clears} }
+    sub STORE { $_[0]{values}{$_[1]} = $_[2] }
+    sub FETCH { $_[0]{values}{$_[1]} }
+    sub FIRSTKEY { my $self = shift; keys %{$self->{values}}; each %{$self->{values}} }
+    sub NEXTKEY { each %{$_[0]{values}} }
+    sub clears { $_[0]{clears} }
+
+    package Local::TiedArray;
+    sub TIEARRAY { bless { values => [1, 2], clears => 0 }, shift }
+    sub STORESIZE { $#{$_[0]{values}} = $_[1] - 1 }
+    sub CLEAR { $_[0]{values} = []; ++$_[0]{clears} }
+    sub FETCHSIZE { scalar @{$_[0]{values}} }
+    sub clears { $_[0]{clears} }
+}
+
+tie my %hash, 'Local::TiedHash';
+my $hash_object = tied %hash;
+undef %hash;
+is_deeply([keys %hash], [], 'undef tied hash dispatches CLEAR');
+is($hash_object->clears, 1, 'tied hash CLEAR called once');
+
+tie my @array, 'Local::TiedArray';
+my $array_object = tied @array;
+undef @array;
+is(scalar @array, 0, 'undef tied array dispatches CLEAR');
+is($array_object->clears, 1, 'tied array CLEAR called once');

--- a/src/test/resources/unit/tied_hash_weak_owner_cleanup.t
+++ b/src/test/resources/unit/tied_hash_weak_owner_cleanup.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Scalar::Util qw(weaken);
+use Test::More tests => 3;
+
+{
+    package Local::TiedOwner;
+    our $destroyed = 0;
+    sub TIEHASH { bless {}, shift }
+    sub DESTROY { ++$destroyed }
+}
+
+my $hash = {};
+tie %$hash, 'Local::TiedOwner';
+my $owner = $hash;
+my $object = tied %$hash;
+weaken($hash);
+weaken($object);
+undef $owner;
+
+ok(!defined $hash, 'weak reference to abandoned tied hash clears immediately');
+ok(!defined $object, 'weak reference to tie object clears immediately');
+is($Local::TiedOwner::destroyed, 1, 'tie object DESTROY runs immediately');


### PR DESCRIPTION
## Summary

- fix compiler/runtime behavior required by `Password::OWASP`, `Hash::AutoHash`, and `Data::FetchPath`
- implement password crypto compatibility with the existing Bouncy Castle dependency
- bundle `Encode::Alias` and `Encode::Locale` so XML::Parser external-entity tests are self-contained
- fix readonly pad-constant weak references and lexical regexp warning propagation in both backends

## Verification

- `./jcpan -t Password::OWASP`: 4 files / 40 tests pass
- `./jcpan -t Hash::AutoHash`: 32 files / 2785 tests pass
- `./jcpan -t Data::FetchPath`: 4 files / 19 tests pass
- `make`: passes
- `make test-bundled-modules`: 375/375 module files pass
- focused XML::Parser and Encode::Locale suites pass
- new regexp warning regression passes under system Perl, JVM backend, and interpreter
