### PR TITLE
feat: start Perl threads implementation phase 1

### DIFF
--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -1,894 +1,491 @@
-# PerlOnJava Concurrency: Unified Design
+# Perl Threads Implementation Plan
 
-**Version:** 1.1  
-**Date:** 2026-03-26  
-**Status:** Design Proposal (Technically Reviewed)  
-**Supersedes:** `threads.md`, `fork.md`, `multiplicity.md` (consolidates all three)
+**Status:** Active implementation plan
+**Version:** 2.0
+**Date:** 2026-08-10
+**Supersedes:** the previous `concurrency.md` proposal and
+`dev/prompts/multiplicity-v2-plan.md`
 
----
+## 1. Goal and Non-Negotiable Delivery Rule
 
-## Executive Summary
+Implement Perl 5 interpreter threads (ithreads) on the JVM. Each Perl thread
+owns an isolated, cloned interpreter. Perl values are copied at thread creation
+unless their storage was explicitly marked shared.
 
-This document presents a unified, realistic plan for concurrency in PerlOnJava.
-It replaces the separate `threads.md`, `fork.md`, and `multiplicity.md` documents
-with a single plan grounded in what JRuby, Jython, and TruffleRuby have actually
-shipped — not theoretical designs.
+Every numbered phase below is an independent pull request. A phase may be split
+further when its audit shows that it cannot be reviewed or reverted safely, but
+two numbered phases must not be combined. At every merge boundary:
 
-**Key insight from research:** Every successful JVM language implementation chose
-**one** primary concurrency model and made it work well, rather than trying to
-faithfully replicate every native-language concurrency mechanism.
+- the compiler and both execution backends remain functional;
+- `make` passes;
+- the previously supported Perl surface remains supported;
+- `Config` continues to report `useithreads` as false until the activation
+  phase;
+- no partially exposed `threads` API is advertised;
+- the phase can be reverted without reverting a later phase.
 
-### Recommended Strategy
+The earlier multiplicity implementation in PR #480 violated this rule: it moved
+roughly 10,000 lines across 96 files and was reverted by PR #487 after an
+unbound regex-timeout worker broke version parsing. Its branches are useful as
+file-level references, not as commits to cherry-pick.
 
-1. **JRuby model (proven):** Map Perl threads directly to JVM threads; make the
-   runtime thread-safe; accept that `fork()` cannot work.
-2. **ThreadLocal-based runtime context** instead of classloader isolation
-   (Jython learned this the hard way — ThreadLocal is simpler and faster).
-3. **Incremental de-static-ification** of global state, starting with the
-   smallest subsystems.
-4. **No GIL/global lock** — follow JRuby's lead: make core data structures
-   safe, document what isn't safe, let users synchronize where needed.
+## 2. Compatibility Target
 
-### Key Definitions
+The target is Perl 5 ithread behavior, not JRuby-style threads sharing one
+runtime:
 
-**threads (ithreads)**: Perl's official mechanism for parallel execution within a
-single process. Each Perl thread runs in its own cloned interpreter (not sharing
-memory by default). All variables are deep-copied at thread creation time. Shared
-variables require explicit `:shared` attribute. This provides "fork-like semantics
-without forking" — isolation by default. Note: The use of interpreter-based threads
-is officially "discouraged" in Perl 5 documentation, but it remains the only
-officially supported threading model.
+1. `threads->create($code, @args)` creates a child `PerlRuntime`.
+2. The entry code, arguments, globals, closures, and reachable Perl value graph
+   are cloned into that runtime with identity, aliases, and cycles preserved.
+3. Ordinary values are isolated. Explicitly shared storage retains identity
+   across runtimes.
+4. The child runs on one Java platform thread and exclusively owns its runtime.
+5. Join results and uncaught errors cross back through the same graph-cloning
+   boundary.
+6. `CLONE_SKIP` and `CLONE` are honored.
+7. Compilation may be serialized; already compiled Perl code may execute in
+   parallel once runtime isolation is complete.
 
-**fork()**: Process-level parallelism by creating a child process with copied
-memory. Uses copy-on-write semantics for efficiency. **Cannot be implemented on
-the JVM** — JRuby confirmed this over 20 years of attempts. The JVM's GC can crash
-between fork and exec, and JVM state cannot be safely split across processes.
+This plan does not implement POSIX `fork()`. Process creation remains the
+supported replacement for fork-and-exec patterns. Virtual threads are a later,
+optional optimization: Java 22 still has pinning and diagnostic limitations,
+while cloning an ithread interpreter already dominates thread creation cost.
 
-**multiplicity**: Running multiple Perl interpreter instances within the same
-process. In Perl 5, this is the internal mechanism (`perl_clone()`) that enables
-ithreads. In PerlOnJava, this is achieved through `PerlRuntime` instances. Use
-cases include web server request isolation (mod_perl model) and JSR-223 embedding.
+## 3. Architecture
 
----
+### 3.1 Runtime ownership and binding
 
-## 1. Lessons from Other JVM Language Projects
-
-### 1.1 JRuby (most relevant — 20 years of production use)
-
-**Threading model:**
-- Ruby threads map 1:1 to JVM threads (real OS threads)
-- No Global VM Lock — true parallel execution
-- The JRuby runtime itself is thread-safe for structural operations:
-  defining methods, modifying constants, modifying global variables
-- Core mutable data structures (String, Array, Hash) are **not** thread-safe;
-  users must synchronize explicitly
-- `volatile` writes for method tables, constant tables, class variables,
-  global variables
-- Non-volatile: instance variables, local variables in closures
-
-**Fork handling:**
-- `Kernel#fork` raises `NotImplementedError` on JRuby
-- JRuby tried POSIX `fork+exec` via JNA for `system()`/backticks but
-  abandoned it as too dangerous (JVM GC can crash between fork and exec)
-- Recommendation: use `Process.spawn`, `system()`, or threads instead
-- This is **universally accepted** by the JRuby community
-
-**Key lesson:** Don't waste time on fork emulation. Focus on making threads
-work well. The ecosystem adapts.
-
-### 1.2 Jython (cautionary tale)
-
-**Threading model:**
-- Python threads map 1:1 to JVM threads
-- No GIL (unlike CPython) — true parallel execution
-- `dict`, `list`, `set` are thread-safe (no corruption, but updates can be lost)
-- All Python attribute get/set are volatile (backed by ConcurrentHashMap)
-- Sequential consistency for Python code
-
-**ThreadState problem:**
-- Jython used ThreadLocal to store execution context (`ThreadState`)
-- They later recognized this was a design mistake that "slows things down
-  and unnecessarily limits what a given thread can do"
-- Planned refactoring to remove ThreadState but never completed it
-  (project stalled before this happened)
-
-**Key lesson:** ThreadLocal for runtime context is a pragmatic starting point
-but has performance costs. Plan for eventual migration to explicit parameter
-passing — but don't let that block the initial implementation.
-
-### 1.3 TruffleRuby / GraalVM
-
-**Threading model:**
-- True parallel threads via GraalVM's managed threading
-- Each `Context` is single-threaded; multi-threading requires multiple contexts
-  or explicit opt-in via `allowAllAccess`
-- Polyglot contexts provide natural isolation
-
-**Key lesson:** Context-per-thread is the cleanest isolation model. PerlOnJava's
-eventual `PerlRuntime` instances serve the same role.
-
-### 1.4 Perl 5 ithreads (what we're implementing)
-
-**How it works in CPython Perl:**
-- Each thread gets a **cloned copy** of the entire interpreter
-- All variables are copied by default (deep clone at thread creation)
-- Shared variables require explicit `:shared` attribute
-- The `threads::shared` module mediates all cross-thread access
-- `CLONE` method called on objects during thread creation
-- Heavy — thread creation is expensive (full interpreter clone)
-
-**What mod_perl 2.0 does:**
-- Pre-creates a pool of Perl interpreter instances
-- Each Apache worker thread gets its own interpreter
-- Same pattern as the multiplicity.md "runtime pool" idea
-
----
-
-## 2. PerlOnJava Global State Inventory
-
-The following mutable static state must be addressed before any concurrency:
-
-| Class | Mutable Static Fields | Size | Risk |
-|-------|----------------------|------|------|
-| `GlobalVariable` | `globalVariables`, `globalArrays`, `globalHashes`, `globalCodeRefs`, `globalIORefs`, `globalFormatRefs`, `pinnedCodeRefs`, `stashAliases`, `globAliases`, `globalGlobs`, `isSubs`, `packageExistsCache`, `globalClassLoader` | ~13 maps + 1 classloader | **Critical** — all Perl variables live here |
-| `RuntimeIO` | `stdout`, `stderr`, `stdin` | 3 fields | **High** — I/O misdirection under concurrency |
-| `CallerStack` | `callerStack` (List) | 1 list | **High** — stack traces cross threads |
-| `SpecialBlock` | `endBlocks`, `initBlocks`, `checkBlocks` | 3 arrays | **Medium** — phase blocks interfere |
-| `DynamicVariableManager` | `variableStack` (Deque) | 1 deque | **High** — `local` scoping is per-execution-context |
-| `RuntimeScalar` | `dynamicStateStack` (Stack) | 1 stack | **High** — dynamic state per thread |
-| `RuntimeCode` | `evalBeginIds`, `methodHandleCache`, `evalRuntimeContext` (ThreadLocal), `argsStack` (ThreadLocal) | 2 maps + 2 ThreadLocals | **Medium** — some already ThreadLocal |
-| `PerlLanguageProvider` | `globalInitialized` | 1 boolean | **Low** — initialization guard |
-| `InheritanceResolver` | `methodCache`, `linearizedClassesCache`, `overloadContextCache`, `isaStateCache`, `packageMRO` | 5 maps | **Medium** — stale under concurrent class modification |
-| `RuntimeCode` (additional) | `anonSubs`, `interpretedSubs`, `evalContext`, `methodHandleCache` | 4 maps | **Medium** — compiler/eval caches |
-| `RuntimeRegex` | regex state, special vars | state | **Medium** — `$1`, `$2` etc. must be per-thread |
-
-**Already ThreadLocal:** `RuntimeCode.evalRuntimeContext`, `RuntimeCode.argsStack`  
-**Pure functions (safe):** `RuntimeScalarCache`, most operator methods, `Base64Util`  
-**Read-only after init (safe):** `Configuration`, `ParserTables`
-
----
-
-## 3. Architecture Decision: ThreadLocal Runtime Context
-
-### Why not classloader isolation?
-
-The multiplicity.md document proposed classloader-based isolation first.
-After reviewing JRuby and Jython's experience, **this is not recommended** as
-the primary approach:
-
-- **Type barriers** make inter-runtime communication impossible without reflection
-- **Memory overhead** — duplicate class loading for every runtime instance
-- **Debugging nightmare** — class identity issues, serialization failures
-- **JRuby abandoned this pattern** for user-facing isolation (only used internally
-  for OSGi compatibility)
-- **Jython never used it** — went straight to ThreadLocal
-
-### Recommended: ThreadLocal + PerlRuntime instances
+`PerlRuntime` is an interpreter instance, not a Java thread. It is explicitly
+bound while Perl code executes:
 
 ```java
-public final class PerlRuntime {
-    private static final ThreadLocal<PerlRuntime> CURRENT = new ThreadLocal<>();
-
-    // Per-runtime mutable state (moved from static fields)
-    final VariableStorage variables;    // was GlobalVariable statics
-    final IOSystem io;                  // was RuntimeIO statics
-    final CallerStackManager callStack; // was CallerStack statics
-    final DynamicScopeManager dynamicScope; // was DynamicVariableManager + RuntimeScalar statics
-    final SpecialBlockManager blocks;   // was SpecialBlock statics
-    final RegexState regexState;        // $1, $2, match state
-
-    public static PerlRuntime current() {
-        return CURRENT.get();
-    }
-
-    public static void setCurrent(PerlRuntime rt) {
-        CURRENT.set(rt);
-    }
+try (PerlRuntime.Binding ignored = runtime.bind()) {
+    code.apply(args, context);
 }
 ```
 
-**Migration path:** Replace `GlobalVariable.getGlobalVariable("main::x")` with
-`PerlRuntime.current().variables.getGlobalVariable("main::x")`. This can be done
-incrementally, subsystem by subsystem.
+Binding must save and restore the previous value in `finally`, support nesting,
+and remove an empty binding. Do not use `InheritableThreadLocal`: executor
+workers are reused and inherited state leaks between tasks. Every callback or
+worker that accesses Perl state must capture a runtime and bind it explicitly.
 
----
+One runtime may move between Java threads when idle, but it must never execute
+concurrently on two threads.
 
-## 4. Concurrency Models to Support
+### 3.2 Compilation boundary
 
-### 4.1 Primary: `threads` (ithreads) — Full Implementation
+Parser and emitter state is not currently safe for concurrent use. A global
+reentrant compile lock is the initial correctness boundary. It covers parsing
+and code generation, including nested `eval STRING`, `require`, and `BEGIN`
+compilation. Generated code execution occurs outside the lock.
 
-This is the **only** concurrency model that Perl 5 officially supports via CPAN.
-It maps naturally to JVM threads.
+The lock is deliberately temporary. It may only be narrowed or removed after a
+separate audit proves all compile-time mutable state is isolated or immutable.
 
-```perl
-use threads;
-use threads::shared;
+### 3.3 Runtime state
 
-my $counter :shared = 0;
+All mutable state must be classified as one of:
 
-my @threads;
-for (1..4) {
-    push @threads, threads->create(sub {
-        lock($counter);
-        $counter++;
-    });
-}
-$_->join() for @threads;
-print "Counter: $counter\n";  # 4
+- immutable process-global data;
+- a synchronized process service;
+- per-`PerlRuntime` interpreter state;
+- per-execution-stack state inside a runtime.
+
+Static facade methods may remain during migration, delegating to
+`PerlRuntime.current()`, so generated bytecode descriptors do not all change at
+once. Runtime isolation is not claimed until every mutable-runtime inventory
+item has been classified and migrated.
+
+The inventory includes, but is not limited to:
+
+- global scalars, arrays, hashes, code, globs, stashes, aliases, formats, IO,
+  declarations, package caches, and class loaders;
+- caller state, dynamic/local save stacks, special blocks, hints, warnings,
+  source maps, eval caches, inline caches, regex captures, and state variables;
+- mortal/deferred cleanup state, weak references, `DESTROY` dispatch and rescue
+  state, `MyVarCleanupStack`, and blessed-object tracking;
+- standard handles, selected handles, descriptor/child-process registries,
+  phantom handle tracking, CWD, PID, `_` stat cache, and random state;
+- alarms, signal queues, data-section consumption, flip-flop/glob registries,
+  debugger state, and tied proxy state.
+
+Every migration PR repeats a mutable-static and thread-spawn search. New state
+added while this project is in progress must be classified in the same PR that
+adds it.
+
+### 3.4 Background work
+
+A state migration and every worker that touches that state land atomically in
+one PR. Known worker paths include regex timeouts, alarms, pipe input/output,
+`SystemOperator` stream routers, process callbacks, and terminal executors.
+Shutdown hooks may remain process-global only when they do not call runtime
+facades requiring a current binding.
+
+The original failure proves this rule: moving regex state to `PerlRuntime`
+without binding the timeout executor made `Scalar::Util` version parsing fail.
+
+### 3.5 Value graph cloning
+
+Thread cloning uses a dedicated `RuntimeGraphCloner` with an identity map. It
+must not use `Storable::dclone`, Java serialization, reflection over arbitrary
+constructors, or ordinary shallow `clone()` methods.
+
+Adapters explicitly cover:
+
+- scalar payloads, readonly values, dual values, references, arrays, hashes,
+  globs, stashes, and aliases;
+- repeated references and cycles;
+- blessed, weak, tied, and magical values;
+- JVM and interpreter closures with explicit capture metadata;
+- code references, state variables, and recursive closures;
+- the thread entry code and arguments as one graph;
+- return values and errors crossing back to the joining runtime.
+
+Filehandles and native resources require type-specific policies. We do not
+promise independent file positions or silently turn every Java `Closeable` into
+undef. `CLONE_SKIP`, module `CLONE` methods, and documented adapters determine
+the behavior.
+
+### 3.6 Shared storage
+
+The current `:shared` attribute is accepted as a no-op. Real sharing must mark
+storage identity so the graph cloner preserves it. A subclass that overrides
+only `set()` and `toString()` is insufficient because current runtime code also
+accesses scalar fields and collection elements directly.
+
+Shared scalars, arrays, and hashes therefore require storage indirection (or a
+completed accessor migration) plus `ReentrantLock`/`Condition`. Lock ownership,
+recursive locking, lexical unlock, condition wait atomicity, and wakeup behavior
+must match Perl tests.
+
+## 4. Validation Contract for Every PR
+
+All output is captured to files. Every `jperl`, `jcpan`, and `prove` invocation
+is wrapped in `timeout`.
+
+Required for every phase:
+
+```bash
+make > /tmp/perl-threads-make.log 2>&1
 ```
 
-**Implementation:**
+Also run `make test-all` when that target is healthy at the start of the phase.
+If it has baseline failures, record them and run the affected suites plus the
+full `make` gate; never conceal a new failure as baseline noise.
 
-```java
-public static RuntimeScalar threadsCreate(RuntimeScalar codeRef, RuntimeArray args) {
-    PerlRuntime parent = PerlRuntime.current();
+For every new or changed Perl `.t` file, system Perl runs first:
 
-    // Clone runtime state for new thread (deep copy by default)
-    PerlRuntime child = parent.clone(CloneMode.THREAD);
-
-    // Copy shared variable references (not values) to child
-    child.linkSharedVariables(parent);
-
-    Thread javaThread = Thread.ofVirtual().start(() -> {
-        PerlRuntime.setCurrent(child);
-        try {
-            RuntimeCode.apply(codeRef, args, RuntimeContextType.VOID);
-        } finally {
-            PerlRuntime.setCurrent(null);
-        }
-    });
-
-    return new RuntimeScalar(new PerlThread(javaThread, child));
-}
+```bash
+timeout 300 prove path/to/test.t > /tmp/perl-threads-system-perl.log 2>&1
 ```
 
-**Shared variables** use a wrapper that synchronizes access:
+Semantic tests then run on JVM and interpreter backends. Runtime migration PRs
+also run:
 
-```java
-public class SharedScalar extends RuntimeScalar {
-    private final ReentrantLock lock = new ReentrantLock();
-
-    @Override
-    public RuntimeScalar set(RuntimeScalar value) {
-        lock.lock();
-        try {
-            return super.set(value);
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    @Override
-    public String toString() {
-        lock.lock();
-        try {
-            return super.toString();
-        } finally {
-            lock.unlock();
-        }
-    }
-}
+```bash
+timeout 60 ./jperl -e 'use Scalar::Util; print $Scalar::Util::VERSION, "\n"'
+timeout 60 ./jperl --interpreter -e 'use Scalar::Util; print $Scalar::Util::VERSION, "\n"'
 ```
 
-**Virtual Threads (Java 21+):** Since PerlOnJava requires Java 22+, we can use
-virtual threads (`Thread.ofVirtual()`) for lightweight thread creation. This is a
-significant advantage over native Perl's heavy interpreter-cloning ithreads.
-
-**Virtual Thread Pinning Caveat:** In Java 21-24, virtual threads become "pinned"
-to their carrier OS thread when executing inside a `synchronized` block or native
-method. This means blocking I/O inside `synchronized` blocks will block the
-carrier thread rather than unmounting the virtual thread. JEP 491 ("Synchronize
-Virtual Threads without Pinning") addresses this and will be available in future
-Java releases. For now, **SharedScalar/SharedArray/SharedHash use `ReentrantLock`
-instead of `synchronized`** — this is critical because `ReentrantLock` uses
-`LockSupport.park()` which properly unmounts virtual threads.
-
-### 4.2 Secondary: `fork()` — Stub with Documentation
-
-Following JRuby's proven approach:
-
-```java
-public static RuntimeScalar fork() {
-    // Set $! to explain why
-    WarnDie.warn("fork() is not available on the JVM. " +
-                 "Use threads, system(), or ProcessBuilder instead.");
-    GlobalVariable.getGlobalVariable("main::!").set("Function not implemented");
-    return RuntimeScalarCache.scalarUndef;  // returns undef
-}
-```
-
-**Rationale:** JRuby has shipped `NotImplementedError` for fork for 20 years.
-The community adapted. Most fork usage falls into patterns that have alternatives:
-
-| Perl Pattern | JVM Alternative |
-|--------------|----------------|
-| `fork + exec` | `system()`, `ProcessBuilder` |
-| `fork` for parallelism | `threads` |
-| `fork` for daemon | `Thread` + process management |
-| `fork` in test harness | Thread-based test runner |
-| `open(PIPE, "-\|")` | `ProcessBuilder` with piped streams |
-
-### 4.3 Web Server Concurrency — Runtime Pool
-
-For JSR-223 and web server use cases (the most immediately useful):
-
-```java
-public class PerlRuntimePool {
-    private final BlockingQueue<PerlRuntime> pool;
-    private final PerlRuntime template;
-    private final int maxPoolSize;
-    private final int minPoolSize;
-    private final long maxIdleTimeMs;
-
-    public PerlRuntimePool(int size) {
-        this(size, size, 0);  // Default: fixed pool, no idle timeout
-    }
-
-    public PerlRuntimePool(int minSize, int maxSize, long maxIdleTimeMs) {
-        this.minPoolSize = minSize;
-        this.maxPoolSize = maxSize;
-        this.maxIdleTimeMs = maxIdleTimeMs;
-        this.template = PerlRuntime.createDefault();
-        this.pool = new ArrayBlockingQueue<>(maxSize);
-        for (int i = 0; i < minSize; i++) {
-            pool.add(template.clone(CloneMode.INDEPENDENT));
-        }
-    }
-
-    public PerlRuntime acquire() throws InterruptedException {
-        return pool.take();
-    }
-
-    public void release(PerlRuntime rt) {
-        rt.reset();  // Clear request-scoped state
-        pool.offer(rt);
-    }
-}
-```
-
-**Configuration options** (exposed via system properties or API):
-- `minPoolSize`: Minimum runtimes to keep warm (default: 1)
-- `maxPoolSize`: Maximum concurrent runtimes (default: CPU cores × 2)
-- `maxIdleTimeMs`: Time before idle runtimes are destroyed (0 = never)
-
----
-
-## 5. Thread Creation: What Gets Cloned
-
-When `threads->create()` is called, a new `PerlRuntime` is created by deep-cloning
-the parent. This section details the cloning semantics for each category of
-runtime state — this is the most technically challenging part of the implementation.
-
-### 5.1 Closure Capture Cloning
-
-PerlOnJava has two closure representations, both of which capture lexical
-variables by **Java object reference**:
-
-**JVM backend:** Closures are compiled JVM classes where captured lexicals
-become constructor parameters stored as instance fields on the generated class
-object (`RuntimeCode.codeObject`). The `RuntimeCode.methodHandle` is bound to
-this specific object instance.
-
-**Interpreter backend:** Closures store captures in an explicit array:
-```java
-// InterpretedCode.java
-public final RuntimeBase[] capturedVars; // Closure support (captured from outer scope)
-```
-
-**Cloning rules:**
-
-| What | Clone? | Rationale |
-|------|--------|----------|
-| Compiled JVM bytecode / MethodHandle | **No** — share | Immutable code, safe to share across threads |
-| `InterpretedCode.bytecode` / `constants` / `stringPool` | **No** — share | Immutable arrays, safe to share |
-| `RuntimeCode.codeObject` (JVM backend) | **Yes** — deep copy | Holds mutable captured variable references |
-| `InterpretedCode.capturedVars` (interpreter) | **Yes** — deep copy | Holds mutable captured variable references |
-| Each captured `RuntimeScalar` / `RuntimeArray` / `RuntimeHash` | **Yes** — deep copy | New thread gets independent values (ithreads semantics) |
-| `RuntimeCode.stateVariable` / `stateArray` / `stateHash` | **Yes** — deep copy | `state` variables are per-closure-instance |
-| Variables marked `:shared` | **No** — share reference | Both threads get a reference to the same `SharedScalar` wrapper |
-
-**Reference fixup challenge:** After deep-copying all closures, captured variables
-that point to globals must be redirected to the **child's** copies of those globals,
-not the parent's originals. This requires a two-pass clone:
-
-1. **Pass 1:** Deep-copy all `VariableStorage` (globals) and all `RuntimeCode`
-   objects, building an identity map: `parentObject → childObject`.
-2. **Pass 2:** Walk all closure captures in the child. For each capture that
-   appears in the identity map, replace it with the child's copy.
-
-This is the same approach Perl 5 uses internally (`perl_clone()` + pointer fixup
-table in `sv.c`).
-
-### 5.2 CLONE Method and External Resources
-
-Perl 5 calls `CLONE($package)` on every package that defines it whenever a new
-thread is created. This is the mechanism by which modules handle thread safety.
-
-**DBI example (Perl 5 behavior):**
-```perl
-package DBI;
-sub CLONE {
-    # Called in the NEW thread's context after cloning
-    # Invalidate all cached database handles — they point to
-    # the parent's JDBC Connection and are unusable here
-    # Child must call DBI->connect() again
-}
-```
-
-**Implementation plan:**
-
-1. After cloning `PerlRuntime`, walk all packages in the child's symbol table.
-2. For each package that has a `CLONE` subroutine defined, call it with the
-   package name as argument.
-3. The call happens **in the child thread's context** (after `PerlRuntime.setCurrent(child)`).
-
-**External resource handling rules:**
-
-| Resource Type | Action in Child | Rationale |
-|---------------|----------------|----------|
-| JDBC `Connection` (via DBI) | Invalidate → undef | Cannot share connections across threads |
-| File handles (`RuntimeIO`) | Clone with independent position | Perl 5 duplicates file descriptors |
-| Sockets | Invalidate → undef | OS socket FDs can't be shared |
-| Java objects (generic) | Shallow copy (reference) | User's responsibility via CLONE |
-| Tied variables | Clone the tie object | CLONE on tie class handles specifics |
-
-**Safety net:** During clone, any `RuntimeScalar` whose value wraps a Java object
-that implements `java.io.Closeable` or `java.sql.Connection` should be set to
-`undef` in the child by default. The module's `CLONE` method can then reconnect
-if needed. This prevents silent use of stale connections.
-
-### 5.3 Method Cache Invalidation
-
-The `InheritanceResolver` maintains several static caches that are critical for
-performance but dangerous under concurrency:
-
-```java
-// InheritanceResolver.java — all static, all mutable
-static final Map<String, List<String>> linearizedClassesCache;  // MRO linearization
-private static final Map<String, RuntimeScalar> methodCache;     // method resolution
-private static final Map<Integer, OverloadContext> overloadContextCache;
-private static final Map<String, List<String>> isaStateCache;    // @ISA change detection
-```
-
-Additionally, `RuntimeCode` has:
-```java
-private static final Map<Class<?>, MethodHandle> methodHandleCache;  // MethodHandle lookup
-```
+Expected version is the version bundled by the branch (`1.70` when this plan
+was finalized). Moo/module-loading smoke tests accompany it.
 
-**Thread creation policy:**
+Performance-sensitive phases record the global, lexical, method, closure,
+regex, and eval benchmarks against the same-base master build. A hot-path
+regression over 5% blocks that phase unless the design document records a
+reviewed exception.
 
-| Cache | Action at Thread Creation | Rationale |
-|-------|--------------------------|----------|
-| `methodCache` | **Clear in child** | Child may modify `@ISA` independently |
-| `linearizedClassesCache` | **Clear in child** | Depends on `@ISA` which is cloned |
-| `overloadContextCache` | **Clear in child** | Overload resolution depends on stash state |
-| `isaStateCache` | **Clear in child** | Must detect changes relative to child's `@ISA` |
-| `methodHandleCache` | **Share (read-only)** | Maps `Class<?>` → `MethodHandle`; immutable after creation |
-
-**Clearing is always correct** because caches are just performance optimizations.
-The child pays a cold-cache penalty on first method resolution but is guaranteed
-correct behavior.
+Before ending an investigation, inspect exact Java command lines and terminate
+only workers proven to belong to an abandoned test. Never kill from a CPU list
+alone.
 
-**Long-term:** Once these caches are moved into `PerlRuntime` (Phase 5), each
-runtime has its own caches and no cross-thread invalidation is needed.
+## 5. Pull Request Train
 
-**JRuby parallel:** JRuby uses volatile writes for method table modifications
-and call-site invalidation on structural changes. We follow the same principle:
-structural changes (method definition, `@ISA` modification) invalidate caches.
+### Phase 1 — Import health and compiler identity safety
 
-### 5.4 Thread Creation Checklist
+Make Perl 5 imports reproducible, repair any stale/malformed patches found by a
+full sync, convert generated class/call-site identifiers to atomic allocation,
+make immutable compiler constants final, and instantiate mutable control-flow
+visitors per invocation.
 
-Complete sequence for `threads->create()`:
+Acceptance:
 
-| Step | What | How |
-|------|------|-----|
-| 1 | Clone `VariableStorage` | Deep-copy all global scalars/arrays/hashes/code refs |
-| 2 | Clone closure captures | Deep-copy `capturedVars`/`codeObject` in every `RuntimeCode` |
-| 3 | Fixup capture references | Redirect cloned captures to child's globals (identity map) |
-| 4 | Handle `:shared` vars | Don't clone; wrap in `SharedScalar`/`SharedArray`/`SharedHash` |
-| 5 | Invalidate external resources | Set `Closeable`/`Connection`-backed scalars to undef |
-| 6 | Clear method caches | Clear `methodCache`, `linearizedClassesCache`, `overloadContextCache`, `isaStateCache` |
-| 7 | Clone I/O state | Fresh `stdout`/`stderr`/`stdin` per `IOSystem` |
-| 8 | Clone execution context | Fresh `CallerStack`, `DynamicScope`, `SpecialBlocks`, `RegexState` |
-| 9 | Start JVM thread | `Thread.ofVirtual().start(...)` with `PerlRuntime.setCurrent(child)` |
-| 10 | Call `CLONE($pkg)` | Walk all packages in child, call CLONE where defined |
-| 11 | Execute user code | Apply the code reference with provided arguments |
-
-Steps 2-3 (closure capture cloning with reference fixup) are the most technically
-challenging part. The identity-map approach from Perl 5's `perl_clone()` is the
-proven solution.
-
----
-
-## 6. Implementation Phases
-
-### Phase 0: Thread-Safety Audit (2 weeks)
-
-(See Section 5 for detailed thread-creation semantics that inform all phases.)
-
-Before any new features, make the existing single-threaded runtime safe for
-the case where multiple JSR-223 `eval()` calls might overlap:
-
-- Add `synchronized` to `GlobalVariable` map operations
-- Make `RuntimeIO.stdout`/`stderr`/`stdin` volatile
-- Add `synchronized` to `CallerStack` operations
-- Document what is and isn't thread-safe
-
-**Deliverable:** Existing functionality works under a global lock. No new APIs.
-
-### Phase 1: PerlRuntime Shell (4 weeks)
-
-Create the `PerlRuntime` class as a thin shell around existing statics:
-
-1. Create `PerlRuntime` with `ThreadLocal<PerlRuntime> CURRENT`
-2. Add `PerlRuntime.current()` accessor
-3. Keep all existing static fields — just route through `PerlRuntime.current()`
-4. Wire up `PerlLanguageProvider` to create and set a default `PerlRuntime`
-
-**Key constraint:** No behavior change. Every existing test must still pass.
-The `PerlRuntime` is just a new entry point that delegates to existing statics.
-
-**Deliverable:** `PerlRuntime.current()` works; JSR-223 can create isolated
-contexts (even if they still share state internally).
-
-### Phase 2: De-static-ify I/O (3 weeks)
-
-Move `RuntimeIO.stdout/stderr/stdin` into `PerlRuntime`:
-
-```java
-// Before: RuntimeIO.stdout
-// After:  PerlRuntime.current().io.stdout
-
-public class IOSystem {
-    public RuntimeIO stdout;
-    public RuntimeIO stderr;
-    public RuntimeIO stdin;
-}
-```
-
-This is the **smallest subsystem** and provides immediate value for JSR-223:
-each ScriptEngine can redirect I/O independently.
-
-**Deliverable:** JSR-223 `ScriptContext.getWriter()` works correctly per-context.
-
-### Phase 3: De-static-ify CallerStack + DynamicScope (4 weeks)
-
-Move `CallerStack.callerStack` and `DynamicVariableManager.variableStack` and
-`RuntimeScalar.dynamicStateStack` into `PerlRuntime`:
-
-```java
-public class ExecutionContext {
-    final List<Object> callerStack = new ArrayList<>();
-    final Deque<DynamicState> dynamicScope = new ArrayDeque<>();
-    final Stack<RuntimeScalar> dynamicStateStack = new Stack<>();
-}
-```
-
-**Deliverable:** Call stacks and `local` variables are per-runtime.
-
-### Phase 4: De-static-ify SpecialBlocks + RegexState (2 weeks)
-
-Move `SpecialBlock.endBlocks/initBlocks/checkBlocks` and regex match state
-(`$1`, `$2`, `$&`, etc.) into `PerlRuntime`.
-
-**Regex State Isolation Detail:**
-
-The following regex-related variables must be per-runtime (not per-thread-global):
-
-| Variable | Description | Storage Location |
-|----------|-------------|------------------|
-| `$1`, `$2`, ... `$N` | Capture groups | `PerlRuntime.regexState.captures` |
-| `$&` | Entire matched string | `PerlRuntime.regexState.lastMatch` |
-| `$`` | String before match | `PerlRuntime.regexState.priorMatch` |
-| `$'` | String after match | `PerlRuntime.regexState.postMatch` |
-| `$+` | Last bracket matched | `PerlRuntime.regexState.lastBracket` |
-| `@-` | Match start positions | `PerlRuntime.regexState.matchStarts` |
-| `@+` | Match end positions | `PerlRuntime.regexState.matchEnds` |
-
-```java
-public class RegexState {
-    final RuntimeArray captures = new RuntimeArray();  // $1, $2, etc.
-    RuntimeScalar lastMatch;     // $&
-    RuntimeScalar priorMatch;    // $`
-    RuntimeScalar postMatch;     // $'
-    RuntimeScalar lastBracket;   // $+
-    final RuntimeArray matchStarts = new RuntimeArray();  // @-
-    final RuntimeArray matchEnds = new RuntimeArray();    // @+
-}
-```
-
-**Implementation**: Modify `RuntimeRegex` to store results in `PerlRuntime.current().regexState`
-instead of static fields. The `ScalarSpecialVariable` class for capture variables must
-look up values from the current runtime's regex state.
-
-**Deliverable:** Regex captures and END blocks don't leak between runtimes.
-
-### Phase 5: De-static-ify GlobalVariable (8 weeks)
-
-This is the largest and most invasive change. Move all 13+ maps from
-`GlobalVariable` into `PerlRuntime.variables`:
-
-```java
-public class VariableStorage {
-    final Map<String, RuntimeScalar> globalVariables = new HashMap<>();
-    final Map<String, RuntimeArray> globalArrays = new HashMap<>();
-    final Map<String, RuntimeHash> globalHashes = new HashMap<>();
-    final Map<String, RuntimeScalar> globalCodeRefs = new HashMap<>();
-    final Map<String, RuntimeGlob> globalIORefs = new HashMap<>();
-    final Map<String, RuntimeFormat> globalFormatRefs = new HashMap<>();
-    // ... etc
-}
-```
-
-**Strategy:** Use IDE "Find Usages" on each static field. Replace with
-`PerlRuntime.current().variables.xxx`. Compile, test, repeat.
-
-This is pure mechanical refactoring but touches hundreds of call sites.
-
-**Deliverable:** Full runtime isolation. Multiple `PerlRuntime` instances
-can run concurrently without interference.
-
-### Phase 6: threads Module (4-6 weeks)
-
-With runtime isolation complete, implement the `threads` Perl module.
-See **Section 5** for the full thread-creation cloning protocol.
-
-**Core API:**
-1. `threads->create(\&sub, @args)` — clone runtime (Section 5.4) + start JVM thread
-2. `threads->join()` — wait for completion, return value
-3. `threads->detach()` — fire and forget
-4. `threads->list()` — list running threads
-5. `threads->self()` — current thread object
-6. `threads->tid()` — thread ID (unique integer, main thread = 0)
-7. `threads->yield()` — hint to scheduler (maps to `Thread.yield()`)
-8. `threads->exit($status)` — exit current thread (see below)
-
-**threads::shared API:**
-9. `share($var)` / `:shared` attribute — SharedScalar/SharedArray/SharedHash wrappers
-10. `lock($var)` — mutex on shared variables
-11. `cond_wait()`/`cond_signal()`/`cond_broadcast()` — condition variables
-12. `is_shared($var)` — check if variable is shared
-
-**Internal callbacks:**
-13. `CLONE($package)` callback — called in child after cloning (Section 5.2)
-14. Closure capture cloning with reference fixup (Section 5.1)
-15. Method cache invalidation in child (Section 5.3)
-
-**threads->exit() Semantics:**
-
-In Perl 5 ithreads, `exit()` in a non-main thread exits only that thread, not the
-entire process. This must be implemented carefully:
-
-```java
-public static void threadsExit(int status) {
-    PerlThread current = PerlThread.current();
-    if (current.isMainThread()) {
-        // Main thread: exit the process
-        System.exit(status);
-    } else {
-        // Worker thread: exit only this thread
-        current.setExitStatus(status);
-        throw new ThreadExitException(status);
-    }
-}
-```
-
-The `ThreadExitException` should be caught by the thread wrapper created in
-`threads->create()` and should NOT propagate to the main thread or cause
-"Perl exited with active threads" warnings.
-
-**Virtual Threads note:** Use `Thread.ofVirtual()` by default. Perl's
-ithreads are already "heavy" (full interpreter clone), so making the actual
-JVM thread lightweight is a net win.
-
-**Timeline Note:** This phase is estimated at 4 weeks but may take 6 weeks
-due to the complexity of closure capture cloning with reference fixup (the
-most technically challenging part of the entire implementation).
-
-### Phase 7: Runtime Pool + JSR-223 Thread Safety (3 weeks)
-
-1. Implement `PerlRuntimePool` for web server use cases
-2. Declare `THREADING` parameter as `"THREAD-ISOLATED"` in ScriptEngineFactory
-3. Update JSR-223 to use pool automatically
-4. Benchmark: target 1000+ concurrent requests without interference
-
----
-
-## 7. What We Explicitly Don't Implement
-
-| Feature | Reason | Alternative |
-|---------|--------|-------------|
-| True `fork()` | JVM cannot split processes (JRuby proved this) | `system()`, `threads`, `ProcessBuilder` |
-| Classloader isolation | Type barriers, memory overhead, debugging pain (Jython lesson) | ThreadLocal + PerlRuntime instances |
-| Copy-on-write cloning | JVM has no COW memory; deep copy is the only option | Full clone at thread creation (like Perl 5 ithreads) |
-| `fork()` in test harnesses | Many CPAN test suites use fork | Thread-based test runner (`jprove`) |
-| `open(PIPE, "-\|")` | Requires fork | `ProcessBuilder` wrapper |
-
----
-
-## 8. Performance Considerations
-
-### ThreadLocal Overhead
-
-ThreadLocal access is ~2-5ns per call on modern JVMs. With an estimated
-10-50 ThreadLocal lookups per Perl statement, overhead is 20-250ns per
-statement. Perl statement execution is typically 100ns-10µs, so overhead
-is 0.25-25% — acceptable for the concurrency it enables.
-
-**Optimization:** Hot paths (like `GlobalVariable.getGlobalVariable`) can
-cache the PerlRuntime reference in a local variable at method entry.
-
-### Thread Creation Cost
-
-Perl 5 ithreads clone the entire interpreter (~100ms for a complex program).
-PerlOnJava thread creation involves:
-- Deep-copying `VariableStorage` maps (~1-10ms depending on variable count)
-- Deep-copying closure captures + reference fixup (~0.5-5ms)
-- Clearing method caches in child (~0.1ms)
-- Calling `CLONE` on all packages (~0.1-1ms)
-- Creating a virtual thread (~0.1ms)
-- Linking shared variables (~0.1ms)
-
-**Expected:** 2-15ms per thread creation — still significantly faster than Perl 5.
-
-### Memory Per Runtime
-
-Each `PerlRuntime` holds copies of all global variables. For a typical program
-with ~1000 global variables, each runtime adds ~100KB-1MB of memory. This is
-comparable to Perl 5 interpreter clones.
-
----
-
-## 9. Testing Strategy
-
-### Unit Tests
-- Runtime isolation: create 2 runtimes, modify globals in one, verify other is unchanged
-- SharedVariable: concurrent increment from N threads, verify final count
-- CallerStack isolation: nested calls in separate runtimes don't interfere
-- Closure capture isolation: modify captured lexical in child, verify parent is unchanged
-- Method cache isolation: modify `@ISA` in child, verify parent's method resolution unchanged
-
-### Integration Tests
-- `threads->create()` with arguments and return values
-- `threads::shared` with lock/cond_wait/cond_signal
-- JSR-223 concurrent eval from multiple Java threads
-- Existing test suite passes unchanged (regression)
-- CLONE method called correctly: DBI handle invalidation in child
-- Closure with `:shared` variable: both threads see same value
-- Nested closures: captured-of-captured variables cloned correctly
-
-### Stress Tests
-- 100 concurrent threads modifying shared variables
-- 1000 concurrent JSR-223 eval calls
-- Thread creation/destruction churn
-
-### Perl 5 Test Compatibility
-- Run `perl5_t/t/op/threads.t` (adapted for PerlOnJava)
-- Run representative CPAN module tests that use threads
-
----
-
-## 10. Success Criteria
-
-- ✅ Multiple `PerlRuntime` instances run concurrently without interference
-- ✅ `threads->create()` and `threads->join()` work for basic patterns
-- ✅ `threads::shared` variables are correctly synchronized
-- ✅ JSR-223 can handle concurrent `eval()` calls
-- ✅ `fork()` returns undef with clear error message (not crash)
-- ✅ No regression in existing single-threaded functionality
-- ✅ Thread creation < 10ms for typical programs
-- ✅ < 5% performance overhead for single-threaded programs
-
----
-
-## 11. Timeline Summary
-
-| Phase | Duration | Deliverable | Risk |
-|-------|----------|-------------|------|
-| 0: Thread-Safety Audit | 2 weeks | Global lock safety | Low |
-| 1: PerlRuntime Shell | 4 weeks | ThreadLocal routing | Low |
-| 2: De-static I/O | 3 weeks | JSR-223 I/O isolation | Low |
-| 3: De-static CallerStack + DynamicScope | 4 weeks | Per-runtime call stacks | Low |
-| 4: De-static SpecialBlocks + Regex | 2 weeks | Per-runtime regex/blocks | Low |
-| 5: De-static GlobalVariable | 8-12 weeks | Full runtime isolation | **High** |
-| 6: threads Module | 4-6 weeks | Perl `use threads` works | **Medium** |
-| 7: Runtime Pool + JSR-223 | 3 weeks | Production web server | Low |
-| **Total** | **30-38 weeks** | | |
-
-**Risk Notes:**
-
-- **Phase 5** is the critical path bottleneck. The estimate of 8 weeks is optimistic;
-  it touches "hundreds of call sites" and requires careful testing. Budget 10-12 weeks.
-- **Phase 6** closure capture cloning with reference fixup is the most technically
-  challenging part of the implementation. May require additional time for edge cases.
-- Phases 0-2 provide immediate value for JSR-223 embedding use cases and should be
-  prioritized.
-- Phase 6 is only possible after Phase 5 is complete.
-
----
-
-## 12. Open Questions
-
-1. **Virtual threads vs platform threads:** Should `threads->create()` default
-   to virtual threads? Virtual threads are cheap but have caveats with
-   `synchronized` blocks (pinning). Test both and choose based on benchmarks.
-   **Update:** JEP 491 will resolve the pinning issue in future Java releases.
-   Recommend defaulting to virtual threads for I/O-bound Perl code.
-
-2. **Clone depth:** Should thread creation clone `@INC`, `%INC`, loaded modules?
-   Perl 5 clones everything. We could optimize by sharing read-only state.
-
-3. **Signal handling:** `$SIG{INT}` etc. — should signals be per-runtime or
-   process-wide? Perl 5 delivers to the main thread.
-
-4. **Reference fixup performance:** The two-pass clone (deep copy + identity
-   map fixup) may be expensive for programs with many closures. Profile
-   Perl 5's `perl_clone()` for comparison benchmarks.
-
-5. **Nested closures:** A closure that captures a variable which is itself
-   captured from an outer scope creates chains. The fixup pass must follow
-   these chains transitively. Verify with test cases.
-
-6. **Runtime Pool Configuration:** For web server scenarios, should expose
-   configurable limits: `maxPoolSize`, `minPoolSize`, `maxIdleTime`.
-
-### Resolved Questions
-
-- **CLONE method priority:** Yes, implement in Phase 6. Required for DBI,
-  Storable, and any module that holds external resources. (See Section 5.2)
-- **Method cache handling:** Clear all caches in child at thread creation.
-  Move to per-runtime in Phase 5. (See Section 5.3)
-- **DBI handles in child:** Invalidate automatically for `Closeable`/`Connection`
-  objects; module's CLONE method reconnects if needed. (See Section 5.2)
-- **`exit()` semantics:** Resolved in Phase 6 design. `exit()` in a non-main
-  thread exits only that thread via `ThreadExitException`. (See Section 6)
-
----
+- affected filtered syncs are idempotent;
+- the full import manifest completes without a failed patch;
+- concurrent class-name generation produces no duplicates;
+- `make` passes;
+- no claim of concurrent compilation is made yet.
+
+### Phase 2 — Serialized compilation
+
+Add one documented `ReentrantLock` around every initial and runtime compilation
+path. Preserve reentrant nested compilation and release the lock before code
+execution.
+
+Acceptance: concurrent JVM/bytecode compilations, nested `BEGIN`/`require`, and
+both `eval STRING` paths are deterministic and deadlock-free.
+
+### Phase 3 — `PerlRuntime` shell and scoped binding
+
+Introduce the runtime object and scoped binding API without moving state. Bind
+all CLI, test, JSR-223, `require`, and eval entry points.
+
+Acceptance: absent binding fails clearly; nested/exceptional bindings restore
+the prior runtime; two Java threads bind different empty runtimes without
+leakage.
+
+### Phase 4 — I/O state isolation
+
+Move standard/selected handles and current I/O bookkeeping into `PerlRuntime`.
+Preserve static facades and generated bytecode compatibility.
+
+Acceptance: two runtimes can redirect stdin/stdout/stderr independently and all
+existing IO tests pass.
+
+### Phase 5 — Execution stacks and special blocks
+
+Move caller stacks, dynamic scope, every `local` save/restore stack, cleanup
+stacks, and `BEGIN`/`CHECK`/`INIT`/`UNITCHECK`/`END` collections.
+
+Acceptance: `local`, caller, defer/lifecycle, and special-block tests show no
+cross-runtime state.
+
+### Phase 6 — Regex state and timeout binding
+
+Move all numbered/named captures, whole/prior/post-match values, last-capture
+state, match offsets, and `/g` state, and bind the regex-timeout worker in the
+same PR.
+
+Acceptance: simultaneous matches are isolated; alarm-based matching retains
+state; Scalar::Util/Moo regression gates pass.
+
+### Phase 7 — Inheritance and method caches
+
+Move MRO/package state, method/overload/ISA caches, generations, and
+invalidation state.
+
+Acceptance: runtimes may define conflicting packages and methods; method and
+closure benchmarks remain within budget.
+
+### Phase 8a — Core global values
+
+Move global scalar, array, and hash storage.
+
+### Phase 8b — Code and subroutine globals
+
+Move code references, pinned code, prototypes, and `is_sub` state.
+
+### Phase 8c — IO and format globals
+
+Move global IO slots and formats, reconciling them with Phase 4 ownership.
+
+### Phase 8d — Globs, aliases, and stashes
+
+Move glob tables, stash/package objects, and alias maps.
+
+### Phase 8e — Declarations and package services
+
+Move declared-global sets, package-existence caches, class-loader ownership, and
+remaining symbol-table runtime state.
+
+Each Phase 8 subphase is its own PR. Acceptance for each: conflicting global
+state in two runtimes remains isolated on JVM and interpreter backends; global,
+lexical, and eval benchmarks meet the budget.
+
+### Phase 9 — RuntimeCode and eval caches
+
+Move eval IDs/cache/context/depth, anonymous/interpreted sub registries, method
+handles, and inline caches. Update emitted access only where facade preservation
+is impossible.
+
+Acceptance: eval, parser, goto-sub, closure, and fallback suites pass on both
+backends with independent runtime caches.
+
+### Phase 10 — Hints, warnings, filters, and source mapping
+
+Classify compile-time versus runtime portions of warnings/hints and move runtime
+stacks, filter state, and bytecode source maps. Keep compile-only registries
+inside Phase 2's lock until independently made safe.
+
+Acceptance: lexical warnings/features and error locations remain correct during
+alternating and concurrent runtime use.
+
+### Phase 11 — Lifecycle and miscellaneous runtime state
+
+Migrate the remaining lifecycle, weak/destroy, signal/alarm, CWD/PID, stat,
+random, state-variable, data-section, debugger, tied-proxy, flip-flop, and IO
+registry inventory. Split this phase into independently green PRs if the audit
+finds unrelated ownership domains; document the split here before coding.
+
+Worker binding for alarms, pipes, system stream routers, and callbacks lands
+with the state each worker accesses.
+
+Acceptance: the mutable-static/thread-spawn audit has no unclassified
+runtime-dependent state.
+
+### Phase 12 — Multiplicity completion
+
+Expose a lifecycle-managed API for independent runtimes, including initialize,
+bind, execute, and close. Prohibit concurrent ownership of one runtime.
+
+Acceptance: concurrent Java integration tests execute conflicting Perl programs
+in isolated runtimes. `useithreads` remains false.
+
+### Phase 13 — Multiplicity performance recovery
+
+Apply only measured optimizations: cache `PerlRuntime.current()` in hot methods,
+batch stack transitions, and remove redundant state work. Reference
+`origin/feature/multiplicity-opt` selectively.
+
+Acceptance: all benchmark gates are within 5% or have a reviewed exception.
+
+### Phase 14 — Identity-preserving value graph cloner
+
+Implement the explicit graph-cloning core for non-code Perl values, including
+cycles, aliasing, blessings, weak references, readonly values, and documented
+tie/resource policies.
+
+Acceptance: system-Perl-validated graph fixtures match, and the original graph
+is never mutated.
+
+### Phase 15 — Closure and code cloning
+
+Clone JVM and interpreter code using explicit capture metadata; support scalar,
+array, hash, state, recursive, and nested captures. Do not reflect over Java
+field order.
+
+Acceptance: closure graphs behave identically on both backends after cloning.
+
+### Phase 16 — Runtime snapshot, `CLONE_SKIP`, and `CLONE`
+
+Compose runtime-state and graph cloning. Clone entry code and arguments as one
+graph, create fresh execution stacks, apply type-specific resource policies,
+preflight `CLONE_SKIP`, and invoke `CLONE` in the child.
+
+Acceptance: child mutation cannot affect the parent; alias/cycle identity is
+correct; package hooks run in Perl-compatible order.
+
+### Phase 17 — Internal thread control block
+
+Implement unique IDs, ownership, state transitions, completion, errors,
+join/detach, registry cleanup, and parent/child relationships at Java level.
+Use platform threads. Do not change the public Perl stub or `Config` yet.
+
+Acceptance: Java-level race, double-join/detach, cleanup, and nested-control
+tests pass without leaked threads.
+
+### Phase 18 — Basic Perl `threads` API
+
+Replace the stub with `create`/`new`/`async`, `self`, `tid`, `list`, state
+queries, `join`, `detach`, `yield`, and equality. Clone arguments into the child
+and results/errors into the joiner with context-correct return behavior.
+
+Acceptance: a selected basic compatibility tranche passes on both backends,
+while `Config useithreads` remains false for unrelated core suites.
+
+### Phase 19 — Thread termination and lifecycle
+
+Implement thread-local `threads->exit`, child `END` blocks, uncaught-error
+reporting, `error()`, nested threads, detached cleanup, and main-program shutdown
+rules. Do not use unsafe Java thread stopping.
+
+Acceptance: exit/error/lifecycle tests match system Perl for the supported API;
+limitations of `kill` are explicit.
+
+### Phase 20 — Shared storage and `threads::shared`
+
+Make `:shared` real and implement `share`, `is_shared`, and `shared_clone` for
+supported scalar/array/hash graphs. Define blessed/tied restrictions before
+exposure.
+
+Acceptance: shared identity survives clone while ordinary identity does not;
+concurrent mutations do not corrupt storage.
+
+### Phase 21 — Locks and condition variables
+
+Implement `lock`, `cond_wait`, `cond_timedwait`, `cond_signal`, and
+`cond_broadcast` with `ReentrantLock` and `Condition`.
+
+Acceptance: lexical and recursive locking, atomic wait/reacquire, timeout,
+signal/broadcast, lost-wakeup, and stress tests pass.
+
+### Phase 22 — Compatibility activation
+
+Set `Config` thread flags, implement/document import options and stringification,
+run the applicable Perl core `threads*` suites and representative CPAN suites,
+and update documents that currently call `:shared` a no-op or advertise a
+single-threaded PSGI environment.
+
+Acceptance: the supported compatibility matrix is green and the compiler is
+fully functional with ithreads advertised.
+
+### Phase 23 — Optional virtual threads and runtime pooling
+
+After correctness and diagnostics are stable, benchmark an opt-in virtual-thread
+executor and reusable runtime pools. Neither is required for Perl compatibility.
+
+Acceptance: no semantic change, no pinning surprise in supported workloads, and
+measured benefit over platform threads/full clone.
+
+## 6. Known Reference Material and Warnings
+
+- `dev/prompts/multiplicity-v2-plan.md` documents the incremental response to
+  PR #480, but its phase ordering and inventory are now stale.
+- `origin/feature/multiplicity` and `origin/feature/multiplicity-opt` contain
+  useful target-state examples.
+- Do not trust `origin/feature/multiplicity-v2` as a branch-tip reference:
+  `d87fe1885` adds regex worker binding and later `f98ce32be` removes it.
+- `dev/design/clone.md` does not meet the identity/cycle/closure requirements
+  above and must not be reused as the ithread cloning algorithm.
+- `dev/design/attributes.md` is correct that `shared` is currently a no-op; it
+  is updated only in Phase 20/22 when that changes.
+
+## 7. Progress Tracking
+
+### Current Status: Phase 1 complete; awaiting review
+
+### Completed Phases
+
+- [x] Phase 1: Import health and compiler identity safety (2026-08-10)
+  - Made the 208-entry Perl 5 import replay idempotent.
+  - Preserved CPAN provider/prerequisite/heap adaptations as importer patches.
+  - Repaired malformed Data::Dumper and stale manifest-test patches.
+  - Made compiler-generated identifiers atomic and control-flow analysis local.
+  - Added concurrent generated-class-name coverage.
+  - Validation: `make` passed; `make test-all` completed with the recorded
+    compatibility baseline (core 82.9%, bundled modules 80.8%).
+
+### Phase 1 Work Completed (2026-08-10)
+
+- [x] Audited the four files changed by `dev/import-perl5/sync.pl`.
+- [x] Identified lost PerlOnJava adaptations and a malformed Data::Dumper patch.
+- [x] Added replayable CPAN script/module/queue patches and repaired Data::Dumper.
+- [x] Repaired the stale manifest-test patch against the current Perl 5 source.
+- [x] Verified affected filtered sync operations are idempotent.
+- [x] Converted current compiler-generated ID allocation to atomic operations.
+- [x] Removed shared mutable control-flow visitor state.
+- [x] Added a concurrent generated-class-name uniqueness test.
+- [x] Ran full import replay twice with zero diff.
+- [x] Ran targeted system-Perl/JVM/interpreter tests.
+- [x] Ran full `make` and the available comprehensive gate.
+- [x] Prepared the final Phase 1 commit for review.
+
+### Next Steps
+
+1. Complete Phase 1 validation and open its PR.
+2. Merge Phase 1 before starting Phase 2.
+3. Implement the global reentrant compilation boundary in Phase 2.
+
+### Open Questions
+
+- Exact Perl-compatible cloning policy for each filehandle/native resource type.
+- Which tied and magical value classes can be safely shared in the first
+  `threads::shared` compatibility tranche.
+- Which core/CPAN thread suites define the Phase 22 minimum activation matrix.
 
 ## Related Documents
 
-- `threads.md` — Original threading specification (superseded by this document)
-- `fork.md` — Fork analysis (superseded by this document)
-- `multiplicity.md` — Multiplicity design (superseded by this document)
-- `jsr223-perlonjava-web.md` — Web integration (benefits from Phases 2 and 7)
-
-## External References
-
-- [JRuby Concurrency Wiki](https://github.com/jruby/jruby/wiki/Concurrency-in-jruby)
-- [Jython Concurrency Guide](https://jython.readthedocs.io/en/latest/Concurrency/)
-- [perlthrtut](https://perldoc.perl.org/perlthrtut) — Perl threading tutorial
-- [threads](https://perldoc.perl.org/threads) — Perl threads module documentation
-- [threads::shared](https://perldoc.perl.org/threads::shared) — Perl shared variable documentation
-- [JEP 444: Virtual Threads](https://openjdk.org/jeps/444) — Java virtual threads specification
-- [JEP 491: Synchronize Virtual Threads without Pinning](https://openjdk.org/jeps/491) — Future fix for synchronized pinning
-- [Oracle Virtual Threads Guide](https://docs.oracle.com/en/java/javase/21/core/virtual-threads.html) — Java 21 virtual threads documentation
-
----
-
-## Technical Review Summary
-
-**Review Date:** 2026-03-26  
-**Status:** APPROVED with minor recommendations
-
-### Key Findings
-
-1. **Strategy is sound:** The JRuby-inspired ThreadLocal + PerlRuntime model is correct.
-2. **Global state inventory verified:** All static mutable state correctly identified.
-3. **Perl 5 compatibility achievable:** ithreads semantics can be faithfully implemented.
-4. **Virtual threads recommended:** Use `Thread.ofVirtual()` with `ReentrantLock` (not `synchronized`).
-5. **fork() approach proven:** JRuby's 20-year track record validates returning undef.
-
-### Performance Expectations
-
-- **Thread creation:** 2-15ms (5-50x faster than Perl 5)
-- **Single-threaded overhead:** 0.25-25% from ThreadLocal routing (acceptable)
-- **Memory per runtime:** ~100KB-1MB (comparable to Perl 5)
-
-### Recommendations Incorporated
-
-- Added `threads->exit()` semantics (Section 6)
-- Added `threads->yield()` and `threads->tid()` to API (Section 6)
-- Added regex state isolation detail (Section 4, Phase 4)
-- Updated virtual thread pinning caveat with JEP 491 reference
-- Updated timeline with risk assessment
-- Moved resolved questions out of open questions
+- `dev/prompts/multiplicity-v2-plan.md` — historical incremental plan
+- `dev/design/clone.md` — historical clone exploration, not the ithread cloner
+- `dev/design/attributes.md` — current attribute behavior
+- `dev/design/fork_open_emulation.md` — process/fork-related alternatives

--- a/dev/import-perl5/config.yaml
+++ b/dev/import-perl5/config.yaml
@@ -43,6 +43,7 @@ imports:
   # CPAN client script - required by jcpan wrapper
   - source: perl5/cpan/CPAN/scripts/cpan
     target: src/main/perl/bin/cpan
+    patch: CPAN-cpan.patch
 
   - source: perl5/lib/Benchmark.pm
     target: src/main/perl/lib/Benchmark.pm
@@ -781,6 +782,16 @@ imports:
   - source: perl5/cpan/CPAN/lib/CPAN
     target: src/main/perl/lib/CPAN
     type: directory
+
+  # PerlOnJava dependency-slot and bundled-provider integration. These are
+  # replayed after the CPAN directory import so a full sync remains idempotent.
+  - source: perl5/cpan/CPAN/lib/CPAN/Module.pm
+    target: src/main/perl/lib/CPAN/Module.pm
+    patch: CPAN-Module.pm.patch
+
+  - source: perl5/cpan/CPAN/lib/CPAN/Queue.pm
+    target: src/main/perl/lib/CPAN/Queue.pm
+    patch: CPAN-Queue.pm.patch
 
   # PerlOnJava tweaks (see git history / CPAN client integration)
   - source: perl5/cpan/CPAN/lib/CPAN/HandleConfig.pm

--- a/dev/import-perl5/patches/CPAN-Module.pm.patch
+++ b/dev/import-perl5/patches/CPAN-Module.pm.patch
@@ -1,0 +1,78 @@
+--- perl5/cpan/CPAN/lib/CPAN/Module.pm
++++ src/main/perl/lib/CPAN/Module.pm
+@@ -16,0 +17,6 @@
++sub perlonjava_provider {
++    my ($self) = @_;
++    require PerlOnJava::ProviderManifest;
++    return PerlOnJava::ProviderManifest->provider_for($self->{ID});
++}
++
+@@ -460,7 +466,7 @@
+     CPAN->debug("dist-reqtype[$pack->{reqtype}]".
+                 "self-reqtype[$self->{reqtype}]") if $CPAN::DEBUG;
+         if ($pack->{reqtype}) {
+-            if ($pack->{reqtype} eq "b" && $self->{reqtype} =~ /^[rc]$/) {
++            if ($pack->{reqtype} =~ /^(?:b|t|q)$/ && $self->{reqtype} =~ /^[rc]$/) {
+                 $pack->{reqtype} = $self->{reqtype};
+                 if (
+                     exists $pack->{install}
+@@ -473,7 +479,7 @@
+                    ) {
+                     delete $pack->{install};
+                     $CPAN::Frontend->mywarn
+-                        ("Promoting $pack->{ID} from 'build_requires' to 'requires'");
++                        ("Promoting $pack->{ID} from a non-runtime prerequisite to 'requires'");
+                 }
+             }
+         } else {
+@@ -509,6 +515,14 @@
+ #-> sub CPAN::Module::test ;
+ sub test   {
+     my $self = shift;
++    if ($ENV{PERLONJAVA_PROVIDER_CONFORMANCE}) {
++        my $provider = $self->perlonjava_provider
++            or die $self->id . " is not declared in PerlOnJava's provider manifest\n";
++        $CPAN::Frontend->myprint(sprintf(
++            "Testing upstream %s conformance for PerlOnJava's %s provider (%s); installation remains disabled.\n",
++            $self->id, $provider->{provider}, $provider->{version},
++        ));
++    }
+     # $self->{badtestcnt} ||= 0;
+     $self->rematein('test',@_);
+ }
+@@ -532,6 +546,8 @@
+ #-> sub CPAN::Module::uptodate ;
+ sub uptodate {
+     my ($self) = @_;
++    my $provider = $self->perlonjava_provider;
++    return 1 if $provider && $provider->{shadow_policy} eq 'forbidden';
+     local ($_);
+     my $inst = $self->inst_version or return 0;
+     my $cpan = $self->cpan_version;
+@@ -569,6 +585,16 @@
+ #-> sub CPAN::Module::install ;
+ sub install {
+     my($self) = @_;
++    if (my $provider = $self->perlonjava_provider) {
++        if ($provider->{shadow_policy} eq 'forbidden') {
++            $CPAN::Frontend->myprint(sprintf(
++                "%s is supplied by PerlOnJava's %s provider (%s); refusing a shadowing install.\n",
++                $self->id, $provider->{provider}, $provider->{version},
++            ));
++            delete $self->{force_update};
++            return 1;
++        }
++    }
+     my($doit) = 0;
+     if ($self->uptodate
+         &&
+@@ -652,6 +678,9 @@
+ #-> sub CPAN::Module::inst_version ;
+ sub inst_version {
+     my($self) = @_;
++    if (my $provider = $self->perlonjava_provider) {
++        return $provider->{version};
++    }
+     my $parsefile = $self->inst_file or return;
+     my $have = $self->parse_version($parsefile);
+     $have;

--- a/dev/import-perl5/patches/CPAN-Queue.pm.patch
+++ b/dev/import-perl5/patches/CPAN-Queue.pm.patch
@@ -1,0 +1,34 @@
+--- perl5/cpan/CPAN/lib/CPAN/Queue.pm
++++ src/main/perl/lib/CPAN/Queue.pm
+@@ -16,1 +16,2 @@
+-# r => requires, b => build_requires, c => commandline
++# r => runtime requires, b => build requires, t => test requires,
++# q => configure requires, c => commandline
+@@ -126,14 +127,12 @@
+         # treat it as commandline
+         $what[0]{reqtype} = "c";
+     }
+-    my $inherit_reqtype = $what[0]{reqtype} =~ /^(c|r)$/ ? "r" : "b";
++    my $parent_reqtype = $what[0]{reqtype};
++    my $inherit_reqtype = $parent_reqtype =~ /^(c|r)$/ ? "r" : $parent_reqtype;
+   WHAT: for my $what_tuple (@what) {
+         my($qmod,$reqtype,$optional) = @$what_tuple{qw(qmod reqtype optional)};
+-        if ($reqtype eq "r"
+-            &&
+-            $inherit_reqtype eq "b"
+-           ) {
+-            $reqtype = "b";
++        if ($reqtype eq "r" && $inherit_reqtype =~ /^(b|t|q)$/) {
++            $reqtype = $inherit_reqtype;
+         }
+         my $jumped = 0;
+         for (my $i=0; $i<$#All;$i++) { #prevent deep recursion
+@@ -196,7 +195,7 @@
+             last;
+         } elsif ($c eq "r") {
+             $best = $c;
+-        } elsif ($c eq "b") {
++        } elsif ($c =~ /^(b|q|t)$/) {
+             if ($best eq "") {
+                 $best = $c;
+             }

--- a/dev/import-perl5/patches/CPAN-cpan.patch
+++ b/dev/import-perl5/patches/CPAN-cpan.patch
@@ -1,0 +1,15 @@
+--- perl5/cpan/CPAN/scripts/cpan
++++ src/main/perl/bin/cpan
+@@ -5,0 +6,12 @@
++
++# CPAN itself retains a large metadata graph and may need a larger heap than
++# individual distribution tests. Keep test JVMs bounded independently so a
++# parent started with a large -Xmx does not multiply that reservation across
++# every Test::Harness child. Preserve non-heap options such as -Xss.
++if (!exists $ENV{PERLONJAVA_TEST_JPERL_OPTS}) {
++    my $test_opts = $ENV{JPERL_OPTS} || '';
++    $test_opts =~ s/(?:^|\s)-Xmx\S+//g;
++    $test_opts =~ s/^\s+|\s+$//g;
++    $ENV{PERLONJAVA_TEST_JPERL_OPTS} =
++        join ' ', grep { length } $test_opts, '-Xmx768m';
++}

--- a/dev/import-perl5/patches/Data-Dumper.pm.patch
+++ b/dev/import-perl5/patches/Data-Dumper.pm.patch
@@ -1,14 +1,13 @@
 --- perl5/dist/Data-Dumper/Dumper.pm
 +++ src/main/perl/lib/Data/Dumper.pm
-@@ -580,6 +580,11 @@
+@@ -580,7 +580,9 @@
        $out .= sprintf "v%vd", $val;
      }
      # \d here would treat "1\x{660}" as a safe decimal number
+-    elsif ($val =~ /^(?:0|-?[1-9][0-9]{0,8})\z/) { # safe decimal number
 +    elsif (defined &Data::Dumper::_perlonjava_numified_safe_decimal
 +       ? Data::Dumper::_perlonjava_numified_safe_decimal($val)
 +       : $val =~ /^(?:0|-?[1-9][0-9]{0,8})\z/) {
-+      $out .= $val;
-+    }
--    elsif ($val =~ /^(?:0|-?[1-9][0-9]{0,8})\z/) { # safe decimal number
--      $out .= $val;
--    }
+       $out .= $val;
+     }
+     else {                 # string

--- a/dev/import-perl5/patches/manifest.t.patch
+++ b/dev/import-perl5/patches/manifest.t.patch
@@ -9,13 +9,14 @@
  
      my $result = runperl('progfile' => 'Porting/manisort',
                           'args'     => [ '-c', $manifest ],
-@@ -84,7 +86,8 @@
+@@ -87,7 +89,8 @@
  }
  
  SKIP: {
 -    find_git_or_skip(6);
 +    ## PerlOnJava - skip git tests (not running in perl5 git repo)
 +    skip("Not applicable in PerlOnJava - requires perl5 git repo", 6);
+     my $skip = maniskip;
      my %seen; # De-dup ls-files output (can appear more than once)
      my @repo= grep {
          chomp();

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -17,6 +17,7 @@ import org.perlonjava.runtime.runtimetypes.*;
 
 import java.math.BigInteger;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * BytecodeCompiler traverses the AST and generates interpreter bytecode.
@@ -84,7 +85,7 @@ public class BytecodeCompiler implements Visitor {
     // outermost expression's first line.
     int callerLineTokenOverride = -1;
     // Callsite ID counter for /o modifier support (unique across all compilations)
-    private static int nextCallsiteId = 1;
+    private static final AtomicInteger nextCallsiteId = new AtomicInteger(1);
     // Track last result register for expression chaining
     int lastResultReg = -1;
     // Target output register for ALIAS elimination (same save/restore pattern as currentCallContext).
@@ -5123,7 +5124,7 @@ public class BytecodeCompiler implements Visitor {
      * Each callsite with /o gets a unique ID so the pattern is compiled only once per callsite.
      */
     int allocateCallsiteId() {
-        return nextCallsiteId++;
+        return nextCallsiteId.getAndIncrement();
     }
 
     int allocateOutputRegister() {
@@ -5633,7 +5634,7 @@ public class BytecodeCompiler implements Visitor {
 
         int beginId = 0;
         if (!closureVarIndices.isEmpty()) {
-            beginId = EmitterMethodCreator.classCounter++;
+            beginId = EmitterMethodCreator.classCounter.getAndIncrement();
 
             // Store each closure variable in PersistentVariable globals
             for (int i = 0; i < closureVarNames.size(); i++) {

--- a/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
@@ -287,7 +287,7 @@ public class EvalStringHandler {
                 adjustedRegistry.put("@_", 1);
                 adjustedRegistry.put("wantarray", 2);
                 // Per-eval-invocation unique alias namespace for seeded lexicals.
-                int seedBeginId = EmitterMethodCreator.classCounter++;
+                int seedBeginId = EmitterMethodCreator.classCounter.getAndIncrement();
                 String seedPkg = PersistentVariable.beginPackage(seedBeginId);
                 int captureIndex = 0;
                 for (Map.Entry<String, Integer> entry : sortedVars) {

--- a/src/main/java/org/perlonjava/backend/jvm/Dereference.java
+++ b/src/main/java/org/perlonjava/backend/jvm/Dereference.java
@@ -14,9 +14,11 @@ import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
 import static org.perlonjava.backend.jvm.EmitSubroutine.handleSelfCallOperator;
 import static org.perlonjava.runtime.perlmodule.Strict.HINT_STRICT_REFS;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class Dereference {
     // Callsite ID counter for inline method caching (unique across all compilations)
-    private static int nextMethodCallsiteId = 0;
+    private static final AtomicInteger nextMethodCallsiteId = new AtomicInteger(0);
     
     /**
      * Handles the postfix `[]` operator.
@@ -970,7 +972,7 @@ public class Dereference {
             // pushCallContext() is a side-effect-free inline emission and can be called at each use point.
 
             // Allocate a unique callsite ID for inline method caching
-            int callsiteId = nextMethodCallsiteId++;
+            int callsiteId = nextMethodCallsiteId.getAndIncrement();
             // Perl reports the method expression start for ordinary multi-line
             // calls, but literal anon sub/block arguments report the block line.
             Object annotatedCallerLine = node.getAnnotation("callerLineTokenOverride");

--- a/src/main/java/org/perlonjava/backend/jvm/EmitEval.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitEval.java
@@ -135,7 +135,7 @@ public class EmitEval {
 
         // Generate unique identifier for this eval site
         // This counter is incremented globally, ensuring each eval gets a unique tag
-        int counter = EmitterMethodCreator.classCounter++;
+        int counter = EmitterMethodCreator.classCounter.getAndIncrement();
 
         // Create compiler options specific to this eval
         // The filename becomes "(eval N)" for better error messages

--- a/src/main/java/org/perlonjava/backend/jvm/EmitRegex.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitRegex.java
@@ -9,6 +9,7 @@ import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * The EmitRegex class is responsible for handling regex-related operations
@@ -18,7 +19,7 @@ import java.util.HashMap;
  */
 public class EmitRegex {
     // Callsite ID counter for /o modifier support (unique across all JVM compilations)
-    private static int nextCallsiteId = 100000;  // Start at 100000 to avoid collision with interpreter IDs
+    private static final AtomicInteger nextCallsiteId = new AtomicInteger(100000);
 
     private static boolean unicodeStringsEnabled(EmitterVisitor emitterVisitor) {
         return emitterVisitor.ctx.symbolTable != null
@@ -318,7 +319,7 @@ public class EmitRegex {
 
         // Create the regex matcher (use 3-argument version for /o or m?PAT?)
         if (needsCallsiteCache) {
-            int callsiteId = nextCallsiteId++;
+            int callsiteId = nextCallsiteId.getAndIncrement();
             emitterVisitor.ctx.mv.visitLdcInsn(callsiteId);
             emitterVisitor.ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                     "org/perlonjava/runtime/regex/RuntimeRegex", "getQuotedRegex",

--- a/src/main/java/org/perlonjava/backend/jvm/EmitterMethodCreator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitterMethodCreator.java
@@ -27,6 +27,7 @@ import java.lang.reflect.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * EmitterMethodCreator is a utility class that uses the ASM library to dynamically generate Java
@@ -70,13 +71,13 @@ public class EmitterMethodCreator implements Opcodes {
         SPILL_SLOT_COUNT = (s != null) ? Integer.parseInt(s) : 16;
     }
     // Number of local variables to skip when processing a closure (this, @_, wantarray)
-    public static int skipVariables = 3;
+    public static final int skipVariables = 3;
     // Counter for generating unique class names
-    public static int classCounter = 0;
+    public static final AtomicInteger classCounter = new AtomicInteger(0);
 
     // Generate a unique internal class name
     public static String generateClassName() {
-        return "org/perlonjava/anon" + classCounter++;
+        return "org/perlonjava/anon" + classCounter.getAndIncrement();
     }
 
     private static String insnToString(AbstractInsnNode n) {

--- a/src/main/java/org/perlonjava/backend/jvm/astrefactor/LargeBlockRefactorer.java
+++ b/src/main/java/org/perlonjava/backend/jvm/astrefactor/LargeBlockRefactorer.java
@@ -24,9 +24,6 @@ import static org.perlonjava.backend.jvm.astrefactor.BlockRefactor.*;
  */
 public class LargeBlockRefactorer {
 
-    // Reusable visitor for control flow detection
-    private static final ControlFlowDetectorVisitor controlFlowDetector = new ControlFlowDetectorVisitor();
-
     private static long estimateTotalBytecodeSizeCapped(List<Node> nodes, long capInclusive) {
         long total = 0;
         for (Node node : nodes) {
@@ -103,7 +100,7 @@ public class LargeBlockRefactorer {
     private static boolean tryWholeBlockRefactoring(EmitterVisitor emitterVisitor, BlockNode node) {
         // Check for unsafe control flow using ControlFlowDetectorVisitor
         // This properly handles loop depth - unlabeled next/last/redo inside loops are safe
-        controlFlowDetector.reset();
+        ControlFlowDetectorVisitor controlFlowDetector = new ControlFlowDetectorVisitor();
         controlFlowDetector.scan(node);
         if (controlFlowDetector.hasUnsafeControlFlow()) {
             return false;

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -565,7 +565,7 @@ public class OperatorParser {
             if (operator.equals("state")) {
                 // Give the variable a persistent id (See: PersistentVariable.java)
                 if (operandNode.id == 0) {
-                    operandNode.id = EmitterMethodCreator.classCounter++;
+                    operandNode.id = EmitterMethodCreator.classCounter.getAndIncrement();
                 }
             }
 

--- a/src/main/java/org/perlonjava/frontend/parser/SpecialBlockParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SpecialBlockParser.java
@@ -282,7 +282,7 @@ public class SpecialBlockParser {
                     isFromOuterScope = RuntimeCode.evalBeginIds.containsKey(ast);
                     int beginId = RuntimeCode.evalBeginIds.computeIfAbsent(
                             ast,
-                            k -> EmitterMethodCreator.classCounter++);
+                            k -> EmitterMethodCreator.classCounter.getAndIncrement());
                     packageName = PersistentVariable.beginPackage(beginId);
                     // Emit: package BEGIN_PKG
                     nodes.add(

--- a/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
@@ -366,7 +366,7 @@ public class StatementResolver {
 
                                 // For state variables, assign a unique ID for persistent tracking
                                 if (declaration.equals("state")) {
-                                    innerVarNode.id = EmitterMethodCreator.classCounter++;
+                                    innerVarNode.id = EmitterMethodCreator.classCounter.getAndIncrement();
                                 }
 
                                 // Now create the outer declaration node (state/my $hiddenVarName)

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -1483,7 +1483,7 @@ public class SubroutineParser {
                     } else {
                         beginId = RuntimeCode.evalBeginIds.computeIfAbsent(
                                 ast,
-                                k -> EmitterMethodCreator.classCounter++);
+                                k -> EmitterMethodCreator.classCounter.getAndIncrement());
                     }
                     variableName = NameNormalizer.normalizeVariableName(
                             entry.name().substring(1),

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Symbol.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Symbol.java
@@ -49,7 +49,7 @@ public class Symbol extends PerlModuleBase {
      */
     public static RuntimeList gensym(RuntimeArray args, int ctx) {
         // Create a unique anonymous glob
-        String globName = "Symbol::GEN" + EmitterMethodCreator.classCounter++;
+        String globName = "Symbol::GEN" + EmitterMethodCreator.classCounter.getAndIncrement();
         RuntimeGlob glob = new RuntimeGlob(globName);
         
         // Return a reference to the glob (not the glob itself)
@@ -101,7 +101,7 @@ public class Symbol extends PerlModuleBase {
      */
     public static RuntimeList geniosym(RuntimeArray args, int ctx) {
         // Create a unique anonymous glob (same as gensym)
-        String globName = "Symbol::GEN" + EmitterMethodCreator.classCounter++;
+        String globName = "Symbol::GEN" + EmitterMethodCreator.classCounter.getAndIncrement();
         RuntimeGlob glob = new RuntimeGlob(globName);
 
         // Initialize the IO slot (equivalent to Perl's: select(select $sym))

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -2012,7 +2012,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                             if (ast != null) {
                                 int beginId = evalBeginIds.computeIfAbsent(
                                         ast,
-                                        k -> EmitterMethodCreator.classCounter++);
+                                        k -> EmitterMethodCreator.classCounter.getAndIncrement());
                                 String packageName = PersistentVariable.beginPackage(beginId);
                                 String varNameWithoutSigil = entry.name().substring(1);
                                 String fullName = packageName + "::" + varNameWithoutSigil;
@@ -2467,7 +2467,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                             if (operatorAst != null) {
                                 int beginId = evalBeginIds.computeIfAbsent(
                                         operatorAst,
-                                        k -> EmitterMethodCreator.classCounter++);
+                                        k -> EmitterMethodCreator.classCounter.getAndIncrement());
                                 String packageName = PersistentVariable.beginPackage(beginId);
                                 String varNameWithoutSigil = entry.name().substring(1);
                                 String fullName = packageName + "::" + varNameWithoutSigil;

--- a/src/test/java/org/perlonjava/backend/jvm/EmitterMethodCreatorConcurrencyTest.java
+++ b/src/test/java/org/perlonjava/backend/jvm/EmitterMethodCreatorConcurrencyTest.java
@@ -1,0 +1,46 @@
+package org.perlonjava.backend.jvm;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("unit")
+class EmitterMethodCreatorConcurrencyTest {
+
+    @Test
+    void generatedClassNamesRemainUniqueAcrossThreads() throws InterruptedException {
+        int workerCount = 12;
+        int namesPerWorker = 1_000;
+        Set<String> names = ConcurrentHashMap.newKeySet();
+        CountDownLatch ready = new CountDownLatch(workerCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(workerCount);
+
+        for (int worker = 0; worker < workerCount; worker++) {
+            Thread.ofPlatform().start(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    for (int i = 0; i < namesPerWorker; i++) {
+                        names.add(EmitterMethodCreator.generateClassName());
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        ready.await();
+        start.countDown();
+        done.await();
+
+        assertEquals(workerCount * namesPerWorker, names.size());
+    }
+}


### PR DESCRIPTION
## Summary

- finalize the Perl ithreads implementation plan as independently shippable, green-build PR phases
- preserve PerlOnJava CPAN and Data::Dumper adaptations as reproducible import patches
- repair the stale manifest-test patch and make the complete 208-entry Perl import replay idempotent
- allocate compiler-generated class and call-site identifiers atomically
- remove shared mutable state from large-block control-flow detection
- add concurrent generated-class-name uniqueness coverage

## Phase boundary

This is Phase 1 only. It introduces compiler identity safety but does not yet claim concurrent compilation or advertise Perl threads. Phase 2 will add the global reentrant compilation boundary after this PR merges.

## Validation

- full 208-entry import replay succeeds twice with zero diff
- focused system Perl: 5 files, 103 tests pass
- `make`: BUILD SUCCESSFUL
- `make test-all`: completes successfully; recorded compatibility baseline is core 82.9% and bundled modules 80.8%
- Scalar::Util JVM and interpreter smoke: 1.70

Generated with [Codex](https://openai.com/codex/)
