### PR TITLE
Fix CPAN compiler and tooling blockers for Net::DHCP

### DIFF
--- a/dev/modules/bit_vector.md
+++ b/dev/modules/bit_vector.md
@@ -20,10 +20,11 @@ implementation (`BitVector.java`) to replace the C library.
 | Date | Programs Passed | Subtests | Issue |
 |------|----------------|----------|-------|
 | 2026-04-13 | 0/23 | 0 | `Can't load loadable object for module Bit::Vector: no Java XS implementation available` |
+| 2026-08-08 | Net::Frame surface implemented | 11/11 focused tests | Portable `Math::BigInt` implementation covers construction, decimal conversion, concatenation, and chunk reads |
 
-All 23 test files fail at `require Bit::Vector` because `DynaLoader::bootstrap`
-reaches XSLoader's stage 4 (no Java class, no @ISA parent, no PP companion)
-and dies.
+The focused API used by `Net::Frame::Layer::IPv4` is now implemented without XS.
+The full upstream API remains incomplete; unsupported consumers should still be
+tracked against the implementation phases below.
 
 ---
 
@@ -456,3 +457,29 @@ No external dependencies. All backed by JDK standard library.
   - `DigestSHA.java` (OO module wrapping Java APIs)
   - `POSIX.java` (largest, shows method aliasing)
   - `Storable.java` (complex serialization)
+
+---
+
+## Progress Tracking
+
+### Current Status: Net::Frame compatibility complete; full port pending
+
+### Completed Phases
+
+- [x] Net::Frame compatibility surface (2026-08-08)
+  - Added fixed-width `Create`, `new`, `new_Dec`, `from_Dec`, and `to_Dec`
+  - Added `Size`, `Concat`, `Concat_List`, and `Chunk_Read`
+  - Used core `Math::BigInt` so vector values are not machine-word limited
+  - Validated the focused tests against the upstream XS implementation under system Perl
+  - Files: `src/main/perl/lib/Bit/Vector.pm`, `src/test/resources/module/Bit-Vector/t/net-frame-surface.t`
+
+### Next Steps
+
+1. Implement the remaining phases only when another bundled module needs them
+2. Preserve upstream fixed-width and error semantics for each added operation
+3. Run the full 23-file upstream suite once all phases are implemented
+
+### Open Questions
+
+- Whether a future full implementation should remain pure Perl or move the hot
+  operations to the Java `BitSet` design described above

--- a/dev/modules/net_pcap.md
+++ b/dev/modules/net_pcap.md
@@ -1,0 +1,44 @@
+# Net::Pcap Support for PerlOnJava
+
+## Scope
+
+Net::Pcap 0.21 is an XS binding to libpcap. PerlOnJava provides a portable
+offline reader for the API used by Net::Frame::Dump::Offline. It supports
+classic pcap files in both byte orders, microsecond and nanosecond timestamps,
+and pcapng section, interface, enhanced-packet, packet, and simple-packet
+blocks. Live capture is explicitly unsupported.
+
+The implementation is bundled code rather than a distribution preference, so
+all CPAN consumers can use the same offline descriptor API.
+
+## Progress Tracking
+
+### Current Status: Offline capture support complete
+
+### Completed Phases
+
+- [x] Offline descriptor and classic pcap reader (2026-08-08)
+  - Added open, metadata, packet iteration, loop, and close operations
+  - Supports both byte orders and microsecond/nanosecond timestamp formats
+- [x] pcapng reader (2026-08-08)
+  - Added section/interface tracking and the three packet block formats
+  - Honors per-interface timestamp-resolution options
+- [x] Net::Frame compatibility layer (2026-08-08)
+  - Added empty filter compilation/installation and exported pcap aliases
+  - Added focused bundled-module tests
+
+### Next Steps
+
+1. Add BPF evaluation if a consumer needs non-empty offline filters
+2. Implement live capture only through a portable Java packet-capture library
+3. Expand dump-file writing when a bundled consumer requires it
+
+### Open Questions
+
+- Which Java capture library should back live interfaces without introducing
+  platform-specific native setup for ordinary offline consumers
+
+## Related Documents
+
+- `docs/guides/module-porting.md`
+- `dev/design/patch-and-cpan-prefs-layout.md`

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -1384,6 +1384,16 @@ public class BytecodeCompiler implements Visitor {
                 && !node.getBooleanAnnotation("blockIsDoBlock")
                 && outerResultReg < 0);
 
+        // A pragma inside a nested block (for example `use bytes`) changes the
+        // interpreter's runtime call-site hints through APPLY_COMPILER_FLAGS.
+        // Restore the enclosing lexical hints at block exit, matching
+        // EmitBlock.emitPostBlockStrictOptions() in the JVM backend.
+        Object postBlockStrictOptions = node.getAnnotation("postBlockStrictOptions");
+        if (postBlockStrictOptions instanceof Integer hints) {
+            emit(Opcodes.SET_CALL_SITE_HINTS);
+            emit(hints);
+        }
+
         if (needsLocalRestore) {
             emit(Opcodes.POP_LOCAL_LEVEL);
             emitReg(localLevelReg);

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -2512,6 +2512,9 @@ public class BytecodeInterpreter {
                                 }
                             }
 
+                            case Opcodes.SET_CALL_SITE_HINTS ->
+                                WarningBitsRegistry.setCallSiteHints(bytecode[pc++]);
+
                             // =================================================================
                             // DEBUGGER SUPPORT
                             // =================================================================

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -1750,6 +1750,10 @@ public class Disassemble {
                                 .append(" warningScope=").append(warningScopeId).append("\n");
                         break;
                     }
+                    case Opcodes.SET_CALL_SITE_HINTS:
+                        sb.append("SET_CALL_SITE_HINTS hints=")
+                                .append(interpretedCode.bytecode[pc++]).append("\n");
+                        break;
                     case Opcodes.PUSH_LABELED_BLOCK: {
                         int labelIdx = interpretedCode.bytecode[pc++];
                         int exitPc = interpretedCode.bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -2449,6 +2449,9 @@ public class Opcodes {
     /** getpeername SOCKET: Format: GETPEERNAME rd argsReg ctx. */
     public static final short GETPEERNAME = 514;
 
+    /** Restore lexical hints after leaving a nested block. Format: SET_CALL_SITE_HINTS hints. */
+    public static final short SET_CALL_SITE_HINTS = 515;
+
     private Opcodes() {
     } // Utility class - no instantiation
 }

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -979,6 +979,9 @@ public class SubroutineParser {
                 parser.throwMissingRightCurlyOrSquareBracketError();
             }
             TokenUtils.consume(parser, LexerTokenType.OPERATOR, "}");
+            if (attributes != null && !attributes.isEmpty()) {
+                block.setAnnotation("subroutineSourceEndTokenIndex", parser.tokenIndex);
+            }
 
             // Insert signature code in the block
             if (signature != null) {
@@ -1371,6 +1374,19 @@ public class SubroutineParser {
                 : parser.ctx.symbolTable.getCurrentPackage();
         placeholder.isConstantCv = isConstantCvBody(prototype, block);
 
+        // Compile-time attribute handlers can inspect the still-lazy CV with
+        // B::Deparse before compilerSupplier has materialized its body.  Give
+        // attributed placeholders the exact source span that the compiled
+        // RuntimeCode will receive.  Without this, file-backed named subs
+        // inside an eval BLOCK can be mistaken for the enclosing block;
+        // Attribute::Method then deparses its own :Method declaration back
+        // into the replacement and recursively reapplies the attribute.
+        // Keep ordinary lazy CVs untouched: their runtime warning metadata is
+        // established by the normal compilation path below.
+        if (attributes != null && !attributes.isEmpty()) {
+            attachNamedSubDeparseMetadata(placeholder, parser, block);
+        }
+
         // Call MODIFY_CODE_ATTRIBUTES if attributes are present
         // In Perl, this is called at compile time after the sub is defined.
         // The dispatch package is the CvSTASH of the existing code ref (if any),
@@ -1736,6 +1752,27 @@ public class SubroutineParser {
         ListNode result = new ListNode(parser.tokenIndex);
         result.setAnnotation("compileTimeOnly", true);
         return result;
+    }
+
+    private static void attachNamedSubDeparseMetadata(
+            RuntimeCode placeholder, Parser parser, BlockNode block) {
+        if (parser.ctx.errorUtil == null || parser.ctx.compilerOptions == null) {
+            return;
+        }
+        String source = parser.ctx.compilerOptions.deparseSourceCode != null
+                ? parser.ctx.compilerOptions.deparseSourceCode
+                : parser.ctx.compilerOptions.code;
+        if (source == null || source.isEmpty()) {
+            return;
+        }
+        Object endValue = block.getAnnotation("subroutineSourceEndTokenIndex");
+        int startToken = block.getIndex();
+        int endToken = endValue instanceof Integer value ? value : -1;
+        placeholder.deparseSourceText = source;
+        placeholder.deparseSourceOffset = parser.ctx.errorUtil.getSourceOffset(startToken);
+        placeholder.deparseSourceEnd = endToken >= 0
+                ? parser.ctx.errorUtil.getSourceOffset(endToken) : -1;
+
     }
 
     private static void installClosureCaptureMetadata(RuntimeCode code, List<Object> capturedValues) {

--- a/src/main/java/org/perlonjava/runtime/operators/unpack/StringFormatHandler.java
+++ b/src/main/java/org/perlonjava/runtime/operators/unpack/StringFormatHandler.java
@@ -58,18 +58,15 @@ public class StringFormatHandler implements FormatHandler {
                 str = state.isUTF8Flagged ? processString(str) : processStringByteMode(str);
             }
 
-            // Pad if needed and not star count
-            // Note: 'A' and 'Z' formats strip content, so don't pad them back!
-            // Only 'a' format needs padding to maintain exact count
-            if (!isStarCount && format == 'a' && str.length() < count) {
-                StringBuilder padded = new StringBuilder(str);
-                while (padded.length() < count) {
-                    padded.append('\0');
-                }
-                str = padded.toString();
+            RuntimeScalar rs = new RuntimeScalar(str);
+            // A non-UTF8 source remains a byte string even when bytes above
+            // 0x7f are present.  Inferring the scalar type from the Java String
+            // would incorrectly mark such output as UTF-8 and make
+            // `use bytes; length(unpack('a*', $binary))` count encoded bytes.
+            if (!state.isUTF8Flagged) {
+                rs.type = RuntimeScalarType.BYTE_STRING;
             }
-
-            output.add(new RuntimeScalar(str));
+            output.add(rs);
         } else {
             // In byte mode, read from buffer — always ISO-8859-1 (BYTE_STRING)
             ByteBuffer buffer = state.getBuffer();
@@ -179,17 +176,6 @@ public class StringFormatHandler implements FormatHandler {
 
             // Apply format-specific processing (byte mode - ASCII whitespace only)
             result = processStringByteMode(result);
-        }
-
-        // Pad if necessary and not star count
-        // Note: 'A' and 'Z' formats strip content, so don't pad them back!
-        // Only 'a' format needs padding to maintain exact count
-        if (!isStarCount && format == 'a' && result.length() < count) {
-            StringBuilder sb = new StringBuilder(result);
-            while (sb.length() < count) {
-                sb.append('\0');
-            }
-            result = sb.toString();
         }
 
         return result;

--- a/src/main/perl/lib/Bit/Vector.pm
+++ b/src/main/perl/lib/Bit/Vector.pm
@@ -1,0 +1,113 @@
+package Bit::Vector;
+
+use strict;
+use warnings;
+use Math::BigInt;
+
+our $VERSION = '7.4';
+
+sub Version   { '7.4' }
+sub Word_Bits { 64 }
+sub Long_Bits { 64 }
+
+sub new { shift->Create(@_) }
+
+sub Create {
+    my ($class, $bits, $count) = @_;
+    _check_size($bits);
+    $count = 1 unless defined $count;
+
+    my @vectors = map {
+        bless { bits => 0 + $bits, value => Math::BigInt->new(0) }, $class
+    } 1 .. $count;
+
+    return wantarray ? @vectors : $vectors[-1];
+}
+
+sub new_Dec {
+    my ($class, $bits, $value) = @_;
+    my $self = $class->Create($bits);
+    $self->from_Dec($value);
+    return $self;
+}
+
+sub Size { $_[0]->{bits} }
+
+sub from_Dec {
+    my ($self, $value) = @_;
+    die "Bit::Vector::from_Dec(): not a decimal number\n"
+        unless defined($value) && "$value" =~ /\A[+-]?\d+\z/;
+
+    my $modulus = Math::BigInt->new(2)->bpow($self->{bits});
+    my $number = Math::BigInt->new("$value")->bmod($modulus);
+    $number->badd($modulus) if $number->is_neg;
+    $self->{value} = $number;
+    return $self;
+}
+
+sub to_Dec {
+    my ($self) = @_;
+    return '0' unless $self->{bits};
+
+    my $number = $self->{value}->copy;
+    my $sign = Math::BigInt->new(2)->bpow($self->{bits} - 1);
+    if ($number->bcmp($sign) >= 0) {
+        $number->bsub($sign->copy->bmul(2));
+    }
+    return "$number";
+}
+
+sub Concat {
+    my ($self, $other) = @_;
+    return $self->Concat_List($other);
+}
+
+sub Concat_List {
+    my ($self, @others) = @_;
+    my $class = ref($self) || $self;
+    my $bits = $self->{bits};
+    my $value = $self->{value}->copy;
+
+    for my $other (@others) {
+        die "Bit::Vector::Concat_List(): not a Bit::Vector object\n"
+            unless ref($other) && $other->isa('Bit::Vector');
+        $value->blsft($other->{bits})->badd($other->{value});
+        $bits += $other->{bits};
+    }
+
+    return bless { bits => $bits, value => $value }, $class;
+}
+
+sub Chunk_Read {
+    my ($self, $chunk_bits, $offset) = @_;
+    _check_size($chunk_bits);
+    die "Bit::Vector::Chunk_Read(): offset out of range\n"
+        unless defined($offset) && $offset =~ /\A\d+\z/
+            && $offset + $chunk_bits <= $self->{bits};
+
+    my $mask = Math::BigInt->new(2)->bpow($chunk_bits)->bdec;
+    my $chunk = $self->{value}->copy->brsft($offset)->band($mask);
+    return 0 + "$chunk";
+}
+
+sub _check_size {
+    my ($bits) = @_;
+    die "Bit::Vector: bit count must be a non-negative integer\n"
+        unless defined($bits) && "$bits" =~ /\A\d+\z/;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Bit::Vector - portable PerlOnJava compatibility core
+
+=head1 DESCRIPTION
+
+This implementation supplies the fixed-width construction, decimal conversion,
+concatenation, and chunk-reading operations used by C<Net::Frame>.  It uses
+C<Math::BigInt> so values are not limited to a Java or Perl machine word.
+
+=cut

--- a/src/main/perl/lib/JSON/XS.pm
+++ b/src/main/perl/lib/JSON/XS.pm
@@ -1,0 +1,41 @@
+# PerlOnJava compatibility layer for the XS-backed JSON::XS distribution.
+#
+# Cpanel::JSON::XS is already provided by PerlOnJava on top of the bundled
+# JSON::PP implementation.  JSON::XS and Cpanel::JSON::XS intentionally share
+# the core object and functional APIs, so reuse that implementation instead of
+# asking CPAN to build native C code that cannot run on the JVM.
+
+package JSON::XS;
+
+use strict;
+use warnings;
+
+require Cpanel::JSON::XS;
+require Exporter;
+
+our $VERSION    = '4.04';
+our $XS_VERSION = $VERSION;
+our @ISA        = qw(Cpanel::JSON::XS Exporter);
+our @EXPORT     = qw(encode_json decode_json);
+our @EXPORT_OK  = qw(encode_json decode_json true false is_bool);
+
+*encode_json = \&Cpanel::JSON::XS::encode_json;
+*decode_json = \&Cpanel::JSON::XS::decode_json;
+*true        = \&Cpanel::JSON::XS::true;
+*false       = \&Cpanel::JSON::XS::false;
+*is_bool     = \&Cpanel::JSON::XS::is_bool;
+
+1;
+
+__END__
+
+=head1 NAME
+
+JSON::XS - JSON::XS-compatible API via PerlOnJava's bundled JSON backend
+
+=head1 DESCRIPTION
+
+This portability layer reuses the bundled Cpanel::JSON::XS/JSON::PP stack so
+modules requiring JSON::XS can run without loading a native XS extension.
+
+=cut

--- a/src/main/perl/lib/Net/Pcap.pm
+++ b/src/main/perl/lib/Net/Pcap.pm
@@ -1,0 +1,376 @@
+package Net::Pcap;
+
+use strict;
+use warnings;
+use Carp qw(croak);
+use Exporter 'import';
+
+our $VERSION = '0.21';
+
+use constant {
+    PCAP_ERRBUF_SIZE => 256,
+    PCAP_IF_LOOPBACK => 1,
+    PCAP_VERSION_MAJOR => 2,
+    PCAP_VERSION_MINOR => 4,
+    DLT_NULL => 0,
+    DLT_EN10MB => 1,
+    DLT_PPP => 9,
+    DLT_RAW => 12,
+    DLT_IEEE802_11 => 105,
+    DLT_LINUX_SLL => 113,
+    DLT_IEEE802_11_RADIO => 127,
+    DLT_ERF => 197,
+};
+
+my @FUNCTIONS = qw(
+    lookupdev findalldevs lookupnet open_live open_dead open_offline loop
+    breakloop close dispatch next next_ex compile compile_nopcap setfilter
+    freecode offline_filter setnonblock getnonblock dump_open dump dump_file
+    dump_flush dump_close datalink set_datalink datalink_name_to_val
+    datalink_val_to_name datalink_val_to_description snapshot is_swapped
+    major_version minor_version stats file fileno get_selectable_fd geterr
+    strerror perror lib_version createsrcstr parsesrcstr open setbuff
+    setuserbuffer setmode setmintocopy getevent sendpacket sendqueue_alloc
+    sendqueue_queue sendqueue_transmit
+);
+
+our @EXPORT = (
+    qw(PCAP_ERRBUF_SIZE PCAP_IF_LOOPBACK PCAP_VERSION_MAJOR PCAP_VERSION_MINOR
+       DLT_NULL DLT_EN10MB DLT_PPP DLT_RAW DLT_IEEE802_11 DLT_LINUX_SLL
+       DLT_IEEE802_11_RADIO DLT_ERF UNSAFE_SIGNALS),
+    map { "pcap_$_" } @FUNCTIONS,
+);
+our @EXPORT_OK = (@FUNCTIONS, @EXPORT);
+our %EXPORT_TAGS = (functions => [@FUNCTIONS]);
+
+sub UNSAFE_SIGNALS (&) { $_[0]->() }
+
+sub open_offline {
+    croak 'Usage: Net::Pcap::open_offline(fname, err)'
+        unless @_ == 2;
+    my ($path, $error) = @_;
+    croak 'arg2 not a reference' unless ref($error);
+    $$error = '';
+
+    my $fh;
+    unless (CORE::open($fh, '<', $path)) {
+        $$error = "$!";
+        return;
+    }
+    binmode($fh);
+    local $/;
+    my $data = <$fh>;
+    CORE::close($fh);
+
+    my $pcap = eval { _parse_capture($data, $path) };
+    if (!$pcap) {
+        my $message = $@ || 'invalid or unsupported capture file';
+        $message =~ s/\s+\z//;
+        $$error = $message;
+        return;
+    }
+    return $pcap;
+}
+
+sub _parse_capture {
+    my ($data, $path) = @_;
+    die "capture file is shorter than its header\n" unless length($data) >= 4;
+    my $magic = substr($data, 0, 4);
+    return _parse_pcapng($data, $path) if $magic eq "\x0a\x0d\x0d\x0a";
+    return _parse_classic($data, $path);
+}
+
+sub _parse_classic {
+    my ($data, $path) = @_;
+    die "classic pcap header is truncated\n" unless length($data) >= 24;
+    my $magic = substr($data, 0, 4);
+    my ($little, $nanoseconds);
+    if ($magic eq "\xd4\xc3\xb2\xa1") { ($little, $nanoseconds) = (1, 0) }
+    elsif ($magic eq "\xa1\xb2\xc3\xd4") { ($little, $nanoseconds) = (0, 0) }
+    elsif ($magic eq "\x4d\x3c\xb2\xa1") { ($little, $nanoseconds) = (1, 1) }
+    elsif ($magic eq "\xa1\xb2\x3c\x4d") { ($little, $nanoseconds) = (0, 1) }
+    else { die "unrecognized pcap magic\n" }
+
+    my $major = _u16($data, 4, $little);
+    my $minor = _u16($data, 6, $little);
+    my $snaplen = _u32($data, 16, $little);
+    my $linktype = _u32($data, 20, $little);
+    my @packets;
+    my $offset = 24;
+    while ($offset < length($data)) {
+        die "pcap packet header is truncated\n" if $offset + 16 > length($data);
+        my $seconds = _u32($data, $offset, $little);
+        my $fraction = _u32($data, $offset + 4, $little);
+        my $captured = _u32($data, $offset + 8, $little);
+        my $original = _u32($data, $offset + 12, $little);
+        $offset += 16;
+        die "pcap packet data is truncated\n" if $offset + $captured > length($data);
+        push @packets, {
+            raw => substr($data, $offset, $captured),
+            tv_sec => $seconds,
+            tv_usec => $nanoseconds ? int($fraction / 1000) : $fraction,
+            caplen => $captured,
+            len => $original,
+        };
+        $offset += $captured;
+    }
+
+    return bless {
+        packets => \@packets, index => 0, path => $path, linktype => $linktype,
+        snaplen => $snaplen, major => $major, minor => $minor,
+        swapped => $little == _host_is_little() ? 0 : 1, error => '',
+    }, 'pcap_tPtr';
+}
+
+sub _parse_pcapng {
+    my ($data, $path) = @_;
+    my (@packets, @interfaces);
+    my ($little, $major, $minor) = (undef, 1, 0);
+    my $offset = 0;
+
+    while ($offset + 12 <= length($data)) {
+        my $raw_type = substr($data, $offset, 4);
+        if ($raw_type eq "\x0a\x0d\x0d\x0a") {
+            die "pcapng section header is truncated\n" if $offset + 16 > length($data);
+            my $bom = substr($data, $offset + 8, 4);
+            $little = $bom eq "\x4d\x3c\x2b\x1a" ? 1
+                    : $bom eq "\x1a\x2b\x3c\x4d" ? 0
+                    : die "invalid pcapng byte-order magic\n";
+        }
+        die "pcapng block precedes section header\n" unless defined $little;
+        my $type = _u32($data, $offset, $little);
+        my $length = _u32($data, $offset + 4, $little);
+        die "invalid pcapng block length\n"
+            if $length < 12 || $offset + $length > length($data);
+        die "mismatched pcapng block length\n"
+            unless _u32($data, $offset + $length - 4, $little) == $length;
+
+        if ($type == 0x0a0d0d0a) {
+            $major = _u16($data, $offset + 12, $little);
+            $minor = _u16($data, $offset + 14, $little);
+            @interfaces = ();
+        }
+        elsif ($type == 1) {
+            my $interface = {
+                linktype => _u16($data, $offset + 8, $little),
+                snaplen => _u32($data, $offset + 12, $little),
+                resolution => 1000000,
+            };
+            my $option = $offset + 16;
+            my $option_end = $offset + $length - 4;
+            while ($option + 4 <= $option_end) {
+                my $code = _u16($data, $option, $little);
+                my $size = _u16($data, $option + 2, $little);
+                last if $code == 0;
+                if ($code == 9 && $size >= 1) {
+                    my $power = ord(substr($data, $option + 4, 1));
+                    $interface->{resolution} = $power & 0x80
+                        ? 2 ** ($power & 0x7f) : 10 ** $power;
+                }
+                $option += 4 + (($size + 3) & ~3);
+            }
+            push @interfaces, $interface;
+        }
+        elsif ($type == 6) {
+            my $id = _u32($data, $offset + 8, $little);
+            my $hi = _u32($data, $offset + 12, $little);
+            my $lo = _u32($data, $offset + 16, $little);
+            my $captured = _u32($data, $offset + 20, $little);
+            my $original = _u32($data, $offset + 24, $little);
+            my $interface = $interfaces[$id] || { linktype => 1, resolution => 1000000 };
+            _push_pcapng_packet(\@packets, $data, $offset + 28, $captured,
+                $original, $hi, $lo, $interface);
+        }
+        elsif ($type == 2) {
+            my $id = _u16($data, $offset + 8, $little);
+            my $hi = _u32($data, $offset + 12, $little);
+            my $lo = _u32($data, $offset + 16, $little);
+            my $captured = _u32($data, $offset + 20, $little);
+            my $original = _u32($data, $offset + 24, $little);
+            my $interface = $interfaces[$id] || { linktype => 1, resolution => 1000000 };
+            _push_pcapng_packet(\@packets, $data, $offset + 28, $captured,
+                $original, $hi, $lo, $interface);
+        }
+        elsif ($type == 3) {
+            my $original = _u32($data, $offset + 8, $little);
+            my $available = $length - 16;
+            my $interface = $interfaces[0] || { linktype => 1, snaplen => $available };
+            my $captured = $original < $interface->{snaplen} ? $original : $interface->{snaplen};
+            $captured = $available if $captured > $available;
+            _push_pcapng_packet(\@packets, $data, $offset + 12, $captured,
+                $original, 0, 0, $interface);
+        }
+        $offset += $length;
+    }
+
+    my $interface = $interfaces[0] || { linktype => 1, snaplen => 65535 };
+    return bless {
+        packets => \@packets, index => 0, path => $path,
+        linktype => $interface->{linktype}, snaplen => $interface->{snaplen},
+        major => $major, minor => $minor, swapped => 0, error => '',
+    }, 'pcap_tPtr';
+}
+
+sub _push_pcapng_packet {
+    my ($packets, $data, $start, $captured, $original, $hi, $lo, $interface) = @_;
+    die "pcapng packet data is truncated\n" if $start + $captured > length($data);
+    my $ticks = $hi * 4294967296 + $lo;
+    my $resolution = $interface->{resolution} || 1000000;
+    my $seconds = int($ticks / $resolution);
+    my $microseconds = int(($ticks - $seconds * $resolution) * 1000000 / $resolution);
+    push @$packets, {
+        raw => substr($data, $start, $captured), tv_sec => $seconds,
+        tv_usec => $microseconds, caplen => $captured, len => $original,
+    };
+}
+
+sub next {
+    croak 'Usage: Net::Pcap::next(p, pkt_header)' unless @_ == 2;
+    my ($pcap, $header) = @_;
+    croak 'p is not of type pcap_tPtr' unless ref($pcap) eq 'pcap_tPtr';
+    croak 'arg2 not a hash ref' unless ref($header) eq 'HASH';
+    return if $pcap->{closed} || $pcap->{index} >= @{$pcap->{packets}};
+    my $packet = $pcap->{packets}->[$pcap->{index}++];
+    for my $key (qw(tv_sec tv_usec caplen len)) { $header->{$key} = $packet->{$key} }
+    return $packet->{raw};
+}
+
+sub next_ex {
+    croak 'Usage: Net::Pcap::next_ex(p, pkt_header, pkt_data)' unless @_ == 3;
+    my ($pcap, $header, $data) = @_;
+    croak 'arg3 not a scalar ref' unless ref($data) eq 'SCALAR';
+    my $packet = Net::Pcap::next($pcap, $header);
+    return -2 if $pcap->{closed};
+    return -2 unless defined $packet;
+    $$data = $packet;
+    return 1;
+}
+
+sub datalink { _descriptor($_[0])->{linktype} }
+sub snapshot { _descriptor($_[0])->{snaplen} }
+sub is_swapped { _descriptor($_[0])->{swapped} }
+sub major_version { _descriptor($_[0])->{major} }
+sub minor_version { _descriptor($_[0])->{minor} }
+sub file { _descriptor($_[0])->{path} }
+sub geterr { _descriptor($_[0])->{error} || '' }
+
+sub close {
+    my ($pcap) = @_;
+    _descriptor($pcap)->{closed} = 1;
+    return;
+}
+
+sub compile {
+    croak 'Usage: Net::Pcap::compile(p, fp, str, optimize, netmask)' unless @_ == 5;
+    my ($pcap, $filter, $expression) = @_;
+    _descriptor($pcap);
+    croak 'arg2 not a scalar ref' unless ref($filter) eq 'SCALAR';
+    $$filter = bless { expression => defined($expression) ? "$expression" : '' }, 'bpf_programPtr';
+    return 0;
+}
+
+sub setfilter {
+    my ($pcap, $filter) = @_;
+    _descriptor($pcap)->{filter} = $filter;
+    return 0;
+}
+
+sub freecode { return }
+sub breakloop { _descriptor($_[0])->{breakloop} = 1; return }
+
+sub loop {
+    my ($pcap, $count, $callback, $user) = @_;
+    my $processed = 0;
+    while ($count < 0 || $processed < $count) {
+        my (%header, $packet);
+        last unless defined($packet = Net::Pcap::next($pcap, \%header));
+        $callback->($user, \%header, $packet);
+        $processed++;
+        if (delete $pcap->{breakloop}) { return -2 }
+    }
+    return $processed;
+}
+
+sub dispatch { goto &loop }
+
+sub open_dead {
+    my ($linktype, $snaplen) = @_;
+    croak 'Usage: Net::Pcap::open_dead(linktype, snaplen)' unless @_ == 2;
+    return bless {
+        packets => [], index => 0, linktype => $linktype, snaplen => $snaplen,
+        major => 2, minor => 4, swapped => 0, error => '',
+    }, 'pcap_tPtr';
+}
+
+sub lib_version { 'libpcap version 1.0 (PerlOnJava offline reader)' }
+sub stats { my (undef, $stats) = @_; %$stats = (ps_recv => 0, ps_drop => 0, ps_ifdrop => 0); return 0 }
+sub set_datalink { -1 }
+sub setnonblock { 0 }
+sub getnonblock { 0 }
+sub get_selectable_fd { -1 }
+sub fileno { -1 }
+sub strerror { defined($_[0]) ? "$_[0]" : '' }
+sub perror { return }
+
+sub datalink_name_to_val {
+    my %values = (NULL => 0, EN10MB => 1, PPP => 9, RAW => 12,
+        IEEE802_11 => 105, LINUX_SLL => 113, IEEE802_11_RADIO => 127);
+    return -1 unless defined $_[0];
+    return exists($values{uc($_[0])}) ? $values{uc($_[0])} : -1;
+}
+
+sub datalink_val_to_name {
+    my %names = (0 => 'NULL', 1 => 'EN10MB', 9 => 'PPP', 12 => 'RAW',
+        105 => 'IEEE802_11', 113 => 'LINUX_SLL', 127 => 'IEEE802_11_RADIO');
+    return $names{$_[0]};
+}
+
+sub datalink_val_to_description {
+    my %descriptions = (0 => 'BSD loopback', 1 => 'Ethernet', 9 => 'PPP',
+        12 => 'Raw IP', 105 => '802.11', 113 => 'Linux cooked',
+        127 => '802.11 plus radiotap header');
+    return $descriptions{$_[0]};
+}
+
+sub _descriptor {
+    my ($pcap) = @_;
+    croak 'p is not of type pcap_tPtr' unless ref($pcap) eq 'pcap_tPtr';
+    return $pcap;
+}
+
+sub _u16 { unpack($_[2] ? 'v' : 'n', substr($_[0], $_[1], 2)) }
+sub _u32 { unpack($_[2] ? 'V' : 'N', substr($_[0], $_[1], 4)) }
+sub _host_is_little { unpack('C', pack('S', 1)) == 1 }
+
+sub _unsupported {
+    my ($name, @args) = @_;
+    my $last = @args ? $args[-1] : undef;
+    $$last = "$name is unavailable: PerlOnJava Net::Pcap supports offline captures"
+        if ref($last) eq 'SCALAR';
+    return;
+}
+
+{
+    no strict 'refs';
+    for my $name (@FUNCTIONS) {
+        *{__PACKAGE__ . "::$name"} = sub { _unsupported($name, @_) }
+            unless __PACKAGE__->can($name);
+        *{__PACKAGE__ . "::pcap_$name"} = \&{__PACKAGE__ . "::$name"};
+    }
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Net::Pcap - portable offline capture reader for PerlOnJava
+
+=head1 DESCRIPTION
+
+This compatibility implementation reads classic pcap and pcapng captures and
+implements the descriptor operations used by C<Net::Frame::Dump::Offline>.
+Live packet capture remains unavailable.
+
+=cut

--- a/src/test/java/org/perlonjava/PerlScriptExecutionTest.java
+++ b/src/test/java/org/perlonjava/PerlScriptExecutionTest.java
@@ -168,9 +168,13 @@ public class PerlScriptExecutionTest {
                         // Compiler-integration fixtures are kept in the dedicated
                         // shard so adding them does not reshuffle every later test
                         // across the state-sensitive round-robin shards.
+                        "unit/attribute_method_named_sub_deparse.t",
+                        "unit/bytes_scope_interpreter.t",
                         "unit/exporter_lexical_compile_scope.t",
                         "unit/html_content_extractor_jsoup.t",
-                        "unit/jvm_eval_nested_compound_assignment.t"
+                        "unit/json_xs_compat.t",
+                        "unit/jvm_eval_nested_compound_assignment.t",
+                        "unit/unpack_short_string.t"
                     );
                     java.util.function.Predicate<String> isHeavy = s -> {
                         String norm = s.replace('\\', '/');

--- a/src/test/resources/module/Bit-Vector/t/net-frame-surface.t
+++ b/src/test/resources/module/Bit-Vector/t/net-frame-surface.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More tests => 11;
+use Bit::Vector;
+
+is(Bit::Vector::Version(), '7.4', 'reports the compatible API version');
+cmp_ok(Bit::Vector::Word_Bits(), '>=', 32, 'word size is usable');
+
+my $version = Bit::Vector->new_Dec(4, 4);
+my $hlen = Bit::Vector->new_Dec(4, 5);
+my $header = $version->Concat_List($hlen);
+
+isa_ok($header, 'Bit::Vector');
+is($header->Size, 8, 'concatenation adds vector widths');
+is($header->to_Dec, 69, 'concatenation preserves network bit order');
+is($header->Chunk_Read(4, 0), 5, 'zero offset reads low chunk');
+is($header->Chunk_Read(4, 4), 4, 'higher offset reads high chunk');
+
+is(Bit::Vector->new_Dec(4, 15)->to_Dec, -1,
+    'decimal output uses fixed-width signed representation');
+is(Bit::Vector->new_Dec(4, -1)->Chunk_Read(4, 0), 15,
+    'negative input is stored in twos-complement form');
+
+my @vectors = Bit::Vector->Create(3, 2);
+is(scalar @vectors, 2, 'Create supports a vector count in list context');
+is($vectors[0]->Size, 3, 'created vectors retain their width');

--- a/src/test/resources/module/Net-Pcap/t/offline-reader.t
+++ b/src/test/resources/module/Net-Pcap/t/offline-reader.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+use File::Temp qw(tempfile);
+use Test::More tests => 18;
+use Net::Pcap;
+
+my ($classic_fh, $classic_path) = tempfile();
+binmode($classic_fh);
+my $classic_packet = "\x01\x02\x03\x04";
+print {$classic_fh} pack('a4vvVVVV', "\xd4\xc3\xb2\xa1", 2, 4, 0, 0, 65535, 1);
+print {$classic_fh} pack('VVVVa*', 10, 250, 4, 4, $classic_packet);
+close($classic_fh);
+
+my $error = '';
+my $pcap = Net::Pcap::open_offline($classic_path, \$error);
+isa_ok($pcap, 'pcap_tPtr');
+is($error, '', 'classic capture opens without an error');
+is(Net::Pcap::datalink($pcap), DLT_EN10MB, 'classic link type is read');
+is(Net::Pcap::snapshot($pcap), 65535, 'classic snapshot length is read');
+is(Net::Pcap::major_version($pcap), 2, 'classic major version is read');
+
+my %header;
+is(Net::Pcap::next($pcap, \%header), $classic_packet, 'classic packet bytes are read');
+is_deeply(\%header, { tv_sec => 10, tv_usec => 250, caplen => 4, len => 4 },
+    'classic packet metadata is read');
+ok(!defined Net::Pcap::next($pcap, \%header), 'classic end of capture returns undef');
+
+my ($ng_fh, $ng_path) = tempfile();
+binmode($ng_fh);
+my $section = pack('VVa4vvVVV', 0x0a0d0d0a, 28, "\x4d\x3c\x2b\x1a",
+    1, 0, 0xffffffff, 0xffffffff, 28);
+my $interface = pack('VVvvVV', 1, 20, 1, 0, 65535, 20);
+my $ng_packet = "ABCD";
+my $enhanced = pack('VVVVVVVa4V', 6, 36, 0, 0, 500000, 4, 4, $ng_packet, 36);
+print {$ng_fh} $section, $interface, $enhanced;
+close($ng_fh);
+
+$error = '';
+$pcap = Net::Pcap::open_offline($ng_path, \$error);
+isa_ok($pcap, 'pcap_tPtr');
+is($error, '', 'pcapng capture opens without an error');
+is(Net::Pcap::datalink($pcap), DLT_EN10MB, 'pcapng interface link type is read');
+
+my $raw;
+%header = ();
+is(Net::Pcap::next_ex($pcap, \%header, \$raw), 1, 'pcapng next_ex reports a packet');
+is($raw, $ng_packet, 'pcapng packet bytes are read');
+is($header{tv_usec}, 500000, 'pcapng timestamp resolution defaults to microseconds');
+is(Net::Pcap::next_ex($pcap, \%header, \$raw), -2, 'pcapng end of capture is reported');
+
+my $filter;
+is(Net::Pcap::compile($pcap, \$filter, '', 0, 0), 0, 'empty offline filter compiles');
+is(Net::Pcap::setfilter($pcap, $filter), 0, 'offline filter can be installed');
+like(Net::Pcap::lib_version(), qr/^libpcap version/, 'compatible version string is returned');
+
+unlink($classic_path, $ng_path);

--- a/src/test/resources/unit/attribute_method_named_sub_deparse.t
+++ b/src/test/resources/unit/attribute_method_named_sub_deparse.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+use Test::More tests => 6;
+use Attribute::Handlers;
+use B::Deparse;
+
+package LocalMethodAttribute;
+
+my $deparse;
+my @deparsed_sources;
+BEGIN { $deparse = B::Deparse->new('-l') }
+
+sub import {
+    my $package = caller;
+    no strict 'refs';
+    *{"${package}::self"} = \undef;
+}
+
+sub UNIVERSAL::Method : ATTR(RAWDATA) {
+    my ($package, $symbol, $code, undef, $arguments) = @_;
+    my $source = $deparse->coderef2text($code);
+    push @deparsed_sources, $source;
+    $source =~ s/\{/{\nmy \$self = shift;\n/;
+    my $name = *{$symbol}{NAME};
+    no warnings 'redefine';
+    eval "package $package; sub $name $source";
+    die $@ if $@;
+}
+
+eval {
+    package NamedSubDeparse;
+    use strict;
+    use warnings;
+    BEGIN { LocalMethodAttribute->import }
+
+    sub new : Method {
+        42;
+    }
+
+    sub get : Method {
+        43;
+    }
+};
+
+package main;
+
+is($@, '', 'attribute handler does not recursively reapply a named-sub attribute');
+is(NamedSubDeparse->new, 42, 'first deparsed replacement preserves its body');
+is(NamedSubDeparse->get, 43, 'second deparsed replacement preserves its body');
+
+my $new_source = $deparse->coderef2text(\&NamedSubDeparse::new);
+my $get_source = $deparse->coderef2text(\&NamedSubDeparse::get);
+unlike($new_source, qr/:\s*Method/, 'replacement source omits the original attribute');
+unlike($get_source, qr/:\s*Method/, 'second replacement source omits the original attribute');
+like($deparsed_sources[1], qr/43/, 'compile-time handler receives the second exact source span');

--- a/src/test/resources/unit/bytes_scope_interpreter.t
+++ b/src/test/resources/unit/bytes_scope_interpreter.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More tests => 5;
+
+sub preserve_wide_string_after_bytes_block {
+    my $wide = "\x{20ac}";
+    {
+        use bytes;
+        is(length($wide), 3, 'nested bytes scope sees UTF-8 octets');
+    }
+
+    my $copy = $wide . '';
+    return $copy;
+}
+
+my $direct = preserve_wide_string_after_bytes_block();
+ok(utf8::is_utf8($direct), 'outer scope restores the UTF-8 flag for concatenation');
+is(ord($direct), 0x20ac, 'outer concatenation preserves the Unicode character');
+
+my $from_eval = eval q{
+    use utf8;
+    my $wide = "\x{20ac}";
+    { use bytes; my $octets = length($wide) }
+    $wide . '';
+};
+is($@, '', 'interpreter-backed eval compiles successfully');
+is(ord($from_eval), 0x20ac, 'interpreter-backed eval restores outer lexical hints');

--- a/src/test/resources/unit/json_xs_compat.t
+++ b/src/test/resources/unit/json_xs_compat.t
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+use Test::More tests => 8;
+use JSON::XS qw(encode_json decode_json);
+
+is($JSON::XS::VERSION, '4.04', 'reports the compatible JSON::XS version');
+is(encode_json({ answer => 42 }), '{"answer":42}', 'functional encoder');
+is_deeply(decode_json('{"items":[1,2]}'), { items => [1, 2] }, 'functional decoder');
+
+my $json = JSON::XS->new->canonical(1)->allow_nonref(1);
+isa_ok($json, 'JSON::XS');
+is($json->encode({ b => 2, a => 1 }), '{"a":1,"b":2}', 'object options are inherited');
+is($json->decode('42'), 42, 'object decoder honors allow_nonref');
+ok(JSON::XS::is_bool(JSON::XS::true()), 'true is recognized as a JSON boolean');
+ok(!JSON::XS::is_bool(0), 'ordinary scalars are not JSON booleans');

--- a/src/test/resources/unit/unpack_short_string.t
+++ b/src/test/resources/unit/unpack_short_string.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More tests => 12;
+
+for my $case (
+    [ ''   => 0, ''     ],
+    [ '0'  => 1, '30'   ],
+    [ '12' => 2, '3132' ],
+) {
+    my ($input, $length, $hex) = @$case;
+    my $unpacked = unpack('a4', $input);
+    is(length($unpacked), $length, "a4 does not pad input of length $length");
+    is(unpack('H*', $unpacked), $hex, "a4 preserves available bytes for length $length");
+}
+
+my @chunks = unpack('(a4)*', '123456');
+is(scalar @chunks, 2, 'repeated group returns a partial final chunk');
+is(unpack('H*', $chunks[0]), '31323334', 'repeated group returns the full chunk');
+is(unpack('H*', $chunks[1]), '3536', 'repeated group does not pad the final chunk');
+
+my $binary = "\xff\xff\xff\0";
+my $binary_chunk = unpack('a4', $binary);
+is(length($binary_chunk), 4, 'a4 returns four high-byte characters');
+{
+    use bytes;
+    is(length($binary_chunk), 4, 'a4 preserves the byte-string flag');
+}
+is(unpack('H*', $binary_chunk), 'ffffff00', 'a4 preserves high bytes exactly');


### PR DESCRIPTION
## Summary

- preserve exact source spans for attributed named subs so `B::Deparse` does not recursively reapply `Attribute::Method`
- match Perl's short-input and byte-flag behavior for `unpack('a...')`, fixing Net::DHCP address decoding
- restore enclosing lexical hints after interpreted blocks, fixing Text::CSV Unicode output after nested `use bytes`
- provide portable compatibility layers for `JSON::XS`, the Net::Frame subset of `Bit::Vector`, and offline classic-pcap/pcapng reading through `Net::Pcap`
- add system-Perl-validated regression tests and module progress documentation

## CPAN validation

- `./jcpan -t Net::DHCP` — PASS (34 files, 219 tests)
- `./jcpan -t List::Compare` — PASS
- `./jcpan -t Math::Derivative` — PASS
- `./jcpan -t File::Find::Upwards` — PASS

## Test plan

- `make` — PASS
- `make test-bundled-modules` — PASS (377 files)
- `make test-interpreter` — completed; new lexical-hint regression passes 5/5, existing interpreter suite pass rate 98.0%
- Text::CSV `50_utf8.t`, `51_utf8.t`, and `76_magic.t` — PASS (344 assertions)
- focused new tests validated with system Perl before JPerl
- `perl dev/tools/check_opcodes.pl src/main/java/org/perlonjava/backend/bytecode/Opcodes.java` — no duplicate opcodes

Generated with [Codex](https://openai.com/codex/)
