### PR TITLE
Fix interpreter regex state for ExifTool

### DIFF
--- a/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
+++ b/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
@@ -93,6 +93,16 @@ public class PerlLanguageProvider {
                                               boolean isTopLevelScript,
                                               int callerContext) throws Exception {
 
+        // The compiler options are also the source of truth for nested loads.
+        // ModuleOperators creates fresh CompilerOptions instances for require/use
+        // and reads RuntimeCode.USE_INTERPRETER when choosing their backend.  If
+        // an embedding caller sets useInterpreter directly (rather than using the
+        // CLI, which updates that runtime flag), the top-level program would run
+        // in the interpreter while its modules were still compiled as JVM code.
+        // Publish the option before parsing, since BEGIN/use statements can load
+        // modules during this execution.
+        RuntimeCode.setUseInterpreter(compilerOptions.useInterpreter);
+
         if (isTopLevelScript) {
             ArgumentParser.applyPerlShebangSwitches(compilerOptions.code, compilerOptions);
             GlobalContext.setThreadTaintMode(compilerOptions.taintMode);
@@ -297,6 +307,11 @@ public class PerlLanguageProvider {
                                              List<LexerToken> tokens,
                                              CompilerOptions compilerOptions,
                                              int contextType) throws Exception {
+
+        // Keep AST execution consistent with source execution.  ASTs are used
+        // by BEGIN-block wrappers, and those wrappers can themselves execute
+        // require/use during compilation.
+        RuntimeCode.setUseInterpreter(compilerOptions.useInterpreter);
 
         if (compilerOptions.taintMode) {
             GlobalContext.setThreadTaintMode(true);

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -1215,6 +1215,7 @@ public class BytecodeCompiler implements Visitor {
 
         int regexSaveReg = -1;
         if (!node.getBooleanAnnotation("blockIsSubroutine")
+                && !node.getBooleanAnnotation("skipRegexSaveRestore")
                 && RegexUsageDetector.containsRegexOperation(node)) {
             regexSaveReg = allocateRegister();
             emit(Opcodes.SAVE_REGEX_STATE);
@@ -6022,6 +6023,9 @@ public class BytecodeCompiler implements Visitor {
             foreachRegexSaveReg = allocateRegister();
             emit(Opcodes.SAVE_REGEX_STATE);
             emitReg(foreachRegexSaveReg);
+            if (node.body != null) {
+                node.body.setAnnotation("skipRegexSaveRestore", true);
+            }
         }
 
         // Step 2: Create iterator from the list
@@ -6359,6 +6363,9 @@ public class BytecodeCompiler implements Visitor {
             loopRegexSaveReg = allocateRegister();
             emit(Opcodes.SAVE_REGEX_STATE);
             emitReg(loopRegexSaveReg);
+            if (node.body != null) {
+                node.body.setAnnotation("skipRegexSaveRestore", true);
+            }
         }
 
         // Step 1: Execute initialization (for C-style loops only)


### PR DESCRIPTION
## Summary

- Fixes interpreter-mode propagation for nested `use`/`require` and AST execution.
- Prevents loop-body regex state restoration from resetting `$1` and `/g` positions in the interpreter.
- Resolves the ExifTool UTF-8 detection regression from issue #329.

## Validation

- `make` passes.
- ExifTool interpreter suite: 351/351 executed tests pass, with no failures or timeouts.
- `Text.t`: 7/7 tests pass in interpreter mode.

Closes #329
