### PR TITLE
Fix compiler and CPAN tooling across legacy modules

### DIFF
--- a/dev/tools/perl_test_runner.pl
+++ b/dev/tools/perl_test_runner.pl
@@ -417,9 +417,14 @@ sub run_single_test {
 sub timeout_for_test {
     my ($test_file) = @_;
 
+    # The through-pipe matrix starts hundreds of child processes and performs
+    # blocking reads for each read/write combination.  Give both line-ending
+    # variants twice the caller's normal allowance, while keeping custom
+    # --timeout values proportional and leaving every other test unchanged.
+    return $timeout * 2 if $test_file =~ m{(?:^|/)perl5_t/t/io/(?:crlf_)?through\.t$};
+
     return 600 if $test_file =~ m{
           (?:^|/)perl5_t/t/lib/croak\.t$
-        | (?:^|/)perl5_t/t/io/(?:crlf_)?through\.t$
         | (?:^|/)perl5_t/t/re/pat\.t$
     }x && $timeout < 600;
     return $timeout;

--- a/src/main/java/org/perlonjava/app/cli/ArgumentParser.java
+++ b/src/main/java/org/perlonjava/app/cli/ArgumentParser.java
@@ -1459,6 +1459,18 @@ public class ArgumentParser {
             }
         }
 
+        // The Perl test harness may protect a value containing spaces with
+        // an outer pair of quotes.  The shell removes those quotes for a
+        // native Perl invocation; jperl receives them literally when the
+        // launcher has already tokenized the argument.
+        if (varValue.length() >= 2) {
+            char first = varValue.charAt(0);
+            char last = varValue.charAt(varValue.length() - 1);
+            if ((first == '\'' && last == '\'') || (first == '"' && last == '"')) {
+                varValue = varValue.substring(1, varValue.length() - 1);
+            }
+        }
+
         // Add the variable assignment to be prepended to the code
         if (parsedArgs.rudimentarySwitchAssignments == null) {
             parsedArgs.rudimentarySwitchAssignments = new StringBuilder();

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -2300,7 +2300,8 @@ public class BytecodeInterpreter {
                                  Opcodes.GETLOGIN, Opcodes.GETPWNAM, Opcodes.GETPWUID,
                                  Opcodes.GETGRNAM, Opcodes.GETGRGID, Opcodes.GETGRENT,
                                  Opcodes.SETGRENT, Opcodes.ENDGRENT,
-                                 Opcodes.GETHOSTBYADDR, Opcodes.GETSERVBYNAME,
+                                 Opcodes.GETHOSTBYNAME, Opcodes.GETHOSTBYADDR,
+                                 Opcodes.GETSERVBYNAME,
                                  Opcodes.GETSERVBYPORT, Opcodes.GETPROTOBYNAME,
                                  Opcodes.GETPROTOBYNUMBER, Opcodes.ENDHOSTENT,
                                  Opcodes.ENDNETENT, Opcodes.ENDPROTOENT,
@@ -3573,6 +3574,9 @@ public class BytecodeInterpreter {
             }
             case Opcodes.GETHOSTBYADDR -> {
                 return MiscOpcodeHandler.execute(Opcodes.GETHOSTBYADDR, bytecode, pc, registers);
+            }
+            case Opcodes.GETHOSTBYNAME -> {
+                return MiscOpcodeHandler.execute(Opcodes.GETHOSTBYNAME, bytecode, pc, registers);
             }
             case Opcodes.GETSERVBYNAME -> {
                 return MiscOpcodeHandler.execute(Opcodes.GETSERVBYNAME, bytecode, pc, registers);

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -1480,6 +1480,10 @@ public class CompileOperator {
                 arrayReg = bc.allocateRegister();
                 if (bc.isStrictRefsEnabled()) { bc.emitWithToken(Opcodes.DEREF_ARRAY, node.getIndex()); bc.emitReg(arrayReg); bc.emitReg(refReg); }
                 else { int pkgIdx = bc.addToStringPool(bc.getCurrentPackage()); bc.emitWithToken(Opcodes.DEREF_ARRAY_NONSTRICT, node.getIndex()); bc.emitReg(arrayReg); bc.emitReg(refReg); bc.emit(pkgIdx); }
+            } else if (operandOp.operator.equals("@")) {
+                // `$#{@{...}}` already produces the dereferenced array.
+                operandOp.accept(bc);
+                arrayReg = bc.lastResultReg;
             } else bc.throwCompilerException("$# requires array variable or dereferenced array");
         } else if (node.operand instanceof IdentifierNode) {
             String varName = "@" + ((IdentifierNode) node.operand).name;

--- a/src/main/java/org/perlonjava/frontend/parser/Variable.java
+++ b/src/main/java/org/perlonjava/frontend/parser/Variable.java
@@ -128,6 +128,24 @@ public class Variable {
             return new StringNode("", parser.tokenIndex);
         }
 
+        // `$#{@{...}}` is the last-index operator applied to a braced array
+        // dereference. Do not treat the `{` as hash access on a variable
+        // named `@`; parse the array expression as the operand of `$#`.
+        if (sigil.equals("$#") && nextNonWsToken.text.equals("{")) {
+            int contentIndex = Whitespace.skipWhitespace(parser, nextNonWsIndex + 1, parser.tokens);
+            if (contentIndex < parser.tokens.size()
+                    && parser.tokens.get(contentIndex).text.equals("@")) {
+                parser.tokenIndex = nextNonWsIndex;
+                TokenUtils.consume(parser, LexerTokenType.OPERATOR, "{");
+                Node arrayExpression = parser.parseExpression(0);
+                if (!TokenUtils.peek(parser).text.equals("}")) {
+                    parser.throwError("Missing closing brace in $# array expression");
+                }
+                TokenUtils.consume(parser, LexerTokenType.OPERATOR, "}");
+                return new OperatorNode("$#", arrayExpression, parser.tokenIndex);
+            }
+        }
+
         // Special case 3: ${...}, @{...}, %{...} - braced variable forms
         // PRE-CHECK: If next token is '{', skip identifier parsing and go directly to parseBracedVariable
         // This avoids backtracking and heredoc processing issues

--- a/src/main/java/org/perlonjava/runtime/ForkOpenCompleteException.java
+++ b/src/main/java/org/perlonjava/runtime/ForkOpenCompleteException.java
@@ -1,6 +1,7 @@
 package org.perlonjava.runtime;
 
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+import org.perlonjava.runtime.runtimetypes.RuntimeCode;
 
 /**
  * Exception thrown when a fork-open emulation completes successfully.
@@ -34,6 +35,9 @@ public class ForkOpenCompleteException extends RuntimeException {
      * The filehandle that was set up with the pipe.
      */
     public final RuntimeScalar fileHandle;
+
+    /** The Perl code frame that opened the emulated pipe. */
+    public final RuntimeCode boundaryCode;
     
     /**
      * Creates a new ForkOpenCompleteException.
@@ -43,9 +47,15 @@ public class ForkOpenCompleteException extends RuntimeException {
      * @param fileHandle The configured filehandle
      */
     public ForkOpenCompleteException(long pid, String capturedOutput, RuntimeScalar fileHandle) {
+        this(pid, capturedOutput, fileHandle, null);
+    }
+
+    public ForkOpenCompleteException(long pid, String capturedOutput, RuntimeScalar fileHandle,
+                                     RuntimeCode boundaryCode) {
         super("Fork-open completed successfully");
         this.pid = pid;
         this.capturedOutput = capturedOutput;
         this.fileHandle = fileHandle;
+        this.boundaryCode = boundaryCode;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/ForkOpenState.java
+++ b/src/main/java/org/perlonjava/runtime/ForkOpenState.java
@@ -1,6 +1,7 @@
 package org.perlonjava.runtime;
 
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+import org.perlonjava.runtime.runtimetypes.RuntimeCode;
 
 /**
  * Thread-local state for fork-open emulation.
@@ -60,11 +61,16 @@ public class ForkOpenState {
         
         /** I/O layers to apply (e.g., ":utf8") */
         public final String ioLayers;
+
+        /** The Perl subroutine that initiated the fork-open operation. */
+        public final RuntimeCode boundaryCode;
         
-        public PendingForkOpen(RuntimeScalar fileHandle, int tokenIndex, String ioLayers) {
+        public PendingForkOpen(RuntimeScalar fileHandle, int tokenIndex, String ioLayers,
+                               RuntimeCode boundaryCode) {
             this.fileHandle = fileHandle;
             this.tokenIndex = tokenIndex;
             this.ioLayers = ioLayers != null ? ioLayers : "";
+            this.boundaryCode = boundaryCode;
         }
     }
     
@@ -79,7 +85,8 @@ public class ForkOpenState {
      * @param ioLayers Optional I/O layers (e.g., ":utf8")
      */
     public static void setPending(RuntimeScalar fileHandle, int tokenIndex, String ioLayers) {
-        pendingState.set(new PendingForkOpen(fileHandle, tokenIndex, ioLayers));
+        pendingState.set(new PendingForkOpen(fileHandle, tokenIndex, ioLayers,
+                RuntimeCode.getActiveCodeAt(0)));
     }
     
     /**

--- a/src/main/java/org/perlonjava/runtime/nativ/ExtendedNativeUtils.java
+++ b/src/main/java/org/perlonjava/runtime/nativ/ExtendedNativeUtils.java
@@ -276,18 +276,15 @@ public class ExtendedNativeUtils extends NativeUtils {
 
     // ================== Network Information Functions ==================
 
-    public static RuntimeArray gethostbyname(int ctx, RuntimeBase... args) {
-        if (args.length < 1) return new RuntimeArray();
+    public static RuntimeBase gethostbyname(int ctx, RuntimeBase... args) {
+        if (args.length < 1) return ctx == SCALAR ? RuntimeScalarCache.scalarUndef : new RuntimeArray();
         String hostname = args[0].toString();
 
         String cacheKey = "host:" + hostname;
         if (hostInfoCache.containsKey(cacheKey)) {
             RuntimeArray cached = hostInfoCache.get(cacheKey);
             if (ctx == SCALAR && cached.size() >= 5) {
-                RuntimeBase packedAddress = cached.get(4);
-                RuntimeArray scalarResult = new RuntimeArray();
-                RuntimeArray.push(scalarResult, packedAddress);
-                return scalarResult;
+                return cached.get(4);
             }
             return cached;
         }
@@ -309,9 +306,7 @@ public class ExtendedNativeUtils extends NativeUtils {
             hostInfoCache.put(cacheKey, result);
 
             if (ctx == SCALAR) {
-                RuntimeArray scalarResult = new RuntimeArray();
-                RuntimeArray.push(scalarResult, packedAddress);
-                return scalarResult;
+                return packedAddress;
             }
         } catch (Exception e) {
         }
@@ -828,7 +823,7 @@ public class ExtendedNativeUtils extends NativeUtils {
 
         if (iterator.hasNext()) {
             String hostname = iterator.next();
-            return gethostbyname(ctx, new RuntimeScalar(hostname));
+            return (RuntimeArray) gethostbyname(RuntimeContextType.LIST, new RuntimeScalar(hostname));
         }
 
         return new RuntimeArray();

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -687,8 +687,13 @@ public class IOOperator {
         String mode = args[1].toString();
         RuntimeList runtimeList = new RuntimeList(Arrays.copyOfRange(args, 1, args.length));
 
-        // Clear any stale pending fork-open state before new open operation
-        ForkOpenState.clear();
+        // Preserve a pending fork-open while the child redirects STDOUT/ERR
+        // before exec.  The emulated child runs on this same JVM thread, so
+        // those setup opens must not erase the state that the subsequent exec
+        // consumes.  exec() and close() clear it when the operation completes.
+        if (!ForkOpenState.hasPending()) {
+            ForkOpenState.clear();
+        }
 
         RuntimeIO fh;
 

--- a/src/main/java/org/perlonjava/runtime/operators/OperatorHandler.java
+++ b/src/main/java/org/perlonjava/runtime/operators/OperatorHandler.java
@@ -217,7 +217,7 @@ public record OperatorHandler(String className, String methodName, int methodTyp
         put("endgrent", "endgrent", "org/perlonjava/runtime/nativ/ExtendedNativeUtils", "(I[Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");
 
         // Network Information Functions
-        put("gethostbyname", "gethostbyname", "org/perlonjava/runtime/nativ/ExtendedNativeUtils", "(I[Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)Lorg/perlonjava/runtime/runtimetypes/RuntimeArray;");
+        put("gethostbyname", "gethostbyname", "org/perlonjava/runtime/nativ/ExtendedNativeUtils", "(I[Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;");
         put("gethostbyaddr", "gethostbyaddr", "org/perlonjava/runtime/nativ/ExtendedNativeUtils", "(I[Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)Lorg/perlonjava/runtime/runtimetypes/RuntimeArray;");
         put("getservbyname", "getservbyname", "org/perlonjava/runtime/nativ/ExtendedNativeUtils", "(I[Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)Lorg/perlonjava/runtime/runtimetypes/RuntimeArray;");
         put("getservbyport", "getservbyport", "org/perlonjava/runtime/nativ/ExtendedNativeUtils", "(I[Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)Lorg/perlonjava/runtime/runtimetypes/RuntimeArray;");

--- a/src/main/java/org/perlonjava/runtime/operators/SystemOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/SystemOperator.java
@@ -5,6 +5,7 @@ import org.perlonjava.runtime.ForkOpenCompleteException;
 import org.perlonjava.runtime.ForkOpenState;
 import org.perlonjava.runtime.io.IOHandle;
 import org.perlonjava.runtime.io.LayeredIOHandle;
+import org.perlonjava.runtime.io.ProcessInputHandle;
 import org.perlonjava.runtime.mro.InheritanceResolver;
 import org.perlonjava.runtime.nativ.NativeUtils;
 import org.perlonjava.runtime.runtimetypes.*;
@@ -13,6 +14,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -171,7 +173,6 @@ public class SystemOperator {
         checkTaintEnvironment();
         // Flatten the arguments - arrays and lists should be expanded to individual elements
         List<String> flattenedArgs = flattenToStringList(args.elements);
-        
         if (flattenedArgs.isEmpty()) {
             throw new PerlCompilerException("system: no command specified");
         }
@@ -1008,7 +1009,7 @@ public class SystemOperator {
         checkTaintEnvironment();
         // Flatten the arguments - arrays and lists should be expanded to individual elements
         List<String> flattenedArgs = flattenToStringList(args.elements);
-        
+
         if (flattenedArgs.isEmpty()) {
             // Perl returns false and sets errno (typically ENOENT) — does not die.
             getGlobalVariable("main::!").set(2);
@@ -1082,7 +1083,7 @@ public class SystemOperator {
         
         try {
             flushAllHandles();
-            
+
             // Build the command - mirror the logic from exec() for consistency
             List<String> command;
             if (hasHandle && flattenedArgs.size() >= 2) {
@@ -1110,13 +1111,13 @@ public class SystemOperator {
             } else {
                 command = flattenedArgs;
             }
-            
+
             // Run command and capture output
             ProcessBuilder processBuilder = new ProcessBuilder(resolveCommandForProcessBuilder(command));
             processBuilder.directory(new File(System.getProperty("user.dir")));
             copyPerlEnvToProcessBuilder(processBuilder);
             processBuilder.redirectErrorStream(false);  // Keep stderr separate
-            
+
             Process process = processBuilder.start();
             
             // Read all output as raw bytes to preserve exact output
@@ -1136,11 +1137,27 @@ public class SystemOperator {
             // Set $? to the exit status
             setGlobalVariable("main::?", String.valueOf(exitCode << 8));
             
-            // Throw exception to return control to caller with captured output
+            // The child-side exec can be wrapped in helper subroutines (Git.pm
+            // is one example).  Install the captured output into the original
+            // filehandle before unwinding to the subroutine that opened it.
+            RuntimeIO input = new RuntimeIO(new ProcessInputHandle(
+                    new ByteArrayInputStream(capturedOutput.getBytes(StandardCharsets.ISO_8859_1))));
+            RuntimeIO existing = pending.fileHandle.getRuntimeIO();
+            if (existing != null) {
+                existing.replaceStateFrom(input);
+            } else if (pending.fileHandle.value instanceof RuntimeGlob glob) {
+                glob.setIO(input);
+            } else {
+                pending.fileHandle.set(input);
+            }
+
+            // Throw exception to unwind helper subs and resume at the
+            // subroutine that initiated the fork-open.
             throw new ForkOpenCompleteException(
                     process.pid(),
                     capturedOutput,
-                    pending.fileHandle
+                    pending.fileHandle,
+                    pending.boundaryCode
             );
             
         } catch (ForkOpenCompleteException e) {
@@ -1150,7 +1167,7 @@ public class SystemOperator {
             // Command failed to run
             setGlobalVariable("main::!", e.getMessage());
             // Throw with empty output on failure
-            throw new ForkOpenCompleteException(0, "", pending.fileHandle);
+            throw new ForkOpenCompleteException(0, "", pending.fileHandle, pending.boundaryCode);
         }
     }
 

--- a/src/main/java/org/perlonjava/runtime/operators/sprintf/SprintfNumericFormatter.java
+++ b/src/main/java/org/perlonjava/runtime/operators/sprintf/SprintfNumericFormatter.java
@@ -321,19 +321,14 @@ public class SprintfNumericFormatter {
                     requestedPrecision, precision, conversion);
         }
 
-        // Java Formatter rounds large integral doubles through a short decimal
-        // representation (2^64 becomes 18446744073709552000). Perl formats the
-        // exact binary value, which matters once nvsize exposes the 64-bit
-        // sprintf matrix.
-        if ((conversion == 'f' || conversion == 'F') && precision == 0
-                && Double.isFinite(value) && Math.abs(value) >= 0x1.0p53
-                && value == Math.rint(value)) {
-            String result = new BigDecimal(value).setScale(0, RoundingMode.HALF_UP).toPlainString();
-            if (value >= 0) {
-                if (cleanFlags.contains("+")) result = "+" + result;
-                else if (cleanFlags.contains(" ")) result = " " + result;
-            }
-            return SprintfPaddingHelper.applyWidth(result, width, cleanFlags);
+        // Perl delegates decimal floating-point formatting to printf, whose
+        // default IEEE-754 rounding mode is ties-to-even. Java Formatter uses
+        // half-up for decimal conversions instead (for example, %.0f formats
+        // 2.5 as 3), which changes real calculations at exact half-way values.
+        // Format %f/%F from the exact binary double so both ordinary rounding
+        // and exact ties agree with Perl.
+        if (conversion == 'f' || conversion == 'F') {
+            return formatFixedPoint(value, cleanFlags, width, precision);
         }
 
         // Build format string for String.format
@@ -359,6 +354,26 @@ public class SprintfNumericFormatter {
         // Perl uses 'Inf' instead of Java's 'Infinity'
         result = result.replace("Infinity", "Inf");
         return result;
+    }
+
+    private String formatFixedPoint(double value, String flags, int width, int precision) {
+        boolean negative = Double.doubleToRawLongBits(value) < 0;
+        BigDecimal magnitude = new BigDecimal(Math.abs(value));
+        String result = magnitude.setScale(precision, RoundingMode.HALF_EVEN).toPlainString();
+
+        if (precision == 0 && flags.contains("#")) {
+            result += ".";
+        }
+
+        if (negative) {
+            result = "-" + result;
+        } else if (flags.contains("+")) {
+            result = "+" + result;
+        } else if (flags.contains(" ")) {
+            result = " " + result;
+        }
+
+        return SprintfPaddingHelper.applyWidth(result, width, flags);
     }
 
     private String formatHexFloatingPoint(double value, String flags, int width,

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Socket.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Socket.java
@@ -204,10 +204,6 @@ public class Socket extends PerlModuleBase {
             if (ipAddress.length() == 4) {
                 // Already in binary format
                 ipBytes = ipAddress.getBytes(StandardCharsets.ISO_8859_1);
-            } else if (ipAddress.length() == 1) {
-                // Handle case where gethostbyname returns a single character in scalar context
-                // This is likely a bug - let's use localhost IP as fallback
-                ipBytes = new byte[]{127, 0, 0, 1}; // 127.0.0.1
             } else {
                 // Parse as dotted decimal notation
                 String[] parts = ipAddress.split("\\.");

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -44,7 +44,12 @@ final class JoniRegexPattern {
         // Oniguruma's MULTILINE option controls whether dot matches newline.
         if (flags.isDotAll()) options |= Option.MULTILINE;
         if (flags.isAscii()) options |= Option.ASCII_RANGE;
+        // Ruby/Oniguruma syntax implicitly makes unnamed groups non-capturing
+        // when a pattern also contains named groups. Perl keeps both kinds of
+        // captures numbered. Force that behavior unless /n explicitly disables
+        // unnamed captures.
         if (flags.isNonCapturing()) options |= Option.DONT_CAPTURE_GROUP;
+        else options |= Option.CAPTURE_GROUP;
         return options;
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -5472,7 +5472,10 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             Throwable targetException = e.getTargetException();
             // Handle fork-open completion (from exec in fork-open emulation)
             if (targetException instanceof ForkOpenCompleteException forkEx) {
-                return forkOpenOutputToList(forkEx.capturedOutput, callContext);
+                if (forkEx.boundaryCode != null && forkEx.boundaryCode != this) {
+                    throw forkEx;
+                }
+                return forkOpenResult(forkEx, callContext);
             }
             if (targetException instanceof RuntimeException re) {
                 throw re;
@@ -5480,7 +5483,10 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             throw new RuntimeException(targetException);
         } catch (ForkOpenCompleteException e) {
             // Handle fork-open completion (from exec in fork-open emulation)
-            return forkOpenOutputToList(e.capturedOutput, callContext);
+            if (e.boundaryCode != null && e.boundaryCode != this) {
+                throw e;
+            }
+            return forkOpenResult(e, callContext);
         } catch (RuntimeException e) {
             throw e;
         } catch (Throwable e) {
@@ -5605,7 +5611,10 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             Throwable targetException = e.getTargetException();
             // Handle fork-open completion (from exec in fork-open emulation)
             if (targetException instanceof ForkOpenCompleteException forkEx) {
-                return forkOpenOutputToList(forkEx.capturedOutput, callContext);
+                if (forkEx.boundaryCode != null && forkEx.boundaryCode != this) {
+                    throw forkEx;
+                }
+                return forkOpenResult(forkEx, callContext);
             }
             if (targetException instanceof RuntimeException re) {
                 throw re;
@@ -5613,7 +5622,10 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             throw new RuntimeException(targetException);
         } catch (ForkOpenCompleteException e) {
             // Handle fork-open completion (from exec in fork-open emulation)
-            return forkOpenOutputToList(e.capturedOutput, callContext);
+            if (e.boundaryCode != null && e.boundaryCode != this) {
+                throw e;
+            }
+            return forkOpenResult(e, callContext);
         } catch (RuntimeException e) {
             throw e;
         } catch (Throwable e) {
@@ -5646,6 +5658,15 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             return new RuntimeList(arr);
         }
         return new RuntimeList(new RuntimeScalar(capturedOutput));
+    }
+
+    private static RuntimeList forkOpenResult(ForkOpenCompleteException exception, int callContext) {
+        if (exception.boundaryCode == null) {
+            return forkOpenOutputToList(exception.capturedOutput, callContext);
+        }
+        RuntimeList result = new RuntimeList();
+        result.add(exception.fileHandle);
+        return result;
     }
 
     /**

--- a/src/main/perl/lib/Module/Build/Base.pm
+++ b/src/main/perl/lib/Module/Build/Base.pm
@@ -86,8 +86,13 @@ if (!$loaded) {
 
         # Merge our local blib additions with whatever PERL5LIB CPAN already set
         my @added = $self->_added_to_INC;
+        # Module::Build's generated helper scripts run in a fresh jperl
+        # process.  Dependency paths that Build.PL added directly to @INC
+        # are otherwise lost when that child receives only PERL5LIB.
+        push @added, grep { defined $_ && length $_ && $_ !~ /^jar:/ && -d $_ } @INC;
         my $sep   = $self->config('path_sep');
-        my @parts = @added;
+        my %seen;
+        my @parts = grep { !$seen{$_}++ } @added;
         push @parts, $ENV{PERL5LIB}
             if defined $ENV{PERL5LIB} && length $ENV{PERL5LIB};
         local $ENV{PERL5LIB} = join $sep, @parts;

--- a/src/main/perl/lib/PerlOnJava/CpanDistroprefs/Class-DBI.yml
+++ b/src/main/perl/lib/PerlOnJava/CpanDistroprefs/Class-DBI.yml
@@ -7,6 +7,6 @@ comment: |
   HasA cache lookup, so a false-overloaded live object is not treated as a
   cache miss.
 match:
-  distribution: "^.*/Class-DBI-"
+  distribution: "^.*/Class-DBI-v?[0-9]"
 patches:
   - "Class-DBI/Class-DBI.pm.patch"

--- a/src/test/resources/unit/cpan_distroprefs_class_dbi_match.t
+++ b/src/test/resources/unit/cpan_distroprefs_class_dbi_match.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More;
+use CPAN::Distroprefs;
+
+my $pref = CPAN::Distroprefs::Pref->new({
+    data => {
+        match => {
+            distribution => '^.*/Class-DBI-v?[0-9]',
+        },
+        patches => [ 'Class-DBI/Class-DBI.pm.patch' ],
+    },
+});
+
+my %match_info = (
+    distribution => 'TMTM/Class-DBI-v3.0.17.tar.gz',
+    module       => [],
+    perl         => $^X,
+    perlconfig   => {},
+    env          => {},
+);
+
+ok(
+    $pref->matches(\%match_info),
+    'Class-DBI distropref matches the main Class-DBI distribution',
+);
+
+$match_info{distribution} = 'TMTM/Class-DBI-Search-Count-1.00.tar.gz';
+ok(
+    !$pref->matches(\%match_info),
+    'Class-DBI distropref does not match Class-DBI-Search-Count',
+);
+
+done_testing;

--- a/src/test/resources/unit/gethostbyname_context.t
+++ b/src/test/resources/unit/gethostbyname_context.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $packed = gethostbyname('127.0.0.1');
+is(length($packed), 4, 'scalar gethostbyname returns a packed IPv4 address');
+is(unpack('H*', $packed), '7f000001', 'scalar address contains the requested IPv4 bytes');
+
+my @host = gethostbyname('127.0.0.1');
+is(scalar @host, 5, 'list gethostbyname returns the host entry fields');
+is(length($host[4]), 4, 'list address field remains packed');
+
+done_testing;

--- a/src/test/resources/unit/regex_recursive_named_and_numbered_captures.t
+++ b/src/test/resources/unit/regex_recursive_named_and_numbered_captures.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $nested_parentheses = qr{
+    (?<nested> \( (?: [^()]++ | (?&nested)++ )*+ \) )
+}x;
+
+my $source = "sub autosplit_target {\n";
+ok(
+    $source =~ /^sub\s+([\w:]+)(\s*(?:\(.*?\))?(?:$nested_parentheses)?)/,
+    'recursive interpolated pattern matches without its optional branch',
+);
+is($1, 'autosplit_target', 'unnamed capture remains numbered beside named recursion');
+is($2, ' ', 'second unnamed capture retains its Perl group number');
+ok(!defined $+{nested}, 'optional named recursive capture did not participate');
+
+done_testing;

--- a/src/test/resources/unit/sprintf_ties_to_even.t
+++ b/src/test/resources/unit/sprintf_ties_to_even.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use Test::More;
+
+is(sprintf('%.0f', 1.5), '2', 'rounds an odd lower integer up at a tie');
+is(sprintf('%.0f', 2.5), '2', 'rounds an even lower integer down at a tie');
+is(sprintf('%.0f', -2.5), '-2', 'rounds negative ties to even');
+is(sprintf('%#.0f', 2.5), '2.', 'alternate form keeps the decimal point');
+is(sprintf('%+06.0f', 2.5), '+00002', 'sign and zero padding follow tie-to-even rounding');
+is(sprintf('%.0f', 2400 - 15 * 0.5), '2392',
+   'rating calculation at an exact half rounds like Perl');
+
+done_testing;


### PR DESCRIPTION
## Summary

- Fix fork-open emulation for Git.pm helper calls, preserve captured child output, and propagate active `@INC` paths through Module::Build helpers.
- Improve command-line `-s` handling, array last-index parsing, and timeout allocation for subprocess-heavy core tests.
- Narrow the Class::DBI distropref so it cannot match Class::DBI::Search::Count.
- Preserve numbered captures alongside named recursive regex groups, fixing NetAddr::IP AutoSplit output.
- Match Perl's ties-to-even fixed-point `sprintf` behavior for Games::Ratings.
- Return packed `gethostbyname` addresses correctly in scalar context and dispatch the opcode in the interpreter.

This unifies the original Git::Repo::Commits / Perl::Critic tooling work with the compiler and CPAN tooling fixes found while testing Class::DBI::Search::Count, Net::Radius::Server, String::Format, Games::Ratings, and their dependencies.

## Validation

- `make` — passed after the unified rebase
- `./jcpan -t Git::Repo::Commits` — 13/13 tests passed in the original PR validation
- `./jcpan -t Class::DBI::Search::Count` — 5 tests passed
- `./jcpan -t String::Format` — 21 tests passed
- `./jcpan -t Games::Ratings` — 123 tests passed
- New regression tests — 16 assertions pass with system Perl and both PerlOnJava backends

Net::Radius::Server itself fails under clean system Perl on upstream `strict subs` constant errors. Authen::PAM also fails system-Perl configuration, and BerkeleyDB requires XS. Those user-approved ignore cases were not patched; the underlying AutoSplit/regex and scalar `gethostbyname` defects exposed by the dependency chain were fixed instead.

Final unified acceptance testing will be performed by the user.
