### PR TITLE
Add scoped Perl runtimes and isolate I/O state

### DIFF
--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -12,9 +12,11 @@ Implement Perl 5 interpreter threads (ithreads) on the JVM. Each Perl thread
 owns an isolated, cloned interpreter. Perl values are copied at thread creation
 unless their storage was explicitly marked shared.
 
-Every numbered phase below is an independent pull request. A phase may be split
-further when its audit shows that it cannot be reviewed or reverted safely, but
-two numbered phases must not be combined. At every merge boundary:
+Each numbered phase below normally forms an independent pull request. A phase
+may be split further when its audit shows that it cannot be reviewed or reverted
+safely. Phases 3 and 4 are the sole current exception: the maintainer explicitly
+requested that the empty binding shell and the first state migration remain in
+one PR. At every merge boundary:
 
 - the compiler and both execution backends remain functional;
 - `make` passes;
@@ -444,7 +446,7 @@ measured benefit over platform threads/full clone.
 
 ## 7. Progress Tracking
 
-### Current Status: Phase 2 complete; awaiting review
+### Current Status: Phases 3 and 4 complete; combined PR ready for review
 
 ### Completed Phases
 
@@ -477,6 +479,49 @@ measured benefit over platform threads/full clone.
   - Audit delta: no runtime state moved and no production worker was added; the
     new lock is the only mutable static and covers the newly identified lazy-sub
     and verifier-fallback compiler escape paths.
+  - Merged as PR #918 on 2026-08-11.
+- [x] Phase 3: `PerlRuntime` shell and scoped binding (2026-08-11)
+  - Added an empty runtime identity object backed by an ordinary, non-inherited
+    `ThreadLocal` binding-frame stack; no mutable interpreter state moved.
+  - Scoped bindings restore exact nested state, remove absent bindings, and
+    reject cross-thread or out-of-order closure.
+  - Bound CLI lifetime, provider ownership roots, JSR-223 engines and compiled
+    scripts, require/do, and both eval compilation/execution families.
+  - Public provider calls temporarily create a shell only when invoked by an
+    unbound embedding caller; nested require/eval paths require the existing
+    runtime so missing worker propagation fails clearly.
+  - Added absence, nesting, exception, ownership, non-inheritance, executor
+    reuse, two-thread isolation, provider, nested require/eval, and JSR-223
+    lifecycle tests.
+  - Deliberately deferred regex timeout and alarm worker binding until the same
+    PR that migrates the state each worker uses. I/O router, process, and Netty
+    callback bindings land with Phase 4 in this combined PR.
+  - `globalInitialized` and all other runtime state remain static by design in
+    this shell-only phase; `Config` thread flags remain disabled.
+- [x] Phase 4: I/O state isolation (2026-08-11)
+  - Moved standard input/output/error handles, the selected/last-used handle
+    bookkeeping, and the open-handle cache into `PerlRuntime` behind stable
+    `RuntimeIO` accessors.
+  - Routed uppercase and lowercase standard-handle globs through the bound
+    runtime, including glob localization/restoration and generated JVM readline
+    bookkeeping.
+  - Captured and scoped the originating runtime in pipe routers, system-process
+    routers, IPC::Open3 copying, PerlOnJava::Process output, and Netty request
+    and streaming callbacks.
+  - Added independent-default, nested-state, simultaneous low-level write,
+    reset isolation, generated-readline bookkeeping, deterministic router
+    propagation, standard-glob lifecycle, and JSR-223 engine ownership tests.
+    Concurrent full Perl execution remains intentionally deferred because
+    Phase 5 stack state is still process-global.
+  - Kept fileno, child-process, phantom-handle, terminal-service, regex, and
+    alarm state explicitly deferred to their inventory phases.
+  - Validation: `make` passed; the final exact-tree `make test-all` completed
+    at core 83.2% and bundled modules 80.8%. Twenty-four focused I/O runs
+    passed across JVM and interpreter backends, as did IPC::Open3 and the
+    Scalar::Util 1.70/Moo 2.005005 smoke tests on both backends.
+  - The interpreter-only TAP miss in `nonblocking_pipe_syswrite.t` assertion 8
+    was reproduced on the exact PR #918 base and is therefore pre-existing;
+    the JVM backend and the remaining focused assertions pass.
 
 ### Phase 1 Work Completed (2026-08-10)
 
@@ -495,10 +540,10 @@ measured benefit over platform threads/full clone.
 
 ### Next Steps
 
-1. Open and merge the independent Phase 2 PR.
-2. Start Phase 3 from updated `master` only after Phase 2 merges.
-3. Introduce the `PerlRuntime` shell and scoped explicit binding without moving
-   mutable runtime state yet.
+1. Review and merge the combined binding and I/O-isolation PR while `Config` thread
+   flags remain disabled.
+2. Start Phase 5 from updated `master`: migrate execution/local/special-block
+   stacks without combining it with later runtime-state phases.
 
 ### Open Questions
 

--- a/src/main/java/org/perlonjava/app/cli/Main.java
+++ b/src/main/java/org/perlonjava/app/cli/Main.java
@@ -4,6 +4,7 @@ import org.perlonjava.app.scriptengine.PerlLanguageProvider;
 import org.perlonjava.runtime.runtimetypes.ErrorMessageUtil;
 import org.perlonjava.runtime.runtimetypes.GlobalVariable;
 import org.perlonjava.runtime.runtimetypes.PerlExitException;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
 import java.util.Locale;
@@ -85,6 +86,12 @@ public class Main {
      * @param args Command-line arguments.
      */
     public static void main(String[] args) {
+        try (PerlRuntime.Binding runtimeBinding = new PerlRuntime().bind()) {
+            run(args);
+        }
+    }
+
+    private static void run(String[] args) {
         CompilerOptions parsedArgs = ArgumentParser.parseArguments(args);
 
         if (parsedArgs.code == null) {
@@ -144,4 +151,3 @@ public class Main {
     }
 
 }
-

--- a/src/main/java/org/perlonjava/app/scriptengine/PerlCompiledScript.java
+++ b/src/main/java/org/perlonjava/app/scriptengine/PerlCompiledScript.java
@@ -52,7 +52,7 @@ public class PerlCompiledScript extends CompiledScript {
      */
     @Override
     public Object eval(ScriptContext context) throws ScriptException {
-        try {
+        try (var ignored = engine.bindRuntime()) {
             // Execute the compiled code with empty arguments via MethodHandle
             RuntimeArray args = new RuntimeArray();
             RuntimeList result = (RuntimeList) invoker.invoke(compiledInstance, args, RuntimeContextType.SCALAR);

--- a/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
+++ b/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
@@ -96,14 +96,15 @@ public class PerlLanguageProvider {
     private static boolean globalInitialized = false;
 
     public static void resetAll() {
-        try (CompilationLockGuard ignored = acquireCompilationLock()) {
+        try (PerlRuntime.Binding runtimeBinding = PerlRuntime.bindCurrentOrNew();
+             CompilationLockGuard ignored = acquireCompilationLock()) {
             globalInitialized = false;
             GlobalContext.setThreadTaintMode(false);
             resetAllGlobals();
             // A prior script may have closed its Perl-level STDIN glob. Script
             // engine resets run multiple top-level programs in one JVM, so give
             // the next program a fresh wrapper around the process standard input.
-            RuntimeIO.stdin = new RuntimeIO(new StandardIO(System.in));
+            RuntimeIO.setStdin(new RuntimeIO(new StandardIO(System.in)));
             DataSection.reset();
         }
     }
@@ -133,6 +134,7 @@ public class PerlLanguageProvider {
                                               boolean isTopLevelScript,
                                               int callerContext) throws Exception {
 
+        try (PerlRuntime.Binding runtimeBinding = PerlRuntime.bindCurrentOrNew()) {
         CompilationLockGuard compilationLock = acquireCompilationLock();
         ScopedSymbolTable savedCurrentScope = null;
         RuntimeCode.EvalRuntimeContext savedEvalRuntimeContext = null;
@@ -337,6 +339,7 @@ public class PerlLanguageProvider {
                 compilationLock.close();
             }
         }
+        }
     }
 
     /**
@@ -368,7 +371,8 @@ public class PerlLanguageProvider {
                                              CompilerOptions compilerOptions,
                                              int contextType) throws Exception {
 
-        try (CompilationLockGuard ignored = acquireCompilationLock()) {
+        try (PerlRuntime.Binding runtimeBinding = PerlRuntime.bindCurrentOrNew();
+             CompilationLockGuard ignored = acquireCompilationLock()) {
 
         // Keep AST execution consistent with source execution.  ASTs are used
         // by BEGIN-block wrappers, and those wrappers can themselves execute
@@ -803,7 +807,8 @@ public class PerlLanguageProvider {
      * @throws Exception if compilation fails
      */
     public static Object compilePerlCode(CompilerOptions compilerOptions) throws Exception {
-        try (CompilationLockGuard ignored = acquireCompilationLock()) {
+        try (PerlRuntime.Binding runtimeBinding = PerlRuntime.bindCurrentOrNew();
+             CompilationLockGuard ignored = acquireCompilationLock()) {
         ScopedSymbolTable savedCurrentScope = SpecialBlockParser.getCurrentScope();
         try {
         ArgumentParser.applyPerlShebangSwitches(compilerOptions.code, compilerOptions);

--- a/src/main/java/org/perlonjava/app/scriptengine/PerlScriptEngine.java
+++ b/src/main/java/org/perlonjava/app/scriptengine/PerlScriptEngine.java
@@ -1,6 +1,7 @@
 package org.perlonjava.app.scriptengine;
 
 import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 import org.perlonjava.runtime.runtimetypes.RuntimeList;
 
 import javax.script.*;
@@ -28,6 +29,7 @@ import java.io.StringWriter;
 public class PerlScriptEngine extends AbstractScriptEngine implements Compilable {
 
     private final ScriptEngineFactory factory;
+    private final PerlRuntime runtime = new PerlRuntime();
 
     public PerlScriptEngine(ScriptEngineFactory factory) {
         this.factory = factory;
@@ -35,7 +37,7 @@ public class PerlScriptEngine extends AbstractScriptEngine implements Compilable
 
     @Override
     public Object eval(String script, ScriptContext context) throws ScriptException {
-        try {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
             CompilerOptions options = new CompilerOptions();
             options.fileName = "<STDIN>";
             options.code = script;
@@ -76,7 +78,7 @@ public class PerlScriptEngine extends AbstractScriptEngine implements Compilable
      */
     @Override
     public CompiledScript compile(String script) throws ScriptException {
-        try {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
             CompilerOptions options = new CompilerOptions();
             options.fileName = "<compiled>";
             options.code = script;
@@ -125,5 +127,9 @@ public class PerlScriptEngine extends AbstractScriptEngine implements Compilable
     @Override
     public ScriptEngineFactory getFactory() {
         return factory;
+    }
+
+    PerlRuntime.Binding bindRuntime() {
+        return runtime.bind();
     }
 }

--- a/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
@@ -203,6 +203,7 @@ public class EvalStringHandler {
                                              int siteStrictOptions,
                                              int siteFeatureFlags,
                                              boolean isEvalbytes) {
+        try (PerlRuntime.Binding runtimeBinding = PerlRuntime.current().bind()) {
         PerlLanguageProvider.CompilationLockGuard compilationLock =
                 PerlLanguageProvider.acquireCompilationLock();
         List<EvalSeedAlias> seedAliases = new ArrayList<>();
@@ -509,6 +510,7 @@ public class EvalStringHandler {
                 compilationLock.close();
             }
         }
+        }
     }
 
     private static void configureEvalSourceOptions(CompilerOptions opts,
@@ -553,6 +555,7 @@ public class EvalStringHandler {
                                            RuntimeBase[] capturedVars,
                                            String sourceName,
                                            int sourceLine) {
+        try (PerlRuntime.Binding runtimeBinding = PerlRuntime.current().bind()) {
         PerlLanguageProvider.CompilationLockGuard compilationLock =
                 PerlLanguageProvider.acquireCompilationLock();
         ScopedSymbolTable savedCurrentScope = SpecialBlockParser.getCurrentScope();
@@ -663,6 +666,7 @@ public class EvalStringHandler {
                 PerlLanguageProvider.COMPILE_LOCK.unlock();
                 compilationLock.close();
             }
+        }
         }
     }
 

--- a/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
@@ -158,9 +158,9 @@ public class EmitOperator {
         } else {
             emitterVisitor.ctx.mv.visitInsn(Opcodes.ACONST_NULL);
         }
-        emitterVisitor.ctx.mv.visitFieldInsn(Opcodes.PUTSTATIC,
+        emitterVisitor.ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                 "org/perlonjava/runtime/runtimetypes/RuntimeIO",
-                "lastReadlineHandleName", "Ljava/lang/String;");
+                "setLastReadlineHandleName", "(Ljava/lang/String;)V", false);
 
         // Emit the File Handle
         emitFileHandle(emitterVisitor.with(RuntimeContextType.SCALAR), node.left);

--- a/src/main/java/org/perlonjava/frontend/analysis/ConstantFoldingVisitor.java
+++ b/src/main/java/org/perlonjava/frontend/analysis/ConstantFoldingVisitor.java
@@ -357,7 +357,12 @@ public class ConstantFoldingVisitor implements Visitor {
 
         // If we can't fold, create a new node with folded operands
         if (foldedLeft != node.left || foldedRight != node.right) {
-            result = new BinaryOperatorNode(node.operator, foldedLeft, foldedRight, node.tokenIndex);
+            BinaryOperatorNode foldedNode =
+                    new BinaryOperatorNode(node.operator, foldedLeft, foldedRight, node.tokenIndex);
+            if (node.annotations != null) {
+                foldedNode.annotations = new java.util.HashMap<>(node.annotations);
+            }
+            result = foldedNode;
         } else {
             result = node;
         }

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -175,6 +175,12 @@ public class OperatorParser {
                                 name = name.substring(colonIdx + 2);
                             }
                             readlineNode.setAnnotation("handleName", name);
+                        } else {
+                            // Standard and other pre-resolved bareword handles may be
+                            // represented by a glob expression rather than an
+                            // IdentifierNode. Preserve the source handle name so the
+                            // generated readline path updates runtime-local diagnostics.
+                            readlineNode.setAnnotation("handleName", tokenText);
                         }
                         return readlineNode;
                     }

--- a/src/main/java/org/perlonjava/runtime/io/PipeInputChannel.java
+++ b/src/main/java/org/perlonjava/runtime/io/PipeInputChannel.java
@@ -1,6 +1,7 @@
 package org.perlonjava.runtime.io;
 
 import org.perlonjava.runtime.runtimetypes.GlobalVariable;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 import org.perlonjava.runtime.runtimetypes.RuntimeHash;
 import org.perlonjava.runtime.runtimetypes.RuntimeIO;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
@@ -110,8 +111,10 @@ public class PipeInputChannel implements IOHandle {
 
         // Start a thread to consume stderr and route through Perl STDERR handle
         // This ensures Perl-level redirections are honored (e.g., open STDERR, ">", $file)
+        PerlRuntime runtime = PerlRuntime.current();
         Thread errorThread = new Thread(() -> {
-            try (BufferedReader err = errorReader) {
+            try (PerlRuntime.Binding ignored = runtime.bind();
+                 BufferedReader err = errorReader) {
                 String line;
                 while ((line = err.readLine()) != null) {
                     try {

--- a/src/main/java/org/perlonjava/runtime/io/PipeOutputChannel.java
+++ b/src/main/java/org/perlonjava/runtime/io/PipeOutputChannel.java
@@ -1,6 +1,7 @@
 package org.perlonjava.runtime.io;
 
 import org.perlonjava.runtime.runtimetypes.GlobalVariable;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 import org.perlonjava.runtime.runtimetypes.RuntimeHash;
 import org.perlonjava.runtime.runtimetypes.RuntimeIO;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
@@ -171,8 +172,10 @@ public class PipeOutputChannel implements IOHandle {
 
         // Start threads to consume stdout and stderr and route through Perl handles
         // This ensures Perl-level redirections are honored
+        PerlRuntime runtime = PerlRuntime.current();
         Thread outputThread = new Thread(() -> {
-            try (BufferedReader out = outputReader) {
+            try (PerlRuntime.Binding ignored = runtime.bind();
+                 BufferedReader out = outputReader) {
                 String line;
                 while ((line = out.readLine()) != null) {
                     try {
@@ -194,7 +197,8 @@ public class PipeOutputChannel implements IOHandle {
         outputThread.start();
 
         Thread errorThread = new Thread(() -> {
-            try (BufferedReader err = errorReader) {
+            try (PerlRuntime.Binding ignored = runtime.bind();
+                 BufferedReader err = errorReader) {
                 String line;
                 while ((line = err.readLine()) != null) {
                     try {

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -47,7 +47,7 @@ public class IOOperator {
             // We return the RuntimeIO wrapped as a GLOB scalar, which stringifies
             // to the glob name. This preserves the round-trip: select(select())
             // correctly restores the previous handle for tied handles too.
-            return new RuntimeScalar(RuntimeIO.selectedHandle);
+            return new RuntimeScalar(RuntimeIO.getSelectedHandle());
         }
         if (runtimeList.size() == 4) {
             // select RBITS,WBITS,EBITS,TIMEOUT (syscall)
@@ -86,7 +86,7 @@ public class IOOperator {
             }
         }
         // select FILEHANDLE (returns/sets current filehandle)
-        RuntimeScalar fh = new RuntimeScalar(RuntimeIO.selectedHandle);
+        RuntimeScalar fh = new RuntimeScalar(RuntimeIO.getSelectedHandle());
         RuntimeScalar fileHandleArg = runtimeList.getFirst();
         RuntimeIO newIO = fileHandleArg.getRuntimeIO();
         // Auto-vivify: when called with an undefined scalar, Perl creates a new anonymous
@@ -100,8 +100,8 @@ public class IOOperator {
             fileHandleArg.set(newGlobRef);
             newIO = anonIO;
         }
-        RuntimeIO.selectedHandle = newIO;
-        RuntimeIO.lastAccesseddHandle = newIO;
+        RuntimeIO.setSelectedHandle(newIO);
+        RuntimeIO.setLastAccessedHandle(newIO);
         return fh;
     }
 
@@ -469,7 +469,7 @@ public class IOOperator {
                     whence = runtimeList.elements.get(1).scalar().getInt();
                 }
 
-                RuntimeIO.lastAccesseddHandle = runtimeIO;
+                RuntimeIO.setLastAccessedHandle(runtimeIO);
                 return runtimeIO.ioHandle.seek(position, whence);
             } else {
                 return RuntimeIO.handleIOError("No file handle available for seek");
@@ -527,7 +527,7 @@ public class IOOperator {
         // fall back to the last accessed handle like Perl does.
         if (fh == null) {
             if (argless) {
-                RuntimeIO last = RuntimeIO.lastAccesseddHandle;
+                RuntimeIO last = RuntimeIO.getLastAccessedHandle();
                 if (last != null) {
                     return last.tell();
                 }
@@ -539,7 +539,7 @@ public class IOOperator {
         }
 
         // Update the last accessed filehandle
-        RuntimeIO.lastAccesseddHandle = fh;
+        RuntimeIO.setLastAccessedHandle(fh);
 
         if (fh instanceof TieHandle tieHandle) {
             return TieHandle.tiedTell(tieHandle);
@@ -1103,7 +1103,7 @@ public class IOOperator {
         // Handle undefined or invalid filehandle
         if (fh == null) {
             if (argless) {
-                RuntimeIO last = RuntimeIO.lastAccesseddHandle;
+                RuntimeIO last = RuntimeIO.getLastAccessedHandle();
                 if (last != null) {
                     return last.eof();
                 }
@@ -1136,7 +1136,7 @@ public class IOOperator {
         // Handle undefined or invalid filehandle
         if (fh == null) {
             if (argless) {
-                RuntimeIO last = RuntimeIO.lastAccesseddHandle;
+                RuntimeIO last = RuntimeIO.getLastAccessedHandle();
                 if (last != null) {
                     return last.eof();
                 }
@@ -1689,7 +1689,7 @@ public class IOOperator {
      */
     public static RuntimeScalar write(int ctx, RuntimeBase... args) {
         String formatName;
-        RuntimeIO fh = RuntimeIO.stdout; // Default output handle
+        RuntimeIO fh = RuntimeIO.getStdout(); // Default output handle
 
         if (args.length == 0) {
             // No arguments: write() - use STDOUT format to STDOUT handle
@@ -1707,11 +1707,11 @@ public class IOOperator {
                 if (argFh != null) {
                     // Argument is a filehandle - determine format name from handle
                     fh = argFh;
-                    if (fh == RuntimeIO.stdout) {
+                    if (fh == RuntimeIO.getStdout()) {
                         formatName = "STDOUT";
-                    } else if (fh == RuntimeIO.stderr) {
+                    } else if (fh == RuntimeIO.getStderr()) {
                         formatName = "STDERR";
-                    } else if (fh == RuntimeIO.stdin) {
+                    } else if (fh == RuntimeIO.getStdin()) {
                         formatName = "STDIN";
                     } else {
                         formatName = "STDOUT"; // Default fallback
@@ -2934,11 +2934,11 @@ public class IOOperator {
         // Handle standard file descriptors if no current registry owner exists.
         switch (fd) {
             case 0: // STDIN
-                return RuntimeIO.stdin;
+                return RuntimeIO.getStdin();
             case 1: // STDOUT
-                return RuntimeIO.stdout;
+                return RuntimeIO.getStdout();
             case 2: // STDERR
-                return RuntimeIO.stderr;
+                return RuntimeIO.getStderr();
             default:
                 return null; // Unknown file descriptor
         }
@@ -2971,7 +2971,7 @@ public class IOOperator {
             }
         } else {
             // Handle named filehandles — always use glob table to get the CURRENT handle,
-            // not the static RuntimeIO.stdout/stdin/stderr fields which may be stale
+            // not a cached standard-handle reference which may be stale
             // after redirections like open(STDOUT, ">file") + open(STDOUT, ">&SAVED").
             String normalizedName;
             if (fileName.equalsIgnoreCase("STDIN") || fileName.equalsIgnoreCase("STDOUT") || fileName.equalsIgnoreCase("STDERR")) {
@@ -3010,9 +3010,9 @@ public class IOOperator {
                 if (sourceHandle == null || sourceHandle.ioHandle == null) {
                     // Last resort: try static fields for standard handles
                     switch (fileName.toUpperCase()) {
-                        case "STDIN": sourceHandle = RuntimeIO.stdin; break;
-                        case "STDOUT": sourceHandle = RuntimeIO.stdout; break;
-                        case "STDERR": sourceHandle = RuntimeIO.stderr; break;
+                        case "STDIN": sourceHandle = RuntimeIO.getStdin(); break;
+                        case "STDOUT": sourceHandle = RuntimeIO.getStdout(); break;
+                        case "STDERR": sourceHandle = RuntimeIO.getStderr(); break;
                         default:
                             RuntimeIO.handleIOError(9); // EBADF
                             return null;

--- a/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
@@ -66,7 +66,9 @@ public class ModuleOperators {
      * @return Result of execution (undef on error)
      */
     public static RuntimeBase doFile(RuntimeScalar runtimeScalar, int ctx) {
-        return doFile(runtimeScalar, true, false, ctx); // do FILE always sets %INC and keeps it
+        try (PerlRuntime.Binding ignored = PerlRuntime.current().bind()) {
+            return doFile(runtimeScalar, true, false, ctx); // do FILE always sets %INC and keeps it
+        }
     }
 
     /**
@@ -75,6 +77,7 @@ public class ModuleOperators {
      * so the loaded file inherits the caller's namespace (Perl 5 semantics).
      */
     public static RuntimeBase doFileInPackage(RuntimeScalar runtimeScalar, int ctx, String callerPackage) {
+        try (PerlRuntime.Binding ignored = PerlRuntime.current().bind()) {
         String savedPackage = InterpreterState.currentPackage.get().toString();
         try {
             if (callerPackage != null && !callerPackage.isEmpty()) {
@@ -84,6 +87,7 @@ public class ModuleOperators {
         } finally {
             InterpreterState.currentPackage.get().set(savedPackage);
         }
+        }
     }
 
     /**
@@ -91,6 +95,7 @@ public class ModuleOperators {
      * current package (see doFileInPackage above).
      */
     public static RuntimeScalar requireInPackage(RuntimeScalar runtimeScalar, String callerPackage) {
+        try (PerlRuntime.Binding ignored = PerlRuntime.current().bind()) {
         String savedPackage = InterpreterState.currentPackage.get().toString();
         try {
             if (callerPackage != null && !callerPackage.isEmpty()) {
@@ -99,6 +104,7 @@ public class ModuleOperators {
             return require(runtimeScalar);
         } finally {
             InterpreterState.currentPackage.get().set(savedPackage);
+        }
         }
     }
 
@@ -820,6 +826,7 @@ public class ModuleOperators {
      * @see <a href="https://perldoc.perl.org/functions/require">perldoc require</a>
      */
     public static RuntimeScalar require(RuntimeScalar runtimeScalar) {
+        try (PerlRuntime.Binding ignored = PerlRuntime.current().bind()) {
         // https://perldoc.perl.org/functions/require
 
         // ===== CASE 1: Version checking =====
@@ -935,6 +942,7 @@ public class ModuleOperators {
         // If module_true was enabled, result will be 1
         // If module_true was disabled, result will be the module's actual return value
         return result;
+        }
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/operators/Readline.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Readline.java
@@ -65,7 +65,7 @@ public class Readline {
         }
 
         // Set this as the last accessed handle for $. (INPUT_LINE_NUMBER) special variable
-        RuntimeIO.lastAccesseddHandle = runtimeIO;
+        RuntimeIO.setLastAccessedHandle(runtimeIO);
 
         // Get the input record separator (equivalent to Perl's $/)
         RuntimeScalar rsScalar = getGlobalVariable("main::/");

--- a/src/main/java/org/perlonjava/runtime/operators/SystemOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/SystemOperator.java
@@ -936,9 +936,10 @@ public class SystemOperator {
      * exact output including or excluding trailing newlines.
      * This is used for routing child process stderr/stdout through Perl handles.
      */
-    private static Thread createStreamRouterThread(InputStream stream, boolean isStderr) {
+    static Thread createStreamRouterThread(InputStream stream, boolean isStderr) {
+        PerlRuntime runtime = PerlRuntime.current();
         Thread t = new Thread(() -> {
-            try {
+            try (PerlRuntime.Binding ignored = runtime.bind()) {
                 byte[] buffer = new byte[8192];
                 int bytesRead;
                 while ((bytesRead = stream.read(buffer)) != -1) {

--- a/src/main/java/org/perlonjava/runtime/operators/TieOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/TieOperators.java
@@ -126,8 +126,8 @@ public class TieOperators {
                 glob.IO.value = tieHandle;
                 // Update selectedHandle so that `print` without explicit filehandle
                 // goes through the tied handle (e.g., Test2::Plugin::IOEvents)
-                if (previousValue == RuntimeIO.selectedHandle) {
-                    RuntimeIO.selectedHandle = tieHandle;
+                if (previousValue == RuntimeIO.getSelectedHandle()) {
+                    RuntimeIO.setSelectedHandle(tieHandle);
                 }
             }
             default -> {
@@ -223,8 +223,8 @@ public class TieOperators {
                     IO.type = 0;    // XXX there is no type defined for IO handles
                     IO.value = previousValue;
                     // Restore selectedHandle if it pointed to the tied handle
-                    if (currentTieHandle == RuntimeIO.selectedHandle) {
-                        RuntimeIO.selectedHandle = previousValue;
+                    if (currentTieHandle == RuntimeIO.getSelectedHandle()) {
+                        RuntimeIO.setSelectedHandle(previousValue);
                     }
                     currentTieHandle.releaseTiedObject();
                 }

--- a/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
+++ b/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
@@ -113,7 +113,7 @@ public class WarnDie {
     private static void writeWarningToStderr(String message) {
         RuntimeIO stderrIO = getGlobalIO("main::STDERR").getRuntimeIO();
         if (stderrIO == null) {
-            stderrIO = RuntimeIO.stderr;
+            stderrIO = RuntimeIO.getStderr();
         }
         if (stderrIO != null) {
             stderrIO.write(message);
@@ -704,8 +704,8 @@ public class WarnDie {
      * @return String with filehandle context (including leading ", "), or null if no context
      */
     public static String getFilehandleContext() {
-        if (RuntimeIO.lastAccesseddHandle != null && RuntimeIO.lastAccesseddHandle.currentLineNumber > 0) {
-            String handleName = findFilehandleName(RuntimeIO.lastAccesseddHandle);
+        if (RuntimeIO.getLastAccessedHandle() != null && RuntimeIO.getLastAccessedHandle().currentLineNumber > 0) {
+            String handleName = findFilehandleName(RuntimeIO.getLastAccessedHandle());
             if (handleName != null) {
                 // Perl 5 uses "line" only when $/ is exactly "\n".
                 // Everything else (undef, "", custom separator, ref) uses "chunk".
@@ -718,7 +718,7 @@ public class WarnDie {
                 } catch (Exception ignored) {
                     // Default to "chunk" if we can't read $/
                 }
-                return ", <" + handleName + "> " + unit + " " + RuntimeIO.lastAccesseddHandle.currentLineNumber;
+                return ", <" + handleName + "> " + unit + " " + RuntimeIO.getLastAccessedHandle().currentLineNumber;
             }
         }
         return null;
@@ -742,6 +742,6 @@ public class WarnDie {
             return name;
         }
         // Fall back to the variable name set during the last readline (e.g., "$f")
-        return RuntimeIO.lastReadlineHandleName;
+        return RuntimeIO.getLastReadlineHandleName();
     }
 }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/IPCOpen3.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/IPCOpen3.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalIO;
 import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalVariable;
 
 /**
@@ -441,16 +442,17 @@ public class IPCOpen3 extends PerlModuleBase {
         // Get the named handle
         RuntimeIO targetIO = null;
         if (handleName.equals("STDERR")) {
-            targetIO = getGlobalVariable("main::STDERR").getRuntimeIO();
+            targetIO = getGlobalIO("main::STDERR").getRuntimeIO();
         } else if (handleName.equals("STDOUT")) {
-            targetIO = getGlobalVariable("main::STDOUT").getRuntimeIO();
+            targetIO = getGlobalIO("main::STDOUT").getRuntimeIO();
         }
 
         if (targetIO != null && targetIO.ioHandle != null) {
             final RuntimeIO finalTargetIO = targetIO;
+            PerlRuntime runtime = PerlRuntime.current();
             // Start a thread to copy data from process to target handle
             Thread copier = new Thread(() -> {
-                try {
+                try (PerlRuntime.Binding ignored = runtime.bind()) {
                     byte[] buffer = new byte[4096];
                     int bytesRead;
                     while ((bytesRead = in.read(buffer)) != -1) {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/POSIX.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/POSIX.java
@@ -1297,9 +1297,9 @@ public class POSIX extends PerlModuleBase {
 
         // If targeting fd 0/1/2, update the static handles
         switch (newFd) {
-            case 0 -> RuntimeIO.stdin = target;
-            case 1 -> RuntimeIO.stdout = target;
-            case 2 -> RuntimeIO.stderr = target;
+            case 0 -> RuntimeIO.setStdin(target);
+            case 1 -> RuntimeIO.setStdout(target);
+            case 2 -> RuntimeIO.setStderr(target);
         }
 
         return new RuntimeScalar(newFd == 0 ? "0 but true" : (Object) newFd).getList();
@@ -1312,9 +1312,9 @@ public class POSIX extends PerlModuleBase {
         RuntimeIO rio = RuntimeIO.getByFileno(fd);
         if (rio != null) return rio;
         return switch (fd) {
-            case 0 -> RuntimeIO.stdin;
-            case 1 -> RuntimeIO.stdout;
-            case 2 -> RuntimeIO.stderr;
+            case 0 -> RuntimeIO.getStdin();
+            case 1 -> RuntimeIO.getStdout();
+            case 2 -> RuntimeIO.getStderr();
             default -> null;
         };
     }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/PerlOnJavaProcess.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/PerlOnJavaProcess.java
@@ -2,6 +2,7 @@ package org.perlonjava.runtime.perlmodule;
 
 import org.perlonjava.runtime.operators.SystemOperator;
 import org.perlonjava.runtime.runtimetypes.GlobalVariable;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 import org.perlonjava.runtime.runtimetypes.RuntimeArray;
 import org.perlonjava.runtime.runtimetypes.RuntimeHash;
 import org.perlonjava.runtime.runtimetypes.RuntimeList;
@@ -67,7 +68,12 @@ public class PerlOnJavaProcess extends PerlModuleBase {
             process.getOutputStream().close();
 
             Process activeProcess = process;
-            reader = new Thread(() -> copyOutput(activeProcess.getInputStream(), output, tee),
+            PerlRuntime runtime = PerlRuntime.current();
+            reader = new Thread(() -> {
+                try (PerlRuntime.Binding ignored = runtime.bind()) {
+                    copyOutput(activeProcess.getInputStream(), output, tee);
+                }
+            },
                 "perlonjava-process-output");
             reader.setDaemon(true);
             reader.start();

--- a/src/main/java/org/perlonjava/runtime/perlmodule/PlackHandlerNetty.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/PlackHandlerNetty.java
@@ -345,6 +345,7 @@ public class PlackHandlerNetty extends PerlModuleBase {
                                         boolean sslEnabled, String sslCert, String sslKey,
                                         String sslCa, String[] sslProtocols, String sslCiphers)
                                         throws InterruptedException {
+        PerlRuntime runtime = PerlRuntime.current();
 
         // Build SSL context if enabled
         io.netty.handler.ssl.SslContext sslContext = null;
@@ -399,7 +400,7 @@ public class PlackHandlerNetty extends PerlModuleBase {
                      pipeline.addLast(new HttpObjectAggregator(maxRequestSize));
 
                      // PSGI request handler
-                     pipeline.addLast(new PSGIRequestHandler(psgiApp, host, port, keepAlive));
+                     pipeline.addLast(new PSGIRequestHandler(psgiApp, host, port, keepAlive, runtime));
                  }
              })
              .option(ChannelOption.SO_BACKLOG, backlog)
@@ -442,62 +443,65 @@ public class PlackHandlerNetty extends PerlModuleBase {
         private final String serverName;
         private final int serverPort;
         private final boolean keepAlive;
+        private final PerlRuntime runtime;
 
         public PSGIRequestHandler(RuntimeScalar psgiApp, String serverName,
-                                  int serverPort, boolean keepAlive) {
+                                  int serverPort, boolean keepAlive, PerlRuntime runtime) {
             this.psgiApp = psgiApp;
             this.serverName = serverName;
             this.serverPort = serverPort;
             this.keepAlive = keepAlive;
+            this.runtime = runtime;
         }
 
         @Override
         protected void channelRead0(ChannelHandlerContext ctx, FullHttpRequest req) {
-            RuntimeHash env = null;
-            try {
-                // Detect if connection is SSL/TLS by checking for SslHandler in pipeline
-                boolean isHttps = ctx.pipeline().get(io.netty.handler.ssl.SslHandler.class) != null;
+            try (PerlRuntime.Binding ignored = runtime.bind()) {
+                try {
+                    // Detect if connection is SSL/TLS by checking for SslHandler in pipeline
+                    boolean isHttps = ctx.pipeline().get(io.netty.handler.ssl.SslHandler.class) != null;
 
-                // Build PSGI environment hash
-                env = buildPSGIEnvironment(req, isHttps);
+                    // Build PSGI environment hash
+                    RuntimeHash env = buildPSGIEnvironment(req, isHttps);
 
-                // Call PSGI app: $response = $app->($env)
-                RuntimeArray args = new RuntimeArray();
-                RuntimeArray.push(args, RuntimeHash.createHashRef(env));
+                    // Call PSGI app: $response = $app->($env)
+                    RuntimeArray args = new RuntimeArray();
+                    RuntimeArray.push(args, RuntimeHash.createHashRef(env));
 
-                RuntimeList resultList = RuntimeCode.apply(psgiApp, args, RuntimeContextType.SCALAR);
-                RuntimeScalar result = resultList.scalar();
+                    RuntimeList resultList = RuntimeCode.apply(psgiApp, args, RuntimeContextType.SCALAR);
+                    RuntimeScalar result = resultList.scalar();
 
-                // Handle streaming responses (coderef) and synchronous responses (arrayref)
-                if (result.type == RuntimeScalarType.CODE) {
-                    // Streaming response - create responder callback
-                    handleStreamingResponse(ctx, req, result, keepAlive);
-                } else if (result.type == RuntimeScalarType.ARRAYREFERENCE) {
-                    // Synchronous array response
-                    handleArrayResponse(ctx, req, result, keepAlive);
-                } else {
+                    // Handle streaming responses (coderef) and synchronous responses (arrayref)
+                    if (result.type == RuntimeScalarType.CODE) {
+                        // Streaming response - create responder callback
+                        handleStreamingResponse(ctx, req, result, keepAlive);
+                    } else if (result.type == RuntimeScalarType.ARRAYREFERENCE) {
+                        // Synchronous array response
+                        handleArrayResponse(ctx, req, result, keepAlive);
+                    } else {
+                        sendErrorResponse(ctx, req,
+                            HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                            "PSGI app must return arrayref [status, headers, body] or coderef for streaming");
+                    }
+
+                } catch (Exception e) {
+                    // Catch all exceptions from PSGI app and return 500
+                    // Log the full stack trace for debugging
+                    System.err.println("PSGI application error:");
+                    System.err.println("  Request: " + req.method() + " " + req.uri());
+                    System.err.println("  Exception: " + e.getClass().getName() + ": " + e.getMessage());
+                    e.printStackTrace(System.err);
+
+                    // Send user-friendly error response
+                    String errorMessage = "Internal Server Error";
+                    if (e.getMessage() != null && !e.getMessage().isEmpty()) {
+                        errorMessage += ": " + e.getMessage();
+                    }
+
                     sendErrorResponse(ctx, req,
                         HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                        "PSGI app must return arrayref [status, headers, body] or coderef for streaming");
+                        errorMessage);
                 }
-
-            } catch (Exception e) {
-                // Catch all exceptions from PSGI app and return 500
-                // Log the full stack trace for debugging
-                System.err.println("PSGI application error:");
-                System.err.println("  Request: " + req.method() + " " + req.uri());
-                System.err.println("  Exception: " + e.getClass().getName() + ": " + e.getMessage());
-                e.printStackTrace(System.err);
-
-                // Send user-friendly error response
-                String errorMessage = "Internal Server Error";
-                if (e.getMessage() != null && !e.getMessage().isEmpty()) {
-                    errorMessage += ": " + e.getMessage();
-                }
-
-                sendErrorResponse(ctx, req,
-                    HttpResponseStatus.INTERNAL_SERVER_ERROR,
-                    errorMessage);
             }
         }
 
@@ -513,7 +517,7 @@ public class PlackHandlerNetty extends PerlModuleBase {
                                             RuntimeScalar streamingCoderef, boolean keepAlive) {
             try {
                 // Create a Java-side callback that Perl can invoke to send HTTP response
-                CallableHttpResponse responseCallback = new CallableHttpResponse(ctx, req, keepAlive);
+                CallableHttpResponse responseCallback = new CallableHttpResponse(ctx, req, keepAlive, runtime);
 
                 // Call Perl helper: Plack::Handler::Netty::_handle_streaming_response($coderef, $callback)
                 RuntimeArray args = new RuntimeArray();
@@ -681,7 +685,7 @@ public class PlackHandlerNetty extends PerlModuleBase {
 
             // psgi.errors - stderr for error logging
             // Wrap in a new RuntimeScalar to ensure it's stored correctly
-            env.put("psgi.errors", new RuntimeScalar(RuntimeIO.stderr));
+            env.put("psgi.errors", new RuntimeScalar(RuntimeIO.getStderr()));
 
             // psgi.multithread - \0 (PerlOnJava doesn't support threads)
             env.put("psgi.multithread", new RuntimeScalar(0));
@@ -822,6 +826,7 @@ public class PlackHandlerNetty extends PerlModuleBase {
         private final ChannelHandlerContext ctx;
         private final FullHttpRequest req;
         private final boolean keepAlive;
+        private final PerlRuntime runtime;
 
         /**
          * Create a responder callback for the given HTTP context.
@@ -830,7 +835,8 @@ public class PlackHandlerNetty extends PerlModuleBase {
          * @param req      Original HTTP request (for keep-alive detection)
          * @param keepAlive Whether to keep connection alive
          */
-        public CallableHttpResponse(ChannelHandlerContext ctx, FullHttpRequest req, boolean keepAlive) {
+        public CallableHttpResponse(ChannelHandlerContext ctx, FullHttpRequest req,
+                                    boolean keepAlive, PerlRuntime runtime) {
             // Pass 'this' as the PerlSubroutine implementation
             super((PerlSubroutine) null, null);
             // Set the subroutine after construction
@@ -838,6 +844,7 @@ public class PlackHandlerNetty extends PerlModuleBase {
             this.ctx = ctx;
             this.req = req;
             this.keepAlive = keepAlive;
+            this.runtime = runtime;
         }
 
         /**
@@ -846,7 +853,7 @@ public class PlackHandlerNetty extends PerlModuleBase {
          */
         @Override
         public RuntimeList apply(RuntimeArray args, int context) {
-            try {
+            try (PerlRuntime.Binding ignored = runtime.bind()) {
                 if (args.size() < 1) {
                     throw new IllegalArgumentException("Responder requires at least 1 argument");
                 }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/TermReadKey.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/TermReadKey.java
@@ -110,7 +110,7 @@ public class TermReadKey extends PerlModuleBase {
         }
 
         // Get filehandle (defaults to STDIN)
-        RuntimeIO fh = RuntimeIO.stdin;
+        RuntimeIO fh = RuntimeIO.getStdin();
         if (args.size() > 1) {
             RuntimeScalar fileHandle = args.get(1);
             fh = RuntimeIO.getRuntimeIO(fileHandle);
@@ -126,7 +126,7 @@ public class TermReadKey extends PerlModuleBase {
      */
     public static RuntimeList readKey(RuntimeArray args, int ctx) {
         double timeout = 0; // Default is blocking
-        RuntimeIO fh = RuntimeIO.stdin;
+        RuntimeIO fh = RuntimeIO.getStdin();
 
         if (!args.isEmpty() && args.get(0).getDefinedBoolean()) {
             timeout = args.get(0).getDouble();
@@ -157,7 +157,7 @@ public class TermReadKey extends PerlModuleBase {
      */
     public static RuntimeList readLine(RuntimeArray args, int ctx) {
         double timeout = 0; // Default is blocking
-        RuntimeIO fh = RuntimeIO.stdin;
+        RuntimeIO fh = RuntimeIO.getStdin();
 
         if (!args.isEmpty() && args.get(0).getDefinedBoolean()) {
             timeout = args.get(0).getDouble();
@@ -188,7 +188,7 @@ public class TermReadKey extends PerlModuleBase {
      * Returns (width, height, xpixels, ypixels)
      */
     public static RuntimeList getTerminalSize(RuntimeArray args, int ctx) {
-        RuntimeIO fh = RuntimeIO.stdout;
+        RuntimeIO fh = RuntimeIO.getStdout();
         if (!args.isEmpty()) {
             RuntimeScalar fileHandle = args.get(0);
             fh = RuntimeIO.getRuntimeIO(fileHandle);
@@ -222,7 +222,7 @@ public class TermReadKey extends PerlModuleBase {
         int xpixels = args.get(2).getInt();
         int ypixels = args.get(3).getInt();
 
-        RuntimeIO fh = RuntimeIO.stdout;
+        RuntimeIO fh = RuntimeIO.getStdout();
         if (args.size() > 4) {
             RuntimeScalar fileHandle = args.get(4);
             fh = RuntimeIO.getRuntimeIO(fileHandle);
@@ -238,7 +238,7 @@ public class TermReadKey extends PerlModuleBase {
      * Returns (input_speed, output_speed)
      */
     public static RuntimeList getSpeed(RuntimeArray args, int ctx) {
-        RuntimeIO fh = RuntimeIO.stdin;
+        RuntimeIO fh = RuntimeIO.getStdin();
         if (!args.isEmpty()) {
             RuntimeScalar fileHandle = args.get(0);
             fh = RuntimeIO.getRuntimeIO(fileHandle);
@@ -262,7 +262,7 @@ public class TermReadKey extends PerlModuleBase {
      * Returns an array containing key/value pairs suitable for a hash
      */
     public static RuntimeList getControlChars(RuntimeArray args, int ctx) {
-        RuntimeIO fh = RuntimeIO.stdin;
+        RuntimeIO fh = RuntimeIO.getStdin();
         if (!args.isEmpty()) {
             RuntimeScalar fileHandle = args.get(0);
             fh = RuntimeIO.getRuntimeIO(fileHandle);
@@ -289,7 +289,7 @@ public class TermReadKey extends PerlModuleBase {
             throw new PerlCompilerException("Usage: Term::ReadKey::SetControlChars(%charpairs,file=STDIN)");
         }
 
-        RuntimeIO fh = RuntimeIO.stdin;
+        RuntimeIO fh = RuntimeIO.getStdin();
         RuntimeArray controlArgs = new RuntimeArray();
 
         RuntimeScalar first = args.get(0);

--- a/src/main/java/org/perlonjava/runtime/perlmodule/TermReadLine.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/TermReadLine.java
@@ -176,8 +176,8 @@ public class TermReadLine extends PerlModuleBase {
 
             // Print prompt to STDOUT using RuntimeIO
             if (!displayPrompt.isEmpty()) {
-                RuntimeIO.stdout.write(displayPrompt);
-                RuntimeIO.stdout.flush();
+                RuntimeIO.getStdout().write(displayPrompt);
+                RuntimeIO.getStdout().flush();
             }
 
             // Flush all file handles to ensure prompt is visible
@@ -222,7 +222,7 @@ public class TermReadLine extends PerlModuleBase {
      */
     public static RuntimeList getInputHandle(RuntimeArray args, int ctx) {
         // Return a Perl glob for STDIN
-        return new RuntimeList(new RuntimeScalar(RuntimeIO.stdin));
+        return new RuntimeList(new RuntimeScalar(RuntimeIO.getStdin()));
     }
 
     /**
@@ -230,7 +230,7 @@ public class TermReadLine extends PerlModuleBase {
      */
     public static RuntimeList getOutputHandle(RuntimeArray args, int ctx) {
         // Return a Perl glob for STDOUT
-        return new RuntimeList(new RuntimeScalar(RuntimeIO.stdout));
+        return new RuntimeList(new RuntimeScalar(RuntimeIO.getStdout()));
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/DiamondIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/DiamondIO.java
@@ -241,11 +241,11 @@ public class DiamondIO {
             // Use the resolved path to ensure we write to the correct location
             currentWriter = RuntimeIO.open(originalPath.toString(), ">");
             getGlobalIO("main::ARGVOUT").set(currentWriter);
-            RuntimeIO.lastAccesseddHandle = currentWriter;
+            RuntimeIO.setLastAccessedHandle(currentWriter);
 
             // CRITICAL: Update selectedHandle so print statements without explicit filehandle
             // write to the original file during in-place editing
-            RuntimeIO.selectedHandle = currentWriter;
+            RuntimeIO.setSelectedHandle(currentWriter);
         }
 
         // Open the renamed file for reading

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
@@ -370,6 +370,10 @@ public class GlobalVariable {
         nextCompiledCodeRefId = 1;
         globalIORefs.clear();
         hiddenIORefsAfterStashDelete.clear();
+        PerlRuntime runtime = PerlRuntime.currentOrNull();
+        if (runtime != null) {
+            runtime.resetStandardIOGlobVisibility();
+        }
         globalFormatRefs.clear();
         globalGlobs.clear();
         isSubs.clear();
@@ -565,6 +569,12 @@ public class GlobalVariable {
     }
 
     static void hideIORefAfterStashDelete(String key) {
+        PerlRuntime runtime = PerlRuntime.currentOrNull();
+        if (runtime != null && runtime.standardIOGlob(key) != null) {
+            runtime.hideStandardIOGlob(key);
+            invalidateStashEnumerationCache();
+            return;
+        }
         if (key != null && globalIORefs.containsKey(key)) {
             if (hiddenIORefsAfterStashDelete.add(key)) {
                 invalidateStashEnumerationCache();
@@ -574,6 +584,11 @@ public class GlobalVariable {
 
     static void markStashEntryVisible(String key) {
         if (key != null) {
+            PerlRuntime runtime = PerlRuntime.currentOrNull();
+            if (runtime != null && runtime.standardIOGlob(key) != null) {
+                runtime.showStandardIOGlob(key);
+                invalidateStashEnumerationCache();
+            }
             if (hiddenIORefsAfterStashDelete.remove(key)) {
                 invalidateStashEnumerationCache();
             }
@@ -581,22 +596,56 @@ public class GlobalVariable {
     }
 
     static boolean isIORefHiddenAfterStashDelete(String key) {
+        PerlRuntime runtime = PerlRuntime.currentOrNull();
+        if (runtime != null && runtime.standardIOGlob(key) != null) {
+            return !runtime.isStandardIOGlobVisible(key);
+        }
         return key != null && hiddenIORefsAfterStashDelete.contains(key);
     }
 
     static boolean isVisibleGlobalIORef(String key) {
+        PerlRuntime runtime = PerlRuntime.currentOrNull();
+        if (runtime != null && runtime.standardIOGlob(key) != null) {
+            return runtime.isStandardIOGlobVisible(key);
+        }
         return key != null
                 && globalIORefs.containsKey(key)
                 && !hiddenIORefsAfterStashDelete.contains(key);
     }
 
     static boolean containsVisibleGlobalIORefWithPrefix(String prefix) {
+        PerlRuntime runtime = PerlRuntime.currentOrNull();
+        if (runtime != null) {
+            for (String key : runtime.standardIOGlobNames()) {
+                if (key.startsWith(prefix) && runtime.isStandardIOGlobVisible(key)) {
+                    return true;
+                }
+            }
+        }
         for (String key : globalIORefs.keySet()) {
             if (key.startsWith(prefix) && !hiddenIORefsAfterStashDelete.contains(key)) {
                 return true;
             }
         }
         return false;
+    }
+
+    static Iterable<String> visibleGlobalIOKeys() {
+        ArrayList<String> keys = new ArrayList<>();
+        PerlRuntime runtime = PerlRuntime.currentOrNull();
+        if (runtime != null) {
+            for (String key : runtime.standardIOGlobNames()) {
+                if (runtime.isStandardIOGlobVisible(key)) {
+                    keys.add(key);
+                }
+            }
+        }
+        for (String key : globalIORefs.keySet()) {
+            if (!hiddenIORefsAfterStashDelete.contains(key)) {
+                keys.add(key);
+            }
+        }
+        return keys;
     }
 
     static void clearHiddenIORefsForNamespace(String prefix) {
@@ -1617,6 +1666,10 @@ public class GlobalVariable {
      * @return The RuntimeScalar representing the global IO reference.
      */
     public static RuntimeGlob getGlobalIO(String key) {
+        RuntimeGlob standardGlob = currentRuntimeStandardIOGlob(key);
+        if (standardGlob != null) {
+            return standardGlob;
+        }
         // A stash glob is itself the lvalue that owns an alias. Resolving it
         // through the currently aliased hash would make a second assignment
         // (`*Alias:: = *Other::`) replace the old source stash instead.
@@ -1654,6 +1707,10 @@ public class GlobalVariable {
      * nameOverride without creating an empty glob as a side effect.
      */
     public static RuntimeGlob peekGlobalIO(String key) {
+        RuntimeGlob standardGlob = currentRuntimeStandardIOGlob(key);
+        if (standardGlob != null) {
+            return standardGlob;
+        }
         String resolvedKey = resolveStashHashRedirect(key);
         return globalIORefs.get(resolvedKey);
     }
@@ -1683,6 +1740,8 @@ public class GlobalVariable {
      * @return True if the global IO reference exists, false otherwise.
      */
     public static boolean existsGlobalIO(String key) {
+        PerlRuntime runtime = PerlRuntime.currentOrNull();
+        if (runtime != null && runtime.isStandardIOGlobVisible(key)) return true;
         if (isVisibleGlobalIORef(key)) return true;
         // Follow stash hash redirects so a bareword-handle existence probe in
         // an aliased package sees IO placeholders that got redirected at
@@ -1703,7 +1762,10 @@ public class GlobalVariable {
      * @return True if the IO reference exists and has a real IO handle, false otherwise.
      */
     public static boolean isGlobalIODefined(String key) {
-        RuntimeGlob glob = globalIORefs.get(key);
+        RuntimeGlob glob = currentRuntimeStandardIOGlob(key);
+        if (glob == null) {
+            glob = globalIORefs.get(key);
+        }
         if (glob != null && glob.type == RuntimeScalarType.GLOB) {
             // Check the IO slot, not glob.value - IO is stored in glob.IO
             return glob.IO != null && glob.IO.getDefinedBoolean();
@@ -1720,7 +1782,33 @@ public class GlobalVariable {
      * @return The RuntimeGlob if it exists in the stash, null otherwise.
      */
     public static RuntimeGlob getExistingGlobalIO(String key) {
-        return globalIORefs.get(key);
+        RuntimeGlob standardGlob = currentRuntimeStandardIOGlob(key);
+        return standardGlob != null ? standardGlob : globalIORefs.get(key);
+    }
+
+    /** Replace an IO glob without leaking standard-handle localization across runtimes. */
+    static void replaceGlobalIO(String key, RuntimeGlob glob) {
+        PerlRuntime runtime = PerlRuntime.currentOrNull();
+        if (runtime != null && runtime.standardIOGlob(key) != null) {
+            runtime.replaceStandardIOGlob(key, glob);
+            runtime.showStandardIOGlob(key);
+        } else {
+            globalIORefs.put(key, glob);
+        }
+    }
+
+    private static RuntimeGlob currentRuntimeStandardIOGlob(String key) {
+        PerlRuntime runtime = PerlRuntime.currentOrNull();
+        return runtime != null ? runtime.standardIOGlob(key) : null;
+    }
+
+    static void removeGlobalIORefsForNamespace(String prefix) {
+        globalIORefs.keySet().removeIf(key -> key.startsWith(prefix));
+        PerlRuntime runtime = PerlRuntime.currentOrNull();
+        if (runtime != null) {
+            runtime.hideStandardIOGlobsWithPrefix(prefix);
+        }
+        invalidateStashEnumerationCache();
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/HashSpecialVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/HashSpecialVariable.java
@@ -207,11 +207,8 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
         addCachedStashEntriesFromGlobalKeys(namespace, GlobalVariable.globalArrays.keySet(), uniqueKeys, entries);
         addCachedStashEntriesFromGlobalKeys(namespace, GlobalVariable.globalHashes.keySet(), uniqueKeys, entries);
         addCachedStashEntriesFromGlobalKeys(namespace, GlobalVariable.globalCodeRefs.keySet(), uniqueKeys, entries);
-        for (String key : GlobalVariable.globalIORefs.keySet()) {
-            if (!GlobalVariable.isIORefHiddenAfterStashDelete(key)) {
-                addCachedStashEntryFromGlobalKey(namespace, key, uniqueKeys, entries);
-            }
-        }
+        addCachedStashEntriesFromGlobalKeys(
+                namespace, GlobalVariable.visibleGlobalIOKeys(), uniqueKeys, entries);
         addCachedStashEntriesFromGlobalKeys(namespace, GlobalVariable.globalFormatRefs.keySet(), uniqueKeys, entries);
         return entries;
     }
@@ -247,7 +244,7 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
         return GlobalVariable.globalArrays.containsKey(fullName)
                 || GlobalVariable.globalHashes.containsKey(fullName)
                 || GlobalVariable.globalCodeRefs.containsKey(fullName)
-                || GlobalVariable.globalIORefs.containsKey(fullName)
+                || GlobalVariable.isVisibleGlobalIORef(fullName)
                 || GlobalVariable.globalFormatRefs.containsKey(fullName);
     }
 
@@ -343,7 +340,7 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
             RuntimeScalar scalar = GlobalVariable.globalVariables.remove(fullKey);
             RuntimeArray array = GlobalVariable.globalArrays.remove(fullKey);
             RuntimeHash hash = GlobalVariable.globalHashes.remove(fullKey);
-            RuntimeGlob io = GlobalVariable.globalIORefs.get(fullKey);
+            RuntimeGlob io = GlobalVariable.getExistingGlobalIO(fullKey);
             if (io != null) {
                 GlobalVariable.hideIORefAfterStashDelete(fullKey);
             }
@@ -371,7 +368,7 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
             GlobalVariable.globalArrays.keySet().removeIf(k -> k.startsWith(prefix));
             GlobalVariable.globalHashes.keySet().removeIf(k -> k.startsWith(prefix));
             GlobalVariable.globalCodeRefs.keySet().removeIf(k -> k.startsWith(prefix));
-            GlobalVariable.globalIORefs.keySet().removeIf(k -> k.startsWith(prefix));
+            GlobalVariable.removeGlobalIORefsForNamespace(prefix);
             GlobalVariable.globalFormatRefs.keySet().removeIf(k -> k.startsWith(prefix));
             GlobalVariable.invalidateStashEnumerationCache();
             GlobalVariable.clearHiddenIORefsForNamespace(prefix);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/OutputAutoFlushVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/OutputAutoFlushVariable.java
@@ -10,8 +10,8 @@ public class OutputAutoFlushVariable extends RuntimeScalar {
     private static final Stack<State> stateStack = new Stack<>();
 
     private static RuntimeIO currentHandle() {
-        RuntimeIO handle = RuntimeIO.selectedHandle;
-        return handle != null ? handle : RuntimeIO.stdout;
+        RuntimeIO handle = RuntimeIO.getSelectedHandle();
+        return handle != null ? handle : RuntimeIO.getStdout();
     }
 
     @Override

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -1,0 +1,213 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.perlonjava.runtime.io.IOHandle;
+import org.perlonjava.runtime.io.StandardIO;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Identity and scoped thread binding for one Perl interpreter instance.
+ *
+ * <p>Runtime subsystems migrate into this object in independently tested phases.
+ * Bindings are explicit and scoped:
+ * they do not inherit into child or executor threads, whose tasks must capture
+ * and bind the intended runtime themselves.</p>
+ */
+public final class PerlRuntime {
+    private static final ThreadLocal<BindingFrame> CURRENT = new ThreadLocal<>();
+
+    RuntimeIO ioStdout;
+    RuntimeIO ioStderr;
+    RuntimeIO ioStdin;
+    RuntimeIO ioSelectedHandle;
+    RuntimeIO ioLastWrittenHandle;
+    RuntimeIO ioLastAccessedHandle;
+    String ioLastReadlineHandleName;
+    final Map<IOHandle, Boolean> ioOpenHandles = new LinkedHashMap<>(RuntimeIO.MAX_OPEN_HANDLES, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<IOHandle, Boolean> eldest) {
+            if (size() <= RuntimeIO.MAX_OPEN_HANDLES) {
+                return false;
+            }
+            try {
+                eldest.getKey().flush();
+            } catch (Exception ignored) {
+                // Eviction is best-effort; the handle remains externally owned.
+            }
+            return true;
+        }
+    };
+    private final Map<String, RuntimeGlob> standardIOGlobs = new HashMap<>();
+    private final Set<String> hiddenStandardIOGlobs = new HashSet<>();
+
+    public PerlRuntime() {
+        ioStdout = new RuntimeIO(new StandardIO(System.out, true));
+        ioStderr = new RuntimeIO(new StandardIO(System.err, false));
+        ioStderr.autoFlush = true;
+        ioStdin = new RuntimeIO(new StandardIO(System.in));
+        ioSelectedHandle = ioStdout;
+        ioLastWrittenHandle = ioStdout;
+
+        installInitialStandardGlob("main::STDOUT", ioStdout);
+        installInitialStandardGlob("main::stdout", ioStdout);
+        installInitialStandardGlob("main::STDERR", ioStderr);
+        installInitialStandardGlob("main::stderr", ioStderr);
+        installInitialStandardGlob("main::STDIN", ioStdin);
+        installInitialStandardGlob("main::stdin", ioStdin);
+        ioStdout.globName = "main::STDOUT";
+        ioStderr.globName = "main::STDERR";
+        ioStdin.globName = "main::STDIN";
+    }
+
+    /** Return the runtime bound to this thread, failing clearly when absent. */
+    public static PerlRuntime current() {
+        PerlRuntime runtime = currentOrNull();
+        if (runtime == null) {
+            throw new IllegalStateException(
+                    "No PerlRuntime is bound to the current thread; use PerlRuntime.bind() in a scoped block");
+        }
+        return runtime;
+    }
+
+    /** Return the runtime bound to this thread, or {@code null}. */
+    public static PerlRuntime currentOrNull() {
+        BindingFrame frame = CURRENT.get();
+        return frame != null ? frame.runtime : null;
+    }
+
+    /** Bind this runtime until the returned scope is closed. */
+    public Binding bind() {
+        BindingFrame frame = new BindingFrame(this, CURRENT.get());
+        CURRENT.set(frame);
+        return new Binding(frame, Thread.currentThread());
+    }
+
+    /** Convenience form for {@code runtime.bind()}. */
+    public static Binding bind(PerlRuntime runtime) {
+        return Objects.requireNonNull(runtime, "runtime").bind();
+    }
+
+    /**
+     * Bind the existing runtime again, or create a temporary runtime when
+     * called at a public Java entry point. Closing always restores the exact
+     * prior state, including absence.
+     */
+    public static Binding bindCurrentOrNew() {
+        PerlRuntime runtime = currentOrNull();
+        return (runtime != null ? runtime : new PerlRuntime()).bind();
+    }
+
+    RuntimeGlob standardIOGlob(String name) {
+        return standardIOGlobs.get(name);
+    }
+
+    Set<String> standardIOGlobNames() {
+        return standardIOGlobs.keySet();
+    }
+
+    boolean isStandardIOGlobVisible(String name) {
+        return standardIOGlobs.containsKey(name) && !hiddenStandardIOGlobs.contains(name);
+    }
+
+    void hideStandardIOGlob(String name) {
+        if (standardIOGlobs.containsKey(name)) {
+            hiddenStandardIOGlobs.add(name);
+        }
+    }
+
+    void showStandardIOGlob(String name) {
+        hiddenStandardIOGlobs.remove(name);
+    }
+
+    void hideStandardIOGlobsWithPrefix(String prefix) {
+        for (String name : standardIOGlobs.keySet()) {
+            if (name.startsWith(prefix)) {
+                hiddenStandardIOGlobs.add(name);
+            }
+        }
+    }
+
+    void resetStandardIOGlobVisibility() {
+        hiddenStandardIOGlobs.clear();
+    }
+
+    void replaceStandardIOGlob(String name, RuntimeGlob glob) {
+        standardIOGlobs.put(name, glob);
+        if (glob != null && glob.IO != null && glob.IO.value instanceof RuntimeIO io) {
+            replaceStandardHandle(name, io);
+        }
+    }
+
+    void replaceStandardHandle(String name, RuntimeIO io) {
+        switch (name) {
+        case "main::STDOUT" -> {
+            ioStdout = io;
+            updateStandardGlobHandle(name, io);
+        }
+        case "main::STDERR" -> {
+            ioStderr = io;
+            updateStandardGlobHandle(name, io);
+        }
+        case "main::STDIN" -> {
+            ioStdin = io;
+            updateStandardGlobHandle(name, io);
+        }
+        case "main::stdout", "main::stderr", "main::stdin" ->
+            updateStandardGlobHandle(name, io);
+        default -> throw new IllegalArgumentException("Not a standard I/O glob: " + name);
+        }
+        io.globName = name;
+    }
+
+    private void installInitialStandardGlob(String name, RuntimeIO io) {
+        RuntimeGlob glob = new RuntimeGlob(name);
+        glob.IO = new RuntimeScalar(io);
+        standardIOGlobs.put(name, glob);
+    }
+
+    private void updateStandardGlobHandle(String name, RuntimeIO io) {
+        RuntimeGlob glob = standardIOGlobs.get(name);
+        if (glob != null) {
+            glob.IO = new RuntimeScalar(io);
+        }
+    }
+
+    private record BindingFrame(PerlRuntime runtime, BindingFrame previous) {
+    }
+
+    /** Owns exactly one binding frame and restores the prior frame on close. */
+    public static final class Binding implements AutoCloseable {
+        private final BindingFrame frame;
+        private final Thread owner;
+        private boolean closed;
+
+        private Binding(BindingFrame frame, Thread owner) {
+            this.frame = frame;
+            this.owner = owner;
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+            if (Thread.currentThread() != owner) {
+                throw new IllegalStateException("PerlRuntime binding must be closed by its owning thread");
+            }
+            if (CURRENT.get() != frame) {
+                throw new IllegalStateException("PerlRuntime bindings must be closed in LIFO order");
+            }
+            closed = true;
+            if (frame.previous == null) {
+                CURRENT.remove();
+            } else {
+                CURRENT.set(frame.previous);
+            }
+        }
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -1844,7 +1844,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      */
     public static Class<?> evalStringHelper(RuntimeScalar code, String evalTag, Object[] runtimeValues) throws Exception {
 
-        try (PerlLanguageProvider.CompilationLockGuard ignored =
+        try (PerlRuntime.Binding runtimeBinding = PerlRuntime.current().bind();
+             PerlLanguageProvider.CompilationLockGuard ignored =
                      PerlLanguageProvider.acquireCompilationLock()) {
 
         rejectTaintedEval(code);
@@ -2366,6 +2367,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             RuntimeArray args,
             int callContext) throws Throwable {
 
+        try (PerlRuntime.Binding runtimeBinding = PerlRuntime.current().bind()) {
         PerlLanguageProvider.CompilationLockGuard compilationLock =
                 PerlLanguageProvider.acquireCompilationLock();
         try {
@@ -2853,6 +2855,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         }
         } finally {
             compilationLock.close();
+        }
         }
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
@@ -626,9 +626,9 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
             // Update selectedHandle if the old IO was the currently selected output handle.
             // This ensures that `local *STDOUT = $fh` redirects bare `print` (no filehandle)
             // to the new handle, not just explicit `print STDOUT`.
-            if (oldRuntimeIO != null && oldRuntimeIO == RuntimeIO.selectedHandle
+            if (oldRuntimeIO != null && oldRuntimeIO == RuntimeIO.getSelectedHandle()
                     && value.IO != null && value.IO.value instanceof RuntimeIO newRIO) {
-                RuntimeIO.selectedHandle = newRIO;
+                RuntimeIO.setSelectedHandle(newRIO);
             }
 
             return value.scalar();
@@ -732,9 +732,9 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         targetIO.IO = ioSource;
 
         // Update selectedHandle if the old IO was the currently selected output handle
-        if (oldRuntimeIO != null && oldRuntimeIO == RuntimeIO.selectedHandle
+        if (oldRuntimeIO != null && oldRuntimeIO == RuntimeIO.getSelectedHandle()
                 && ioSource != null && ioSource.value instanceof RuntimeIO newRIO) {
-            RuntimeIO.selectedHandle = newRIO;
+            RuntimeIO.setSelectedHandle(newRIO);
         }
 
         // Alias the ARRAY slot: both names point to the same RuntimeArray object.
@@ -1049,9 +1049,10 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         // If the IO scalar contains a RuntimeIO, set its glob name
         if (io.value instanceof RuntimeIO runtimeIO) {
             runtimeIO.globName = this.globName;
+            updateStandardRuntimeHandle(runtimeIO);
             // Update selectedHandle if the old IO was the selected handle
-            if (oldIO != null && oldIO == RuntimeIO.selectedHandle) {
-                RuntimeIO.selectedHandle = runtimeIO;
+            if (oldIO != null && oldIO == RuntimeIO.getSelectedHandle()) {
+                RuntimeIO.setSelectedHandle(runtimeIO);
             }
         }
         return this;
@@ -1077,9 +1078,10 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         // Update selectedHandle if the old IO was the selected handle
         // This ensures that when STDOUT is redirected, print without explicit
         // filehandle uses the new handle
-        if (oldIO != null && oldIO == RuntimeIO.selectedHandle) {
-            RuntimeIO.selectedHandle = io;
+        if (oldIO != null && oldIO == RuntimeIO.getSelectedHandle()) {
+            RuntimeIO.setSelectedHandle(io);
         }
+        updateStandardRuntimeHandle(io);
         return this;
     }
 
@@ -1088,7 +1090,7 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
                 && this.IO.type != RuntimeScalarType.TIED_SCALAR
                 && this.IO.value instanceof RuntimeIO existingIO
                 && existingIO != io) {
-            RuntimeIO oldSelected = existingIO == RuntimeIO.selectedHandle ? existingIO : null;
+            RuntimeIO oldSelected = existingIO == RuntimeIO.getSelectedHandle() ? existingIO : null;
             existingIO.replaceStateFrom(io);
             existingIO.globName = this.globName;
             Integer standardFd = standardFdForGlobName(this.globName);
@@ -1096,7 +1098,7 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
                 existingIO.registerExternalFd(standardFd);
             }
             if (oldSelected != null) {
-                RuntimeIO.selectedHandle = existingIO;
+                RuntimeIO.setSelectedHandle(existingIO);
             }
             return this;
         }
@@ -1114,6 +1116,12 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
             return 2;
         }
         return null;
+    }
+
+    private void updateStandardRuntimeHandle(RuntimeIO io) {
+        if (PerlRuntime.current().standardIOGlob(globName) != null) {
+            PerlRuntime.current().replaceStandardHandle(globName, io);
+        }
     }
 
     /**
@@ -1331,7 +1339,7 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
             GlobalVariable.globalArrays.keySet().removeIf(k -> k.startsWith(prefix));
             GlobalVariable.globalHashes.keySet().removeIf(k -> k.startsWith(prefix));
             GlobalVariable.globalCodeRefs.keySet().removeIf(k -> k.startsWith(prefix));
-            GlobalVariable.globalIORefs.keySet().removeIf(k -> k.startsWith(prefix));
+            GlobalVariable.removeGlobalIORefsForNamespace(prefix);
             GlobalVariable.globalFormatRefs.keySet().removeIf(k -> k.startsWith(prefix));
             GlobalVariable.invalidateStashEnumerationCache();
             GlobalVariable.invalidatePackageRootSnapshot();
@@ -1381,25 +1389,26 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         RuntimeScalar savedScalar = GlobalVariable.globalVariables.get(this.globName);
         RuntimeArray savedArray = GlobalVariable.globalArrays.get(this.globName);
         RuntimeHash savedHash = GlobalVariable.globalHashes.get(this.globName);
-        RuntimeScalar savedCode = GlobalVariable.getGlobalCodeRef(this.globName);
+        RuntimeScalar savedCode = GlobalVariable.globalCodeRefs.get(this.globName);
         // Save the current IO object reference (not its state) so we can restore it later.
         // This allows captured glob references to keep the "local" IO even after restore.
         RuntimeScalar savedIO = this.IO;
+        boolean savedIOVisible = GlobalVariable.isVisibleGlobalIORef(this.globName);
         // Save selectedHandle if this glob's IO is the currently selected handle.
         // This is needed for local(*STDOUT) to correctly restore selectedHandle
         // after Capture::Tiny or similar modules localize STDOUT.
         RuntimeIO savedSelectedHandle = null;
         boolean isSelectedHandle = false;
-        if (this.IO != null && this.IO.value instanceof RuntimeIO rio && rio == RuntimeIO.selectedHandle) {
-            savedSelectedHandle = RuntimeIO.selectedHandle;
+        if (this.IO != null && this.IO.value instanceof RuntimeIO rio && rio == RuntimeIO.getSelectedHandle()) {
+            savedSelectedHandle = RuntimeIO.getSelectedHandle();
             isSelectedHandle = true;
-        } else if (this.IO != null && this.IO.type == TIED_SCALAR && this.IO.value == RuntimeIO.selectedHandle) {
-            savedSelectedHandle = RuntimeIO.selectedHandle;
+        } else if (this.IO != null && this.IO.type == TIED_SCALAR && this.IO.value == RuntimeIO.getSelectedHandle()) {
+            savedSelectedHandle = RuntimeIO.getSelectedHandle();
             isSelectedHandle = true;
         }
         globSlotStack.push(new GlobSlotSnapshot(this.globName,
                 savedScalar, savedArray, savedHash,
-                savedCode, savedIO, savedSelectedHandle));
+                savedCode, savedIO, savedSelectedHandle, savedIOVisible));
 
         // Replace global table entries with NEW empty objects instead of mutating the
         // existing ones in-place. This is critical because the existing objects may be
@@ -1466,10 +1475,10 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
             RuntimeIO stubIO = new RuntimeIO();
             stubIO.globName = this.globName;
             newGlob.IO = new RuntimeScalar(stubIO);
-            RuntimeIO.selectedHandle = stubIO;
+            RuntimeIO.setSelectedHandle(stubIO);
         }
 
-        GlobalVariable.globalIORefs.put(this.globName, newGlob);
+        GlobalVariable.replaceGlobalIO(this.globName, newGlob);
     }
 
     @Override
@@ -1483,13 +1492,13 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         // This ensures that after local(*STDOUT) + restore, print without explicit
         // filehandle goes through the correct (possibly tied) handle.
         if (snap.savedSelectedHandle != null) {
-            RuntimeIO.selectedHandle = snap.savedSelectedHandle;
+            RuntimeIO.setSelectedHandle(snap.savedSelectedHandle);
         }
 
         // Put this (old) glob back in globalIORefs, replacing the local scope's glob.
         // Any references captured during the local scope still point to the local glob,
         // which is now an independent orphaned glob (matching Perl 5 GV behavior).
-        GlobalVariable.globalIORefs.put(snap.globName, this);
+        GlobalVariable.replaceGlobalIO(snap.globName, this);
 
         // Restore saved objects directly - they were never mutated, so no
         // dynamicRestoreState() call is needed.
@@ -1547,8 +1556,12 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
                 removedLocalCodeForReachabilityCheck = localCodeObj;
             }
         }
-        GlobalVariable.markPackageGlobalRoot(snap.code);
-        GlobalVariable.globalCodeRefs.put(snap.globName, snap.code);
+        if (snap.code != null) {
+            GlobalVariable.markPackageGlobalRoot(snap.code);
+            GlobalVariable.globalCodeRefs.put(snap.globName, snap.code);
+        } else {
+            GlobalVariable.globalCodeRefs.remove(snap.globName);
+        }
         GlobalVariable.invalidatePackageRootSnapshot();
         if (removedLocalCodeForReachabilityCheck != null
                 && removedLocalCodeForReachabilityCheck.activeOwnerCount() == 0
@@ -1570,6 +1583,12 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         InheritanceResolver.invalidateCache();
 
         GlobalVariable.getGlobalFormatRef(snap.globName).dynamicRestoreState();
+        // Restoring the other glob slots may mark the stash entry visible as a
+        // side effect. Reapply the saved IO-slot visibility last so a deleted
+        // standard handle does not leak back into the runtime's stash view.
+        if (!snap.ioWasVisible) {
+            GlobalVariable.hideIORefAfterStashDelete(snap.globName);
+        }
     }
 
     private record GlobSlotSnapshot(
@@ -1579,6 +1598,7 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
             RuntimeHash hash,
             RuntimeScalar code,
             RuntimeScalar io,
-            RuntimeIO savedSelectedHandle) {
+            RuntimeIO savedSelectedHandle,
+            boolean ioWasVisible) {
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
@@ -94,68 +94,27 @@ public class RuntimeIO extends RuntimeScalar {
      * Maximum number of file handles to keep in the LRU cache.
      * Older handles are flushed (not closed) when this limit is exceeded.
      */
-    private static final int MAX_OPEN_HANDLES = 100;
+    static final int MAX_OPEN_HANDLES = 100;
 
-    /**
-     * LRU (Least Recently Used) cache for managing open file handles.
-     * This helps prevent resource exhaustion by limiting open handles and
-     * automatically flushing less recently used ones.
-     */
-    private static final Map<IOHandle, Boolean> openHandles = new LinkedHashMap<IOHandle, Boolean>(MAX_OPEN_HANDLES, 0.75f, true) {
-        @Override
-        protected boolean removeEldestEntry(Map.Entry<IOHandle, Boolean> eldest) {
-            if (size() > MAX_OPEN_HANDLES) {
-                try {
-                    // Flush but don't close the eldest handle
-                    eldest.getKey().flush();
-                } catch (Exception e) {
-                    // Handle exception if needed
-                }
-                return true;
-            }
-            return false;
-        }
-    };
-
+    /** Child processes remain process-global until the later registry migration. */
     private static final Map<Long, Process> childProcesses = new java.util.concurrent.ConcurrentHashMap<>();
-    /**
-     * Standard output stream handle (STDOUT)
-     */
-    public static RuntimeIO stdout = new RuntimeIO(new StandardIO(System.out, true));
-    /**
-     * Standard error stream handle (STDERR)
-     * Note: autoFlush is set to true to match Perl's unbuffered stderr behavior
-     */
-    public static RuntimeIO stderr = new RuntimeIO(new StandardIO(System.err, false));
-    
-    static {
-        // STDERR should be unbuffered (autoFlush) by default, like in Perl
-        stderr.autoFlush = true;
-    }
-    
-    /**
-     * Standard input stream handle (STDIN)
-     */
-    public static RuntimeIO stdin = new RuntimeIO(new StandardIO(System.in));
-    /**
-     * The last accessed filehandle, used for Perl's ${^LAST_FH} special variable.
-     * Updated whenever a filehandle is used for I/O operations.
-     */
-    public static RuntimeIO lastAccesseddHandle;
-    /**
-     * The variable/handle name used in the last readline operation (e.g., "$f", "STDIN").
-     * Set by the JVM backend before calling readline, used by WarnDie for error messages
-     * when the handle's globName is null (e.g., lexical filehandles).
-     */
-    public static String lastReadlineHandleName;
-    // Tracks the last handle used for output writes (print/say/etc). This must not
-    // clobber lastAccesseddHandle, which is used for ${^LAST_FH} and $.
-    public static RuntimeIO lastWrittenHandle;
-    /**
-     * The currently selected filehandle for output operations.
-     * Used by print/printf when no filehandle is specified.
-     */
-    public static RuntimeIO selectedHandle;
+
+    public static RuntimeIO getStdout() { return PerlRuntime.current().ioStdout; }
+    public static void setStdout(RuntimeIO io) { PerlRuntime.current().replaceStandardHandle("main::STDOUT", io); }
+    public static RuntimeIO getStderr() { return PerlRuntime.current().ioStderr; }
+    public static void setStderr(RuntimeIO io) { PerlRuntime.current().replaceStandardHandle("main::STDERR", io); }
+    public static RuntimeIO getStdin() { return PerlRuntime.current().ioStdin; }
+    public static void setStdin(RuntimeIO io) { PerlRuntime.current().replaceStandardHandle("main::STDIN", io); }
+    public static RuntimeIO getLastAccessedHandle() { return PerlRuntime.current().ioLastAccessedHandle; }
+    public static void setLastAccessedHandle(RuntimeIO io) { PerlRuntime.current().ioLastAccessedHandle = io; }
+    public static String getLastReadlineHandleName() { return PerlRuntime.current().ioLastReadlineHandleName; }
+    public static void setLastReadlineHandleName(String name) { PerlRuntime.current().ioLastReadlineHandleName = name; }
+    public static RuntimeIO getLastWrittenHandle() { return PerlRuntime.current().ioLastWrittenHandle; }
+    public static void setLastWrittenHandle(RuntimeIO io) { PerlRuntime.current().ioLastWrittenHandle = io; }
+    public static RuntimeIO getSelectedHandle() { return PerlRuntime.current().ioSelectedHandle; }
+    public static void setSelectedHandle(RuntimeIO io) { PerlRuntime.current().ioSelectedHandle = io; }
+
+    private static Map<IOHandle, Boolean> openHandles() { return PerlRuntime.current().ioOpenHandles; }
 
     /**
      * Fileno registry for select() support.
@@ -499,7 +458,7 @@ public class RuntimeIO extends RuntimeScalar {
      * @param out the OutputStream to wrap
      */
     public static void setCustomOutputStream(OutputStream out) {
-        lastWrittenHandle = new RuntimeIO(new CustomOutputStreamHandle(out));
+        setLastWrittenHandle(new RuntimeIO(new CustomOutputStreamHandle(out)));
     }
 
     /**
@@ -585,20 +544,20 @@ public class RuntimeIO extends RuntimeScalar {
      */
     public static void initStdHandles() {
         // Initialize STDOUT, STDERR, STDIN in the main package
-        getGlobalIO("main::STDOUT").setIO(stdout);
-        getGlobalIO("main::STDERR").setIO(stderr);
-        getGlobalIO("main::STDIN").setIO(stdin);
+        getGlobalIO("main::STDOUT").setIO(getStdout());
+        getGlobalIO("main::STDERR").setIO(getStderr());
+        getGlobalIO("main::STDIN").setIO(getStdin());
         // Perl exposes lowercase aliases for the three standard handles in
         // main's symbol table as well.
-        getGlobalIO("main::stdout").setIO(stdout);
-        getGlobalIO("main::stderr").setIO(stderr);
-        getGlobalIO("main::stdin").setIO(stdin);
-        stdout.globName = "main::STDOUT";
-        stderr.globName = "main::STDERR";
-        stdin.globName = "main::STDIN";
-        lastAccesseddHandle = null;
-        lastWrittenHandle = stdout;
-        selectedHandle = stdout;
+        getGlobalIO("main::stdout").setIO(getStdout());
+        getGlobalIO("main::stderr").setIO(getStderr());
+        getGlobalIO("main::stdin").setIO(getStdin());
+        getStdout().globName = "main::STDOUT";
+        getStderr().globName = "main::STDERR";
+        getStdin().globName = "main::STDIN";
+        setLastAccessedHandle(null);
+        setLastWrittenHandle(getStdout());
+        setSelectedHandle(getStdout());
     }
 
     /**
@@ -1044,11 +1003,11 @@ public class RuntimeIO extends RuntimeScalar {
      */
     public static void flushFileHandles() {
         // Flush stdout and stderr before sleep, in case we are displaying a prompt
-        if (stdout.needFlush) {
-            stdout.flush();
+        if (getStdout().needFlush) {
+            getStdout().flush();
         }
-        if (stderr.needFlush) {
-            stderr.flush();
+        if (getStderr().needFlush) {
+            getStderr().flush();
         }
     }
 
@@ -1058,8 +1017,9 @@ public class RuntimeIO extends RuntimeScalar {
      * @param handle the IOHandle to cache
      */
     public static void addHandle(IOHandle handle) {
-        synchronized (openHandles) {
-            openHandles.put(handle, Boolean.TRUE);
+        Map<IOHandle, Boolean> handles = openHandles();
+        synchronized (handles) {
+            handles.put(handle, Boolean.TRUE);
         }
     }
 
@@ -1069,8 +1029,9 @@ public class RuntimeIO extends RuntimeScalar {
      * @param handle the IOHandle to remove
      */
     public static void removeHandle(IOHandle handle) {
-        synchronized (openHandles) {
-            openHandles.remove(handle);
+        Map<IOHandle, Boolean> handles = openHandles();
+        synchronized (handles) {
+            handles.remove(handle);
         }
     }
 
@@ -1079,8 +1040,9 @@ public class RuntimeIO extends RuntimeScalar {
      * This ensures all buffered data is written without closing files.
      */
     public static void flushAllHandles() {
-        synchronized (openHandles) {
-            for (IOHandle handle : openHandles.keySet()) {
+        Map<IOHandle, Boolean> handles = openHandles();
+        synchronized (handles) {
+            for (IOHandle handle : handles.keySet()) {
                 handle.flush();
             }
         }
@@ -1093,8 +1055,9 @@ public class RuntimeIO extends RuntimeScalar {
      */
     public static void closeAllHandles() {
         flushAllHandles();
-        synchronized (openHandles) {
-            for (IOHandle handle : openHandles.keySet()) {
+        Map<IOHandle, Boolean> handles = openHandles();
+        synchronized (handles) {
+            for (IOHandle handle : handles.keySet()) {
                 try {
                     handle.close();
                     handle = new ClosedIOHandle();
@@ -1102,7 +1065,7 @@ public class RuntimeIO extends RuntimeScalar {
                     // Handle exception if needed
                 }
             }
-            openHandles.clear(); // Clear the cache after closing all handles
+            handles.clear(); // Clear the cache after closing all handles
         }
     }
 
@@ -1499,7 +1462,7 @@ public class RuntimeIO extends RuntimeScalar {
      * @return RuntimeScalar with true if at EOF
      */
     public RuntimeScalar eof() {
-        lastAccesseddHandle = this;
+        setLastAccessedHandle(this);
         return ioHandle.eof();
     }
 
@@ -1510,7 +1473,7 @@ public class RuntimeIO extends RuntimeScalar {
      * @return RuntimeScalar with the current position
      */
     public RuntimeScalar tell() {
-        lastAccesseddHandle = this;
+        setLastAccessedHandle(this);
         return ioHandle.tell();
     }
 
@@ -1522,7 +1485,7 @@ public class RuntimeIO extends RuntimeScalar {
      * @return RuntimeScalar indicating success/failure
      */
     public RuntimeScalar seek(long pos) {
-        lastAccesseddHandle = this;
+        setLastAccessedHandle(this);
         return ioHandle.seek(pos);
     }
 
@@ -1559,14 +1522,14 @@ public class RuntimeIO extends RuntimeScalar {
         needFlush = true;
         // Only flush lastAccessedHandle if it's a different handle AND doesn't share the same ioHandle
         // (duplicated handles share the same ioHandle, so flushing would be redundant and could cause deadlocks)
-        if (lastWrittenHandle != null &&
-                lastWrittenHandle != this &&
-                lastWrittenHandle.needFlush &&
-                lastWrittenHandle.ioHandle != this.ioHandle) {
+        if (getLastWrittenHandle() != null &&
+                getLastWrittenHandle() != this &&
+                getLastWrittenHandle().needFlush &&
+                getLastWrittenHandle().ioHandle != this.ioHandle) {
             // Synchronize terminal output for stdout and stderr
-            lastWrittenHandle.flush();
+            getLastWrittenHandle().flush();
         }
-        lastWrittenHandle = this;
+        setLastWrittenHandle(this);
 
         // When no encoding layer is active, check for wide characters (> 0xFF).
         // Perl 5 warns and outputs UTF-8 encoding of the entire string in this case.

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStash.java
@@ -181,7 +181,7 @@ public class RuntimeStash extends RuntimeHash {
         RuntimeScalar savedScalar = GlobalVariable.globalVariables.get(fullKey);
         RuntimeArray savedArray = GlobalVariable.globalArrays.get(fullKey);
         RuntimeHash savedHash = GlobalVariable.globalHashes.get(fullKey);
-        RuntimeGlob savedIO = GlobalVariable.globalIORefs.get(fullKey);
+        RuntimeGlob savedIO = GlobalVariable.getExistingGlobalIO(fullKey);
         RuntimeScalar savedCode = GlobalVariable.globalCodeRefs.get(fullKey);
 
         // Delete all slots from GlobalVariable. The CODE slot helper removes
@@ -254,7 +254,7 @@ public class RuntimeStash extends RuntimeHash {
         GlobalVariable.globalVariables.keySet().removeIf(key -> key.startsWith(childPrefix));
         GlobalVariable.globalArrays.keySet().removeIf(key -> key.startsWith(childPrefix));
         GlobalVariable.globalHashes.keySet().removeIf(key -> key.startsWith(childPrefix));
-        GlobalVariable.globalIORefs.keySet().removeIf(key -> key.startsWith(childPrefix));
+        GlobalVariable.removeGlobalIORefsForNamespace(childPrefix);
         GlobalVariable.globalFormatRefs.keySet().removeIf(key -> key.startsWith(childPrefix));
         GlobalVariable.invalidateStashEnumerationCache();
         GlobalVariable.clearHiddenIORefsForNamespace(childPrefix);
@@ -428,7 +428,7 @@ public class RuntimeStash extends RuntimeHash {
         GlobalVariable.globalArrays.keySet().removeIf(k -> k.startsWith(prefix));
         GlobalVariable.globalHashes.keySet().removeIf(k -> k.startsWith(prefix));
         GlobalVariable.globalCodeRefs.keySet().removeIf(k -> k.startsWith(prefix));
-        GlobalVariable.globalIORefs.keySet().removeIf(k -> k.startsWith(prefix));
+        GlobalVariable.removeGlobalIORefsForNamespace(prefix);
         GlobalVariable.globalFormatRefs.keySet().removeIf(k -> k.startsWith(prefix));
         GlobalVariable.invalidateStashEnumerationCache();
         GlobalVariable.clearHiddenIORefsForNamespace(prefix);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarSpecialVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarSpecialVariable.java
@@ -84,9 +84,9 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
     public RuntimeScalar set(RuntimeScalar value) {
         if (variableId == Id.INPUT_LINE_NUMBER) {
             vivify();
-            if (RuntimeIO.lastAccesseddHandle != null) {
-                RuntimeIO.lastAccesseddHandle.currentLineNumber = value.getInt();
-                lvalue.set(RuntimeIO.lastAccesseddHandle.currentLineNumber);
+            if (RuntimeIO.getLastAccessedHandle() != null) {
+                RuntimeIO.getLastAccessedHandle().currentLineNumber = value.getInt();
+                lvalue.set(RuntimeIO.getLastAccessedHandle().currentLineNumber);
             } else {
                 lvalue.set(value);
             }
@@ -179,10 +179,10 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
                     yield postmatch != null ? makeRegexResultScalar(postmatch) : scalarUndef;
                 }
                 case LAST_FH -> {
-                    if (RuntimeIO.lastAccesseddHandle == null) {
+                    if (RuntimeIO.getLastAccessedHandle() == null) {
                         yield scalarUndef;
                     }
-                    String globName = RuntimeIO.lastAccesseddHandle.globName;
+                    String globName = RuntimeIO.getLastAccessedHandle().globName;
                     if (globName != null) {
                         // Extract package and name from the glob name
                         String packageName;
@@ -208,16 +208,16 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
                         }
                     }
                     // Fallback to the RuntimeIO object if no glob name is available
-                    yield new RuntimeScalar(RuntimeIO.lastAccesseddHandle);
+                    yield new RuntimeScalar(RuntimeIO.getLastAccessedHandle());
                 }
                 case INPUT_LINE_NUMBER -> {
-                    if (RuntimeIO.lastAccesseddHandle == null) {
+                    if (RuntimeIO.getLastAccessedHandle() == null) {
                         if (lvalue != null) {
                             yield lvalue;
                         }
                         yield scalarUndef;
                     }
-                    yield getScalarInt(RuntimeIO.lastAccesseddHandle.currentLineNumber);
+                    yield getScalarInt(RuntimeIO.getLastAccessedHandle().currentLineNumber);
                 }
                 case LAST_PAREN_MATCH -> {
                     String lastCapture = RuntimeRegex.lastCaptureString();
@@ -430,7 +430,7 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
     @Override
     public void dynamicSaveState() {
         if (variableId == Id.INPUT_LINE_NUMBER) {
-            RuntimeIO handle = RuntimeIO.lastAccesseddHandle;
+            RuntimeIO handle = RuntimeIO.getLastAccessedHandle();
             int lineNumber = handle != null ? handle.currentLineNumber : (lvalue != null ? lvalue.getInt() : 0);
             RuntimeScalar localValue = lvalue != null ? new RuntimeScalar(lvalue) : null;
             inputLineStateStack.push(new InputLineState(handle, lineNumber, localValue));
@@ -450,7 +450,7 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
         if (variableId == Id.INPUT_LINE_NUMBER) {
             if (!inputLineStateStack.isEmpty()) {
                 InputLineState previous = inputLineStateStack.pop();
-                RuntimeIO.lastAccesseddHandle = previous.lastHandle;
+                RuntimeIO.setLastAccessedHandle(previous.lastHandle);
                 if (previous.lastHandle != null) {
                     previous.lastHandle.currentLineNumber = previous.lastLineNumber;
                 }
@@ -466,7 +466,7 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
     @Override
     public Object dynamicSuspendState() {
         if (variableId == Id.INPUT_LINE_NUMBER) {
-            RuntimeIO handle = RuntimeIO.lastAccesseddHandle;
+            RuntimeIO handle = RuntimeIO.getLastAccessedHandle();
             InputLineState active = new InputLineState(
                     handle,
                     handle != null ? handle.currentLineNumber : (lvalue != null ? lvalue.getInt() : 0),
@@ -481,7 +481,7 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
     public void dynamicResumeState(Object token) {
         if (variableId == Id.INPUT_LINE_NUMBER && token instanceof InputLineState active) {
             dynamicSaveState();
-            RuntimeIO.lastAccesseddHandle = active.lastHandle;
+            RuntimeIO.setLastAccessedHandle(active.lastHandle);
             if (active.lastHandle != null) {
                 active.lastHandle.currentLineNumber = active.lastLineNumber;
             }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/TieHandle.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/TieHandle.java
@@ -176,7 +176,7 @@ public class TieHandle extends RuntimeIO {
 
     @Override
     public RuntimeScalar write(String data) {
-        RuntimeIO.lastWrittenHandle = this;
+        RuntimeIO.setLastWrittenHandle(this);
         RuntimeList args = new RuntimeList(new RuntimeScalar(data));
         return tiedPrint(this, args);
     }

--- a/src/main/java/org/perlonjava/runtime/terminal/UnixTerminalHandler.java
+++ b/src/main/java/org/perlonjava/runtime/terminal/UnixTerminalHandler.java
@@ -97,7 +97,7 @@ public abstract class UnixTerminalHandler implements TerminalHandler {
 
     @Override
     public char readSingleChar(double timeoutSeconds, RuntimeIO fh) throws IOException {
-        if (fh != RuntimeIO.stdin) {
+        if (fh != RuntimeIO.getStdin()) {
             RuntimeScalar result = fh.ioHandle.read(1);
             if (!result.getDefinedBoolean()) {
                 return 0;
@@ -147,7 +147,7 @@ public abstract class UnixTerminalHandler implements TerminalHandler {
     @Override
     public String readLineWithTimeout(double timeoutSeconds, RuntimeIO fh) throws IOException {
         BufferedReader reader = new BufferedReader(new InputStreamReader(
-                fh == RuntimeIO.stdin ? System.in : new ByteArrayInputStream(new byte[0])));
+                fh == RuntimeIO.getStdin() ? System.in : new ByteArrayInputStream(new byte[0])));
 
         if (timeoutSeconds < 0) {
             // Non-blocking read

--- a/src/main/java/org/perlonjava/runtime/terminal/WindowsTerminalHandler.java
+++ b/src/main/java/org/perlonjava/runtime/terminal/WindowsTerminalHandler.java
@@ -57,7 +57,7 @@ public class WindowsTerminalHandler implements TerminalHandler {
 
     @Override
     public char readSingleChar(double timeoutSeconds, RuntimeIO fh) throws IOException {
-        if (fh != RuntimeIO.stdin) {
+        if (fh != RuntimeIO.getStdin()) {
             RuntimeScalar result = fh.ioHandle.read(1);
             if (!result.getDefinedBoolean()) {
                 return 0;

--- a/src/test/java/org/perlonjava/CommandLineWarningOverrideTest.java
+++ b/src/test/java/org/perlonjava/CommandLineWarningOverrideTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("unit")
-public class CommandLineWarningOverrideTest {
+public class CommandLineWarningOverrideTest extends PerlRuntimeTestBase {
     private RuntimeIO originalStdout;
     private RuntimeIO originalStderr;
     private ByteArrayOutputStream stdout;
@@ -28,23 +28,23 @@ public class CommandLineWarningOverrideTest {
     void setUp() {
         PerlLanguageProvider.resetAll();
 
-        originalStdout = RuntimeIO.stdout;
-        originalStderr = RuntimeIO.stderr;
+        originalStdout = RuntimeIO.getStdout();
+        originalStderr = RuntimeIO.getStderr();
         stdout = new ByteArrayOutputStream();
         stderr = new ByteArrayOutputStream();
 
-        RuntimeIO.stdout = new RuntimeIO(new StandardIO(stdout, true));
-        RuntimeIO.stderr = new RuntimeIO(new StandardIO(stderr, false));
-        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.stdout);
-        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.stderr);
+        RuntimeIO.setStdout(new RuntimeIO(new StandardIO(stdout, true)));
+        RuntimeIO.setStderr(new RuntimeIO(new StandardIO(stderr, false)));
+        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.getStdout());
+        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.getStderr());
     }
 
     @AfterEach
     void tearDown() {
-        RuntimeIO.stdout = originalStdout;
-        RuntimeIO.stderr = originalStderr;
-        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.stdout);
-        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.stderr);
+        RuntimeIO.setStdout(originalStdout);
+        RuntimeIO.setStderr(originalStderr);
+        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.getStdout());
+        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.getStderr());
         PerlLanguageProvider.resetAll();
     }
 
@@ -70,8 +70,8 @@ public class CommandLineWarningOverrideTest {
         CompilerOptions options = ArgumentParser.parseArguments(args);
 
         PerlLanguageProvider.executePerlCode(options, true);
-        RuntimeIO.stdout.flush();
-        RuntimeIO.stderr.flush();
+        RuntimeIO.getStdout().flush();
+        RuntimeIO.getStderr().flush();
 
         return new String(stdout.toByteArray(), StandardCharsets.ISO_8859_1)
                 + new String(stderr.toByteArray(), StandardCharsets.ISO_8859_1);

--- a/src/test/java/org/perlonjava/ModuleTestExecutionTest.java
+++ b/src/test/java/org/perlonjava/ModuleTestExecutionTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Unlike unit tests (which are self-contained), module tests may
  * reference external data files and assume a specific working directory.
  */
-public class ModuleTestExecutionTest {
+public class ModuleTestExecutionTest extends PerlRuntimeTestBase {
 
     static {
         Locale.setDefault(Locale.US);
@@ -153,18 +153,18 @@ public class ModuleTestExecutionTest {
         originalUserDir = System.getProperty("user.dir");
 
         StandardIO newStdout = new StandardIO(outputStream, true);
-        RuntimeIO.stdout = new RuntimeIO(newStdout);
-        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.stdout);
-        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.stderr);
+        RuntimeIO.setStdout(new RuntimeIO(newStdout));
+        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.getStdout());
+        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.getStderr());
         System.setOut(new PrintStream(outputStream));
     }
 
     @AfterEach
     void tearDown() {
         // Restore original stdout
-        RuntimeIO.stdout = new RuntimeIO(new StandardIO(originalOut, true));
-        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.stdout);
-        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.stderr);
+        RuntimeIO.setStdout(new RuntimeIO(new StandardIO(originalOut, true)));
+        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.getStdout());
+        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.getStderr());
         System.setOut(originalOut);
 
         // Restore original working directory

--- a/src/test/java/org/perlonjava/PerlRuntimeTestBase.java
+++ b/src/test/java/org/perlonjava/PerlRuntimeTestBase.java
@@ -1,0 +1,26 @@
+package org.perlonjava;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
+
+/** Keeps one explicit runtime bound for tests that configure global Perl facades. */
+public abstract class PerlRuntimeTestBase {
+    private PerlRuntime runtime;
+    private PerlRuntime.Binding binding;
+
+    @BeforeEach
+    protected void bindPerlRuntime() {
+        runtime = new PerlRuntime();
+        binding = runtime.bind();
+    }
+
+    @AfterEach
+    protected void unbindPerlRuntime() {
+        binding.close();
+    }
+
+    protected final PerlRuntime perlRuntime() {
+        return runtime;
+    }
+}

--- a/src/test/java/org/perlonjava/PerlScriptExecutionTest.java
+++ b/src/test/java/org/perlonjava/PerlScriptExecutionTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * This class uses JUnit 5 for testing and includes parameterized tests
  * to run multiple Perl scripts located in the resources directory.
  */
-public class PerlScriptExecutionTest {
+public class PerlScriptExecutionTest extends PerlRuntimeTestBase {
 
     static {
         // Set default locale to US (uses dot as decimal separator)
@@ -217,17 +217,17 @@ public class PerlScriptExecutionTest {
         // Create a new StandardIO with the capture stream
         StandardIO newStdout = new StandardIO(outputStream, true);
 
-        // Replace RuntimeIO.stdout with a new instance
-        RuntimeIO.stdout = new RuntimeIO(newStdout);
+        // Replace RuntimeIO.getStdout() with a new instance
+        RuntimeIO.setStdout(new RuntimeIO(newStdout));
         // Tests can apply persistent PerlIO layers to STDERR (for example via
         // `open ':std'`). Give every script a fresh standard handle so those
         // layers cannot leak into later parameterized cases.
-        RuntimeIO.stderr = new RuntimeIO(new StandardIO(System.err, false));
-        RuntimeIO.stderr.setAutoFlush(true);
+        RuntimeIO.setStderr(new RuntimeIO(new StandardIO(System.err, false)));
+        RuntimeIO.getStderr().setAutoFlush(true);
         // Keep Perl's global *STDOUT/*STDERR in sync with the RuntimeIO static fields.
         // Some tests call `binmode STDOUT/STDERR` and expect it to affect the real globals.
-        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.stdout);
-        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.stderr);
+        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.getStdout());
+        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.getStderr());
 
         // Also update System.out for any direct Java calls
         System.setOut(new PrintStream(outputStream));
@@ -239,11 +239,11 @@ public class PerlScriptExecutionTest {
     @AfterEach
     void tearDown() {
         // Restore original stdout
-        RuntimeIO.stdout = new RuntimeIO(new StandardIO(originalOut, true));
-        RuntimeIO.stderr = new RuntimeIO(new StandardIO(System.err, false));
-        RuntimeIO.stderr.setAutoFlush(true);
-        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.stdout);
-        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.stderr);
+        RuntimeIO.setStdout(new RuntimeIO(new StandardIO(originalOut, true)));
+        RuntimeIO.setStderr(new RuntimeIO(new StandardIO(System.err, false)));
+        RuntimeIO.getStderr().setAutoFlush(true);
+        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.getStdout());
+        GlobalVariable.getGlobalIO("main::STDERR").setIO(RuntimeIO.getStderr());
         System.setOut(originalOut);
     }
 

--- a/src/test/java/org/perlonjava/app/scriptengine/CompilationLockTest.java
+++ b/src/test/java/org/perlonjava/app/scriptengine/CompilationLockTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.PerlRuntimeTestBase;
 import org.perlonjava.runtime.io.StandardIO;
 import org.perlonjava.runtime.runtimetypes.GlobalVariable;
 import org.perlonjava.runtime.runtimetypes.RuntimeIO;
@@ -21,25 +22,28 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("unit")
-class CompilationLockTest {
+class CompilationLockTest extends PerlRuntimeTestBase {
     private RuntimeIO savedStdout;
 
     @BeforeEach
     void setUp() {
         PerlLanguageProvider.resetAll();
-        savedStdout = RuntimeIO.stdout;
+        savedStdout = RuntimeIO.getStdout();
     }
 
     @AfterEach
     void tearDown() {
-        RuntimeIO.stdout = savedStdout;
+        RuntimeIO.setStdout(savedStdout);
         GlobalVariable.getGlobalIO("main::STDOUT").setIO(savedStdout);
     }
 
     @Test
     void compileEntryPointQueuesBehindTheGlobalLock() throws Exception {
-        FutureTask<Object> compilation = new FutureTask<>(() ->
-                PerlLanguageProvider.compilePerlCode(options("40 + 2", false)));
+        FutureTask<Object> compilation = new FutureTask<>(() -> {
+            try (var ignored = perlRuntime().bind()) {
+                return PerlLanguageProvider.compilePerlCode(options("40 + 2", false));
+            }
+        });
         Thread worker = Thread.ofPlatform().name("queued-perl-compiler").unstarted(compilation);
 
         PerlLanguageProvider.COMPILE_LOCK.lock();
@@ -80,24 +84,40 @@ class CompilationLockTest {
         CountDownLatch ready = new CountDownLatch(workerCount);
         CountDownLatch start = new CountDownLatch(1);
         List<FutureTask<Object>> tasks = new ArrayList<>();
+        List<Thread> workers = new ArrayList<>();
 
         for (int i = 0; i < workerCount; i++) {
             int id = i;
             FutureTask<Object> task = new FutureTask<>(() -> {
-                ready.countDown();
-                assertTrue(start.await(10, TimeUnit.SECONDS));
-                return PerlLanguageProvider.compilePerlCode(options(
-                        "package Phase2::P" + id + "; sub f" + id + " { qr/x/o; " + id + " } f" + id + "()",
-                        (id & 1) != 0));
+                try (var ignored = perlRuntime().bind()) {
+                    ready.countDown();
+                    assertTrue(start.await(10, TimeUnit.SECONDS));
+                    return PerlLanguageProvider.compilePerlCode(options(
+                            "package Phase2::P" + id + "; sub f" + id + " { qr/x/o; " + id + " } f" + id + "()",
+                            (id & 1) != 0));
+                }
             });
             tasks.add(task);
-            Thread.ofPlatform().name("concurrent-perl-compiler-" + id).start(task);
+            workers.add(Thread.ofPlatform().name("concurrent-perl-compiler-" + id).start(task));
         }
 
-        assertTrue(ready.await(10, TimeUnit.SECONDS));
-        start.countDown();
-        for (FutureTask<Object> task : tasks) {
-            assertNotNull(task.get(60, TimeUnit.SECONDS));
+        try {
+            try {
+                assertTrue(ready.await(10, TimeUnit.SECONDS));
+            } finally {
+                start.countDown();
+            }
+            for (FutureTask<Object> task : tasks) {
+                assertNotNull(task.get(60, TimeUnit.SECONDS));
+            }
+        } finally {
+            start.countDown();
+            for (Thread worker : workers) {
+                worker.join(TimeUnit.SECONDS.toMillis(10));
+            }
+            for (Thread worker : workers) {
+                assertFalse(worker.isAlive(), "compiler worker did not terminate");
+            }
         }
     }
 
@@ -114,11 +134,14 @@ class CompilationLockTest {
     @Test
     void ordinaryExecutionDoesNotRetainItsCompilationHold() throws Exception {
         BlockingOutputStream output = new BlockingOutputStream();
-        RuntimeIO.stdout = new RuntimeIO(new StandardIO(output, true));
-        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.stdout);
+        RuntimeIO.setStdout(new RuntimeIO(new StandardIO(output, true)));
+        GlobalVariable.getGlobalIO("main::STDOUT").setIO(RuntimeIO.getStdout());
 
-        FutureTask<RuntimeList> execution = new FutureTask<>(() ->
-                PerlLanguageProvider.executePerlCode(options("print 'x'; 42", false), false));
+        FutureTask<RuntimeList> execution = new FutureTask<>(() -> {
+            try (var ignored = perlRuntime().bind()) {
+                return PerlLanguageProvider.executePerlCode(options("print 'x'; 42", false), false);
+            }
+        });
         Thread worker = Thread.ofPlatform().name("blocked-perl-execution").start(execution);
         try {
             assertTrue(output.entered.await(30, TimeUnit.SECONDS), "program did not reach output flush");

--- a/src/test/java/org/perlonjava/app/scriptengine/PerlRuntimeEntrypointTest.java
+++ b/src/test/java/org/perlonjava/app/scriptengine/PerlRuntimeEntrypointTest.java
@@ -1,0 +1,112 @@
+package org.perlonjava.app.scriptengine;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
+import org.perlonjava.runtime.runtimetypes.RuntimeList;
+
+import javax.script.Compilable;
+import javax.script.CompiledScript;
+import javax.script.ScriptEngine;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class PerlRuntimeEntrypointTest {
+
+    @BeforeEach
+    void resetGlobals() {
+        PerlLanguageProvider.resetAll();
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void providerTemporarilyBindsUnboundJvmAndInterpreterCallers() throws Exception {
+        for (boolean interpreter : new boolean[]{false, true}) {
+            FutureTask<EntryResult> invocation = new FutureTask<>(() -> {
+                assertNull(PerlRuntime.currentOrNull());
+                RuntimeList result = PerlLanguageProvider.executePerlCode(
+                        options("40 + 2", interpreter), false);
+                return new EntryResult(result.scalar().getInt(), PerlRuntime.currentOrNull());
+            });
+            Thread worker = Thread.ofPlatform().name("unbound-provider-entry").start(invocation);
+            worker.join(TimeUnit.SECONDS.toMillis(30));
+            assertFalse(worker.isAlive());
+            EntryResult result = invocation.get(1, TimeUnit.SECONDS);
+            assertEquals(42, result.value);
+            assertNull(result.runtimeAfter);
+        }
+    }
+
+    @Test
+    void nestedBeginRequireAndEvalPreserveTheCallersRuntime() throws Exception {
+        PerlRuntime runtime = new PerlRuntime();
+        String source = "BEGIN { require strict; eval q{ BEGIN { $main::phase3 = 40 } }; die $@ if $@ } $main::phase3 + 2";
+
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            for (boolean interpreter : new boolean[]{false, true}) {
+                PerlLanguageProvider.resetAll();
+                RuntimeList result = PerlLanguageProvider.executePerlCode(
+                        options(source, interpreter), false);
+                assertEquals(42, result.scalar().getInt());
+                assertSame(runtime, PerlRuntime.current());
+            }
+        }
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void jsr223EvalCompileAndCompiledEvalDoNotLeakBindings() throws Exception {
+        FutureTask<Void> invocation = new FutureTask<>(() -> {
+            assertNull(PerlRuntime.currentOrNull());
+            ScriptEngine engine = new PerlScriptEngineFactory().getScriptEngine();
+            assertEquals("42", engine.eval("40 + 2"));
+            assertNull(PerlRuntime.currentOrNull());
+
+            CompiledScript compiled = ((Compilable) engine).compile("40 + 2");
+            assertNull(PerlRuntime.currentOrNull());
+            assertEquals("42", compiled.eval());
+            assertNull(PerlRuntime.currentOrNull());
+
+            assertThrows(Exception.class, () -> engine.eval("my $x = ;"));
+            assertNull(PerlRuntime.currentOrNull());
+            return null;
+        });
+        Thread worker = Thread.ofPlatform().name("unbound-jsr223-entry").start(invocation);
+        worker.join(TimeUnit.SECONDS.toMillis(60));
+        assertFalse(worker.isAlive());
+        invocation.get(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void eachScriptEngineOwnsADistinctRuntime() {
+        PerlScriptEngine first = (PerlScriptEngine) new PerlScriptEngineFactory().getScriptEngine();
+        PerlScriptEngine second = (PerlScriptEngine) new PerlScriptEngineFactory().getScriptEngine();
+        PerlRuntime firstRuntime;
+        PerlRuntime secondRuntime;
+
+        try (PerlRuntime.Binding ignored = first.bindRuntime()) {
+            firstRuntime = PerlRuntime.current();
+        }
+        try (PerlRuntime.Binding ignored = second.bindRuntime()) {
+            secondRuntime = PerlRuntime.current();
+        }
+        assertNotSame(firstRuntime, secondRuntime);
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    private static CompilerOptions options(String source, boolean interpreter) {
+        CompilerOptions options = new CompilerOptions();
+        options.fileName = "<perl-runtime-entrypoint-test>";
+        options.code = source;
+        options.useInterpreter = interpreter;
+        return options;
+    }
+
+    private record EntryResult(int value, PerlRuntime runtimeAfter) {
+    }
+}

--- a/src/test/java/org/perlonjava/app/scriptengine/PerlScriptEngineIOIsolationTest.java
+++ b/src/test/java/org/perlonjava/app/scriptengine/PerlScriptEngineIOIsolationTest.java
@@ -1,0 +1,111 @@
+package org.perlonjava.app.scriptengine;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.perlonjava.runtime.io.StandardIO;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
+import org.perlonjava.runtime.runtimetypes.RuntimeIO;
+
+import javax.script.Compilable;
+import javax.script.CompiledScript;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class PerlScriptEngineIOIsolationTest {
+
+    @BeforeEach
+    void resetGlobals() {
+        PerlLanguageProvider.resetAll();
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void compiledScriptsWriteToTheirOwningEngineRuntime() throws Exception {
+        PerlScriptEngine first = (PerlScriptEngine) new PerlScriptEngineFactory().getScriptEngine();
+        PerlScriptEngine second = (PerlScriptEngine) new PerlScriptEngineFactory().getScriptEngine();
+
+        // Initialize the remaining process-global runtime tables before
+        // alternating between engines; Phase 4 isolates I/O, not global stacks.
+        assertEquals("1", first.eval("1"));
+        assertEquals("1", second.eval("1"));
+        assertEquals("1", first.eval("exists $main::{STDOUT} ? 1 : 0"));
+        assertEquals("1", first.eval("scalar(grep { $_ eq 'STDOUT' } keys %main::)"));
+
+        ByteArrayOutputStream firstBytes = new ByteArrayOutputStream();
+        ByteArrayOutputStream secondBytes = new ByteArrayOutputStream();
+        configureOutput(first, firstBytes);
+        configureOutput(second, secondBytes);
+
+        assertEquals("1", first.eval("print 'first-eval'; 1"));
+        assertEquals("1", second.eval("print 'second-eval'; 1"));
+
+        CompiledScript firstScript = ((Compilable) first).compile(
+                "print 'first-bare'; print STDOUT '-first-explicit'; 41 + 1");
+        CompiledScript secondScript = ((Compilable) second).compile(
+                "print 'second-bare'; print STDOUT '-second-explicit'; 40 + 3");
+
+        // Execution-stack state remains process-global until Phase 5, so this
+        // phase verifies engine ownership without claiming concurrent Perl
+        // execution support. The lower-level I/O test exercises simultaneous
+        // writes without entering those still-global stacks.
+        assertEquals("42", firstScript.eval());
+        assertEquals("43", secondScript.eval());
+        flushOutput(first);
+        flushOutput(second);
+        assertEquals("first-evalfirst-bare-first-explicit",
+                firstBytes.toString(StandardCharsets.ISO_8859_1));
+        assertEquals("second-evalsecond-bare-second-explicit",
+                secondBytes.toString(StandardCharsets.ISO_8859_1));
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void engineEvaluationRestoresAnOuterRuntimeAndItsSelectedHandle() throws Exception {
+        PerlScriptEngine engine = (PerlScriptEngine) new PerlScriptEngineFactory().getScriptEngine();
+        PerlRuntime outer = new PerlRuntime();
+        RuntimeIO outerSelected = new RuntimeIO(new StandardIO(new ByteArrayOutputStream(), true));
+
+        try (PerlRuntime.Binding ignored = outer.bind()) {
+            RuntimeIO.setSelectedHandle(outerSelected);
+            assertEquals("42", engine.eval("40 + 2"));
+            assertSame(outer, PerlRuntime.current());
+            assertSame(outerSelected, RuntimeIO.getSelectedHandle());
+        }
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void jvmReadlineEmitterUpdatesTheOwningRuntime() throws Exception {
+        PerlScriptEngine engine = (PerlScriptEngine) new PerlScriptEngineFactory().getScriptEngine();
+        try (PerlRuntime.Binding ignored = engine.bindRuntime()) {
+            RuntimeIO.setStdin(new RuntimeIO(new StandardIO(
+                    new ByteArrayInputStream("line\n".getBytes(StandardCharsets.ISO_8859_1)))));
+        }
+
+        assertEquals("line\n", engine.eval("<STDIN>"));
+        try (PerlRuntime.Binding ignored = engine.bindRuntime()) {
+            assertEquals("STDIN", RuntimeIO.getLastReadlineHandleName());
+        }
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    private static void configureOutput(PerlScriptEngine engine, ByteArrayOutputStream bytes) {
+        try (PerlRuntime.Binding ignored = engine.bindRuntime()) {
+            RuntimeIO output = new RuntimeIO(new StandardIO(bytes, true));
+            RuntimeIO.setStdout(output);
+            RuntimeIO.setSelectedHandle(output);
+            RuntimeIO.setLastWrittenHandle(output);
+        }
+    }
+
+    private static void flushOutput(PerlScriptEngine engine) {
+        try (PerlRuntime.Binding ignored = engine.bindRuntime()) {
+            RuntimeIO.getStdout().flush();
+        }
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/operators/SystemOperatorRuntimeBindingTest.java
+++ b/src/test/java/org/perlonjava/runtime/operators/SystemOperatorRuntimeBindingTest.java
@@ -1,0 +1,47 @@
+package org.perlonjava.runtime.operators;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.runtime.io.StandardIO;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
+import org.perlonjava.runtime.runtimetypes.RuntimeIO;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@Tag("unit")
+class SystemOperatorRuntimeBindingTest {
+
+    @Test
+    void streamRoutersUseTheRuntimeCapturedAtCreation() throws Exception {
+        assertRoute(false, "stdout-worker");
+        assertRoute(true, "stderr-worker");
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    private static void assertRoute(boolean stderr, String marker) throws Exception {
+        PerlRuntime runtime = new PerlRuntime();
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        Thread router;
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            RuntimeIO output = new RuntimeIO(new StandardIO(bytes, true));
+            if (stderr) {
+                RuntimeIO.setStderr(output);
+            } else {
+                RuntimeIO.setStdout(output);
+            }
+            router = SystemOperator.createStreamRouterThread(
+                    new ByteArrayInputStream(marker.getBytes(StandardCharsets.ISO_8859_1)), stderr);
+        }
+
+        router.start();
+        router.join(10_000);
+        assertFalse(router.isAlive(), "stream router did not finish");
+        assertEquals(marker, bytes.toString(StandardCharsets.ISO_8859_1));
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeIOIsolationTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeIOIsolationTest.java
@@ -1,0 +1,318 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+import org.perlonjava.runtime.io.StandardIO;
+import org.perlonjava.runtime.operators.Readline;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class PerlRuntimeIOIsolationTest {
+
+    @Test
+    void newRuntimesOwnIndependentStandardAndBookkeepingHandles() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+
+        IOState firstState = snapshot(first);
+        IOState secondState = snapshot(second);
+
+        assertNotSame(firstState.stdout, secondState.stdout);
+        assertNotSame(firstState.stderr, secondState.stderr);
+        assertNotSame(firstState.stdin, secondState.stdin);
+        assertSame(firstState.stdout, firstState.selected);
+        assertSame(secondState.stdout, secondState.selected);
+        assertSame(firstState.stdout, firstState.lastWritten);
+        assertSame(secondState.stdout, secondState.lastWritten);
+        assertNull(firstState.lastAccessed);
+        assertNull(secondState.lastAccessed);
+        assertNull(firstState.lastReadlineName);
+        assertNull(secondState.lastReadlineName);
+        assertTrue(firstState.stderr.isAutoFlush());
+        assertTrue(secondState.stderr.isAutoFlush());
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void nestedBindingsRestoreAllCurrentHandleState() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        IOState configuredFirst = configure(first, "first");
+        IOState configuredSecond = configure(second, "second");
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            assertState(configuredFirst);
+            try (PerlRuntime.Binding nested = second.bind()) {
+                assertState(configuredSecond);
+            }
+            assertState(configuredFirst);
+        }
+
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void stdinReadsAndStderrWritesRemainInTheirRuntime() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        ByteArrayOutputStream firstError = new ByteArrayOutputStream();
+        ByteArrayOutputStream secondError = new ByteArrayOutputStream();
+
+        installInputAndError(first, "first-input", firstError);
+        installInputAndError(second, "second-input", secondError);
+
+        assertEquals("first-input", readInputAndWriteError(first, "first-error"));
+        assertEquals("second-input", readInputAndWriteError(second, "second-error"));
+        assertEquals("first-error", firstError.toString(StandardCharsets.ISO_8859_1));
+        assertEquals("second-error", secondError.toString(StandardCharsets.ISO_8859_1));
+    }
+
+    @Test
+    void replacingUppercaseStdoutDoesNotReplaceTheLowercaseGlob() {
+        PerlRuntime runtime = new PerlRuntime();
+        RuntimeIO replacement = output(new ByteArrayOutputStream());
+
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            RuntimeIO lowercaseBefore = GlobalVariable.getGlobalIO("main::stdout").getRuntimeIO();
+            assertSame(RuntimeIO.getStdout(), lowercaseBefore);
+            RuntimeIO.setStdout(replacement);
+            assertSame(replacement, RuntimeIO.getStdout());
+            assertSame(replacement,
+                    GlobalVariable.getGlobalIO("main::STDOUT").getRuntimeIO());
+            assertSame(lowercaseBefore,
+                    GlobalVariable.getGlobalIO("main::stdout").getRuntimeIO());
+        }
+    }
+
+    @Test
+    void deletingStdoutHidesItsStashEntryButPreservesItsHandle() {
+        PerlRuntime runtime = new PerlRuntime();
+        PerlRuntime other = new PerlRuntime();
+        RuntimeIO otherStdout;
+        try (PerlRuntime.Binding ignored = other.bind()) {
+            otherStdout = RuntimeIO.getStdout();
+        }
+
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            RuntimeIO stdout = RuntimeIO.getStdout();
+            HashSpecialVariable stash = new HashSpecialVariable(
+                    HashSpecialVariable.Id.STASH, "main::");
+            RuntimeGlob stdoutGlob = GlobalVariable.getGlobalIO("main::STDOUT");
+
+            RuntimeScalar deleted = stash.remove("STDOUT");
+
+            assertSame(stdout, deleted.getRuntimeIO());
+            assertFalse(GlobalVariable.existsGlobalIO("main::STDOUT"));
+            assertFalse(stash.containsKey("STDOUT"));
+            assertSame(stdout, RuntimeIO.getStdout());
+            assertSame(stdout, GlobalVariable.getGlobalIO("main::STDOUT").getRuntimeIO());
+
+            stdoutGlob.dynamicSaveState();
+            assertTrue(GlobalVariable.existsGlobalIO("main::STDOUT"));
+            stdoutGlob.dynamicRestoreState();
+            assertFalse(GlobalVariable.existsGlobalIO("main::STDOUT"));
+        }
+
+        try (PerlRuntime.Binding ignored = other.bind()) {
+            assertTrue(GlobalVariable.existsGlobalIO("main::STDOUT"));
+            assertSame(otherStdout, RuntimeIO.getStdout());
+            assertSame(otherStdout, GlobalVariable.getGlobalIO("main::STDOUT").getRuntimeIO());
+        }
+    }
+
+    @Test
+    void concurrentWritesAndBookkeepingRemainInTheirRuntime() throws Exception {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        ByteArrayOutputStream firstBytes = new ByteArrayOutputStream();
+        ByteArrayOutputStream secondBytes = new ByteArrayOutputStream();
+        RuntimeIO firstOutput = output(firstBytes);
+        RuntimeIO secondOutput = output(secondBytes);
+
+        installOutput(first, firstOutput);
+        installOutput(second, secondOutput);
+
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        FutureTask<IOState> firstTask = writeTask(first, firstOutput, "first", ready, start);
+        FutureTask<IOState> secondTask = writeTask(second, secondOutput, "second", ready, start);
+        Thread firstThread = Thread.ofPlatform().name("perl-io-first").start(firstTask);
+        Thread secondThread = Thread.ofPlatform().name("perl-io-second").start(secondTask);
+
+        try {
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+        } finally {
+            start.countDown();
+            firstThread.join(TimeUnit.SECONDS.toMillis(10));
+            secondThread.join(TimeUnit.SECONDS.toMillis(10));
+        }
+        assertFalse(firstThread.isAlive());
+        assertFalse(secondThread.isAlive());
+
+        IOState firstState = firstTask.get(1, TimeUnit.SECONDS);
+        IOState secondState = secondTask.get(1, TimeUnit.SECONDS);
+        assertEquals("first", firstBytes.toString(StandardCharsets.ISO_8859_1));
+        assertEquals("second", secondBytes.toString(StandardCharsets.ISO_8859_1));
+        assertSame(firstOutput, firstState.stdout);
+        assertSame(firstOutput, firstState.selected);
+        assertSame(firstOutput, firstState.lastWritten);
+        assertSame(firstOutput, firstState.lastAccessed);
+        assertEquals("first-fh", firstState.lastReadlineName);
+        assertSame(secondOutput, secondState.stdout);
+        assertSame(secondOutput, secondState.selected);
+        assertSame(secondOutput, secondState.lastWritten);
+        assertSame(secondOutput, secondState.lastAccessed);
+        assertEquals("second-fh", secondState.lastReadlineName);
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void resetReplacesOnlyTheBoundRuntimesStandardInput() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        IOState firstBefore = configure(first, "first");
+        IOState secondBefore = configure(second, "second");
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            PerlLanguageProvider.resetAll();
+            IOState firstAfter = snapshotCurrent();
+            assertSame(firstBefore.stdout, firstAfter.stdout);
+            assertSame(firstBefore.stderr, firstAfter.stderr);
+            assertNotSame(firstBefore.stdin, firstAfter.stdin);
+            assertSame(firstBefore.selected, firstAfter.selected);
+            assertSame(firstBefore.lastWritten, firstAfter.lastWritten);
+            assertSame(firstBefore.lastAccessed, firstAfter.lastAccessed);
+            assertEquals(firstBefore.lastReadlineName, firstAfter.lastReadlineName);
+        }
+
+        assertState(second, secondBefore);
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    private static FutureTask<IOState> writeTask(
+            PerlRuntime runtime,
+            RuntimeIO output,
+            String marker,
+            CountDownLatch ready,
+            CountDownLatch start) {
+        return new FutureTask<>(() -> {
+            try (PerlRuntime.Binding ignored = runtime.bind()) {
+                ready.countDown();
+                assertTrue(start.await(10, TimeUnit.SECONDS));
+                output.write(marker);
+                output.flush();
+                RuntimeIO.setLastAccessedHandle(output);
+                RuntimeIO.setLastReadlineHandleName(marker + "-fh");
+                return snapshotCurrent();
+            }
+        });
+    }
+
+    private static void installOutput(PerlRuntime runtime, RuntimeIO output) {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            RuntimeIO.setStdout(output);
+            RuntimeIO.setSelectedHandle(output);
+            RuntimeIO.setLastWrittenHandle(output);
+        }
+    }
+
+    private static void installInputAndError(
+            PerlRuntime runtime, String input, ByteArrayOutputStream error) {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            RuntimeIO.setStdin(new RuntimeIO(new StandardIO(
+                    new ByteArrayInputStream(input.getBytes(StandardCharsets.ISO_8859_1)))));
+            RuntimeIO.setStderr(output(error));
+        }
+    }
+
+    private static String readInputAndWriteError(PerlRuntime runtime, String error) {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            RuntimeIO input = RuntimeIO.getStdin();
+            String value = Readline.readline(input).toString();
+            assertSame(input, RuntimeIO.getLastAccessedHandle());
+            RuntimeIO.getStderr().write(error);
+            RuntimeIO.getStderr().flush();
+            assertSame(input, RuntimeIO.getLastAccessedHandle());
+            return value;
+        }
+    }
+
+    private static IOState configure(PerlRuntime runtime, String name) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        RuntimeIO stdout = output(bytes);
+        RuntimeIO stderr = output(new ByteArrayOutputStream());
+        RuntimeIO stdin = new RuntimeIO(new StandardIO(
+                new ByteArrayInputStream(name.getBytes(StandardCharsets.ISO_8859_1))));
+        RuntimeIO selected = output(new ByteArrayOutputStream());
+        RuntimeIO lastWritten = output(new ByteArrayOutputStream());
+        RuntimeIO lastAccessed = output(new ByteArrayOutputStream());
+
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            RuntimeIO.setStdout(stdout);
+            RuntimeIO.setStderr(stderr);
+            RuntimeIO.setStdin(stdin);
+            RuntimeIO.setSelectedHandle(selected);
+            RuntimeIO.setLastWrittenHandle(lastWritten);
+            RuntimeIO.setLastAccessedHandle(lastAccessed);
+            RuntimeIO.setLastReadlineHandleName(name + "-fh");
+            return snapshotCurrent();
+        }
+    }
+
+    private static RuntimeIO output(ByteArrayOutputStream bytes) {
+        return new RuntimeIO(new StandardIO(bytes, true));
+    }
+
+    private static IOState snapshot(PerlRuntime runtime) {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            return snapshotCurrent();
+        }
+    }
+
+    private static IOState snapshotCurrent() {
+        return new IOState(
+                RuntimeIO.getStdout(),
+                RuntimeIO.getStderr(),
+                RuntimeIO.getStdin(),
+                RuntimeIO.getSelectedHandle(),
+                RuntimeIO.getLastWrittenHandle(),
+                RuntimeIO.getLastAccessedHandle(),
+                RuntimeIO.getLastReadlineHandleName());
+    }
+
+    private static void assertState(PerlRuntime runtime, IOState expected) {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            assertState(expected);
+        }
+    }
+
+    private static void assertState(IOState expected) {
+        IOState actual = snapshotCurrent();
+        assertSame(expected.stdout, actual.stdout);
+        assertSame(expected.stderr, actual.stderr);
+        assertSame(expected.stdin, actual.stdin);
+        assertSame(expected.selected, actual.selected);
+        assertSame(expected.lastWritten, actual.lastWritten);
+        assertSame(expected.lastAccessed, actual.lastAccessed);
+        assertEquals(expected.lastReadlineName, actual.lastReadlineName);
+    }
+
+    private record IOState(
+            RuntimeIO stdout,
+            RuntimeIO stderr,
+            RuntimeIO stdin,
+            RuntimeIO selected,
+            RuntimeIO lastWritten,
+            RuntimeIO lastAccessed,
+            String lastReadlineName) {
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeTest.java
@@ -1,0 +1,163 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class PerlRuntimeTest {
+
+    @Test
+    void absentBindingFailsClearly() {
+        IllegalStateException error = assertThrows(IllegalStateException.class, PerlRuntime::current);
+        assertTrue(error.getMessage().contains("No PerlRuntime"));
+    }
+
+    @Test
+    void nestedBindingsRestoreThePriorRuntime() {
+        PerlRuntime outer = new PerlRuntime();
+        PerlRuntime inner = new PerlRuntime();
+
+        try (PerlRuntime.Binding ignored = outer.bind()) {
+            assertSame(outer, PerlRuntime.current());
+            try (PerlRuntime.Binding nested = inner.bind()) {
+                assertSame(inner, PerlRuntime.current());
+            }
+            assertSame(outer, PerlRuntime.current());
+        }
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void exceptionalScopeExitRestoresThePriorRuntime() {
+        PerlRuntime outer = new PerlRuntime();
+        PerlRuntime inner = new PerlRuntime();
+
+        try (PerlRuntime.Binding ignored = outer.bind()) {
+            assertThrows(IllegalArgumentException.class, () -> {
+                try (PerlRuntime.Binding nested = inner.bind()) {
+                    throw new IllegalArgumentException("boom");
+                }
+            });
+            assertSame(outer, PerlRuntime.current());
+        }
+    }
+
+    @Test
+    void publicRootBindingCreatesTemporarilyAndPreservesAnExistingRuntime() {
+        assertNull(PerlRuntime.currentOrNull());
+        try (PerlRuntime.Binding ignored = PerlRuntime.bindCurrentOrNew()) {
+            assertNotNull(PerlRuntime.current());
+        }
+        assertNull(PerlRuntime.currentOrNull());
+
+        PerlRuntime outer = new PerlRuntime();
+        try (PerlRuntime.Binding ignored = outer.bind()) {
+            try (PerlRuntime.Binding nested = PerlRuntime.bindCurrentOrNew()) {
+                assertSame(outer, PerlRuntime.current());
+            }
+            assertSame(outer, PerlRuntime.current());
+        }
+    }
+
+    @Test
+    void bindingIsNotInheritedByChildThreads() throws Exception {
+        try (PerlRuntime.Binding ignored = new PerlRuntime().bind()) {
+            FutureTask<PerlRuntime> childCurrent = new FutureTask<>(PerlRuntime::currentOrNull);
+            Thread child = Thread.ofPlatform().name("unbound-perl-runtime-child").start(childCurrent);
+            child.join(TimeUnit.SECONDS.toMillis(10));
+            assertFalse(child.isAlive());
+            assertNull(childCurrent.get(1, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void twoThreadsBindDifferentRuntimesWithoutLeakage() throws Exception {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        CountDownLatch bothBound = new CountDownLatch(2);
+        CountDownLatch inspect = new CountDownLatch(1);
+
+        FutureTask<PerlRuntime> firstTask = boundTask(first, bothBound, inspect);
+        FutureTask<PerlRuntime> secondTask = boundTask(second, bothBound, inspect);
+        Thread firstThread = Thread.ofPlatform().name("perl-runtime-first").start(firstTask);
+        Thread secondThread = Thread.ofPlatform().name("perl-runtime-second").start(secondTask);
+
+        try {
+            assertTrue(bothBound.await(10, TimeUnit.SECONDS));
+        } finally {
+            inspect.countDown();
+            firstThread.join(TimeUnit.SECONDS.toMillis(10));
+            secondThread.join(TimeUnit.SECONDS.toMillis(10));
+        }
+        assertFalse(firstThread.isAlive());
+        assertFalse(secondThread.isAlive());
+        assertSame(first, firstTask.get(1, TimeUnit.SECONDS));
+        assertSame(second, secondTask.get(1, TimeUnit.SECONDS));
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void outOfOrderAndCrossThreadCloseAreRejected() throws Exception {
+        PerlRuntime runtime = new PerlRuntime();
+        PerlRuntime.Binding outer = runtime.bind();
+        PerlRuntime.Binding inner = runtime.bind();
+        try {
+            assertThrows(IllegalStateException.class, outer::close);
+
+            FutureTask<Throwable> crossThreadClose = new FutureTask<>(() -> {
+                try {
+                    inner.close();
+                    return null;
+                } catch (Throwable error) {
+                    return error;
+                }
+            });
+            Thread thread = Thread.ofPlatform().start(crossThreadClose);
+            thread.join(TimeUnit.SECONDS.toMillis(10));
+            assertInstanceOf(IllegalStateException.class,
+                    crossThreadClose.get(1, TimeUnit.SECONDS));
+        } finally {
+            inner.close();
+            outer.close();
+        }
+    }
+
+    @Test
+    void reusedExecutorThreadDoesNotRetainAClosedBinding() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor(
+                Thread.ofPlatform().name("perl-runtime-reused-worker").factory());
+        try {
+            PerlRuntime runtime = new PerlRuntime();
+            assertSame(runtime, executor.submit(() -> {
+                try (PerlRuntime.Binding ignored = runtime.bind()) {
+                    return PerlRuntime.current();
+                }
+            }).get(10, TimeUnit.SECONDS));
+            assertNull(executor.submit(PerlRuntime::currentOrNull).get(10, TimeUnit.SECONDS));
+        } finally {
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    private static FutureTask<PerlRuntime> boundTask(
+            PerlRuntime runtime,
+            CountDownLatch bothBound,
+            CountDownLatch inspect) {
+        return new FutureTask<>(() -> {
+            try (PerlRuntime.Binding ignored = runtime.bind()) {
+                bothBound.countDown();
+                assertTrue(inspect.await(10, TimeUnit.SECONDS));
+                return PerlRuntime.current();
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- add the empty `PerlRuntime` identity shell with strict scoped, non-inherited bindings
- bind CLI, provider, JSR-223, require/do, and eval ownership boundaries
- isolate standard handles, selected/last-handle bookkeeping, readline context, and open-handle caching per runtime
- route standard globs and glob localization/deletion through the bound runtime
- explicitly propagate runtime identity into pipe/system/process routers and Netty callbacks
- update the final threads plan and mark Phases 3 and 4 complete

Phases 3 and 4 are intentionally combined in this PR at maintainer direction. All other mutable interpreter state remains process-global, concurrent full Perl execution is not yet advertised, and `Config` thread flags remain disabled.

## Validation

- `make` — passed
- `make test-all` — passed; core 83.2%, bundled modules 80.8%
- 24 focused I/O regression runs across JVM and interpreter backends — passed by process status
- Scalar::Util 1.70 and Moo 2.005005 smoke tests — passed on both backends
- IPC::Open3 and standard-glob lifecycle checks — passed on both backends
- `git diff --check` — passed

The interpreter-only TAP miss in `nonblocking_pipe_syswrite.t` assertion 8 was reproduced on the exact PR #918 base; it is pre-existing. Its JVM run and the remaining focused assertions pass.

## Next phase

After merge, Phase 5 migrates execution, local-save, dynamic-scope, and special-block stacks into `PerlRuntime`. Perl `threads` remains unavailable until the later cloning and API activation phases.
