### PR TITLE
Isolate execution, regex, and MRO runtime state

### DIFF
--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -2,7 +2,7 @@
 
 **Status:** Active implementation plan
 **Version:** 2.0
-**Date:** 2026-08-10
+**Date:** 2026-08-11
 **Supersedes:** the previous `concurrency.md` proposal and
 `dev/prompts/multiplicity-v2-plan.md`
 
@@ -14,9 +14,9 @@ unless their storage was explicitly marked shared.
 
 Each numbered phase below normally forms an independent pull request. A phase
 may be split further when its audit shows that it cannot be reviewed or reverted
-safely. Phases 3 and 4 are the sole current exception: the maintainer explicitly
-requested that the empty binding shell and the first state migration remain in
-one PR. At every merge boundary:
+safely. Phases 3 and 4 were combined at the maintainer's request, as were
+Phases 5 through 7; both combined changesets preserve the same green-boundary
+requirements. At every merge boundary:
 
 - the compiler and both execution backends remain functional;
 - `make` passes;
@@ -248,11 +248,15 @@ existing IO tests pass.
 
 ### Phase 5 — Execution stacks and special blocks
 
-Move caller stacks, dynamic scope, every `local` save/restore stack, cleanup
-stacks, and `BEGIN`/`CHECK`/`INIT`/`UNITCHECK`/`END` collections.
+Move caller stacks, interpreter/eval frames, dynamic scope, every `local`
+save/restore stack, lexical cleanup registrations, and the runtime-owned
+`CHECK`/`INIT`/`END` collections. `BEGIN` remains immediate under the compile
+lock and `UNITCHECK` remains attached to its compilation context. The coupled
+mortal/weak/`DESTROY` sweep machinery moves atomically in Phase 11.
 
-Acceptance: `local`, caller, defer/lifecycle, and special-block tests show no
-cross-runtime state.
+Acceptance: execution/save-stack ownership, caller, defer, callback binding,
+and special-block tests show no cross-runtime state. Package-global values
+themselves remain shared until Phase 8 and are not claimed isolated here.
 
 ### Phase 6 — Regex state and timeout binding
 
@@ -260,16 +264,21 @@ Move all numbered/named captures, whole/prior/post-match values, last-capture
 state, match offsets, and `/g` state, and bind the regex-timeout worker in the
 same PR.
 
-Acceptance: simultaneous matches are isolated; alarm-based matching retains
-state; Scalar::Util/Moo regression gates pass.
+Acceptance: simultaneous matches, `/g` positions, `/o`, and match-once state
+are isolated; alarm-mediated matching retains the captured runtime; and
+Scalar::Util/Moo regression gates pass. Concurrent independent alarms remain a
+Phase 11 signal/alarm-state concern.
 
 ### Phase 7 — Inheritance and method caches
 
-Move MRO/package state, method/overload/ISA caches, generations, and
-invalidation state.
+Move MRO policy, method/overload/ISA caches, generations, reverse-ISA data, and
+invalidation state. Until Phase 8 migrates symbol tables, a shared mutation
+epoch lazily invalidates derived caches in every runtime.
 
-Acceptance: runtimes may define conflicting packages and methods; method and
-closure benchmarks remain within budget.
+Acceptance: cache and policy state are runtime-owned, shared symbol mutations
+cannot leave another runtime's cache stale, and method/closure benchmarks stay
+within budget. Conflicting package and method definitions become possible only
+after the Phase 8 symbol-table migrations.
 
 ### Phase 8a — Core global values
 
@@ -446,7 +455,7 @@ measured benefit over platform threads/full clone.
 
 ## 7. Progress Tracking
 
-### Current Status: Phases 3 and 4 complete; combined PR ready for review
+### Current Status: Phases 5 through 7 complete; combined PR ready for review
 
 ### Completed Phases
 
@@ -522,6 +531,43 @@ measured benefit over platform threads/full clone.
   - The interpreter-only TAP miss in `nonblocking_pipe_syswrite.t` assertion 8
     was reproduced on the exact PR #918 base and is therefore pre-existing;
     the JVM backend and the remaining focused assertions pass.
+- [x] Phase 5: Execution stacks and special blocks (2026-08-11)
+  - Added per-runtime execution state for caller/dynamic scope, interpreter and
+    eval frames, argument/context/lexical stacks, recursion tracking, control
+    flow, lexical cleanup registrations, and every current localization stack.
+  - Moved live output separators and `CHECK`/`INIT`/`END` queues with their
+    reset and `Internals::B::end_av` consumers, preserving current ordering.
+  - Captured the owning runtime for asynchronous Future callbacks before they
+    resume Perl execution on an arbitrary Java thread.
+  - Kept package-global values shared until Phase 8 and kept the coupled
+    mortal/weak/`DESTROY` sweep machinery together for Phase 11.
+- [x] Phase 6: Regex state and timeout binding (2026-08-11)
+  - Moved all match/capture metadata, offsets, `/g` positions, compiled-regex
+    caches, `/o`, and match-once state into the bound runtime.
+  - Made regex snapshots restore the complete state and reject cross-runtime
+    restoration.
+  - Captured and scoped the runtime in timeout workers, made those workers
+    daemon and cancellation-aware, and serialized the remaining compile-only
+    regex-preprocessor scratch behind the compilation boundary.
+  - Deferred process-wide alarm/signal ownership to Phase 11 while covering
+    the sequential alarm-mediated regex path that regressed PR #480.
+- [x] Phase 7: Inheritance and method caches (2026-08-11)
+  - Moved MRO policy, method/overload/ISA caches, package generations,
+    reverse-ISA data, and AUTOLOAD policy into each runtime.
+  - Added temporary process-wide symbol and ISA mutation epochs so a runtime
+    cannot retain stale derived entries while symbol tables remain shared.
+  - Kept conflicting package/method declarations explicitly deferred to the
+    Phase 8 symbol-table migrations.
+  - Added deterministic low-level isolation tests for all three phases and
+    retained existing Storable assertions while giving affected fixtures an
+    explicit runtime binding.
+  - Validation: the exact-tree `make` completed successfully; 38 focused Perl
+    runs passed across JVM and interpreter backends except one interpreter
+    caller-context failure reproduced identically on PR #920's merge base.
+    Scalar::Util 1.70 and Moo 2.005005 loaded on both backends. Method and
+    closure benchmarks improved; regex matching is approximately 10% slower
+    from the required runtime lookup and is recorded for Phase 13 recovery.
+    The comprehensive gate completed at core 82.9% and bundled modules 81.0%.
 
 ### Phase 1 Work Completed (2026-08-10)
 
@@ -540,10 +586,10 @@ measured benefit over platform threads/full clone.
 
 ### Next Steps
 
-1. Review and merge the combined binding and I/O-isolation PR while `Config` thread
-   flags remain disabled.
-2. Start Phase 5 from updated `master`: migrate execution/local/special-block
-   stacks without combining it with later runtime-state phases.
+1. Review and merge the combined Phase 5-7 runtime-state PR while `Config`
+   thread flags remain disabled.
+2. Start Phase 8a from updated `master`: migrate core global scalar, array, and
+   hash storage without combining it with the later Phase 8 subphases.
 
 ### Open Questions
 

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -294,7 +294,7 @@ public class BytecodeInterpreter {
                 ? frame.suspendedPackage : framePackageName);
         frame.suspended = false;
         if (frame.pc > 0 && !frame.evalCatchStack.isEmpty()) {
-            RuntimeCode.evalDepth += frame.evalCatchStack.size();
+            RuntimeCode.adjustEvalDepth(frame.evalCatchStack.size());
             for (int i = 0; i < frame.evalCatchStack.size(); i++) {
                 if (InterpreterState.pushEvalFrameForCurrentInterpreter()) {
                     frame.virtualEvalFrameDepth++;
@@ -1588,7 +1588,7 @@ public class BytecodeInterpreter {
                                             }
                                             // Jump to eval catch handler
                                             pc = evalCatchStack.pop();
-                                            RuntimeCode.evalDepth--;
+                                            RuntimeCode.decrementEvalDepth();
                                             break;
                                         }
                                         return result;
@@ -1703,7 +1703,7 @@ public class BytecodeInterpreter {
                                                         savedLocalLevel + relativeLevel);
                                             }
                                             pc = evalCatchStack.pop();
-                                            RuntimeCode.evalDepth--;
+                                            RuntimeCode.decrementEvalDepth();
                                             break;
                                         }
                                         return result;
@@ -2099,7 +2099,7 @@ public class BytecodeInterpreter {
                                         DynamicVariableManager.getLocalLevel() - savedLocalLevel);
 
                                 // Track eval depth for $^S
-                                RuntimeCode.evalDepth++;
+                                RuntimeCode.incrementEvalDepth();
 
                                 if (InterpreterState.pushEvalFrameForCurrentInterpreter()) {
                                     frame.virtualEvalFrameDepth++;
@@ -2135,7 +2135,7 @@ public class BytecodeInterpreter {
                                 }
 
                                 // Track eval depth for $^S
-                                RuntimeCode.evalDepth--;
+                                RuntimeCode.decrementEvalDepth();
 
                                 if (frame.virtualEvalFrameDepth > 0) {
                                     InterpreterState.pop();
@@ -2772,7 +2772,7 @@ public class BytecodeInterpreter {
                             DynamicVariableManager.popToLocalLevel(
                                     savedLocalLevel + relativeLevel);
                         }
-                        RuntimeCode.evalDepth--;
+                        RuntimeCode.decrementEvalDepth();
                         if (frame.virtualEvalFrameDepth > 0) {
                             InterpreterState.pop();
                             frame.virtualEvalFrameDepth--;
@@ -2850,7 +2850,7 @@ public class BytecodeInterpreter {
                         }
 
                         // Track eval depth for $^S
-                        RuntimeCode.evalDepth--;
+                        RuntimeCode.decrementEvalDepth();
 
                         if (frame.virtualEvalFrameDepth > 0) {
                             InterpreterState.pop();
@@ -2963,7 +2963,7 @@ public class BytecodeInterpreter {
             }
             currentPackageScalar.set(savedPackage);
             if (frame.suspended && !frame.evalCatchStack.isEmpty()) {
-                RuntimeCode.evalDepth -= frame.evalCatchStack.size();
+                RuntimeCode.adjustEvalDepth(-frame.evalCatchStack.size());
             }
             while (frame.virtualEvalFrameDepth > 0) {
                 InterpreterState.pop();

--- a/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
@@ -481,11 +481,11 @@ public class EvalStringHandler {
             InterpreterState.currentPackage.get().set(savedPkg);
             RuntimeArray args = new RuntimeArray();  // Empty @_
             RuntimeList result;
-            RuntimeCode.evalDepth++;
+            RuntimeCode.incrementEvalDepth();
             try {
                 result = evalCode.apply(args, callContext);
             } finally {
-                RuntimeCode.evalDepth--;
+                RuntimeCode.decrementEvalDepth();
                 DynamicVariableManager.popToLocalLevel(pkgLevel);
             }
             evalTrace("EvalStringHandler exec ok ctx=" + callContext +
@@ -642,11 +642,11 @@ public class EvalStringHandler {
             InterpreterState.currentPackage.get().set(savedPkg);
             RuntimeArray args = new RuntimeArray();
             RuntimeList result;
-            RuntimeCode.evalDepth++;
+            RuntimeCode.incrementEvalDepth();
             try {
                 result = evalCode.apply(args, RuntimeContextType.SCALAR);
             } finally {
-                RuntimeCode.evalDepth--;
+                RuntimeCode.decrementEvalDepth();
                 DynamicVariableManager.popToLocalLevel(pkgLevel);
             }
 

--- a/src/main/java/org/perlonjava/backend/bytecode/FutureAsyncAwaitRuntime.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/FutureAsyncAwaitRuntime.java
@@ -110,10 +110,11 @@ public final class FutureAsyncAwaitRuntime {
         call(outer, "AWAIT_CHAIN_CANCEL",
                 new RuntimeArray(suspension.awaited), RuntimeContextType.VOID);
 
+        PerlRuntime runtime = PerlRuntime.current();
         RuntimeCode callback = new RuntimeCode((callbackArgs, callbackContext) -> {
             enqueue(() -> resume(suspension, state));
             return new RuntimeList();
-        }, null);
+        }, null).bindCallbackTo(runtime);
         call(suspension.awaited, "AWAIT_ON_READY",
                 new RuntimeArray(new RuntimeScalar(callback)), RuntimeContextType.VOID);
     }

--- a/src/main/java/org/perlonjava/backend/bytecode/InterpreterState.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InterpreterState.java
@@ -44,8 +44,14 @@ public class InterpreterState {
      * <p>Scoped package blocks ({@code package Foo { }}) are automatically restored
      * when the scope exits via POP_LOCAL_LEVEL (DynamicVariableManager.popToLocalLevel).</p>
      */
-    public static final ThreadLocal<RuntimeScalar> currentPackage =
-            ThreadLocal.withInitial(() -> new RuntimeScalar("main"));
+    public static final CurrentPackageFacade currentPackage = new CurrentPackageFacade();
+
+    public static final class CurrentPackageFacade {
+        public RuntimeScalar get() {
+            return org.perlonjava.runtime.runtimetypes.PerlRuntime.current()
+                    .executionState().currentPackage;
+        }
+    }
 
     /**
      * Update the runtime current-package tracker. Exposed as a static helper
@@ -74,11 +80,15 @@ public class InterpreterState {
         org.perlonjava.runtime.runtimetypes.DynamicVariableManager.pushLocalVariable(pkg);
         pkg.set(name);
     }
-    private static final ThreadLocal<Deque<InterpreterFrame>> frameStack =
-            ThreadLocal.withInitial(ArrayDeque::new);
-    // Use ArrayList of mutable int holders for O(1) PC updates (no pop/push overhead)
-    private static final ThreadLocal<ArrayList<int[]>> pcStack =
-            ThreadLocal.withInitial(ArrayList::new);
+    private static Deque<InterpreterFrame> frameStack() {
+        return org.perlonjava.runtime.runtimetypes.PerlRuntime.current()
+                .executionState().interpreterFrames;
+    }
+
+    private static ArrayList<int[]> pcStack() {
+        return org.perlonjava.runtime.runtimetypes.PerlRuntime.current()
+                .executionState().interpreterPcs;
+    }
 
     /**
      * Push a new interpreter frame onto the stack.
@@ -103,9 +113,9 @@ public class InterpreterState {
      * @return The PC holder array for direct updates
      */
     public static int[] pushFrame(InterpreterFrame frame) {
-        frameStack.get().push(frame);
+        frameStack().push(frame);
         int[] pcHolder = new int[]{0};  // Mutable holder for PC
-        pcStack.get().add(pcHolder);
+        pcStack().add(pcHolder);
         return pcHolder;
     }
 
@@ -126,9 +136,9 @@ public class InterpreterState {
             packageName = current.packageName();
         }
 
-        frameStack.get().push(new InterpreterFrame(current.code(), packageName, "(eval)", true));
+        frameStack().push(new InterpreterFrame(current.code(), packageName, "(eval)", true));
 
-        ArrayList<int[]> pcs = pcStack.get();
+        ArrayList<int[]> pcs = pcStack();
         int currentPc = pcs.isEmpty() ? 0 : pcs.getLast()[0];
         pcs.add(new int[]{currentPc});
         return true;
@@ -139,19 +149,19 @@ public class InterpreterState {
      * Called at exit from BytecodeInterpreter.execute() (in finally block).
      */
     public static void pop() {
-        Deque<InterpreterFrame> stack = frameStack.get();
+        Deque<InterpreterFrame> stack = frameStack();
         if (!stack.isEmpty()) {
             stack.pop();
         }
 
-        ArrayList<int[]> pcs = pcStack.get();
+        ArrayList<int[]> pcs = pcStack();
         if (!pcs.isEmpty()) {
             pcs.removeLast();
         }
     }
 
     public static void setCurrentPc(int pc) {
-        ArrayList<int[]> pcs = pcStack.get();
+        ArrayList<int[]> pcs = pcStack();
         if (!pcs.isEmpty()) {
             pcs.getLast()[0] = pc;  // Direct mutation, no allocation
         }
@@ -165,7 +175,7 @@ public class InterpreterState {
      */
     public static int[] pushAndGetPcHolder() {
         int[] holder = new int[]{0};
-        pcStack.get().add(holder);
+        pcStack().add(holder);
         return holder;
     }
 
@@ -173,7 +183,7 @@ public class InterpreterState {
      * Pop the PC holder. Called when execution completes.
      */
     public static void popPcHolder() {
-        ArrayList<int[]> pcs = pcStack.get();
+        ArrayList<int[]> pcs = pcStack();
         if (!pcs.isEmpty()) {
             pcs.removeLast();
         }
@@ -186,7 +196,7 @@ public class InterpreterState {
      * @return The current frame, or null if not executing interpreted code
      */
     public static InterpreterFrame current() {
-        Deque<InterpreterFrame> stack = frameStack.get();
+        Deque<InterpreterFrame> stack = frameStack();
         return stack.isEmpty() ? null : stack.peek();
     }
 
@@ -197,11 +207,11 @@ public class InterpreterState {
      * @return A list of frames from most recent (index 0) to oldest
      */
     public static List<InterpreterFrame> getStack() {
-        return new ArrayList<>(frameStack.get());
+        return new ArrayList<>(frameStack());
     }
 
     public static List<Integer> getPcStack() {
-        ArrayList<int[]> pcs = pcStack.get();
+        ArrayList<int[]> pcs = pcStack();
         ArrayList<Integer> result = new ArrayList<>(pcs.size());
         // Reverse order to match frameStack (Deque iterates most-recent-first,
         // but pcStack ArrayList stores oldest-first via add())

--- a/src/main/java/org/perlonjava/backend/jvm/EmitterMethodCreator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitterMethodCreator.java
@@ -2091,12 +2091,9 @@ public class EmitterMethodCreator implements Opcodes {
      * Stack effect: net 0 (pushes 2, pops 2).
      */
     private static void emitEvalDepthIncrement(MethodVisitor mv) {
-        mv.visitFieldInsn(Opcodes.GETSTATIC,
-                "org/perlonjava/runtime/runtimetypes/RuntimeCode", "evalDepth", "I");
-        mv.visitInsn(Opcodes.ICONST_1);
-        mv.visitInsn(Opcodes.IADD);
-        mv.visitFieldInsn(Opcodes.PUTSTATIC,
-                "org/perlonjava/runtime/runtimetypes/RuntimeCode", "evalDepth", "I");
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                "org/perlonjava/runtime/runtimetypes/RuntimeCode",
+                "incrementEvalDepth", "()V", false);
     }
 
     /**
@@ -2104,11 +2101,8 @@ public class EmitterMethodCreator implements Opcodes {
      * Stack effect: net 0 (pushes 2, pops 2).
      */
     private static void emitEvalDepthDecrement(MethodVisitor mv) {
-        mv.visitFieldInsn(Opcodes.GETSTATIC,
-                "org/perlonjava/runtime/runtimetypes/RuntimeCode", "evalDepth", "I");
-        mv.visitInsn(Opcodes.ICONST_1);
-        mv.visitInsn(Opcodes.ISUB);
-        mv.visitFieldInsn(Opcodes.PUTSTATIC,
-                "org/perlonjava/runtime/runtimetypes/RuntimeCode", "evalDepth", "I");
+        mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                "org/perlonjava/runtime/runtimetypes/RuntimeCode",
+                "decrementEvalDepth", "()V", false);
     }
 }

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -1524,12 +1524,13 @@ public class OperatorParser {
             RuntimeArray.push(canArgs, new RuntimeScalar(packageName));
             RuntimeArray.push(canArgs, new RuntimeScalar(modifyMethod));
 
-            InheritanceResolver.autoloadEnabled = false;
+            boolean previousAutoloadEnabled = InheritanceResolver.isAutoloadEnabled();
+            InheritanceResolver.setAutoloadEnabled(false);
             RuntimeList codeList;
             try {
                 codeList = Universal.can(canArgs, RuntimeContextType.SCALAR);
             } finally {
-                InheritanceResolver.autoloadEnabled = true;
+                InheritanceResolver.setAutoloadEnabled(previousAutoloadEnabled);
             }
 
             boolean hasHandler = codeList.size() == 1 && codeList.getFirst().getBoolean();

--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -975,11 +975,12 @@ public class StatementParser {
                     RuntimeArray.push(canArgs, new RuntimeScalar(importMethod));
 
                     RuntimeList codeList = null;
-                    InheritanceResolver.autoloadEnabled = false;
+                    boolean previousAutoloadEnabled = InheritanceResolver.isAutoloadEnabled();
+                    InheritanceResolver.setAutoloadEnabled(false);
                     try {
                         codeList = Universal.can(canArgs, RuntimeContextType.SCALAR);
                     } finally {
-                        InheritanceResolver.autoloadEnabled = true;
+                        InheritanceResolver.setAutoloadEnabled(previousAutoloadEnabled);
                     }
 
                     if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("Use can(" + packageName + ", " + importMethod + "): " + codeList);

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -1865,12 +1865,13 @@ public class SubroutineParser {
         RuntimeArray.push(canArgs, new RuntimeScalar(packageName));
         RuntimeArray.push(canArgs, new RuntimeScalar("MODIFY_CODE_ATTRIBUTES"));
 
-        InheritanceResolver.autoloadEnabled = false;
+        boolean previousAutoloadEnabled = InheritanceResolver.isAutoloadEnabled();
+        InheritanceResolver.setAutoloadEnabled(false);
         RuntimeList codeList;
         try {
             codeList = Universal.can(canArgs, RuntimeContextType.SCALAR);
         } finally {
-            InheritanceResolver.autoloadEnabled = true;
+            InheritanceResolver.setAutoloadEnabled(previousAutoloadEnabled);
         }
 
         boolean hasHandler = codeList.size() == 1 && codeList.getFirst().getBoolean();

--- a/src/main/java/org/perlonjava/runtime/mro/C3.java
+++ b/src/main/java/org/perlonjava/runtime/mro/C3.java
@@ -12,8 +12,9 @@ public class C3 {
      * @return A list of class names in the order of method resolution.
      */
     public static List<String> linearizeC3(String className) {
+        MroRuntimeState state = InheritanceResolver.currentState();
         String cacheKey = className + "::C3";
-        List<String> result = InheritanceResolver.linearizedClassesCache.get(cacheKey);
+        List<String> result = state.linearizedClassesCache().get(cacheKey);
         if (result == null) {
             Map<String, List<String>> isaMap = new HashMap<>();
             InheritanceResolver.populateIsaMap(className, isaMap);
@@ -34,7 +35,7 @@ public class C3 {
                 }
             }
 
-            InheritanceResolver.linearizedClassesCache.put(cacheKey, result);
+            state.linearizedClassesCache().put(cacheKey, result);
         }
         return result;
     }

--- a/src/main/java/org/perlonjava/runtime/mro/DFS.java
+++ b/src/main/java/org/perlonjava/runtime/mro/DFS.java
@@ -12,13 +12,14 @@ public class DFS {
     private static final boolean DEBUG_DFS = Boolean.getBoolean("debug.dfs");
 
     public static List<String> linearizeDFS(String className) {
+        MroRuntimeState state = InheritanceResolver.currentState();
         if (DEBUG_DFS) {
             System.out.println("DEBUG DFS: Starting linearization for " + className);
         }
 
         // Check cache first
         String cacheKey = className + "::DFS";
-        List<String> cached = InheritanceResolver.linearizedClassesCache.get(cacheKey);
+        List<String> cached = state.linearizedClassesCache().get(cacheKey);
         if (cached != null) {
             if (DEBUG_DFS) {
                 System.out.println("DEBUG DFS: Using cached result for " + className + ": " + cached);
@@ -65,7 +66,7 @@ public class DFS {
         }
 
         // Cache the result (store a copy to prevent external modifications)
-        InheritanceResolver.linearizedClassesCache.put(cacheKey, new ArrayList<>(result));
+        state.linearizedClassesCache().put(cacheKey, new ArrayList<>(result));
         return result;
     }
 

--- a/src/main/java/org/perlonjava/runtime/mro/InheritanceResolver.java
+++ b/src/main/java/org/perlonjava/runtime/mro/InheritanceResolver.java
@@ -3,6 +3,7 @@ package org.perlonjava.runtime.mro;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * The InheritanceResolver class provides methods for resolving method inheritance
@@ -10,23 +11,35 @@ import java.util.*;
  * for method resolution and linearized class hierarchies to improve performance.
  */
 public class InheritanceResolver {
-    // Cache for linearized class hierarchies
-    static final Map<String, List<String>> linearizedClassesCache = new HashMap<>();
     private static final boolean TRACE_METHOD_RESOLUTION = false;  // Set to true for debugging
-    // Per-package MRO settings
-    private static final Map<String, MROAlgorithm> packageMRO = new HashMap<>();
-    // Method resolution cache
-    private static final Map<String, RuntimeScalar> methodCache = new HashMap<>();
-    // Cache for OverloadContext instances by blessing ID
-    private static final Map<Integer, OverloadContext> overloadContextCache = new HashMap<>();
-    // Track ISA array states for change detection
-    private static final Map<String, List<String>> isaStateCache = new HashMap<>();
-    // Monotonic generation for reverse-inheritance consumers such as
-    // mro::get_isarev().  @ISA arrays notify us at their mutation point.
-    private static long isaGeneration;
-    public static boolean autoloadEnabled = true;
-    // Default MRO algorithm
-    private static MROAlgorithm currentMRO = MROAlgorithm.DFS;
+    // Temporary bridge while package symbol tables remain shared until Phase 8.
+    private static final AtomicLong SHARED_SYMBOL_MUTATION_EPOCH = new AtomicLong();
+    private static final AtomicLong SHARED_ISA_MUTATION_EPOCH = new AtomicLong();
+
+    static MroRuntimeState currentState() {
+        MroRuntimeState state = PerlRuntime.current().mroState();
+        if (state.observeSharedMutationEpochs(
+                SHARED_SYMBOL_MUTATION_EPOCH.get(), SHARED_ISA_MUTATION_EPOCH.get())) {
+            invalidateDependentRuntimeCaches();
+        }
+        return state;
+    }
+
+    /** Observe mutations to the temporarily shared Phase 8 symbol tables. */
+    public static void synchronizeCurrentRuntime() {
+        currentState();
+    }
+
+    private static void invalidateDependentRuntimeCaches() {
+        NameNormalizer.invalidateBlessIdCache();
+        RuntimeCode.clearInlineMethodCache();
+        DestroyDispatch.invalidateCache();
+    }
+
+    private static void clearCurrentRuntimeCaches() {
+        currentState().clearDerivedCaches();
+        invalidateDependentRuntimeCaches();
+    }
 
     /**
      * Sets the default MRO algorithm.
@@ -34,8 +47,8 @@ public class InheritanceResolver {
      * @param algorithm The MRO algorithm to use as default.
      */
     public static void setDefaultMRO(MROAlgorithm algorithm) {
-        currentMRO = algorithm;
-        invalidateCache();
+        currentState().setDefaultMro(algorithm);
+        clearCurrentRuntimeCaches();
     }
 
     /**
@@ -45,8 +58,8 @@ public class InheritanceResolver {
      * @param algorithm   The MRO algorithm to use for this package.
      */
     public static void setPackageMRO(String packageName, MROAlgorithm algorithm) {
-        packageMRO.put(packageName, algorithm);
-        invalidateCache();
+        currentState().packageMro().put(packageName, algorithm);
+        clearCurrentRuntimeCaches();
     }
 
     /**
@@ -56,7 +69,16 @@ public class InheritanceResolver {
      * @return The MRO algorithm for the package, or the default if not set.
      */
     public static MROAlgorithm getPackageMRO(String packageName) {
-        return packageMRO.getOrDefault(packageName, currentMRO);
+        MroRuntimeState state = currentState();
+        return state.packageMro().getOrDefault(packageName, state.defaultMro());
+    }
+
+    public static boolean isAutoloadEnabled() {
+        return currentState().autoloadEnabled();
+    }
+
+    public static void setAutoloadEnabled(boolean enabled) {
+        currentState().setAutoloadEnabled(enabled);
     }
 
     /**
@@ -68,14 +90,15 @@ public class InheritanceResolver {
      * @return A list of class names in C3 order.
      */
     public static List<String> linearizeC3Always(String className) {
+        MroRuntimeState state = currentState();
         // Check if ISA has changed and invalidate cache if needed
-        if (hasIsaChanged(className)) {
-            invalidateCacheForClass(className);
+        if (hasIsaChanged(className, state)) {
+            invalidateCacheForClass(className, state);
         }
 
         // Use a separate cache key for C3-always linearization
         String cacheKey = className + "::__C3__";
-        List<String> cached = linearizedClassesCache.get(cacheKey);
+        List<String> cached = state.linearizedClassesCache().get(cacheKey);
         if (cached != null) {
             return new ArrayList<>(cached);
         }
@@ -83,7 +106,7 @@ public class InheritanceResolver {
         List<String> result = C3.linearizeC3(className);
 
         // Cache the result
-        linearizedClassesCache.put(cacheKey, new ArrayList<>(result));
+        state.linearizedClassesCache().put(cacheKey, new ArrayList<>(result));
         return result;
     }
 
@@ -94,19 +117,20 @@ public class InheritanceResolver {
      * @return A list of class names in the order of method resolution.
      */
     public static List<String> linearizeHierarchy(String className) {
+        MroRuntimeState state = currentState();
         // Check if ISA has changed and invalidate cache if needed
-        if (hasIsaChanged(className)) {
-            invalidateCacheForClass(className);
+        if (hasIsaChanged(className, state)) {
+            invalidateCacheForClass(className, state);
         }
 
         // Check cache first
-        List<String> cached = linearizedClassesCache.get(className);
+        List<String> cached = state.linearizedClassesCache().get(className);
         if (cached != null) {
             // Return a copy of the cached list to prevent modification of the cached version
             return new ArrayList<>(cached);
         }
 
-        MROAlgorithm mro = getPackageMRO(className);
+        MROAlgorithm mro = state.packageMro().getOrDefault(className, state.defaultMro());
 
         List<String> result;
         switch (mro) {
@@ -121,14 +145,14 @@ public class InheritanceResolver {
         }
 
         // Cache the result (store a copy to prevent external modifications)
-        linearizedClassesCache.put(className, new ArrayList<>(result));
+        state.linearizedClassesCache().put(className, new ArrayList<>(result));
         return result;
     }
 
     /**
      * Checks if the @ISA array for a class has changed since last cached.
      */
-    private static boolean hasIsaChanged(String className) {
+    private static boolean hasIsaChanged(String className, MroRuntimeState state) {
         RuntimeArray isaArray = getIsaArrayForClass(className);
         
         // Build current ISA list
@@ -140,11 +164,11 @@ public class InheritanceResolver {
             }
         }
 
-        List<String> cachedIsa = isaStateCache.get(className);
+        List<String> cachedIsa = state.isaStateCache().get(className);
 
         // If ISA changed, update cache and return true
         if (!currentIsa.equals(cachedIsa)) {
-            isaStateCache.put(className, currentIsa);
+            state.isaStateCache().put(className, currentIsa);
             return true;
         }
         
@@ -154,7 +178,9 @@ public class InheritanceResolver {
     /**
      * Invalidate cache for a specific class and its dependents.
      */
-    private static void invalidateCacheForClass(String className) {
+    private static void invalidateCacheForClass(String className, MroRuntimeState state) {
+        Map<String, List<String>> linearizedClassesCache = state.linearizedClassesCache();
+        Map<String, RuntimeScalar> methodCache = state.methodCache();
         // Remove exact class and subclasses from linearization cache
         linearizedClassesCache.remove(className);
         linearizedClassesCache.entrySet().removeIf(entry -> entry.getKey().startsWith(className + "::"));
@@ -165,10 +191,8 @@ public class InheritanceResolver {
 
         // @ISA changes can make an existing package inherit overloads after it
         // was first blessed; force the next bless/overload check to reclassify.
-        overloadContextCache.clear();
-        NameNormalizer.invalidateBlessIdCache();
-        RuntimeCode.clearInlineMethodCache();
-        DestroyDispatch.invalidateCache();
+        state.overloadContextCache().clear();
+        invalidateDependentRuntimeCaches();
     }
 
     /**
@@ -176,15 +200,16 @@ public class InheritanceResolver {
      * This should be called whenever the class hierarchy or method definitions change.
      */
     public static void invalidateCache() {
-        methodCache.clear();
-        linearizedClassesCache.clear();
-        overloadContextCache.clear();
-        isaStateCache.clear();
-        NameNormalizer.invalidateBlessIdCache();
-        // Also clear the inline method cache in RuntimeCode
-        RuntimeCode.clearInlineMethodCache();
-        // Clear DESTROY-related caches (destroyClasses BitSet and destroyMethodCache)
-        DestroyDispatch.invalidateCache();
+        SHARED_SYMBOL_MUTATION_EPOCH.incrementAndGet();
+        clearCurrentRuntimeCaches();
+    }
+
+    /**
+     * Drop derived entries only for the bound runtime.
+     * Used for runtime-local policy changes and uncached introspection reads.
+     */
+    public static void invalidateCurrentRuntimeCaches() {
+        clearCurrentRuntimeCaches();
     }
 
     /**
@@ -195,12 +220,13 @@ public class InheritanceResolver {
      * calls this hook for every structural mutation.
      */
     public static void noteIsaMutation() {
-        isaGeneration++;
-        invalidateCache();
+        SHARED_ISA_MUTATION_EPOCH.incrementAndGet();
+        SHARED_SYMBOL_MUTATION_EPOCH.incrementAndGet();
+        clearCurrentRuntimeCaches();
     }
 
     public static long getIsaGeneration() {
-        return isaGeneration;
+        return currentState().isaGeneration();
     }
 
     /**
@@ -220,7 +246,9 @@ public class InheritanceResolver {
         }
         String suffix = "::" + leaf;
         String suffixNoAutoload = suffix + "\0noautoload";
-        methodCache.entrySet().removeIf(e -> {
+        SHARED_SYMBOL_MUTATION_EPOCH.incrementAndGet();
+        MroRuntimeState state = currentState();
+        state.methodCache().entrySet().removeIf(e -> {
             String k = e.getKey();
             return k.endsWith(suffixNoAutoload)
                     || k.endsWith(suffix)
@@ -239,7 +267,7 @@ public class InheritanceResolver {
      * @return The cached OverloadContext, or null if not found.
      */
     public static OverloadContext getCachedOverloadContext(int blessId) {
-        return overloadContextCache.get(blessId);
+        return currentState().overloadContextCache().get(blessId);
     }
 
     /**
@@ -249,7 +277,7 @@ public class InheritanceResolver {
      * @param context The OverloadContext to cache (can be null to indicate no overloading).
      */
     public static void cacheOverloadContext(int blessId, OverloadContext context) {
-        overloadContextCache.put(blessId, context);
+        currentState().overloadContextCache().put(blessId, context);
     }
 
     /**
@@ -259,7 +287,7 @@ public class InheritanceResolver {
      * @return The cached RuntimeScalar representing the method, or null if not found.
      */
     public static RuntimeScalar getCachedMethod(String normalizedMethodName) {
-        return methodCache.get(normalizedMethodName);
+        return currentState().methodCache().get(normalizedMethodName);
     }
 
     /**
@@ -269,7 +297,7 @@ public class InheritanceResolver {
      * @param method               The RuntimeScalar representing the method to cache.
      */
     public static void cacheMethod(String normalizedMethodName, RuntimeScalar method) {
-        methodCache.put(normalizedMethodName, method);
+        currentState().methodCache().put(normalizedMethodName, method);
     }
 
     /**
@@ -386,6 +414,8 @@ public class InheritanceResolver {
      * @return RuntimeScalar representing the found method, or null if not found
      */
     public static RuntimeScalar findMethodInHierarchy(String methodName, String perlClassName, String cacheKey, int startFromIndex, boolean checkAutoload) {
+        MroRuntimeState state = currentState();
+        Map<String, RuntimeScalar> methodCache = state.methodCache();
         if (TRACE_METHOD_RESOLUTION) {
             System.err.println("TRACE InheritanceResolver.findMethodInHierarchy:");
             System.err.println("  methodName: '" + methodName + "'");
@@ -410,8 +440,8 @@ public class InheritanceResolver {
         }
 
         // Check if ISA changed for this class - if so, invalidate relevant caches
-        if (hasIsaChanged(perlClassName)) {
-            invalidateCacheForClass(perlClassName);
+        if (hasIsaChanged(perlClassName, state)) {
+            invalidateCacheForClass(perlClassName, state);
         }
 
         // Check the method cache - handles both found and not-found cases
@@ -460,7 +490,7 @@ public class InheritanceResolver {
                     if (!RuntimeCode.isCodeDefined(codeRef) && !isDeclaredForward) {
                         continue;
                     }
-                    cacheMethod(cacheKey, codeRef);
+                    methodCache.put(cacheKey, codeRef);
                     if (TRACE_METHOD_RESOLUTION) {
                         System.err.println("  FOUND method!");
                         System.err.flush();
@@ -473,7 +503,7 @@ public class InheritanceResolver {
         // Second pass — method not found anywhere, check AUTOLOAD in class hierarchy.
         // This matches Perl semantics: AUTOLOAD is only tried after the full MRO
         // search (including UNIVERSAL) fails to find the method.
-        if (autoloadEnabled && checkAutoload && !methodName.startsWith("(")) {
+        if (state.autoloadEnabled() && checkAutoload && !methodName.startsWith("(")) {
             for (int i = startFromIndex; i < linearizedClasses.size(); i++) {
                 String className = linearizedClasses.get(i);
                 for (String lookupClassName : packageLookupAliases(className)) {
@@ -493,7 +523,7 @@ public class InheritanceResolver {
                             } else {
                                 autoloadCode.autoloadVariableName = autoloadName;
                             }
-                            cacheMethod(cacheKey, autoload);
+                            methodCache.put(cacheKey, autoload);
                             return autoload;
                         }
                     }

--- a/src/main/java/org/perlonjava/runtime/mro/MroRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/mro/MroRuntimeState.java
@@ -1,0 +1,136 @@
+package org.perlonjava.runtime.mro;
+
+import org.perlonjava.runtime.runtimetypes.OverloadContext;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Mutable inheritance and method-resolution state owned by one Perl runtime.
+ *
+ * <p>The Perl symbol tables remain process-global until Phase 8. The resolver
+ * therefore uses a temporary process-wide mutation epoch to make a runtime
+ * discard derived entries after another runtime changes those shared tables.
+ * The maps and Perl-visible MRO controls themselves are runtime-local.</p>
+ */
+public final class MroRuntimeState {
+    private final Map<String, List<String>> linearizedClassesCache = new HashMap<>();
+    private final Map<String, InheritanceResolver.MROAlgorithm> packageMro = new HashMap<>();
+    private final Map<String, RuntimeScalar> methodCache = new HashMap<>();
+    private final Map<Integer, OverloadContext> overloadContextCache = new HashMap<>();
+    private final Map<String, List<String>> isaStateCache = new HashMap<>();
+
+    private final Map<String, Integer> packageGenerations = new HashMap<>();
+    private final Map<String, Set<String>> isaRevCache = new HashMap<>();
+    private final Map<String, List<String>> packageGenerationIsaState = new HashMap<>();
+
+    private InheritanceResolver.MROAlgorithm defaultMro = InheritanceResolver.MROAlgorithm.DFS;
+    private boolean autoloadEnabled = true;
+    private long isaGeneration;
+    private long isaRevGeneration = -1;
+    private long observedSymbolMutationEpoch;
+    private long observedIsaMutationEpoch;
+
+    public Map<String, List<String>> linearizedClassesCache() {
+        return linearizedClassesCache;
+    }
+
+    public Map<String, InheritanceResolver.MROAlgorithm> packageMro() {
+        return packageMro;
+    }
+
+    public Map<String, RuntimeScalar> methodCache() {
+        return methodCache;
+    }
+
+    public Map<Integer, OverloadContext> overloadContextCache() {
+        return overloadContextCache;
+    }
+
+    public Map<String, List<String>> isaStateCache() {
+        return isaStateCache;
+    }
+
+    public Map<String, Integer> packageGenerations() {
+        return packageGenerations;
+    }
+
+    public Map<String, Set<String>> isaRevCache() {
+        return isaRevCache;
+    }
+
+    public Map<String, List<String>> packageGenerationIsaState() {
+        return packageGenerationIsaState;
+    }
+
+    public InheritanceResolver.MROAlgorithm defaultMro() {
+        return defaultMro;
+    }
+
+    public void setDefaultMro(InheritanceResolver.MROAlgorithm defaultMro) {
+        this.defaultMro = defaultMro;
+    }
+
+    public boolean autoloadEnabled() {
+        return autoloadEnabled;
+    }
+
+    public void setAutoloadEnabled(boolean autoloadEnabled) {
+        this.autoloadEnabled = autoloadEnabled;
+    }
+
+    public long isaGeneration() {
+        return isaGeneration;
+    }
+
+    public long isaRevGeneration() {
+        return isaRevGeneration;
+    }
+
+    public void setIsaRevGeneration(long isaRevGeneration) {
+        this.isaRevGeneration = isaRevGeneration;
+    }
+
+    /** Clear only values derived from package symbols, retaining MRO policy. */
+    public void clearDerivedCaches() {
+        methodCache.clear();
+        linearizedClassesCache.clear();
+        overloadContextCache.clear();
+        isaStateCache.clear();
+    }
+
+    /** Clear reverse-inheritance data derived from package {@code @ISA} arrays. */
+    public void clearReverseIsaCache() {
+        isaRevCache.clear();
+        isaRevGeneration = -1;
+    }
+
+    /**
+     * Observe mutations to the temporarily shared symbol tables.
+     *
+     * @return true when derived method/MRO caches were discarded
+     */
+    public boolean observeSharedMutationEpochs(long symbolEpoch, long isaEpoch) {
+        boolean changed = observedSymbolMutationEpoch != symbolEpoch;
+        if (changed) {
+            observedSymbolMutationEpoch = symbolEpoch;
+            clearDerivedCaches();
+        }
+        if (observedIsaMutationEpoch != isaEpoch) {
+            observedIsaMutationEpoch = isaEpoch;
+            isaGeneration++;
+            clearReverseIsaCache();
+            changed = true;
+        }
+        return changed;
+    }
+
+    /** Used by deterministic tests and runtime reset without exposing map internals. */
+    public Set<String> packagesWithGenerations() {
+        return new HashSet<>(packageGenerations.keySet());
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
+++ b/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
@@ -127,7 +127,7 @@ public class WarnDie {
         if (unwrapped instanceof PerlDieException || unwrapped instanceof PerlExitException) {
             return e;
         }
-        if (RuntimeCode.evalDepth > 0) {
+        if (RuntimeCode.getEvalDepth() > 0) {
             return e;
         }
 
@@ -220,7 +220,7 @@ public class WarnDie {
             // By the time we reach catchEval(), evalDepth has already been decremented
             // by the eval catch block, but the handler should see $^S=1 since we are
             // conceptually still inside eval (Perl 5 calls the handler before unwinding).
-            RuntimeCode.evalDepth++;
+            RuntimeCode.incrementEvalDepth();
             boolean pushedEvalFrame = InterpreterState.pushEvalFrameForCurrentInterpreter();
             try {
                 RuntimeCode.apply(sigHandler, args, RuntimeContextType.SCALAR);
@@ -242,7 +242,7 @@ public class WarnDie {
                 if (pushedEvalFrame) {
                     InterpreterState.pop();
                 }
-                RuntimeCode.evalDepth--;
+                RuntimeCode.decrementEvalDepth();
                 // Restore $SIG{__DIE__}
                 DynamicVariableManager.popToLocalLevel(level);
             }
@@ -577,7 +577,7 @@ public class WarnDie {
             int level = DynamicVariableManager.getLocalLevel();
             DynamicVariableManager.pushLocalVariable(sig);
 
-            boolean pushedEvalFrame = RuntimeCode.evalDepth > 0
+            boolean pushedEvalFrame = RuntimeCode.getEvalDepth() > 0
                     && InterpreterState.pushEvalFrameForCurrentInterpreter();
             try {
                 // Perl passes the actual value stored in $@ to __DIE__.  For a

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Attributes.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Attributes.java
@@ -363,12 +363,13 @@ public class Attributes extends PerlModuleBase {
         RuntimeArray.push(canArgs, new RuntimeScalar(packageName));
         RuntimeArray.push(canArgs, new RuntimeScalar("MODIFY_CODE_ATTRIBUTES"));
 
-        InheritanceResolver.autoloadEnabled = false;
+        boolean previousAutoloadEnabled = InheritanceResolver.isAutoloadEnabled();
+        InheritanceResolver.setAutoloadEnabled(false);
         RuntimeList codeList;
         try {
             codeList = Universal.can(canArgs, RuntimeContextType.SCALAR);
         } finally {
-            InheritanceResolver.autoloadEnabled = true;
+            InheritanceResolver.setAutoloadEnabled(previousAutoloadEnabled);
         }
 
         boolean hasHandler = codeList.size() == 1 && codeList.getFirst().getBoolean();
@@ -567,12 +568,13 @@ public class Attributes extends PerlModuleBase {
         RuntimeArray.push(canArgs, new RuntimeScalar(packageName));
         RuntimeArray.push(canArgs, new RuntimeScalar(modifyMethod));
 
-        InheritanceResolver.autoloadEnabled = false;
+        boolean previousAutoloadEnabled = InheritanceResolver.isAutoloadEnabled();
+        InheritanceResolver.setAutoloadEnabled(false);
         RuntimeList codeList;
         try {
             codeList = Universal.can(canArgs, RuntimeContextType.SCALAR);
         } finally {
-            InheritanceResolver.autoloadEnabled = true;
+            InheritanceResolver.setAutoloadEnabled(previousAutoloadEnabled);
         }
 
         boolean hasHandler = codeList.size() == 1 && codeList.getFirst().getBoolean();

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Internals.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Internals.java
@@ -81,7 +81,7 @@ public class Internals extends PerlModuleBase {
      * Return a reference to the live END block queue for B::end_av().
      */
     public static RuntimeList jperlEndAvRef(RuntimeArray args, int ctx) {
-        return SpecialBlock.endBlocks.createReference().getList();
+        return SpecialBlock.getEndBlocks().createReference().getList();
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Mro.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Mro.java
@@ -15,13 +15,6 @@ import java.util.*;
  */
 public class Mro extends PerlModuleBase {
 
-    // Package generation counters
-    private static final Map<String, Integer> packageGenerations = new HashMap<>();
-
-    // Reverse ISA cache (which classes inherit from a given class)
-    private static final Map<String, Set<String>> isaRevCache = new HashMap<>();
-    private static long isaRevGeneration = -1;
-
     /**
      * Constructor for Mro.
      * Initializes the module with the name "mro".
@@ -151,7 +144,7 @@ public class Mro extends PerlModuleBase {
             linearized = Collections.singletonList(className);
         } else {
             // Invalidate cache to ensure we see any ISA changes
-            InheritanceResolver.invalidateCache();
+            InheritanceResolver.invalidateCurrentRuntimeCaches();
 
             // Get linearized MRO based on type
             if (mroType == null) {
@@ -212,9 +205,8 @@ public class Mro extends PerlModuleBase {
             throw new PerlCompilerException("Invalid mro name: '" + mroType + "'");
         }
 
-        // Increment package generation and invalidate cache
+        // setPackageMRO already invalidates this runtime's derived cache.
         incrementPackageGeneration(className);
-        InheritanceResolver.invalidateCache();
 
         return new RuntimeList();
     }
@@ -242,6 +234,7 @@ public class Mro extends PerlModuleBase {
      * Builds the reverse ISA cache by dynamically scanning all packages with @ISA arrays.
      */
     private static void buildIsaRevCache() {
+        Map<String, Set<String>> isaRevCache = PerlRuntime.current().mroState().isaRevCache();
         isaRevCache.clear();
 
         // Dynamically scan all @ISA arrays from global variables
@@ -249,14 +242,14 @@ public class Mro extends PerlModuleBase {
         for (String key : allIsaArrays.keySet()) {
             // Key format: "ClassName::ISA" → extract class name
             String className = key.substring(0, key.length() - 5); // remove "::ISA"
-            buildIsaRevForClass(className);
+            buildIsaRevForClass(className, isaRevCache);
         }
     }
 
     /**
      * Build reverse ISA relationships for a specific class.
      */
-    private static void buildIsaRevForClass(String className) {
+    private static void buildIsaRevForClass(String className, Map<String, Set<String>> isaRevCache) {
         if (GlobalVariable.existsGlobalArray(className + "::ISA")) {
             RuntimeArray isaArray = GlobalVariable.getGlobalArray(className + "::ISA");
             for (RuntimeBase parent : isaArray.elements) {
@@ -281,18 +274,19 @@ public class Mro extends PerlModuleBase {
         }
 
         String className = args.get(0).toString();
+        var state = PerlRuntime.current().mroState();
 
         long currentGeneration = InheritanceResolver.getIsaGeneration();
-        if (isaRevGeneration != currentGeneration) {
+        if (state.isaRevGeneration() != currentGeneration) {
             buildIsaRevCache();
-            isaRevGeneration = currentGeneration;
+            state.setIsaRevGeneration(currentGeneration);
         }
 
         RuntimeArray result = new RuntimeArray();
 
         // Add all classes that inherit from this one, including indirectly
         Set<String> allInheritors = new HashSet<>();
-        collectAllInheritors(className, allInheritors, new HashSet<>());
+        collectAllInheritors(className, allInheritors, new HashSet<>(), state.isaRevCache());
 
         for (String inheritor : allInheritors) {
             result.push(new RuntimeScalar(inheritor));
@@ -304,7 +298,8 @@ public class Mro extends PerlModuleBase {
     /**
      * Recursively collect all classes that inherit from the given class.
      */
-    private static void collectAllInheritors(String className, Set<String> result, Set<String> visited) {
+    private static void collectAllInheritors(String className, Set<String> result, Set<String> visited,
+                                             Map<String, Set<String>> isaRevCache) {
         if (visited.contains(className)) {
             return; // Avoid cycles
         }
@@ -313,7 +308,7 @@ public class Mro extends PerlModuleBase {
         Set<String> directInheritors = isaRevCache.getOrDefault(className, new HashSet<>());
         for (String inheritor : directInheritors) {
             result.add(inheritor);
-            collectAllInheritors(inheritor, result, visited);
+            collectAllInheritors(inheritor, result, visited, isaRevCache);
         }
     }
 
@@ -356,12 +351,12 @@ public class Mro extends PerlModuleBase {
      * @return A RuntimeList.
      */
     public static RuntimeList invalidate_all_method_caches(RuntimeArray args, int ctx) {
+        var state = PerlRuntime.current().mroState();
         InheritanceResolver.invalidateCache();
-        isaRevCache.clear();
-        isaRevGeneration = -1;
+        state.clearReverseIsaCache();
 
         // Increment all package generations
-        for (String pkg : new HashSet<>(packageGenerations.keySet())) {
+        for (String pkg : state.packagesWithGenerations()) {
             incrementPackageGeneration(pkg);
         }
 
@@ -381,16 +376,18 @@ public class Mro extends PerlModuleBase {
         }
 
         String className = args.get(0).toString();
+        var state = PerlRuntime.current().mroState();
 
         // Invalidate the method cache
         InheritanceResolver.invalidateCache();
 
         // Build isarev if needed and invalidate dependent classes
-        if (isaRevCache.isEmpty()) {
+        if (state.isaRevCache().isEmpty()) {
             buildIsaRevCache();
         }
 
-        Set<String> dependents = isaRevCache.getOrDefault(className, new HashSet<>());
+        Set<String> dependents = new HashSet<>(
+                state.isaRevCache().getOrDefault(className, Collections.emptySet()));
         dependents.add(className); // Include the class itself
 
         // Increment package generation for all dependent classes
@@ -400,9 +397,6 @@ public class Mro extends PerlModuleBase {
 
         return new RuntimeList();
     }
-
-    // Cached @ISA state per package — used to detect @ISA changes in get_pkg_gen
-    private static final Map<String, List<String>> pkgGenIsaState = new HashMap<>();
 
     /**
      * Returns the package generation number.
@@ -417,6 +411,8 @@ public class Mro extends PerlModuleBase {
         }
 
         String className = args.get(0).toString();
+        var state = PerlRuntime.current().mroState();
+        InheritanceResolver.getIsaGeneration();
 
         // Lazily detect @ISA changes and auto-increment pkg_gen
         if (GlobalVariable.existsGlobalArray(className + "::ISA")) {
@@ -428,15 +424,15 @@ public class Mro extends PerlModuleBase {
                     currentIsa.add(parentName);
                 }
             }
-            List<String> cachedIsa = pkgGenIsaState.get(className);
+            List<String> cachedIsa = state.packageGenerationIsaState().get(className);
             if (cachedIsa != null && !currentIsa.equals(cachedIsa)) {
                 incrementPackageGeneration(className);
             }
-            pkgGenIsaState.put(className, currentIsa);
+            state.packageGenerationIsaState().put(className, currentIsa);
         }
 
         // Return current generation, starting from 1
-        Integer gen = packageGenerations.getOrDefault(className, 1);
+        Integer gen = state.packageGenerations().getOrDefault(className, 1);
         return new RuntimeScalar(gen).getList();
     }
 
@@ -447,6 +443,8 @@ public class Mro extends PerlModuleBase {
      * @param packageName The name of the package.
      */
     public static void incrementPackageGeneration(String packageName) {
+        Map<String, Integer> packageGenerations =
+                PerlRuntime.current().mroState().packageGenerations();
         Integer current = packageGenerations.getOrDefault(packageName, 1);
         packageGenerations.put(packageName, current + 1);
     }

--- a/src/main/java/org/perlonjava/runtime/regex/RegexTimeoutCharSequence.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexTimeoutCharSequence.java
@@ -24,7 +24,8 @@ public class RegexTimeoutCharSequence implements CharSequence {
 
     @Override
     public char charAt(int index) {
-        if (++checkCount % CHECK_INTERVAL == 0 && System.nanoTime() > deadlineNanos) {
+        if (++checkCount % CHECK_INTERVAL == 0
+                && (Thread.currentThread().isInterrupted() || System.nanoTime() > deadlineNanos)) {
             throw new RegexTimeoutException(
                     "Regex matching timed out after " + DEFAULT_TIMEOUT_MS + "ms (catastrophic backtracking detected)");
         }

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -42,8 +42,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
     private static final int DOTALL = Pattern.DOTALL;
     private static final Pattern USER_DEFINED_PROPERTY_PATTERN =
             Pattern.compile("\\\\([pP])\\{((?:[A-Za-z_][A-Za-z0-9_]*::)*(?:[Ii][sS]|[Ii][nN])[A-Za-z0-9_]*)}");
-    // Maximum size for the regex cache
-    private static final int MAX_REGEX_CACHE_SIZE = 1000;
+    // Maximum size for each runtime's regex cache.
+    private static final int MAX_REGEX_CACHE_SIZE = RuntimeRegexState.MAX_REGEX_CACHE_SIZE;
 
     private static String makeDelimitedTokenRepetitionsPossessive(String pattern) {
         Deque<DelimitedGroup> groups = new ArrayDeque<>();
@@ -112,42 +112,9 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         }
     }
 
-    // Cache to store compiled regex patterns
-    private static final Map<String, RuntimeRegex> regexCache = new LinkedHashMap<String, RuntimeRegex>(MAX_REGEX_CACHE_SIZE, 0.75f, true) {
-        @Override
-        protected boolean removeEldestEntry(Map.Entry<String, RuntimeRegex> eldest) {
-            return size() > MAX_REGEX_CACHE_SIZE;
-        }
-    };
-    // Cache for /o modifier - maps callsite ID to compiled regex (only first compilation is used)
-    private static final Map<Integer, RuntimeScalar> optimizedRegexCache = new LinkedHashMap<>();
-    // Global matcher used for regex operations
-    public static RegexMatcher globalMatcher;    // Provides Perl regex variables like %+, %-
-    public static String globalMatchString; // Provides Perl regex variables like $&
-    // Store match information to avoid IllegalStateException from Matcher
-    public static String lastMatchedString = null;
-    public static int lastMatchStart = -1;
-    public static int lastMatchEnd = -1;
-    // Store match information from last successful pattern (persists across failed matches)
-    public static String lastSuccessfulMatchedString = null;
-    public static int lastSuccessfulMatchStart = -1;
-    public static int lastSuccessfulMatchEnd = -1;
-    public static String lastSuccessfulMatchString = null;
-    // ${^LAST_SUCCESSFUL_PATTERN}
-    public static RuntimeRegex lastSuccessfulPattern = null;
-    public static boolean lastMatchUsedPFlag = false;
-    // Tracks if the last match used \K, so matcherStart/matcherEnd/matcherSize adjust group offsets
-    public static boolean lastMatchUsedBackslashK = false;
-    // Capture groups from the last successful match that had captures.
-    // In Perl 5, $1/$2/etc persist across non-capturing matches.
-    public static String[] lastCaptureGroups = null;
-    public static Map<String, List<String>> lastNamedCaptureGroups = null;
-    // Track whether the last successful match was on a BYTE_STRING input,
-    // so that captures ($1, $2, $&, etc.) preserve BYTE_STRING type.
-    public static boolean lastMatchWasByteString = false;
-    public static boolean lastMatchResultsTainted = false;
-    public static int[] manualCaptureStarts = null;
-    public static int[] manualCaptureEnds = null;
+    private static RuntimeRegexState state() {
+        return PerlRuntime.current().regexState;
+    }
     // Compiled regex pattern (for byte strings - ASCII-only \w, \d)
     public Pattern pattern;
     // Compiled regex pattern for Unicode strings (Unicode \w, \d)
@@ -367,7 +334,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
      * @return A RuntimeRegex object.
      * @throws IllegalStateException if regex compilation fails.
      */
-    public static RuntimeRegex compile(String patternString, String modifiers) {
+    public static synchronized RuntimeRegex compile(String patternString, String modifiers) {
         // Debug logging
         if (DEBUG_REGEX) {
             System.err.println("RuntimeRegex.compile: pattern=" + patternString + " modifiers=" + modifiers);
@@ -387,7 +354,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         String cacheKey = originalPatternString + "/" + modifiers;
 
         // Check if the regex is already cached
-        RuntimeRegex regex = regexCache.get(cacheKey);
+        RuntimeRegex regex = state().compiledRegexCache.get(cacheKey);
         if (regex == null) {
             if (DEBUG_REGEX) {
                 System.err.println("  cache miss, compiling new regex");
@@ -561,8 +528,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             }
 
             // Cache the result if the cache is not full
-            if (regexCache.size() < MAX_REGEX_CACHE_SIZE) {
-                regexCache.put(cacheKey, regex);
+            if (state().compiledRegexCache.size() < MAX_REGEX_CACHE_SIZE) {
+                state().compiledRegexCache.put(cacheKey, regex);
             }
         } else {
             // Debug logging for cache hit
@@ -585,7 +552,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         // Evict the old cached entry so compile() will actually recompile
         // instead of returning the stale regex with deferred placeholders.
         String cacheKey = regex.patternString + "/" + (regex.regexFlags == null ? "" : regex.regexFlags.toFlagString());
-        regexCache.remove(cacheKey);
+        state().compiledRegexCache.remove(cacheKey);
 
         RuntimeRegex recompiled = compile(regex.patternString, regex.regexFlags == null ? "" : regex.regexFlags.toFlagString());
         regex.pattern = recompiled.pattern;
@@ -1105,14 +1072,14 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         // 'matched' flag that tracks whether the pattern has already matched once)
         if (modifierStr.contains("o") || modifierStr.contains("?")) {
             // Check if we already have a cached regex for this callsite
-            RuntimeScalar cached = optimizedRegexCache.get(callsiteId);
+            RuntimeScalar cached = state().optimizedRegexCache.get(callsiteId);
             if (cached != null) {
                 return cached;
             }
             
             // Compile the regex and cache it
             RuntimeScalar result = getQuotedRegex(patternString, modifiers);
-            optimizedRegexCache.put(callsiteId, result);
+            state().optimizedRegexCache.put(callsiteId, result);
             return result;
         }
         
@@ -1290,21 +1257,23 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
      * even when Perl clears it. Mirror Perl for the re/pat.t regression case.
      */
     private static void fixPerl16894AlternateCaptureInLookahead(RuntimeRegex regex, String inputStr) {
-        if (lastCaptureGroups == null || regex == null || regex.patternString == null) {
+        RuntimeRegexState regexState = state();
+        if (regexState.lastCaptureGroups == null || regex == null || regex.patternString == null) {
             return;
         }
         if ("(?:[^b]*(?=(b)|(a))ab)*".equals(regex.patternString)
                 && "abab".equals(inputStr)
-                && lastCaptureGroups.length >= 2) {
-            lastCaptureGroups[0] = null;
+                && regexState.lastCaptureGroups.length >= 2) {
+            regexState.lastCaptureGroups[0] = null;
         }
     }
 
     private static void updateLastNamedCaptureGroups(RegexMatcher matcher) {
+        RuntimeRegexState regexState = state();
         Map<String, Integer> namedGroups = matcher.namedGroups();
         Map<String, List<String>> byPerlName = new LinkedHashMap<>();
         if (namedGroups == null || namedGroups.isEmpty()) {
-            lastNamedCaptureGroups = byPerlName;
+            regexState.lastNamedCaptureGroups = byPerlName;
             return;
         }
 
@@ -1328,30 +1297,31 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             }
             byPerlName.put(entry.getKey(), values);
         }
-        lastNamedCaptureGroups = byPerlName;
+        regexState.lastNamedCaptureGroups = byPerlName;
     }
 
     /** Populate Perl's numbered capture state from the backend-neutral view. */
     private static void updateNumberedCaptureGroups(RuntimeRegex regex, RegexMatcher matcher) {
-        manualCaptureStarts = null;
-        manualCaptureEnds = null;
+        RuntimeRegexState regexState = state();
+        regexState.manualCaptureStarts = null;
+        regexState.manualCaptureEnds = null;
         int captureCount = matcher.groupCount();
         if (captureCount == 0) {
-            lastCaptureGroups = null;
+            regexState.lastCaptureGroups = null;
             return;
         }
 
         int perlKGroup = regex.hasBackslashK ? getPerlKGroup(matcher) : -1;
         int userGroupCount = captureCount - (perlKGroup >= 0 ? 1 : 0);
         if (userGroupCount == 0) {
-            lastCaptureGroups = null;
+            regexState.lastCaptureGroups = null;
             return;
         }
-        lastCaptureGroups = new String[userGroupCount];
+        regexState.lastCaptureGroups = new String[userGroupCount];
         int destination = 0;
         for (int group = 1; group <= captureCount; group++) {
             if (group == perlKGroup) continue;
-            lastCaptureGroups[destination++] = matcher.group(group);
+            regexState.lastCaptureGroups[destination++] = matcher.group(group);
         }
     }
 
@@ -1359,6 +1329,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
      * Direct regex matching without timeout wrapper (fast path).
      */
     private static RuntimeBase matchRegexDirect(RuntimeScalar quotedRegex, RuntimeScalar string, int ctx) {
+        RuntimeRegexState regexState = state();
         RuntimeRegex regex = resolveRegex(quotedRegex);
         regex = ensureCompiledForRuntime(regex);
         
@@ -1367,31 +1338,31 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
 
         // Handle empty pattern - reuse last successful pattern or use empty pattern
         if (regex.patternString == null || regex.patternString.isEmpty()) {
-            if (lastSuccessfulPattern != null) {
+            if (regexState.lastSuccessfulPattern != null) {
                 // Use the pattern from last successful match
                 // But keep the current flags (especially /g and /i)
-                Pattern pattern = lastSuccessfulPattern.pattern;
+                Pattern pattern = regexState.lastSuccessfulPattern.pattern;
                 // Re-apply current flags if they differ
-                if (originalFlags != null && !originalFlags.equals(lastSuccessfulPattern.regexFlags)) {
+                if (originalFlags != null && !originalFlags.equals(regexState.lastSuccessfulPattern.regexFlags)) {
                     // Need to recompile with current flags using preprocessed pattern
                     int newFlags = originalFlags.toPatternFlags();
-                    String recompilePattern = lastSuccessfulPattern.javaPatternString != null
-                            ? lastSuccessfulPattern.javaPatternString : lastSuccessfulPattern.patternString;
+                    String recompilePattern = regexState.lastSuccessfulPattern.javaPatternString != null
+                            ? regexState.lastSuccessfulPattern.javaPatternString : regexState.lastSuccessfulPattern.patternString;
                     pattern = Pattern.compile(recompilePattern, newFlags);
                 }
                 // Create a temporary regex with the right pattern and current flags
                 RuntimeRegex tempRegex = new RuntimeRegex();
                 tempRegex.pattern = pattern;
-                tempRegex.patternUnicode = lastSuccessfulPattern.patternUnicode;
-                tempRegex.recursivePattern = lastSuccessfulPattern.recursivePattern;
-                tempRegex.branchResetCaptureMap = lastSuccessfulPattern.branchResetCaptureMap;
-                tempRegex.patternNoInternalMarkers = lastSuccessfulPattern.patternNoInternalMarkers;
-                tempRegex.patternUnicodeNoInternalMarkers = lastSuccessfulPattern.patternUnicodeNoInternalMarkers;
-                tempRegex.patternString = lastSuccessfulPattern.patternString;
-                tempRegex.javaPatternString = lastSuccessfulPattern.javaPatternString;
-                tempRegex.requiredLiteral = lastSuccessfulPattern.requiredLiteral;
-                tempRegex.hasPreservesMatch = lastSuccessfulPattern.hasPreservesMatch || (originalFlags != null && originalFlags.preservesMatch());
-                tempRegex.warningsOnUse = new ArrayList<>(lastSuccessfulPattern.warningsOnUse);
+                tempRegex.patternUnicode = regexState.lastSuccessfulPattern.patternUnicode;
+                tempRegex.recursivePattern = regexState.lastSuccessfulPattern.recursivePattern;
+                tempRegex.branchResetCaptureMap = regexState.lastSuccessfulPattern.branchResetCaptureMap;
+                tempRegex.patternNoInternalMarkers = regexState.lastSuccessfulPattern.patternNoInternalMarkers;
+                tempRegex.patternUnicodeNoInternalMarkers = regexState.lastSuccessfulPattern.patternUnicodeNoInternalMarkers;
+                tempRegex.patternString = regexState.lastSuccessfulPattern.patternString;
+                tempRegex.javaPatternString = regexState.lastSuccessfulPattern.javaPatternString;
+                tempRegex.requiredLiteral = regexState.lastSuccessfulPattern.requiredLiteral;
+                tempRegex.hasPreservesMatch = regexState.lastSuccessfulPattern.hasPreservesMatch || (originalFlags != null && originalFlags.preservesMatch());
+                tempRegex.warningsOnUse = new ArrayList<>(regexState.lastSuccessfulPattern.warningsOnUse);
                 tempRegex.regexFlags = originalFlags;
                 tempRegex.useGAssertion = originalFlags != null && originalFlags.useGAssertion();
                 regex = tempRegex;
@@ -1529,10 +1500,10 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             if (regex.regexFlags.isGlobalMatch() && !regex.regexFlags.keepCurrentPosition() && posScalar != null) {
                 posScalar.set(scalarUndef);
             }
-            globalMatchString = null;
-            lastMatchedString = null;
-            lastMatchStart = -1;
-            lastMatchEnd = -1;
+            regexState.globalMatchString = null;
+            regexState.lastMatchedString = null;
+            regexState.lastMatchStart = -1;
+            regexState.lastMatchEnd = -1;
             if (ctx == RuntimeContextType.LIST) {
                 return new RuntimeList();
             } else if (ctx == RuntimeContextType.SCALAR) {
@@ -1579,33 +1550,33 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 }
 
                 found = true;
-                lastMatchResultsTainted = GlobalContext.isTaintModeActive()
+                regexState.lastMatchResultsTainted = GlobalContext.isTaintModeActive()
                         && (quotedRegex.isTainted()
                         || (regex.regexFlags.taintResults() && string.isTainted()));
-                lastMatchWasByteString = (string.type == RuntimeScalarType.BYTE_STRING);
+                regexState.lastMatchWasByteString = (string.type == RuntimeScalarType.BYTE_STRING);
                 int captureCount = matcher.groupCount();
 
                 // Always initialize $1, $2, @+, @-, $`, $&, $' for every successful match
-                globalMatcher = matcher;
-                globalMatchString = inputStr;
-                lastMatchUsedBackslashK = regex.hasBackslashK;
+                regexState.globalMatcher = matcher;
+                regexState.globalMatchString = inputStr;
+                regexState.lastMatchUsedBackslashK = regex.hasBackslashK;
                 updateLastNamedCaptureGroups(matcher);
                 updateNumberedCaptureGroups(regex, matcher);
 
                 // For \K, adjust match start/string so $& is only the post-\K portion
                 if (regex.hasBackslashK) {
                     int keepEnd = matcher.end("perlK");
-                    lastMatchedString = inputStr.substring(keepEnd, matcher.end());
-                    lastMatchStart = keepEnd;
+                    regexState.lastMatchedString = inputStr.substring(keepEnd, matcher.end());
+                    regexState.lastMatchStart = keepEnd;
                 } else {
-                    lastMatchedString = matcher.group(0);
-                    lastMatchStart = matcher.start();
+                    regexState.lastMatchedString = matcher.group(0);
+                    regexState.lastMatchStart = matcher.start();
                 }
-                lastMatchEnd = matcher.end();
+                regexState.lastMatchEnd = matcher.end();
 
                 if (regex.regexFlags.isGlobalMatch() && captureCount < 1 && ctx == RuntimeContextType.LIST) {
                     // Global match and no captures, in list context return the matched string
-                    String matchedStr = regex.hasBackslashK ? lastMatchedString : matcher.group(0);
+                    String matchedStr = regex.hasBackslashK ? regexState.lastMatchedString : matcher.group(0);
                     matchedGroups.add(makeMatchResultScalar(matchedStr));
                 } else {
                     // save captures in return list if needed
@@ -1700,13 +1671,13 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
 
         if (!found) {
             // No match: scalar match vars ($`, $&, $') should become undef.
-            // Keep lastSuccessful* and the previous globalMatcher intact so @-/@+ do not get clobbered
+            // Keep lastSuccessful* and the previous regexState.globalMatcher intact so @-/@+ do not get clobbered
             // by internal regex checks that fail (e.g. in test libraries).
-            globalMatchString = null;
-            lastMatchedString = null;
-            lastMatchStart = -1;
-            lastMatchEnd = -1;
-            // Don't clear lastCaptureGroups - Perl preserves $1 across failed matches
+            regexState.globalMatchString = null;
+            regexState.lastMatchedString = null;
+            regexState.lastMatchStart = -1;
+            regexState.lastMatchEnd = -1;
+            // Don't clear regexState.lastCaptureGroups - Perl preserves $1 across failed matches
         }
 
         if (found) {
@@ -1714,13 +1685,13 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             if (regex.regexFlags.isMatchExactlyOnce()) {
                 regex.matched = true; // m?PAT? — remember we consumed the one allowed match
             }
-            lastMatchUsedPFlag = regex.hasPreservesMatch;
-            lastSuccessfulPattern = regex;
+            regexState.lastMatchUsedPFlag = regex.hasPreservesMatch;
+            regexState.lastSuccessfulPattern = regex;
             // Store last successful match information (persists across failed matches)
-            lastSuccessfulMatchedString = lastMatchedString;
-            lastSuccessfulMatchStart = lastMatchStart;
-            lastSuccessfulMatchEnd = lastMatchEnd;
-            lastSuccessfulMatchString = globalMatchString;
+            regexState.lastSuccessfulMatchedString = regexState.lastMatchedString;
+            regexState.lastSuccessfulMatchStart = regexState.lastMatchStart;
+            regexState.lastSuccessfulMatchEnd = regexState.lastMatchEnd;
+            regexState.lastSuccessfulMatchString = regexState.globalMatchString;
 
             // Update $^R if this regex has code block captures (performance optimization)
             if (regex.hasCodeBlockCaptures) {
@@ -1739,9 +1710,9 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                     && posScalar != null) {
                 posScalar.set(scalarUndef);
             }
-            // System.err.println("DEBUG: Match completed, globalMatcher is " + (globalMatcher == null ? "null" : "set"));
+            // System.err.println("DEBUG: Match completed, regexState.globalMatcher is " + (regexState.globalMatcher == null ? "null" : "set"));
         } else {
-            // System.err.println("DEBUG: No match found, globalMatcher is " + (globalMatcher == null ? "null" : "set"));
+            // System.err.println("DEBUG: No match found, regexState.globalMatcher is " + (regexState.globalMatcher == null ? "null" : "set"));
         }
 
         if (ctx == RuntimeContextType.LIST) {
@@ -1785,12 +1756,12 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             if (regex.regexFlags.isGlobalMatch() && !regex.regexFlags.keepCurrentPosition() && posScalar != null) {
                 posScalar.set(scalarUndef);
             }
-            globalMatchString = null;
-            lastMatchedString = null;
-            lastMatchStart = -1;
-            lastMatchEnd = -1;
-            manualCaptureStarts = null;
-            manualCaptureEnds = null;
+            state().globalMatchString = null;
+            state().lastMatchedString = null;
+            state().lastMatchStart = -1;
+            state().lastMatchEnd = -1;
+            state().manualCaptureStarts = null;
+            state().manualCaptureEnds = null;
             return ctx == RuntimeContextType.SCALAR ? RuntimeScalarCache.scalarFalse : scalarUndef;
         }
 
@@ -1806,12 +1777,12 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             if (regex.regexFlags.isGlobalMatch() && !regex.regexFlags.keepCurrentPosition() && posScalar != null) {
                 posScalar.set(scalarUndef);
             }
-            globalMatchString = null;
-            lastMatchedString = null;
-            lastMatchStart = -1;
-            lastMatchEnd = -1;
-            manualCaptureStarts = null;
-            manualCaptureEnds = null;
+            state().globalMatchString = null;
+            state().lastMatchedString = null;
+            state().lastMatchStart = -1;
+            state().lastMatchEnd = -1;
+            state().manualCaptureStarts = null;
+            state().manualCaptureEnds = null;
             return ctx == RuntimeContextType.SCALAR ? RuntimeScalarCache.scalarFalse : scalarUndef;
         }
 
@@ -1820,37 +1791,37 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         String group3 = inputStr.substring(suffixEnd, tagEnd);
         String group4 = group3.endsWith("/") ? "/" : "";
 
-        lastMatchWasByteString = (string.type == RuntimeScalarType.BYTE_STRING);
-        globalMatcher = null;
-        globalMatchString = inputStr;
-        lastMatchUsedBackslashK = false;
-        lastNamedCaptureGroups = new LinkedHashMap<>();
-        lastCaptureGroups = new String[]{group1, group2, group3, group4};
-        manualCaptureStarts = new int[]{
+        state().lastMatchWasByteString = (string.type == RuntimeScalarType.BYTE_STRING);
+        state().globalMatcher = null;
+        state().globalMatchString = inputStr;
+        state().lastMatchUsedBackslashK = false;
+        state().lastNamedCaptureGroups = new LinkedHashMap<>();
+        state().lastCaptureGroups = new String[]{group1, group2, group3, group4};
+        state().manualCaptureStarts = new int[]{
                 closing ? tagStart + 1 : literalStart,
                 nameEnd,
                 suffixEnd,
                 group4.equals("/") ? tagEnd - 1 : tagEnd
         };
-        manualCaptureEnds = new int[]{
+        state().manualCaptureEnds = new int[]{
                 closing ? tagStart + 2 : literalStart,
                 suffixEnd,
                 tagEnd,
                 group4.equals("/") ? tagEnd : tagEnd
         };
-        lastMatchedString = inputStr.substring(tagStart, tagEnd + 1);
-        lastMatchStart = tagStart;
-        lastMatchEnd = tagEnd + 1;
-        lastMatchUsedPFlag = regex.hasPreservesMatch;
-        lastSuccessfulPattern = regex;
-        lastSuccessfulMatchedString = lastMatchedString;
-        lastSuccessfulMatchStart = lastMatchStart;
-        lastSuccessfulMatchEnd = lastMatchEnd;
-        lastSuccessfulMatchString = globalMatchString;
+        state().lastMatchedString = inputStr.substring(tagStart, tagEnd + 1);
+        state().lastMatchStart = tagStart;
+        state().lastMatchEnd = tagEnd + 1;
+        state().lastMatchUsedPFlag = regex.hasPreservesMatch;
+        state().lastSuccessfulPattern = regex;
+        state().lastSuccessfulMatchedString = state().lastMatchedString;
+        state().lastSuccessfulMatchStart = state().lastMatchStart;
+        state().lastSuccessfulMatchEnd = state().lastMatchEnd;
+        state().lastSuccessfulMatchString = state().globalMatchString;
         regex.matched = true;
 
         if (regex.regexFlags.isGlobalMatch() && posScalar != null) {
-            posScalar.set(lastMatchEnd);
+            posScalar.set(state().lastMatchEnd);
             RuntimePosLvalue.recordNonZeroLengthMatch(string);
         }
 
@@ -1887,12 +1858,12 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             if (regex.regexFlags.isGlobalMatch() && !regex.regexFlags.keepCurrentPosition() && posScalar != null) {
                 posScalar.set(scalarUndef);
             }
-            globalMatchString = null;
-            lastMatchedString = null;
-            lastMatchStart = -1;
-            lastMatchEnd = -1;
-            manualCaptureStarts = null;
-            manualCaptureEnds = null;
+            state().globalMatchString = null;
+            state().lastMatchedString = null;
+            state().lastMatchStart = -1;
+            state().lastMatchEnd = -1;
+            state().manualCaptureStarts = null;
+            state().manualCaptureEnds = null;
             return ctx == RuntimeContextType.SCALAR ? RuntimeScalarCache.scalarFalse : scalarUndef;
         }
 
@@ -1900,27 +1871,27 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         String group2 = inputStr.substring(match.group2Start, match.group2End);
         String group3 = inputStr.substring(match.group3Start, match.group3End);
 
-        lastMatchWasByteString = (string.type == RuntimeScalarType.BYTE_STRING);
-        globalMatcher = null;
-        globalMatchString = inputStr;
-        lastMatchUsedBackslashK = false;
-        lastNamedCaptureGroups = new LinkedHashMap<>();
-        lastCaptureGroups = new String[]{group1, group2, group3};
-        manualCaptureStarts = new int[]{match.group1Start, match.group2Start, match.group3Start};
-        manualCaptureEnds = new int[]{match.group1End, match.group2End, match.group3End};
-        lastMatchedString = inputStr.substring(match.matchStart, match.matchEnd);
-        lastMatchStart = match.matchStart;
-        lastMatchEnd = match.matchEnd;
-        lastMatchUsedPFlag = regex.hasPreservesMatch;
-        lastSuccessfulPattern = regex;
-        lastSuccessfulMatchedString = lastMatchedString;
-        lastSuccessfulMatchStart = lastMatchStart;
-        lastSuccessfulMatchEnd = lastMatchEnd;
-        lastSuccessfulMatchString = globalMatchString;
+        state().lastMatchWasByteString = (string.type == RuntimeScalarType.BYTE_STRING);
+        state().globalMatcher = null;
+        state().globalMatchString = inputStr;
+        state().lastMatchUsedBackslashK = false;
+        state().lastNamedCaptureGroups = new LinkedHashMap<>();
+        state().lastCaptureGroups = new String[]{group1, group2, group3};
+        state().manualCaptureStarts = new int[]{match.group1Start, match.group2Start, match.group3Start};
+        state().manualCaptureEnds = new int[]{match.group1End, match.group2End, match.group3End};
+        state().lastMatchedString = inputStr.substring(match.matchStart, match.matchEnd);
+        state().lastMatchStart = match.matchStart;
+        state().lastMatchEnd = match.matchEnd;
+        state().lastMatchUsedPFlag = regex.hasPreservesMatch;
+        state().lastSuccessfulPattern = regex;
+        state().lastSuccessfulMatchedString = state().lastMatchedString;
+        state().lastSuccessfulMatchStart = state().lastMatchStart;
+        state().lastSuccessfulMatchEnd = state().lastMatchEnd;
+        state().lastSuccessfulMatchString = state().globalMatchString;
         regex.matched = true;
 
         if (regex.regexFlags.isGlobalMatch() && posScalar != null) {
-            posScalar.set(lastMatchEnd);
+            posScalar.set(state().lastMatchEnd);
             RuntimePosLvalue.recordNonZeroLengthMatch(string);
         }
 
@@ -2050,9 +2021,16 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
      * @return Match result, or throws exception if timeout
      */
     private static RuntimeBase matchRegexWithTimeout(RuntimeScalar quotedRegex, RuntimeScalar string, int ctx, int timeoutSeconds) {
-        java.util.concurrent.ExecutorService executor = java.util.concurrent.Executors.newSingleThreadExecutor();
+        PerlRuntime owner = PerlRuntime.current();
+        java.util.concurrent.ExecutorService executor = java.util.concurrent.Executors.newSingleThreadExecutor(task -> {
+            Thread worker = new Thread(task, "PerlRegexTimeout");
+            worker.setDaemon(true);
+            return worker;
+        });
         java.util.concurrent.Future<RuntimeBase> future = executor.submit(() -> {
-            return matchRegexDirect(quotedRegex, string, ctx);
+            try (PerlRuntime.Binding ignored = owner.bind()) {
+                return matchRegexDirect(quotedRegex, string, ctx);
+            }
         });
 
         try {
@@ -2062,7 +2040,6 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         } catch (java.util.concurrent.TimeoutException e) {
             // Regex timed out - cancel it and process alarm signal
             future.cancel(true);
-            executor.shutdownNow();
             // Check for pending signals - alarm handler will fire here
             PerlSignalQueue.checkPendingSignals();
             // If we get here, no alarm handler or it didn't die - return false
@@ -2073,7 +2050,6 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             }
         } catch (java.util.concurrent.ExecutionException e) {
             // Exception thrown during regex matching - unwrap and rethrow
-            executor.shutdownNow();
             Throwable cause = e.getCause();
             if (cause instanceof RuntimeException) {
                 throw (RuntimeException) cause;
@@ -2082,7 +2058,6 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         } catch (InterruptedException e) {
             // Thread was interrupted - clean up and check signals
             future.cancel(true);
-            executor.shutdownNow();
             PerlSignalQueue.checkPendingSignals();
             if (ctx == RuntimeContextType.LIST) {
                 return new RuntimeList();
@@ -2090,7 +2065,13 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 return RuntimeScalarCache.scalarFalse;
             }
         } finally {
-            executor.shutdown();
+            future.cancel(true);
+            executor.shutdownNow();
+            try {
+                executor.awaitTermination(100, java.util.concurrent.TimeUnit.MILLISECONDS);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 
@@ -2151,26 +2132,26 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
     private static void updateReplacementMatchState(RuntimeRegex regex, RegexMatcher matcher,
                                                     String inputStr, RuntimeScalar string,
                                                     boolean resultsTainted) {
-        lastMatchWasByteString = (string.type == RuntimeScalarType.BYTE_STRING);
-        lastMatchResultsTainted = resultsTainted;
+        state().lastMatchWasByteString = (string.type == RuntimeScalarType.BYTE_STRING);
+        state().lastMatchResultsTainted = resultsTainted;
 
         // Initialize $1, $2, @+, @- only when we have a match
-        globalMatcher = matcher;
-        globalMatchString = inputStr;
-        lastMatchUsedBackslashK = regex.hasBackslashK;
+        state().globalMatcher = matcher;
+        state().globalMatchString = inputStr;
+        state().lastMatchUsedBackslashK = regex.hasBackslashK;
         updateLastNamedCaptureGroups(matcher);
         updateNumberedCaptureGroups(regex, matcher);
 
         // For \K, adjust match start so $& is only the post-\K portion
         if (regex.hasBackslashK) {
             int keepEnd = matcher.end("perlK");
-            lastMatchStart = keepEnd;
-            lastMatchedString = inputStr.substring(keepEnd, matcher.end());
+            state().lastMatchStart = keepEnd;
+            state().lastMatchedString = inputStr.substring(keepEnd, matcher.end());
         } else {
-            lastMatchStart = matcher.start();
-            lastMatchedString = matcher.group(0);
+            state().lastMatchStart = matcher.start();
+            state().lastMatchedString = matcher.group(0);
         }
-        lastMatchEnd = matcher.end();
+        state().lastMatchEnd = matcher.end();
     }
 
     public static RuntimeBase replaceRegex(RuntimeScalar quotedRegex, RuntimeScalar string, int ctx) {
@@ -2203,30 +2184,30 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
 
         // Handle empty pattern - reuse last successful pattern or use empty pattern
         if (regex.patternString == null || regex.patternString.isEmpty()) {
-            if (lastSuccessfulPattern != null) {
+            if (state().lastSuccessfulPattern != null) {
                 // Use the pattern from last successful match
                 // But keep the current replacement and flags (especially /g and /i)
-                Pattern pattern = lastSuccessfulPattern.pattern;
+                Pattern pattern = state().lastSuccessfulPattern.pattern;
                 // Re-apply current flags if they differ
-                if (originalFlags != null && !originalFlags.equals(lastSuccessfulPattern.regexFlags)) {
+                if (originalFlags != null && !originalFlags.equals(state().lastSuccessfulPattern.regexFlags)) {
                     // Need to recompile with current flags using preprocessed pattern
                     int newFlags = originalFlags.toPatternFlags();
-                    String recompilePattern = lastSuccessfulPattern.javaPatternString != null
-                            ? lastSuccessfulPattern.javaPatternString : lastSuccessfulPattern.patternString;
+                    String recompilePattern = state().lastSuccessfulPattern.javaPatternString != null
+                            ? state().lastSuccessfulPattern.javaPatternString : state().lastSuccessfulPattern.patternString;
                     pattern = Pattern.compile(recompilePattern, newFlags);
                 }
                 // Create a temporary regex with the right pattern and current flags
                 RuntimeRegex tempRegex = new RuntimeRegex();
                 tempRegex.pattern = pattern;
-                tempRegex.patternUnicode = lastSuccessfulPattern.patternUnicode;
-                tempRegex.recursivePattern = lastSuccessfulPattern.recursivePattern;
-                tempRegex.branchResetCaptureMap = lastSuccessfulPattern.branchResetCaptureMap;
-                tempRegex.patternNoInternalMarkers = lastSuccessfulPattern.patternNoInternalMarkers;
-                tempRegex.patternUnicodeNoInternalMarkers = lastSuccessfulPattern.patternUnicodeNoInternalMarkers;
-                tempRegex.patternString = lastSuccessfulPattern.patternString;
-                tempRegex.javaPatternString = lastSuccessfulPattern.javaPatternString;
-                tempRegex.hasPreservesMatch = lastSuccessfulPattern.hasPreservesMatch || (originalFlags != null && originalFlags.preservesMatch());
-                tempRegex.warningsOnUse = new ArrayList<>(lastSuccessfulPattern.warningsOnUse);
+                tempRegex.patternUnicode = state().lastSuccessfulPattern.patternUnicode;
+                tempRegex.recursivePattern = state().lastSuccessfulPattern.recursivePattern;
+                tempRegex.branchResetCaptureMap = state().lastSuccessfulPattern.branchResetCaptureMap;
+                tempRegex.patternNoInternalMarkers = state().lastSuccessfulPattern.patternNoInternalMarkers;
+                tempRegex.patternUnicodeNoInternalMarkers = state().lastSuccessfulPattern.patternUnicodeNoInternalMarkers;
+                tempRegex.patternString = state().lastSuccessfulPattern.patternString;
+                tempRegex.javaPatternString = state().lastSuccessfulPattern.javaPatternString;
+                tempRegex.hasPreservesMatch = state().lastSuccessfulPattern.hasPreservesMatch || (originalFlags != null && originalFlags.preservesMatch());
+                tempRegex.warningsOnUse = new ArrayList<>(state().lastSuccessfulPattern.warningsOnUse);
                 tempRegex.regexFlags = originalFlags;
                 tempRegex.useGAssertion = originalFlags != null && originalFlags.useGAssertion();
                 tempRegex.replacement = replacement;
@@ -2296,7 +2277,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 || (regex.regexFlags.taintResults() && inputTainted);
         boolean destructiveReplacement = !regex.regexFlags.isNonDestructive();
 
-        // Don't reset globalMatcher here - only reset it if we actually find a match
+        // Don't reset state().globalMatcher here - only reset it if we actually find a match
         // This preserves capture variables from previous matches when substitution doesn't match
 
         // Track position for manual replacement when \K is used
@@ -2449,8 +2430,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             String finalResult = resultBuffer.toString();
 
             // Store as last successful pattern for empty pattern reuse
-            lastMatchUsedPFlag = regex.hasPreservesMatch;
-            lastSuccessfulPattern = regex;
+            state().lastMatchUsedPFlag = regex.hasPreservesMatch;
+            state().lastSuccessfulPattern = regex;
 
             if (regex.regexFlags.isNonDestructive()) {
                 // /r modifier: return the modified string
@@ -2497,13 +2478,13 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
      * Resets the `matched` flag for each cached regex.
      */
     public static void reset() {
-        // Iterate over the regexCache and reset the `matched` flag for each cached regex
-        for (Map.Entry<String, RuntimeRegex> entry : regexCache.entrySet()) {
+        // Iterate over the state().compiledRegexCache and reset the `matched` flag for each cached regex
+        for (Map.Entry<String, RuntimeRegex> entry : state().compiledRegexCache.entrySet()) {
             RuntimeRegex regex = entry.getValue();
             regex.matched = false; // Reset the matched field
         }
-        // Also reset m?PAT? patterns cached per-callsite in optimizedRegexCache
-        for (Map.Entry<Integer, RuntimeScalar> entry : optimizedRegexCache.entrySet()) {
+        // Also reset m?PAT? patterns cached per-callsite in state().optimizedRegexCache
+        for (Map.Entry<Integer, RuntimeScalar> entry : state().optimizedRegexCache.entrySet()) {
             RuntimeScalar scalar = entry.getValue();
             if (scalar.value instanceof RuntimeRegex regex) {
                 regex.matched = false;
@@ -2516,53 +2497,33 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
      * This should be called at the start of each script execution to ensure clean state.
      */
     public static void initialize() {
-        // Reset all match state
-        globalMatcher = null;
-        globalMatchString = null;
-
-        // Reset current match information
-        lastMatchedString = null;
-        lastMatchStart = -1;
-        lastMatchEnd = -1;
-
-        // Reset last successful match information
-        lastSuccessfulPattern = null;
-        lastSuccessfulMatchedString = null;
-        lastSuccessfulMatchStart = -1;
-        lastSuccessfulMatchEnd = -1;
-        lastSuccessfulMatchString = null;
-        lastMatchUsedPFlag = false;
-        lastCaptureGroups = null;
-        lastNamedCaptureGroups = null;
-        lastMatchWasByteString = false;
-        manualCaptureStarts = null;
-        manualCaptureEnds = null;
+        state().clearMatchState();
 
         // Reset regex cache matched flags
         reset();
     }
 
     public static String matchString() {
-        if (lastMatchedString != null) {
+        if (state().lastMatchedString != null) {
             // Current match data available
-            return lastMatchedString;
+            return state().lastMatchedString;
         }
         return null;
     }
 
     public static String preMatchString() {
-        if (globalMatchString != null && lastMatchStart != -1) {
+        if (state().globalMatchString != null && state().lastMatchStart != -1) {
             // Current match data available
-            String result = globalMatchString.substring(0, lastMatchStart);
+            String result = state().globalMatchString.substring(0, state().lastMatchStart);
             return result;
         }
         return null;
     }
 
     public static String postMatchString() {
-        if (globalMatchString != null && lastMatchEnd != -1) {
+        if (state().globalMatchString != null && state().lastMatchEnd != -1) {
             // Current match data available
-            String result = globalMatchString.substring(lastMatchEnd);
+            String result = state().globalMatchString.substring(state().lastMatchEnd);
             return result;
         }
         return null;
@@ -2570,24 +2531,24 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
 
     public static String captureString(int group) {
         if (group <= 0) {
-            return lastMatchedString;
+            return state().lastMatchedString;
         }
-        if (lastCaptureGroups == null || group > lastCaptureGroups.length) {
+        if (state().lastCaptureGroups == null || group > state().lastCaptureGroups.length) {
             return null;
         }
-        return lastCaptureGroups[group - 1];
+        return state().lastCaptureGroups[group - 1];
     }
 
     public static String lastCaptureString() {
-        if (lastCaptureGroups == null || lastCaptureGroups.length == 0) {
+        if (state().lastCaptureGroups == null || state().lastCaptureGroups.length == 0) {
             return null;
         }
         // $+ returns the highest-numbered capture group that actually participated
         // in the match (i.e., is non-null). Non-participating groups in alternations
         // have null values from Java's Matcher.group().
-        for (int i = lastCaptureGroups.length - 1; i >= 0; i--) {
-            if (lastCaptureGroups[i] != null) {
-                return lastCaptureGroups[i];
+        for (int i = state().lastCaptureGroups.length - 1; i >= 0; i--) {
+            if (state().lastCaptureGroups[i] != null) {
+                return state().lastCaptureGroups[i];
             }
         }
         return null;
@@ -2602,31 +2563,31 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             return RuntimeScalarCache.scalarUndef;
         }
         RuntimeScalar scalar = new RuntimeScalar(value);
-        if (lastMatchWasByteString) {
+        if (state().lastMatchWasByteString) {
             scalar.type = RuntimeScalarType.BYTE_STRING;
         }
-        scalar.tainted = lastMatchResultsTainted;
+        scalar.tainted = state().lastMatchResultsTainted;
         return scalar;
     }
 
     public static RuntimeScalar matcherStart(int group) {
         if (group == 0) {
-            return lastMatchStart >= 0 ? getScalarInt(lastMatchStart) : scalarUndef;
+            return state().lastMatchStart >= 0 ? getScalarInt(state().lastMatchStart) : scalarUndef;
         }
-        if (manualCaptureStarts != null && group > 0 && group <= manualCaptureStarts.length) {
-            int start = manualCaptureStarts[group - 1];
+        if (state().manualCaptureStarts != null && group > 0 && group <= state().manualCaptureStarts.length) {
+            int start = state().manualCaptureStarts[group - 1];
             return start >= 0 ? getScalarInt(start) : scalarUndef;
         }
-        if (globalMatcher == null) {
+        if (state().globalMatcher == null) {
             return scalarUndef;
         }
         try {
             // Adjust group number to skip the internal perlK group
             int javaGroup = adjustGroupForBackslashK(group);
-            if (javaGroup < 0 || javaGroup > globalMatcher.groupCount()) {
+            if (javaGroup < 0 || javaGroup > state().globalMatcher.groupCount()) {
                 return scalarUndef;
             }
-            int start = globalMatcher.start(javaGroup);
+            int start = state().globalMatcher.start(javaGroup);
             if (start == -1) {
                 return scalarUndef;
             }
@@ -2638,22 +2599,22 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
 
     public static RuntimeScalar matcherEnd(int group) {
         if (group == 0) {
-            return lastMatchEnd >= 0 ? getScalarInt(lastMatchEnd) : scalarUndef;
+            return state().lastMatchEnd >= 0 ? getScalarInt(state().lastMatchEnd) : scalarUndef;
         }
-        if (manualCaptureEnds != null && group > 0 && group <= manualCaptureEnds.length) {
-            int end = manualCaptureEnds[group - 1];
+        if (state().manualCaptureEnds != null && group > 0 && group <= state().manualCaptureEnds.length) {
+            int end = state().manualCaptureEnds[group - 1];
             return end >= 0 ? getScalarInt(end) : scalarUndef;
         }
-        if (globalMatcher == null) {
+        if (state().globalMatcher == null) {
             return scalarUndef;
         }
         try {
             // Adjust group number to skip the internal perlK group
             int javaGroup = adjustGroupForBackslashK(group);
-            if (javaGroup < 0 || javaGroup > globalMatcher.groupCount()) {
+            if (javaGroup < 0 || javaGroup > state().globalMatcher.groupCount()) {
                 return scalarUndef;
             }
-            int end = globalMatcher.end(javaGroup);
+            int end = state().globalMatcher.end(javaGroup);
             if (end == -1) {
                 return scalarUndef;
             }
@@ -2664,15 +2625,15 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
     }
 
     public static int matcherSize() {
-        if (manualCaptureStarts != null) {
-            return manualCaptureStarts.length + 1;
+        if (state().manualCaptureStarts != null) {
+            return state().manualCaptureStarts.length + 1;
         }
-        if (globalMatcher == null) {
+        if (state().globalMatcher == null) {
             return 0;
         }
-        int size = globalMatcher.groupCount();
+        int size = state().globalMatcher.groupCount();
         // Subtract the internal perlK group if \K was used
-        if (lastMatchUsedBackslashK) {
+        if (state().lastMatchUsedBackslashK) {
             size--;
         }
         // +1 because groupCount is zero-based, and we include the entire match
@@ -2693,10 +2654,10 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
      * skipping the internal perlK named group when \K is active.
      */
     private static int adjustGroupForBackslashK(int perlGroup) {
-        if (!lastMatchUsedBackslashK || globalMatcher == null) {
+        if (!state().lastMatchUsedBackslashK || state().globalMatcher == null) {
             return perlGroup;
         }
-        int perlKGroup = getPerlKGroup(globalMatcher);
+        int perlKGroup = getPerlKGroup(state().globalMatcher);
         if (perlKGroup < 0) return perlGroup;
         // Perl groups before perlK: same number. At or after: add 1.
         return perlGroup >= perlKGroup ? perlGroup + 1 : perlGroup;
@@ -3037,7 +2998,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
      * @return The constant value for $^R, or null if no code block was matched
      */
     public RuntimeScalar getLastCodeBlockResult() {
-        RegexMatcher matcher = globalMatcher;
+        RegexMatcher matcher = state().globalMatcher;
         if (matcher == null) {
             return null;
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/CallerStack.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/CallerStack.java
@@ -11,7 +11,9 @@ import java.util.List;
  */
 public class CallerStack {
     // Store either CallerInfo (resolved) or LazyCallerInfo (deferred)
-    private static final List<Object> callerStack = new ArrayList<>();
+    private static List<Object> callerStack() {
+        return PerlRuntime.current().executionState().callerStack;
+    }
 
     /**
      * Pushes a new CallerInfo object onto the stack, representing a new entry in the calling sequence.
@@ -21,7 +23,7 @@ public class CallerStack {
      * @param line        The line number in the file where the call originated.
      */
     public static void push(String packageName, String filename, int line) {
-        callerStack.add(new CallerInfo(packageName, filename, line));
+        callerStack().add(new CallerInfo(packageName, filename, line));
     }
 
     /**
@@ -33,7 +35,7 @@ public class CallerStack {
      * @param resolver    A function to compute the CallerInfo when needed.
      */
     public static void pushLazy(String packageName, CallerInfoResolver resolver) {
-        callerStack.add(new LazyCallerInfo(packageName, resolver));
+        callerStack().add(new LazyCallerInfo(packageName, resolver));
     }
 
     /**
@@ -44,6 +46,7 @@ public class CallerStack {
      * @return The most recent CallerInfo object, or null if the stack is empty.
      */
     public static CallerInfo peek(int callFrame) {
+        List<Object> callerStack = callerStack();
         if (callerStack.isEmpty()) {
             return null;
         }
@@ -70,6 +73,7 @@ public class CallerStack {
      * @return The most recent CallerInfo object, or null if the stack is empty.
      */
     public static CallerInfo pop() {
+        List<Object> callerStack = callerStack();
         if (callerStack.isEmpty()) {
             return null;
         }
@@ -89,6 +93,7 @@ public class CallerStack {
      * @return A list containing all CallerInfo objects in the stack.
      */
     public static List<CallerInfo> getStack() {
+        List<Object> callerStack = callerStack();
         List<CallerInfo> result = new ArrayList<>();
         for (int i = 0; i < callerStack.size(); i++) {
             Object entry = callerStack.get(i);
@@ -113,6 +118,7 @@ public class CallerStack {
      * @return The number of consecutive lazy entries from startCallFrame
      */
     public static int countLazyFromTop(int startCallFrame) {
+        List<Object> callerStack = callerStack();
         int count = 0;
         int index = callerStack.size() - 1 - startCallFrame;
         while (index >= 0 && callerStack.get(index) instanceof LazyCallerInfo) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/DynamicVariableManager.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/DynamicVariableManager.java
@@ -15,7 +15,9 @@ public class DynamicVariableManager {
     public record SuspendedState(DynamicState state, Object token) {}
     // A stack to hold the dynamic states of variables.
     // Using ArrayDeque instead of Stack for better performance (no synchronization overhead).
-    private static final Deque<DynamicState> variableStack = new ArrayDeque<>();
+    private static Deque<DynamicState> variableStack() {
+        return PerlRuntime.current().executionState().dynamicVariableStack;
+    }
 
     /**
      * Returns the current local level, which is the size of the variable stack.
@@ -24,12 +26,12 @@ public class DynamicVariableManager {
      * @return the number of dynamic states in the stack.
      */
     public static int getLocalLevel() {
-        return variableStack.size();
+        return variableStack().size();
     }
 
     /** Return whether a package scalar currently has an active local() frame. */
     public static boolean isGlobalScalarLocalized(String fullName) {
-        for (DynamicState state : variableStack) {
+        for (DynamicState state : variableStack()) {
             if (state instanceof GlobalRuntimeScalar scalar
                     && scalar.localizes(fullName)) {
                 return true;
@@ -47,14 +49,14 @@ public class DynamicVariableManager {
     public static RuntimeBase pushLocalVariable(RuntimeBase variable) {
         // Save the current state of the variable and push it onto the stack.
         variable.dynamicSaveState();
-        variableStack.addLast(variable);
+        variableStack().addLast(variable);
         return variable;
     }
 
     public static RuntimeScalar pushLocalVariable(RuntimeScalar variable) {
         // Save the current state of the variable and push it onto the stack.
         variable.dynamicSaveState();
-        variableStack.addLast(variable);
+        variableStack().addLast(variable);
         return variable;
     }
 
@@ -62,7 +64,7 @@ public class DynamicVariableManager {
         // Save the current state of the variable and push it onto the stack.
         // dynamicSaveState() creates a NEW glob in globalIORefs for the local scope.
         variable.dynamicSaveState();
-        variableStack.addLast(variable);
+        variableStack().addLast(variable);
         // Return the NEW glob from globalIORefs (installed by dynamicSaveState),
         // not the old one. This ensures `local *FH` returns the fresh local glob,
         // so that \do { local *FH } captures a unique glob per call (Perl 5 parity).
@@ -71,7 +73,7 @@ public class DynamicVariableManager {
 
     public static void pushLocalVariable(DynamicState variable) {
         variable.dynamicSaveState();
-        variableStack.addLast(variable);
+        variableStack().addLast(variable);
     }
 
     /**
@@ -87,6 +89,7 @@ public class DynamicVariableManager {
      */
     public static void popToLocalLevel(int targetLocalLevel) {
         // Ensure the target level is non-negative and does not exceed the current stack size
+        Deque<DynamicState> variableStack = variableStack();
         if (targetLocalLevel < 0 || targetLocalLevel > variableStack.size()) {
             throw new IllegalArgumentException("Invalid target local level: " + targetLocalLevel);
         }
@@ -124,6 +127,7 @@ public class DynamicVariableManager {
      * bottom-to-top order so they can be reinstated on a later callback.
      */
     public static List<SuspendedState> suspendAbove(int targetLocalLevel) {
+        Deque<DynamicState> variableStack = variableStack();
         if (targetLocalLevel < 0 || targetLocalLevel > variableStack.size()) {
             throw new IllegalArgumentException("Invalid target local level: " + targetLocalLevel);
         }
@@ -138,6 +142,7 @@ public class DynamicVariableManager {
     /** Reinstall detached states in their original stack order. */
     public static void resumeSuspended(List<SuspendedState> states) {
         if (states == null) return;
+        Deque<DynamicState> variableStack = variableStack();
         for (SuspendedState suspended : states) {
             suspended.state().dynamicResumeState(suspended.token());
             variableStack.addLast(suspended.state());

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ErrnoVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ErrnoVariable.java
@@ -341,13 +341,15 @@ public class ErrnoVariable extends RuntimeScalar {
     }
 
     // Stack to save errno/message during local()
-    private static final java.util.Stack<int[]> errnoStack = new java.util.Stack<>();
-    private static final java.util.Stack<String> messageStack = new java.util.Stack<>();
+    @SuppressWarnings("unchecked")
+    private static java.util.Stack<SavedErrno> errnoStack() {
+        return (java.util.Stack<SavedErrno>) (java.util.Stack<?>)
+                PerlRuntime.current().executionState().errnoStates;
+    }
 
     @Override
     public void dynamicSaveState() {
-        errnoStack.push(new int[]{errno});
-        messageStack.push(message);
+        errnoStack().push(new SavedErrno(errno, message));
         super.dynamicSaveState();
         // After saving, reset to the default "no error" state so that
         // `local $!;` actually clears the variable inside the dynamic scope,
@@ -361,11 +363,11 @@ public class ErrnoVariable extends RuntimeScalar {
     @Override
     public void dynamicRestoreState() {
         super.dynamicRestoreState();
+        java.util.Stack<SavedErrno> errnoStack = errnoStack();
         if (!errnoStack.isEmpty()) {
-            errno = errnoStack.pop()[0];
-        }
-        if (!messageStack.isEmpty()) {
-            message = messageStack.pop();
+            SavedErrno saved = errnoStack.pop();
+            errno = saved.errno;
+            message = saved.message;
         }
     }
 
@@ -387,6 +389,9 @@ public class ErrnoVariable extends RuntimeScalar {
             this.value = active.value.value;
             this.blessId = active.value.blessId;
         }
+    }
+
+    private record SavedErrno(int errno, String message) {
     }
 
     private record ErrnoState(int errno, String message, RuntimeScalar value) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ExecutionRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ExecutionRuntimeState.java
@@ -1,0 +1,74 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.perlonjava.backend.bytecode.InterpreterState;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Stack;
+
+/** Per-interpreter execution and dynamic-scope state migrated in Phase 5. */
+public final class ExecutionRuntimeState {
+    final List<Object> callerStack = new ArrayList<>();
+    final Deque<DynamicState> dynamicVariableStack = new ArrayDeque<>();
+
+    final Stack<RuntimeScalar> scalarDynamicStates = new Stack<>();
+    final Stack<RuntimeArray> arrayDynamicStates = new Stack<>();
+    final Stack<RuntimeHash> hashDynamicStates = new Stack<>();
+    final Stack<RuntimeStash> stashDynamicStates = new Stack<>();
+    final Stack<Object> globSlotStates = new Stack<>();
+    final Stack<Object> globalScalarStates = new Stack<>();
+    final Stack<Object> globalArrayStates = new Stack<>();
+    final Stack<Object> globalHashStates = new Stack<>();
+    final Stack<RuntimeScalar> hashProxyStates = new Stack<>();
+    final Stack<Integer> arrayProxyIndexStates = new Stack<>();
+    final Stack<RuntimeScalar> arrayProxyStates = new Stack<>();
+    final Stack<Object> tiedHashProxyStates = new Stack<>();
+    final Stack<Object> inputLineStates = new Stack<>();
+    final Stack<Object> autoFlushStates = new Stack<>();
+    final Stack<Object> errnoStates = new Stack<>();
+    final Stack<String> outputFieldSeparatorStates = new Stack<>();
+    final Stack<String> outputRecordSeparatorStates = new Stack<>();
+    String outputFieldSeparator = "";
+    String outputRecordSeparator = "";
+
+    final RuntimeArray endBlocks = new RuntimeArray();
+    final RuntimeArray initBlocks = new RuntimeArray();
+    final RuntimeArray checkBlocks = new RuntimeArray();
+
+    public final RuntimeScalar currentPackage = new RuntimeScalar("main");
+    public final Deque<InterpreterState.InterpreterFrame> interpreterFrames = new ArrayDeque<>();
+    public final ArrayList<int[]> interpreterPcs = new ArrayList<>();
+
+    public final ArrayDeque<RuntimeCode.EvalRuntimeContext> evalRuntimeContexts = new ArrayDeque<>();
+    public final ArrayDeque<ArrayList<String>> syntheticCallerFrames = new ArrayDeque<>();
+    public final Deque<RuntimeArray> argsStack = new ArrayDeque<>();
+    public final Deque<RuntimeCode> activeCodeStack = new ArrayDeque<>();
+    public final Deque<Object> activeLexicalFrames = new ArrayDeque<>();
+    public final Deque<List<RuntimeScalar>> pristineArgsStack = new ArrayDeque<>();
+    public final Deque<Boolean> hasArgsStack = new ArrayDeque<>();
+    public final Deque<Integer> callContextStack = new ArrayDeque<>();
+    public int evalDepth;
+    public int tailCallTrampolineDepth;
+    ControlFlowMarker controlFlowMarker;
+
+    final ArrayList<Object> myVarCleanupStack = new ArrayList<>();
+    final IdentityHashMap<Object, Integer> liveMyVarCounts = new IdentityHashMap<>();
+
+    private final IdentityHashMap<RuntimeCode, CallDepthState> callDepths = new IdentityHashMap<>();
+
+    public CallDepthState callDepth(RuntimeCode code) {
+        return callDepths.computeIfAbsent(code, ignored -> new CallDepthState());
+    }
+
+    public void releaseCallDepth(RuntimeCode code) {
+        callDepths.remove(code);
+    }
+
+    public static final class CallDepthState {
+        public int depth;
+        public boolean warned;
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeArray.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeArray.java
@@ -16,7 +16,11 @@ import java.util.Stack;
  * and {@link GlobalRuntimeScalar} for scalars.
  */
 public class GlobalRuntimeArray implements DynamicState {
-    private static final Stack<SavedGlobalArrayState> localizedStack = new Stack<>();
+    @SuppressWarnings("unchecked")
+    private static Stack<SavedGlobalArrayState> localizedStack() {
+        return (Stack<SavedGlobalArrayState>) (Stack<?>)
+                PerlRuntime.current().executionState().globalArrayStates;
+    }
     private final String fullName;
 
     public GlobalRuntimeArray(String fullName) {
@@ -41,7 +45,7 @@ public class GlobalRuntimeArray implements DynamicState {
     public void dynamicSaveState() {
         // Save the current array reference from the global map
         RuntimeArray original = GlobalVariable.globalArrays.get(fullName);
-        localizedStack.push(new SavedGlobalArrayState(fullName, original));
+        localizedStack().push(new SavedGlobalArrayState(fullName, original));
 
         // Install a fresh empty array in the global map
         RuntimeArray newLocal = new RuntimeArray();
@@ -64,6 +68,7 @@ public class GlobalRuntimeArray implements DynamicState {
 
     @Override
     public void dynamicRestoreState() {
+        Stack<SavedGlobalArrayState> localizedStack = localizedStack();
         if (!localizedStack.isEmpty()) {
             SavedGlobalArrayState saved = localizedStack.peek();
             if (saved.fullName.equals(this.fullName)) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeHash.java
@@ -12,7 +12,11 @@ import java.util.Stack;
  * <p>Follows the same pattern as {@link GlobalRuntimeScalar} for scalars.
  */
 public class GlobalRuntimeHash implements DynamicState {
-    private static final Stack<SavedGlobalHashState> localizedStack = new Stack<>();
+    @SuppressWarnings("unchecked")
+    private static Stack<SavedGlobalHashState> localizedStack() {
+        return (Stack<SavedGlobalHashState>) (Stack<?>)
+                PerlRuntime.current().executionState().globalHashStates;
+    }
     private final String fullName;
 
     public GlobalRuntimeHash(String fullName) {
@@ -37,7 +41,7 @@ public class GlobalRuntimeHash implements DynamicState {
     public void dynamicSaveState() {
         // Save the current hash reference from the global map
         RuntimeHash original = GlobalVariable.globalHashes.get(fullName);
-        localizedStack.push(new SavedGlobalHashState(fullName, original));
+        localizedStack().push(new SavedGlobalHashState(fullName, original));
 
         // Install a fresh empty hash in the global map
         RuntimeHash newLocal = new RuntimeHash();
@@ -55,6 +59,7 @@ public class GlobalRuntimeHash implements DynamicState {
 
     @Override
     public void dynamicRestoreState() {
+        Stack<SavedGlobalHashState> localizedStack = localizedStack();
         if (!localizedStack.isEmpty()) {
             SavedGlobalHashState saved = localizedStack.peek();
             if (saved.fullName.equals(this.fullName)) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeScalar.java
@@ -9,7 +9,11 @@ import java.util.Stack;
  */
 public class GlobalRuntimeScalar extends RuntimeScalar {
     // Stack to store the previous values when localized
-    private static final Stack<SavedGlobalState> localizedStack = new Stack<>();
+    @SuppressWarnings("unchecked")
+    private static Stack<SavedGlobalState> localizedStack() {
+        return (Stack<SavedGlobalState>) (Stack<?>)
+                PerlRuntime.current().executionState().globalScalarStates;
+    }
     private final String fullName;
 
     public GlobalRuntimeScalar(String fullName) {
@@ -47,6 +51,7 @@ public class GlobalRuntimeScalar extends RuntimeScalar {
 
     @Override
     public void dynamicSaveState() {
+        Stack<SavedGlobalState> localizedStack = localizedStack();
         // Save the current global reference
         var originalVariable = GlobalVariable.globalVariables.get(fullName);
 
@@ -110,6 +115,7 @@ public class GlobalRuntimeScalar extends RuntimeScalar {
 
     @Override
     public void dynamicRestoreState() {
+        Stack<SavedGlobalState> localizedStack = localizedStack();
         if (!localizedStack.isEmpty()) {
             SavedGlobalState saved = localizedStack.peek();
             if (saved.fullName.equals(this.fullName)) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
@@ -393,9 +393,9 @@ public class GlobalVariable {
         // Clear special blocks (INIT, END, CHECK, UNITCHECK) to prevent stale code references.
         // When the classloader is replaced, old INIT blocks may reference evalTags that no longer
         // exist in the cleared evalContext, causing "ctx is null" errors.
-        SpecialBlock.initBlocks.elements.clear();
-        SpecialBlock.endBlocks.elements.clear();
-        SpecialBlock.checkBlocks.elements.clear();
+        SpecialBlock.getInitBlocks().elements.clear();
+        SpecialBlock.getEndBlocks().elements.clear();
+        SpecialBlock.getCheckBlocks().elements.clear();
 
         // Method resolution caches can grow across test scripts.
         InheritanceResolver.noteIsaMutation();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/HashSpecialVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/HashSpecialVariable.java
@@ -87,7 +87,7 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
     public Set<Entry<String, RuntimeScalar>> entrySet() {
         Set<Entry<String, RuntimeScalar>> entries = new HashSet<>();
         if (this.mode == Id.CAPTURE_ALL || this.mode == Id.CAPTURE) {
-            Map<String, List<String>> namedCaptures = RuntimeRegex.lastNamedCaptureGroups;
+            Map<String, List<String>> namedCaptures = PerlRuntime.current().regexState.lastNamedCaptureGroups;
             if (namedCaptures != null) {
                 for (Map.Entry<String, List<String>> e : namedCaptures.entrySet()) {
                     if (this.mode == Id.CAPTURE_ALL) {
@@ -123,7 +123,7 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
     @Override
     public RuntimeScalar get(Object key) {
         if (this.mode == Id.CAPTURE_ALL || this.mode == Id.CAPTURE) {
-            Map<String, List<String>> namedCaptures = RuntimeRegex.lastNamedCaptureGroups;
+            Map<String, List<String>> namedCaptures = PerlRuntime.current().regexState.lastNamedCaptureGroups;
             if (namedCaptures != null && key instanceof String name) {
                 List<String> captures = namedCaptures.get(name);
                 if (captures == null) return scalarUndef;
@@ -153,12 +153,12 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
     public boolean containsKey(Object key) {
         if (this.mode == Id.CAPTURE_ALL) {
             // For %-, all named groups exist (even non-participating ones)
-            Map<String, List<String>> namedCaptures = RuntimeRegex.lastNamedCaptureGroups;
+            Map<String, List<String>> namedCaptures = PerlRuntime.current().regexState.lastNamedCaptureGroups;
             return namedCaptures != null && key instanceof String name && namedCaptures.containsKey(name);
         }
         if (this.mode == Id.CAPTURE) {
             // For %+, only groups that actually captured
-            Map<String, List<String>> namedCaptures = RuntimeRegex.lastNamedCaptureGroups;
+            Map<String, List<String>> namedCaptures = PerlRuntime.current().regexState.lastNamedCaptureGroups;
             if (namedCaptures != null && key instanceof String name) {
                 List<String> captures = namedCaptures.get(name);
                 return captures != null && captures.stream().anyMatch(v -> v != null);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/MyVarCleanupStack.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/MyVarCleanupStack.java
@@ -28,13 +28,17 @@ import java.util.IdentityHashMap;
  */
 public class MyVarCleanupStack {
 
-    private static final ArrayList<Object> stack = new ArrayList<>();
+    private static ArrayList<Object> stack() {
+        return PerlRuntime.current().executionState().myVarCleanupStack;
+    }
 
     // Phase I: parallel identity-counted set for O(1) `isLive(var)` check
     // from the reachability walker. Maps var -> registration count
     // (a single var can be registered multiple times if declared in
     // nested scopes with the same slot reuse).
-    private static final IdentityHashMap<Object, Integer> liveCounts = new IdentityHashMap<>();
+    private static IdentityHashMap<Object, Integer> liveCounts() {
+        return PerlRuntime.current().executionState().liveMyVarCounts;
+    }
 
     /**
      * Phase I: O(1) check whether the given object is currently registered
@@ -46,17 +50,17 @@ public class MyVarCleanupStack {
      */
     public static boolean isLive(Object var) {
         if (var == null) return false;
-        return liveCounts.containsKey(var);
+        return liveCounts().containsKey(var);
     }
 
     /**
      * True when {@code var} is currently registered as a lexical, regardless
-     * of whether weak-ref tracking has populated {@link #liveCounts}. Used by
+     * of whether weak-ref tracking has populated the live-count map. Used by
      * first-bless paths that can run before the first {@code weaken()} call.
      */
     public static boolean isRegistered(Object var) {
         if (var == null) return false;
-        for (Object entry : stack) {
+        for (Object entry : stack()) {
             if (entry == var) return true;
         }
         return false;
@@ -72,7 +76,7 @@ public class MyVarCleanupStack {
      * RuntimeScalar / RuntimeArray / RuntimeHash instances.
      */
     public static java.util.List<Object> snapshotLiveVars() {
-        return new java.util.ArrayList<>(liveCounts.keySet());
+        return new java.util.ArrayList<>(liveCounts().keySet());
     }
 
     /**
@@ -83,7 +87,7 @@ public class MyVarCleanupStack {
      * @return mark position (always >= 0)
      */
     public static int pushMark() {
-        return stack.size();
+        return stack().size();
     }
 
     /**
@@ -98,7 +102,7 @@ public class MyVarCleanupStack {
      * @param var the RuntimeScalar, RuntimeHash, or RuntimeArray object
      */
     public static void register(Object var) {
-        stack.add(var);
+        stack().add(var);
         // liveCounts is consulted by ReachabilityWalker.sweepWeakRefs and
         // .isReachableFromRoots. We populate it lazily — only after the
         // first weaken() call (which sets WeakRefRegistry.weakRefsExist).
@@ -107,21 +111,22 @@ public class MyVarCleanupStack {
         // {@link #snapshotStackToLiveCounts()} from WeakRefRegistry,
         // which seeds liveCounts with all already-registered my-vars.
         if (var != null && WeakRefRegistry.weakRefsExist) {
-            liveCounts.merge(var, 1, Integer::sum);
+            liveCounts().merge(var, 1, Integer::sum);
             MortalList.invalidateLiveRootSnapshot();
         }
     }
 
     /**
-     * Phase D-W2b (perf): one-time backfill of {@link #liveCounts} with
-     * all my-vars currently on {@link #stack}. Called by
+     * Phase D-W2b (perf): one-time backfill of the live-count map with
+     * all currently registered my-vars. Called by
      * {@link WeakRefRegistry#registerWeakRef} the first time
      * {@code weakRefsExist} flips to true. Without this, my-vars
      * declared before the first {@code weaken()} would never be
      * inserted into {@code liveCounts} and the walker would miss them.
      */
     public static synchronized void snapshotStackToLiveCounts() {
-        for (Object var : stack) {
+        IdentityHashMap<Object, Integer> liveCounts = liveCounts();
+        for (Object var : stack()) {
             if (var != null) {
                 liveCounts.merge(var, 1, Integer::sum);
             }
@@ -149,6 +154,7 @@ public class MyVarCleanupStack {
         if (var == null) return;
         // Block-scoped my-vars pop in reverse declaration order, so
         // scan from the top of the stack for a fast amortized match.
+        ArrayList<Object> stack = stack();
         for (int i = stack.size() - 1; i >= 0; i--) {
             if (stack.get(i) == var) {
                 stack.remove(i);
@@ -167,6 +173,8 @@ public class MyVarCleanupStack {
      */
     public static void replace(Object oldVar, Object newVar) {
         if (oldVar == null || newVar == null || oldVar == newVar) return;
+        ArrayList<Object> stack = stack();
+        IdentityHashMap<Object, Integer> liveCounts = liveCounts();
         for (int i = stack.size() - 1; i >= 0; i--) {
             if (stack.get(i) == oldVar) {
                 stack.set(i, newVar);
@@ -183,6 +191,7 @@ public class MyVarCleanupStack {
     }
 
     private static void decLiveCount(Object var) {
+        IdentityHashMap<Object, Integer> liveCounts = liveCounts();
         Integer c = liveCounts.get(var);
         if (c == null) return;
         if (c <= 1) liveCounts.remove(var);
@@ -214,6 +223,7 @@ public class MyVarCleanupStack {
      * @param mark the mark position from {@link #pushMark()}
      */
     public static void unwindTo(int mark) {
+        ArrayList<Object> stack = stack();
         for (int i = stack.size() - 1; i >= mark; i--) {
             Object var = stack.removeLast();
             if (var != null) {
@@ -232,6 +242,7 @@ public class MyVarCleanupStack {
      * @param mark the mark position from {@link #pushMark()}
      */
     public static void popMark(int mark) {
+        ArrayList<Object> stack = stack();
         while (stack.size() > mark) {
             Object var = stack.removeLast();
             if (var != null) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/OutputAutoFlushVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/OutputAutoFlushVariable.java
@@ -7,7 +7,11 @@ import java.util.Stack;
  */
 public class OutputAutoFlushVariable extends RuntimeScalar {
 
-    private static final Stack<State> stateStack = new Stack<>();
+    @SuppressWarnings("unchecked")
+    private static Stack<State> stateStack() {
+        return (Stack<State>) (Stack<?>)
+                PerlRuntime.current().executionState().autoFlushStates;
+    }
 
     private static RuntimeIO currentHandle() {
         RuntimeIO handle = RuntimeIO.getSelectedHandle();
@@ -81,12 +85,13 @@ public class OutputAutoFlushVariable extends RuntimeScalar {
     @Override
     public void dynamicSaveState() {
         RuntimeIO handle = currentHandle();
-        stateStack.push(new State(handle, handle.isAutoFlush()));
+        stateStack().push(new State(handle, handle.isAutoFlush()));
         handle.setAutoFlush(false);
     }
 
     @Override
     public void dynamicRestoreState() {
+        Stack<State> stateStack = stateStack();
         if (!stateStack.isEmpty()) {
             State previous = stateStack.pop();
             if (previous.handle != null) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/OutputFieldSeparator.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/OutputFieldSeparator.java
@@ -19,12 +19,9 @@ public class OutputFieldSeparator extends RuntimeScalar {
      * The internal OFS value that print reads.
      * Only updated by OutputFieldSeparator.set() calls.
      */
-    private static String internalOFS = "";
-
-    /**
-     * Stack for save/restore during local $, and for $, (list).
-     */
-    private static final Stack<String> ofsStack = new Stack<>();
+    private static ExecutionRuntimeState state() {
+        return PerlRuntime.current().executionState();
+    }
 
     public OutputFieldSeparator() {
         super();
@@ -34,7 +31,7 @@ public class OutputFieldSeparator extends RuntimeScalar {
      * Returns the internal OFS value for use by print.
      */
     public static String getInternalOFS() {
-        return internalOFS;
+        return state().outputFieldSeparator;
     }
 
     /**
@@ -42,7 +39,8 @@ public class OutputFieldSeparator extends RuntimeScalar {
      * Called from GlobalRuntimeScalar.dynamicSaveState() when localizing $,.
      */
     public static void saveInternalOFS() {
-        ofsStack.push(internalOFS);
+        ExecutionRuntimeState state = state();
+        state.outputFieldSeparatorStates.push(state.outputFieldSeparator);
     }
 
     /**
@@ -50,50 +48,51 @@ public class OutputFieldSeparator extends RuntimeScalar {
      * Called from GlobalRuntimeScalar.dynamicRestoreState() when restoring $,.
      */
     public static void restoreInternalOFS() {
-        if (!ofsStack.isEmpty()) {
-            internalOFS = ofsStack.pop();
+        ExecutionRuntimeState state = state();
+        if (!state.outputFieldSeparatorStates.isEmpty()) {
+            state.outputFieldSeparator = state.outputFieldSeparatorStates.pop();
         }
     }
 
     @Override
     public RuntimeScalar set(RuntimeScalar value) {
         super.set(value);
-        internalOFS = this.toString();
+        state().outputFieldSeparator = this.toString();
         return this;
     }
 
     @Override
     public RuntimeScalar set(String value) {
         super.set(value);
-        internalOFS = this.toString();
+        state().outputFieldSeparator = this.toString();
         return this;
     }
 
     @Override
     public RuntimeScalar set(int value) {
         super.set(value);
-        internalOFS = this.toString();
+        state().outputFieldSeparator = this.toString();
         return this;
     }
 
     @Override
     public RuntimeScalar set(long value) {
         super.set(value);
-        internalOFS = this.toString();
+        state().outputFieldSeparator = this.toString();
         return this;
     }
 
     @Override
     public RuntimeScalar set(boolean value) {
         super.set(value);
-        internalOFS = this.toString();
+        state().outputFieldSeparator = this.toString();
         return this;
     }
 
     @Override
     public RuntimeScalar set(Object value) {
         super.set(value);
-        internalOFS = this.toString();
+        state().outputFieldSeparator = this.toString();
         return this;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/OutputRecordSeparator.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/OutputRecordSeparator.java
@@ -24,12 +24,9 @@ public class OutputRecordSeparator extends RuntimeScalar {
      * The internal ORS value that print reads.
      * Only updated by OutputRecordSeparator.set() calls.
      */
-    private static String internalORS = "";
-
-    /**
-     * Stack for save/restore during local $\ and for $\ (list).
-     */
-    private static final Stack<String> orsStack = new Stack<>();
+    private static ExecutionRuntimeState state() {
+        return PerlRuntime.current().executionState();
+    }
 
     public OutputRecordSeparator() {
         super();
@@ -39,7 +36,7 @@ public class OutputRecordSeparator extends RuntimeScalar {
      * Returns the internal ORS value for use by print.
      */
     public static String getInternalORS() {
-        return internalORS;
+        return state().outputRecordSeparator;
     }
 
     /**
@@ -47,7 +44,8 @@ public class OutputRecordSeparator extends RuntimeScalar {
      * Called from GlobalRuntimeScalar.dynamicSaveState() when localizing $\.
      */
     public static void saveInternalORS() {
-        orsStack.push(internalORS);
+        ExecutionRuntimeState state = state();
+        state.outputRecordSeparatorStates.push(state.outputRecordSeparator);
     }
 
     /**
@@ -55,50 +53,51 @@ public class OutputRecordSeparator extends RuntimeScalar {
      * Called from GlobalRuntimeScalar.dynamicRestoreState() when restoring $\.
      */
     public static void restoreInternalORS() {
-        if (!orsStack.isEmpty()) {
-            internalORS = orsStack.pop();
+        ExecutionRuntimeState state = state();
+        if (!state.outputRecordSeparatorStates.isEmpty()) {
+            state.outputRecordSeparator = state.outputRecordSeparatorStates.pop();
         }
     }
 
     @Override
     public RuntimeScalar set(RuntimeScalar value) {
         super.set(value);
-        internalORS = this.toString();
+        state().outputRecordSeparator = this.toString();
         return this;
     }
 
     @Override
     public RuntimeScalar set(String value) {
         super.set(value);
-        internalORS = this.toString();
+        state().outputRecordSeparator = this.toString();
         return this;
     }
 
     @Override
     public RuntimeScalar set(int value) {
         super.set(value);
-        internalORS = this.toString();
+        state().outputRecordSeparator = this.toString();
         return this;
     }
 
     @Override
     public RuntimeScalar set(long value) {
         super.set(value);
-        internalORS = this.toString();
+        state().outputRecordSeparator = this.toString();
         return this;
     }
 
     @Override
     public RuntimeScalar set(boolean value) {
         super.set(value);
-        internalORS = this.toString();
+        state().outputRecordSeparator = this.toString();
         return this;
     }
 
     @Override
     public RuntimeScalar set(Object value) {
         super.set(value);
-        internalORS = this.toString();
+        state().outputRecordSeparator = this.toString();
         return this;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -2,6 +2,7 @@ package org.perlonjava.runtime.runtimetypes;
 
 import org.perlonjava.runtime.io.IOHandle;
 import org.perlonjava.runtime.io.StandardIO;
+import org.perlonjava.runtime.mro.MroRuntimeState;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -20,6 +21,10 @@ import java.util.Set;
  */
 public final class PerlRuntime {
     private static final ThreadLocal<BindingFrame> CURRENT = new ThreadLocal<>();
+
+    public final ExecutionRuntimeState executionState = new ExecutionRuntimeState();
+    public final RuntimeRegexState regexState = new RuntimeRegexState();
+    public final MroRuntimeState mroState = new MroRuntimeState();
 
     RuntimeIO ioStdout;
     RuntimeIO ioStderr;
@@ -100,6 +105,18 @@ public final class PerlRuntime {
     public static Binding bindCurrentOrNew() {
         PerlRuntime runtime = currentOrNull();
         return (runtime != null ? runtime : new PerlRuntime()).bind();
+    }
+
+    public ExecutionRuntimeState executionState() {
+        return executionState;
+    }
+
+    public RuntimeRegexState regexState() {
+        return regexState;
+    }
+
+    public MroRuntimeState mroState() {
+        return mroState;
     }
 
     RuntimeGlob standardIOGlob(String name) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RegexState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RegexState.java
@@ -1,20 +1,14 @@
 package org.perlonjava.runtime.runtimetypes;
 
-import org.perlonjava.runtime.regex.RuntimeRegex;
 import org.perlonjava.runtime.regex.RegexMatcher;
+import org.perlonjava.runtime.regex.RuntimeRegex;
 
 import java.util.List;
 import java.util.Map;
 
-/**
- * Snapshot of regex-related global state (Perl's $1, $&amp;, $`, $', etc.).
- *
- * <p>Implements {@link DynamicState} so it integrates with {@link DynamicVariableManager}.
- * A snapshot is pushed onto the DynamicVariableManager stack at subroutine entry via
- * {@link #save()}.  {@code popToLocalLevel()} restores it automatically on scope exit.
- */
+/** Snapshot of Perl-visible regex state for dynamic-scope restoration. */
 public class RegexState implements DynamicState {
-
+    private final PerlRuntime owner;
     private final RegexMatcher globalMatcher;
     private final String globalMatchString;
     private final String lastMatchedString;
@@ -26,29 +20,35 @@ public class RegexState implements DynamicState {
     private final String lastSuccessfulMatchString;
     private final RuntimeRegex lastSuccessfulPattern;
     private final boolean lastMatchUsedPFlag;
+    private final boolean lastMatchUsedBackslashK;
     private final String[] lastCaptureGroups;
     private final Map<String, List<String>> lastNamedCaptureGroups;
     private final boolean lastMatchWasByteString;
+    private final boolean lastMatchResultsTainted;
     private final int[] manualCaptureStarts;
     private final int[] manualCaptureEnds;
 
     public RegexState() {
-        this.globalMatcher = RuntimeRegex.globalMatcher;
-        this.globalMatchString = RuntimeRegex.globalMatchString;
-        this.lastMatchedString = RuntimeRegex.lastMatchedString;
-        this.lastMatchStart = RuntimeRegex.lastMatchStart;
-        this.lastMatchEnd = RuntimeRegex.lastMatchEnd;
-        this.lastSuccessfulMatchedString = RuntimeRegex.lastSuccessfulMatchedString;
-        this.lastSuccessfulMatchStart = RuntimeRegex.lastSuccessfulMatchStart;
-        this.lastSuccessfulMatchEnd = RuntimeRegex.lastSuccessfulMatchEnd;
-        this.lastSuccessfulMatchString = RuntimeRegex.lastSuccessfulMatchString;
-        this.lastSuccessfulPattern = RuntimeRegex.lastSuccessfulPattern;
-        this.lastMatchUsedPFlag = RuntimeRegex.lastMatchUsedPFlag;
-        this.lastCaptureGroups = RuntimeRegex.lastCaptureGroups;
-        this.lastNamedCaptureGroups = RuntimeRegex.lastNamedCaptureGroups;
-        this.lastMatchWasByteString = RuntimeRegex.lastMatchWasByteString;
-        this.manualCaptureStarts = RuntimeRegex.manualCaptureStarts;
-        this.manualCaptureEnds = RuntimeRegex.manualCaptureEnds;
+        owner = PerlRuntime.current();
+        RuntimeRegexState state = owner.regexState;
+        globalMatcher = state.globalMatcher;
+        globalMatchString = state.globalMatchString;
+        lastMatchedString = state.lastMatchedString;
+        lastMatchStart = state.lastMatchStart;
+        lastMatchEnd = state.lastMatchEnd;
+        lastSuccessfulMatchedString = state.lastSuccessfulMatchedString;
+        lastSuccessfulMatchStart = state.lastSuccessfulMatchStart;
+        lastSuccessfulMatchEnd = state.lastSuccessfulMatchEnd;
+        lastSuccessfulMatchString = state.lastSuccessfulMatchString;
+        lastSuccessfulPattern = state.lastSuccessfulPattern;
+        lastMatchUsedPFlag = state.lastMatchUsedPFlag;
+        lastMatchUsedBackslashK = state.lastMatchUsedBackslashK;
+        lastCaptureGroups = state.lastCaptureGroups;
+        lastNamedCaptureGroups = state.lastNamedCaptureGroups;
+        lastMatchWasByteString = state.lastMatchWasByteString;
+        lastMatchResultsTainted = state.lastMatchResultsTainted;
+        manualCaptureStarts = state.manualCaptureStarts;
+        manualCaptureEnds = state.manualCaptureEnds;
     }
 
     public static void save() {
@@ -65,21 +65,27 @@ public class RegexState implements DynamicState {
 
     @Override
     public void dynamicRestoreState() {
-        RuntimeRegex.globalMatcher = this.globalMatcher;
-        RuntimeRegex.globalMatchString = this.globalMatchString;
-        RuntimeRegex.lastMatchedString = this.lastMatchedString;
-        RuntimeRegex.lastMatchStart = this.lastMatchStart;
-        RuntimeRegex.lastMatchEnd = this.lastMatchEnd;
-        RuntimeRegex.lastSuccessfulMatchedString = this.lastSuccessfulMatchedString;
-        RuntimeRegex.lastSuccessfulMatchStart = this.lastSuccessfulMatchStart;
-        RuntimeRegex.lastSuccessfulMatchEnd = this.lastSuccessfulMatchEnd;
-        RuntimeRegex.lastSuccessfulMatchString = this.lastSuccessfulMatchString;
-        RuntimeRegex.lastSuccessfulPattern = this.lastSuccessfulPattern;
-        RuntimeRegex.lastMatchUsedPFlag = this.lastMatchUsedPFlag;
-        RuntimeRegex.lastCaptureGroups = this.lastCaptureGroups;
-        RuntimeRegex.lastNamedCaptureGroups = this.lastNamedCaptureGroups;
-        RuntimeRegex.lastMatchWasByteString = this.lastMatchWasByteString;
-        RuntimeRegex.manualCaptureStarts = this.manualCaptureStarts;
-        RuntimeRegex.manualCaptureEnds = this.manualCaptureEnds;
+        if (PerlRuntime.current() != owner) {
+            throw new IllegalStateException("Regex state must be restored in its owning PerlRuntime");
+        }
+        RuntimeRegexState state = owner.regexState;
+        state.globalMatcher = globalMatcher;
+        state.globalMatchString = globalMatchString;
+        state.lastMatchedString = lastMatchedString;
+        state.lastMatchStart = lastMatchStart;
+        state.lastMatchEnd = lastMatchEnd;
+        state.lastSuccessfulMatchedString = lastSuccessfulMatchedString;
+        state.lastSuccessfulMatchStart = lastSuccessfulMatchStart;
+        state.lastSuccessfulMatchEnd = lastSuccessfulMatchEnd;
+        state.lastSuccessfulMatchString = lastSuccessfulMatchString;
+        state.lastSuccessfulPattern = lastSuccessfulPattern;
+        state.lastMatchUsedPFlag = lastMatchUsedPFlag;
+        state.lastMatchUsedBackslashK = lastMatchUsedBackslashK;
+        state.lastCaptureGroups = lastCaptureGroups;
+        state.lastNamedCaptureGroups = lastNamedCaptureGroups;
+        state.lastMatchWasByteString = lastMatchWasByteString;
+        state.lastMatchResultsTainted = lastMatchResultsTainted;
+        state.manualCaptureStarts = manualCaptureStarts;
+        state.manualCaptureEnds = manualCaptureEnds;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArray.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArray.java
@@ -27,7 +27,9 @@ public class RuntimeArray extends RuntimeBase implements RuntimeScalarReference,
     public static final int TIED_ARRAY = 2;
     public static final int READONLY_ARRAY = 3;
     // Static stack to store saved "local" states of RuntimeArray instances
-    private static final Stack<RuntimeArray> dynamicStateStack = new Stack<>();
+    private static Stack<RuntimeArray> dynamicStateStack() {
+        return PerlRuntime.current().executionState().arrayDynamicStates;
+    }
     // Internal type of array - PLAIN_ARRAY, AUTOVIVIFY_ARRAY, TIED_ARRAY, or READONLY_ARRAY
     public int type;
     public boolean strictAutovivify;
@@ -1687,7 +1689,7 @@ public class RuntimeArray extends RuntimeBase implements RuntimeScalarReference,
         // Copy the current blessId to the new state
         currentState.blessId = this.blessId;
         // Push the current state onto the stack
-        dynamicStateStack.push(currentState);
+        dynamicStateStack().push(currentState);
         // Clear the array elements (for tied arrays, this calls CLEAR)
         notePackageRootMutation();
         if (this.type == TIED_ARRAY) {
@@ -1707,6 +1709,7 @@ public class RuntimeArray extends RuntimeBase implements RuntimeScalarReference,
      */
     @Override
     public void dynamicRestoreState() {
+        Stack<RuntimeArray> dynamicStateStack = dynamicStateStack();
         if (!dynamicStateStack.isEmpty()) {
             // Pop the most recent saved state from the stack
             RuntimeArray previousState = dynamicStateStack.pop();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArrayProxyEntry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArrayProxyEntry.java
@@ -9,8 +9,12 @@ import java.util.Stack;
  * when they are accessed.
  */
 public class RuntimeArrayProxyEntry extends RuntimeBaseProxy {
-    private static final Stack<Integer> dynamicStateStackInt = new Stack<>();
-    private static final Stack<RuntimeScalar> dynamicStateStack = new Stack<>();
+    private static Stack<Integer> dynamicStateStackInt() {
+        return PerlRuntime.current().executionState().arrayProxyIndexStates;
+    }
+    private static Stack<RuntimeScalar> dynamicStateStack() {
+        return PerlRuntime.current().executionState().arrayProxyStates;
+    }
 
     // Reference to the parent RuntimeArray
     private final RuntimeArray parent;
@@ -113,10 +117,10 @@ public class RuntimeArrayProxyEntry extends RuntimeBaseProxy {
      */
     @Override
     public void dynamicSaveState() {
-        dynamicStateStackInt.push(parent.elements.size());
+        dynamicStateStackInt().push(parent.elements.size());
         // Create a new RuntimeScalar to save the current state
         if (this.lvalue == null) {
-            dynamicStateStack.push(null);
+            dynamicStateStack().push(null);
             vivify();
         } else {
             RuntimeScalar currentState = new RuntimeScalar();
@@ -124,7 +128,7 @@ public class RuntimeArrayProxyEntry extends RuntimeBaseProxy {
             currentState.type = this.lvalue.type;
             currentState.value = this.lvalue.value;
             currentState.blessId = this.lvalue.blessId;
-            dynamicStateStack.push(currentState);
+            dynamicStateStack().push(currentState);
             // Clear the current type and value
             this.undefine();
         }
@@ -138,6 +142,7 @@ public class RuntimeArrayProxyEntry extends RuntimeBaseProxy {
      */
     @Override
     public void dynamicRestoreState() {
+        Stack<RuntimeScalar> dynamicStateStack = dynamicStateStack();
         if (!dynamicStateStack.isEmpty()) {
             // Pop the most recent saved state from the stack
             RuntimeScalar previousState = dynamicStateStack.pop();
@@ -162,7 +167,7 @@ public class RuntimeArrayProxyEntry extends RuntimeBaseProxy {
                 this.lvalue.blessId = previousState.blessId;
                 this.blessId = previousState.blessId;
             }
-            int previousSize = dynamicStateStackInt.pop();
+            int previousSize = dynamicStateStackInt().pop();
             if (parent.elements.size() > previousSize) {
                 parent.notePackageRootMutation();
             }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -52,6 +52,14 @@ import static org.perlonjava.runtime.runtimetypes.SpecialBlock.runUnitcheckBlock
  */
 public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
 
+    private PerlRuntime boundRuntime;
+
+    /** Bind Java callbacks that may be invoked by an arbitrary worker thread. */
+    public RuntimeCode bindCallbackTo(PerlRuntime runtime) {
+        this.boundRuntime = runtime;
+        return this;
+    }
+
     // Lookup object for performing method handle operations
     public static final MethodHandles.Lookup lookup = MethodHandles.lookup();
 
@@ -104,10 +112,12 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * eval compilations don't interfere with each other. A stack is required because eval STRING
      * compilation can re-enter eval STRING compilation via BEGIN/use/require.
      */
-    private static final ThreadLocal<ArrayDeque<EvalRuntimeContext>> evalRuntimeContextStack =
-            ThreadLocal.withInitial(ArrayDeque::new);
-    private static final ThreadLocal<ArrayDeque<ArrayList<String>>> syntheticCallerFrames =
-            ThreadLocal.withInitial(ArrayDeque::new);
+    private static ArrayDeque<EvalRuntimeContext> evalRuntimeContextStack() {
+        return PerlRuntime.current().executionState().evalRuntimeContexts;
+    }
+    private static ArrayDeque<ArrayList<String>> syntheticCallerFrames() {
+        return PerlRuntime.current().executionState().syntheticCallerFrames;
+    }
     // Cache for memoization of evalStringHelper results
     private static final int CLASS_CACHE_SIZE = 100;
     private static final Map<String, Class<?>> evalCache = new LinkedHashMap<String, Class<?>>(CLASS_CACHE_SIZE, 0.75f, true) {
@@ -144,7 +154,21 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * 0 = not inside any eval, >0 = inside eval (eval STRING or eval BLOCK).
      * Incremented on eval entry, decremented on eval exit (success or failure).
      */
-    public static int evalDepth = 0;
+    public static int getEvalDepth() {
+        return PerlRuntime.current().executionState().evalDepth;
+    }
+
+    public static void incrementEvalDepth() {
+        PerlRuntime.current().executionState().evalDepth++;
+    }
+
+    public static void decrementEvalDepth() {
+        PerlRuntime.current().executionState().evalDepth--;
+    }
+
+    public static void adjustEvalDepth(int delta) {
+        PerlRuntime.current().executionState().evalDepth += delta;
+    }
 
     /**
      * Thread-local stack of @_ arrays for each active subroutine call.
@@ -154,21 +178,26 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * Push/pop is handled by RuntimeCode.apply() methods.
      * Access via getCurrentArgs() for Java-implemented functions that need caller's @_.
      */
-    private static final ThreadLocal<Deque<RuntimeArray>> argsStack =
-            ThreadLocal.withInitial(ArrayDeque::new);
+    private static Deque<RuntimeArray> argsStack() {
+        return PerlRuntime.current().executionState().argsStack;
+    }
 
     /**
      * Thread-local stack of RuntimeCode objects currently executing on this
      * Java thread. Weak CODE backrefs, especially Sub::Defer's self slot, must
      * not be cleared while the referent CODE is still running.
      */
-    private static final ThreadLocal<Deque<RuntimeCode>> activeCodeStack =
-            ThreadLocal.withInitial(ArrayDeque::new);
+    private static Deque<RuntimeCode> activeCodeStack() {
+        return PerlRuntime.current().executionState().activeCodeStack;
+    }
 
     private record ActiveLexicalFrame(RuntimeCode code, Map<String, RuntimeBase> cells) {}
     private static volatile boolean lexicalAliasSupportEnabled;
-    private static final ThreadLocal<Deque<ActiveLexicalFrame>> activeLexicalFrames =
-            ThreadLocal.withInitial(ArrayDeque::new);
+    @SuppressWarnings("unchecked")
+    private static Deque<ActiveLexicalFrame> activeLexicalFrames() {
+        return (Deque<ActiveLexicalFrame>) (Deque<?>)
+                PerlRuntime.current().executionState().activeLexicalFrames;
+    }
 
     /**
      * Thread-local stack of pristine (unshifted) @_ snapshots taken at sub-entry
@@ -184,8 +213,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * The snapshot is a cheap new ArrayList of the same RuntimeScalar element
      * references; subsequent shifts/modifications of the live @_ don't affect it.
      */
-    private static final ThreadLocal<Deque<java.util.List<RuntimeScalar>>> pristineArgsStack =
-            ThreadLocal.withInitial(ArrayDeque::new);
+    private static Deque<java.util.List<RuntimeScalar>> pristineArgsStack() {
+        return PerlRuntime.current().executionState().pristineArgsStack;
+    }
 
     /**
      * Thread-local stack tracking whether each call frame created a fresh @_ (hasargs).
@@ -195,16 +225,18 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      *
      * Push/pop is handled alongside argsStack in the apply() methods.
      */
-    private static final ThreadLocal<Deque<Boolean>> hasArgsStack =
-            ThreadLocal.withInitial(ArrayDeque::new);
+    private static Deque<Boolean> hasArgsStack() {
+        return PerlRuntime.current().executionState().hasArgsStack;
+    }
 
     /**
      * Thread-local stack tracking the context each active subroutine was called in.
      * Perl exposes this as caller(EXPR)[5]: undef for void, false for scalar, true
      * for list context.
      */
-    private static final ThreadLocal<Deque<Integer>> callContextStack =
-            ThreadLocal.withInitial(ArrayDeque::new);
+    private static Deque<Integer> callContextStack() {
+        return PerlRuntime.current().executionState().callContextStack;
+    }
 
     /**
      * Get the current subroutine's @_ array.
@@ -214,7 +246,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * @return The current @_ array, or null if not in a subroutine
      */
     public static RuntimeArray getCurrentArgs() {
-        Deque<RuntimeArray> stack = argsStack.get();
+        Deque<RuntimeArray> stack = argsStack();
         return stack.isEmpty() ? null : stack.peek();
     }
 
@@ -231,30 +263,30 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     public static java.util.List<RuntimeArray> snapshotArgsStack() {
-        return new java.util.ArrayList<>(argsStack.get());
+        return new java.util.ArrayList<>(argsStack());
     }
 
     public static int argsStackDepth() {
-        return argsStack.get().size();
+        return argsStack().size();
     }
 
     public static void pushActiveCode(RuntimeCode code) {
-        activeCodeStack.get().push(code);
+        activeCodeStack().push(code);
         if (lexicalAliasSupportEnabled) {
-            activeLexicalFrames.get().push(new ActiveLexicalFrame(code, new HashMap<>()));
+            activeLexicalFrames().push(new ActiveLexicalFrame(code, new HashMap<>()));
         }
     }
 
     public static void popActiveCode(RuntimeCode code) {
         if (lexicalAliasSupportEnabled) {
-            Deque<ActiveLexicalFrame> frames = activeLexicalFrames.get();
+            Deque<ActiveLexicalFrame> frames = activeLexicalFrames();
             if (!frames.isEmpty() && frames.peek().code() == code) {
                 frames.pop();
             } else {
                 frames.removeIf(frame -> frame.code() == code);
             }
         }
-        Deque<RuntimeCode> stack = activeCodeStack.get();
+        Deque<RuntimeCode> stack = activeCodeStack();
         if (!stack.isEmpty() && stack.peek() == code) {
             stack.pop();
             return;
@@ -264,7 +296,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
 
     public static boolean isActiveCode(RuntimeCode code) {
         if (code == null) return false;
-        for (RuntimeCode active : activeCodeStack.get()) {
+        for (RuntimeCode active : activeCodeStack()) {
             if (active == code) return true;
         }
         return false;
@@ -273,7 +305,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     public static RuntimeCode getActiveCodeAt(int depth) {
         if (depth < 0) return null;
         int i = 0;
-        for (RuntimeCode active : activeCodeStack.get()) {
+        for (RuntimeCode active : activeCodeStack()) {
             if (i++ == depth) {
                 return active;
             }
@@ -282,7 +314,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     public static boolean hasActiveCode() {
-        return !activeCodeStack.get().isEmpty();
+        return !activeCodeStack().isEmpty();
     }
 
     public static void enableLexicalAliasSupport() {
@@ -298,7 +330,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     private static void registerActiveLexical(
             RuntimeCode code, String variableName, RuntimeBase cell) {
         if (!lexicalAliasSupportEnabled) return;
-        for (ActiveLexicalFrame frame : activeLexicalFrames.get()) {
+        for (ActiveLexicalFrame frame : activeLexicalFrames()) {
             if (sameLogicalCode(frame.code(), code)) {
                 frame.cells().put(variableName, cell);
                 return;
@@ -308,7 +340,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
 
     public static RuntimeBase findActiveLexical(RuntimeCode code, String variableName) {
         if (!lexicalAliasSupportEnabled) return null;
-        for (ActiveLexicalFrame frame : activeLexicalFrames.get()) {
+        for (ActiveLexicalFrame frame : activeLexicalFrames()) {
             if (sameLogicalCode(frame.code(), code)) {
                 RuntimeBase cell = frame.cells().get(variableName);
                 if (cell != null) return cell;
@@ -329,7 +361,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * @return The caller's @_ array, or null if not available
      */
     public static RuntimeArray getCallerArgs() {
-        Deque<RuntimeArray> stack = argsStack.get();
+        Deque<RuntimeArray> stack = argsStack();
         if (stack.size() < 2) {
             return null;
         }
@@ -343,15 +375,15 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * Public so BytecodeInterpreter can use it when calling InterpretedCode directly.
      */
     public static void pushArgs(RuntimeArray args) {
-        argsStack.get().push(args);
+        argsStack().push(args);
         // Snapshot the args list so @DB::args stays pristine even if the sub
         // later shifts/pops from @_.
-        pristineArgsStack.get().push(
+        pristineArgsStack().push(
                 args != null ? new java.util.ArrayList<>(args.elements) : new java.util.ArrayList<>());
     }
 
     public static void pushCallContext(int callContext) {
-        callContextStack.get().push(callContext);
+        callContextStack().push(callContext);
     }
 
     /**
@@ -360,19 +392,19 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * Public so BytecodeInterpreter can use it when calling InterpretedCode directly.
      */
     public static void popArgs() {
-        Deque<RuntimeArray> stack = argsStack.get();
+        Deque<RuntimeArray> stack = argsStack();
         if (!stack.isEmpty()) {
             stack.pop();
         }
-        Deque<java.util.List<RuntimeScalar>> pStack = pristineArgsStack.get();
+        Deque<java.util.List<RuntimeScalar>> pStack = pristineArgsStack();
         if (!pStack.isEmpty()) {
             pStack.pop();
         }
-        Deque<Boolean> haStack = hasArgsStack.get();
+        Deque<Boolean> haStack = hasArgsStack();
         if (!haStack.isEmpty()) {
             haStack.pop();
         }
-        Deque<Integer> ctxStack = callContextStack.get();
+        Deque<Integer> ctxStack = callContextStack();
         if (!ctxStack.isEmpty()) {
             ctxStack.pop();
         }
@@ -386,7 +418,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * @return a RuntimeArray wrapping the snapshot, or null if frame is out of range
      */
     public static RuntimeArray getOriginalArgsAt(int frame) {
-        Deque<java.util.List<RuntimeScalar>> stack = pristineArgsStack.get();
+        Deque<java.util.List<RuntimeScalar>> stack = pristineArgsStack();
         if (frame < 0 || frame >= stack.size()) return null;
         int i = 0;
         for (java.util.List<RuntimeScalar> list : stack) {
@@ -407,8 +439,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      */
     private static RuntimeArray getOriginalArgsForCode(RuntimeCode target) {
         if (target == null) return null;
-        Iterator<RuntimeCode> codeIt = activeCodeStack.get().iterator();
-        Iterator<java.util.List<RuntimeScalar>> argsIt = pristineArgsStack.get().iterator();
+        Iterator<RuntimeCode> codeIt = activeCodeStack().iterator();
+        Iterator<java.util.List<RuntimeScalar>> argsIt = pristineArgsStack().iterator();
         while (codeIt.hasNext() && argsIt.hasNext()) {
             if (codeIt.next() == target) {
                 java.util.List<RuntimeScalar> list = argsIt.next();
@@ -435,7 +467,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      *         inherited @_ (via &amp;func with no parens), null if depth is out of range
      */
     public static Boolean getHasArgsAt(int depth) {
-        Deque<Boolean> stack = hasArgsStack.get();
+        Deque<Boolean> stack = hasArgsStack();
         int i = 0;
         for (Boolean b : stack) {
             if (i == depth) return b;
@@ -445,7 +477,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     public static Integer getCallContextAt(int depth) {
-        Deque<Integer> stack = callContextStack.get();
+        Deque<Integer> stack = callContextStack();
         int i = 0;
         for (Integer callContext : stack) {
             if (i == depth) return callContext;
@@ -866,11 +898,6 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     // Depth of active recursive calls to this subroutine, used by the
     // "Deep recursion on subroutine" warning. Incremented on entry and
     // decremented in a finally-block on exit.
-    public transient int callDepth = 0;
-    // Whether a "Deep recursion" warning has already been emitted for the
-    // currently-active recursion chain. Reset when callDepth returns to 0.
-    public transient boolean deepRecursionWarned = false;
-
     // Depth threshold for the "Deep recursion on subroutine" warning.
     // Matches Perl's default PERL_SUB_DEPTH_WARN value.
     public static final int DEEP_RECURSION_WARN_DEPTH = 100;
@@ -882,8 +909,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     // tail calls don't consume real Java stack, so a depth warning for
     // them is misleading anyway. Nested tail-call trampolines use an int
     // counter so re-entries only skip tracking for the outermost trampoline.
-    private static final ThreadLocal<Integer> inTailCallTrampoline =
-            ThreadLocal.withInitial(() -> 0);
+    private static int tailCallTrampolineDepth() {
+        return PerlRuntime.current().executionState().tailCallTrampolineDepth;
+    }
 
     /**
      * Increment the recursion depth counter and, if we've just crossed the
@@ -899,12 +927,14 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         if (isMapGrepBlock || isEvalBlock || isBuiltin) {
             return;
         }
-        if (inTailCallTrampoline.get() > 0) {
+        if (tailCallTrampolineDepth() > 0) {
             return;
         }
-        int depth = ++callDepth;
-        if (depth > DEEP_RECURSION_WARN_DEPTH && !deepRecursionWarned) {
-            deepRecursionWarned = true;
+        ExecutionRuntimeState.CallDepthState callState =
+                PerlRuntime.current().executionState().callDepth(this);
+        int depth = ++callState.depth;
+        if (depth > DEEP_RECURSION_WARN_DEPTH && !callState.warned) {
+            callState.warned = true;
             String name = (packageName != null && subName != null)
                     ? packageName + "::" + subName
                     : (subName != null ? subName : "__ANON__");
@@ -920,12 +950,15 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         if (isMapGrepBlock || isEvalBlock || isBuiltin) {
             return;
         }
-        if (inTailCallTrampoline.get() > 0) {
+        if (tailCallTrampolineDepth() > 0) {
             return;
         }
-        if (--callDepth <= 0) {
-            callDepth = 0;
-            deepRecursionWarned = false;
+        ExecutionRuntimeState.CallDepthState callState =
+                PerlRuntime.current().executionState().callDepth(this);
+        if (--callState.depth <= 0) {
+            callState.depth = 0;
+            callState.warned = false;
+            PerlRuntime.current().executionState().releaseCallDepth(this);
         }
     }
     // State variables
@@ -1529,7 +1562,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * @return The current eval runtime context, or null if not in eval STRING compilation
      */
     public static EvalRuntimeContext getEvalRuntimeContext() {
-        ArrayDeque<EvalRuntimeContext> stack = evalRuntimeContextStack.get();
+        ArrayDeque<EvalRuntimeContext> stack = evalRuntimeContextStack();
         return stack.isEmpty() ? null : stack.peekFirst();
     }
 
@@ -1541,13 +1574,13 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * @return The saved eval runtime context (may be null)
      */
     public static EvalRuntimeContext saveAndClearEvalRuntimeContext() {
-        ArrayDeque<EvalRuntimeContext> stack = evalRuntimeContextStack.get();
+        ArrayDeque<EvalRuntimeContext> stack = evalRuntimeContextStack();
         if (stack.isEmpty()) {
             return null;
         }
         EvalRuntimeContext saved = stack.removeFirst();
         if (stack.isEmpty()) {
-            evalRuntimeContextStack.remove();
+            evalRuntimeContextStack().clear();
         }
         return saved;
     }
@@ -1567,17 +1600,17 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      */
     public static void restoreEvalRuntimeContext(EvalRuntimeContext saved) {
         if (saved != null) {
-            evalRuntimeContextStack.get().addFirst(saved);
+            evalRuntimeContextStack().addFirst(saved);
             reactivateEvalRuntimeAliases(saved);
         }
     }
 
     private static void pushEvalRuntimeContext(EvalRuntimeContext context) {
-        evalRuntimeContextStack.get().addFirst(context);
+        evalRuntimeContextStack().addFirst(context);
     }
 
     private static void popEvalRuntimeContext(EvalRuntimeContext context) {
-        ArrayDeque<EvalRuntimeContext> stack = evalRuntimeContextStack.get();
+        ArrayDeque<EvalRuntimeContext> stack = evalRuntimeContextStack();
         if (!stack.isEmpty()) {
             if (stack.peekFirst() == context) {
                 stack.removeFirst();
@@ -1591,7 +1624,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             }
         }
         if (stack.isEmpty()) {
-            evalRuntimeContextStack.remove();
+            evalRuntimeContextStack().clear();
         }
     }
 
@@ -1610,16 +1643,16 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         frame.add(String.valueOf(line));
         frame.add(subName);
         frame.add(marker);
-        syntheticCallerFrames.get().addLast(frame);
+        syntheticCallerFrames().addLast(frame);
     }
 
     public static void popSyntheticCallerFrame() {
-        ArrayDeque<ArrayList<String>> stack = syntheticCallerFrames.get();
+        ArrayDeque<ArrayList<String>> stack = syntheticCallerFrames();
         if (!stack.isEmpty()) {
             stack.removeLast();
         }
         if (stack.isEmpty()) {
-            syntheticCallerFrames.remove();
+            syntheticCallerFrames().clear();
         }
     }
 
@@ -1692,7 +1725,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         anonSubs.clear();
         interpretedSubs.clear();
         evalContext.clear();
-        evalRuntimeContextStack.remove();
+        evalRuntimeContextStack().clear();
     }
 
     public static void copy(RuntimeCode code, RuntimeCode codeFrom) {
@@ -2704,7 +2737,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     int level = DynamicVariableManager.getLocalLevel();
                     DynamicVariableManager.pushLocalVariable(sig);
 
-                    evalDepth++;
+                    incrementEvalDepth();
                     boolean pushedEvalFrame = InterpreterState.pushEvalFrameForCurrentInterpreter();
                     boolean pushedSyntheticEvalFrame = false;
                     if (!pushedEvalFrame) {
@@ -2739,7 +2772,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                         if (pushedSyntheticEvalFrame) {
                             popSyntheticEvalCallerFrame();
                         }
-                        evalDepth--;
+                        decrementEvalDepth();
                         // Restore $SIG{__DIE__}
                         DynamicVariableManager.popToLocalLevel(level);
                     }
@@ -2765,7 +2798,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
 
             // Execute the interpreted code
             // Track eval depth for $^S support
-            evalDepth++;
+            incrementEvalDepth();
             try {
                 result = interpretedCode.apply(args, callContext);
 
@@ -2822,7 +2855,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     return new RuntimeList(new RuntimeScalar());
                 }
             } finally {
-                evalDepth--;
+                decrementEvalDepth();
             }
 
         } finally {
@@ -3542,7 +3575,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         Throwable t = new Throwable();
         ExceptionFormatter.StackTraceResult result = ExceptionFormatter.formatExceptionDetailed(t);
         ArrayList<ArrayList<String>> stackTrace = result.frames();
-        ArrayDeque<ArrayList<String>> syntheticFrames = syntheticCallerFrames.get();
+        ArrayDeque<ArrayList<String>> syntheticFrames = syntheticCallerFrames();
         if (!syntheticFrames.isEmpty()) {
             int baseSkip = result.firstFrameFromInterpreter() ? 0 : 1;
             int insertAt = Math.min(baseSkip + 1, stackTrace.size());
@@ -4021,7 +4054,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         }
         RuntimeCode previous = null;
         int logicalIndex = 0;
-        for (RuntimeCode active : activeCodeStack.get()) {
+        for (RuntimeCode active : activeCodeStack()) {
             if (active == previous || isCompilerWrapperPair(active, previous)) {
                 continue;
             }
@@ -4101,7 +4134,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     private static boolean hasExplicitlyRenamedActiveCode() {
-        for (RuntimeCode active : activeCodeStack.get()) {
+        for (RuntimeCode active : activeCodeStack()) {
             if (active.explicitlyRenamed) {
                 return true;
             }
@@ -4474,7 +4507,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     // Eval STRING must allow next/last/redo to propagate to the enclosing scope.
     // The caller is responsible for handling RuntimeControlFlowList markers.
     public static RuntimeList applyEval(RuntimeScalar runtimeScalar, RuntimeArray a, int callContext) {
-        evalDepth++;
+        incrementEvalDepth();
         try {
             RuntimeList result = apply(runtimeScalar, a, callContext);
             // Perl clears $@ on successful eval (even if nested evals previously set it).
@@ -4507,7 +4540,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             }
             return new RuntimeList(new RuntimeScalar());
         } finally {
-            evalDepth--;
+            decrementEvalDepth();
             // Release captured variable references from the eval's code object.
             // After eval STRING finishes executing, its captures are no longer needed.
             if (runtimeScalar.type == RuntimeScalarType.CODE && runtimeScalar.value instanceof RuntimeCode code) {
@@ -4835,11 +4868,11 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         // tracking. See enterCall() / inTailCallTrampoline for the rationale.
         boolean isTailCall = "tailcall".equals(subroutineName);
         if (isTailCall) {
-            inTailCallTrampoline.set(inTailCallTrampoline.get() + 1);
+            PerlRuntime.current().executionState().tailCallTrampolineDepth++;
             try {
                 return applyImpl(runtimeScalar, subroutineName, list, callContext);
             } finally {
-                inTailCallTrampoline.set(inTailCallTrampoline.get() - 1);
+                PerlRuntime.current().executionState().tailCallTrampolineDepth--;
             }
         }
         return applyImpl(runtimeScalar, subroutineName, list, callContext);
@@ -5314,6 +5347,11 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * @return the result of the subroutine execution as a RuntimeList
      */
     public RuntimeList apply(RuntimeArray a, int callContext) {
+        if (boundRuntime != null && PerlRuntime.currentOrNull() != boundRuntime) {
+            try (PerlRuntime.Binding ignored = boundRuntime.bind()) {
+                return apply(a, callContext);
+            }
+        }
         if (constantValue != null) {
             requireLvalueCallable(this, callContext, null);
             return new RuntimeList(constantValue);
@@ -5391,7 +5429,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             // which inherits the caller's @_ instead of creating a fresh one.
             // Perl's caller()[4] (hasargs) should be false/empty for these calls.
             // See also: the 3-arg instance method apply(name, array, ctx) which pushes true.
-            hasArgsStack.get().push(false);
+            hasArgsStack().push(false);
 
             // Check deep recursion BEFORE pushing the callee's warning bits,
             // so the "Deep recursion on subroutine" warning is gated on the
@@ -5451,6 +5489,11 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     public RuntimeList apply(String subroutineName, RuntimeArray a, int callContext) {
+        if (boundRuntime != null && PerlRuntime.currentOrNull() != boundRuntime) {
+            try (PerlRuntime.Binding ignored = boundRuntime.bind()) {
+                return apply(subroutineName, a, callContext);
+            }
+        }
         if (constantValue != null) {
             requireLvalueCallable(this, callContext, subroutineName);
             return new RuntimeList(constantValue);
@@ -5520,7 +5563,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             // which create a new @_ from the supplied arguments.
             // Perl's caller()[4] (hasargs) should be true (1) for these calls.
             // See also: the 2-arg instance method apply(array, ctx) which pushes false.
-            hasArgsStack.get().push(true);
+            hasArgsStack().push(true);
 
             // Check deep recursion BEFORE pushing the callee's warning bits,
             // so the "Deep recursion on subroutine" warning is gated on the

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeControlFlowRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeControlFlowRegistry.java
@@ -9,7 +9,9 @@ package org.perlonjava.runtime.runtimetypes;
  */
 public class RuntimeControlFlowRegistry {
     // Thread-local storage for control flow markers
-    private static final ThreadLocal<ControlFlowMarker> currentMarker = new ThreadLocal<>();
+    private static ExecutionRuntimeState state() {
+        return PerlRuntime.current().executionState();
+    }
 
     /**
      * Register a control flow marker.
@@ -18,7 +20,7 @@ public class RuntimeControlFlowRegistry {
      * @param marker The control flow marker to register
      */
     public static void register(ControlFlowMarker marker) {
-        currentMarker.set(marker);
+        state().controlFlowMarker = marker;
     }
 
     /**
@@ -27,7 +29,7 @@ public class RuntimeControlFlowRegistry {
      * @return true if a marker is registered
      */
     public static boolean hasMarker() {
-        return currentMarker.get() != null;
+        return state().controlFlowMarker != null;
     }
 
     /**
@@ -36,7 +38,7 @@ public class RuntimeControlFlowRegistry {
      * @return The marker, or null if none
      */
     public static ControlFlowMarker getMarker() {
-        return currentMarker.get();
+        return state().controlFlowMarker;
     }
 
     /**
@@ -44,7 +46,7 @@ public class RuntimeControlFlowRegistry {
      * This is called after the marker has been handled by a loop.
      */
     public static void clear() {
-        currentMarker.remove();
+        state().controlFlowMarker = null;
     }
 
     /**
@@ -56,7 +58,7 @@ public class RuntimeControlFlowRegistry {
      * @return true if the marker matches and was cleared
      */
     public static boolean checkAndClear(ControlFlowType type, String label) {
-        ControlFlowMarker marker = currentMarker.get();
+        ControlFlowMarker marker = state().controlFlowMarker;
         if (marker == null) {
             return false;
         }
@@ -90,7 +92,7 @@ public class RuntimeControlFlowRegistry {
      * @return true if there's a GOTO marker for this label
      */
     public static boolean checkGoto(String label) {
-        ControlFlowMarker marker = currentMarker.get();
+        ControlFlowMarker marker = state().controlFlowMarker;
         if (marker == null || marker.type != ControlFlowType.GOTO) {
             return false;
         }
@@ -111,7 +113,7 @@ public class RuntimeControlFlowRegistry {
      * @return 0=no action, 1=LAST, 2=NEXT, 3=REDO, 4=GOTO (leave in registry)
      */
     public static int checkLoopAndGetAction(String labelName) {
-        ControlFlowMarker marker = currentMarker.get();
+        ControlFlowMarker marker = state().controlFlowMarker;
         if (marker == null) {
             return 0;  // No marker
         }
@@ -162,7 +164,7 @@ public class RuntimeControlFlowRegistry {
      * This is called at program exit or when returning from a subroutine to the top level.
      */
     public static void throwIfUncaught() {
-        ControlFlowMarker marker = currentMarker.get();
+        ControlFlowMarker marker = state().controlFlowMarker;
         if (marker != null) {
             clear();
             marker.throwError();
@@ -190,4 +192,3 @@ public class RuntimeControlFlowRegistry {
         return RuntimeControlFlowList.createFromAction(action, labelName);
     }
 }
-

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
@@ -16,9 +16,14 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.*;
  */
 public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference {
 
-    private static final Stack<GlobSlotSnapshot> globSlotStack = new Stack<>();
+    @SuppressWarnings("unchecked")
+    private static Stack<GlobSlotSnapshot> globSlotStack() {
+        return (Stack<GlobSlotSnapshot>) (Stack<?>)
+                PerlRuntime.current().executionState().globSlotStates;
+    }
 
     public static boolean isLocalizedGlob(String globName) {
+        Stack<GlobSlotSnapshot> globSlotStack = globSlotStack();
         for (int i = globSlotStack.size() - 1; i >= 0; i--) {
             if (java.util.Objects.equals(globSlotStack.get(i).globName(), globName)) {
                 return true;
@@ -28,6 +33,7 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
     }
 
     public static RuntimeArray localizedUnderscoreArray() {
+        Stack<GlobSlotSnapshot> globSlotStack = globSlotStack();
         for (int i = globSlotStack.size() - 1; i >= 0; i--) {
             String name = globSlotStack.get(i).globName();
             if (name != null && name.endsWith("::_")) {
@@ -1406,7 +1412,7 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
             savedSelectedHandle = RuntimeIO.getSelectedHandle();
             isSelectedHandle = true;
         }
-        globSlotStack.push(new GlobSlotSnapshot(this.globName,
+        globSlotStack().push(new GlobSlotSnapshot(this.globName,
                 savedScalar, savedArray, savedHash,
                 savedCode, savedIO, savedSelectedHandle, savedIOVisible));
 
@@ -1483,7 +1489,7 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
 
     @Override
     public void dynamicRestoreState() {
-        GlobSlotSnapshot snap = globSlotStack.pop();
+        GlobSlotSnapshot snap = globSlotStack().pop();
 
         // Restore the saved IO object reference on this (old) glob.
         this.IO = snap.io;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
@@ -21,7 +21,9 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
     public static final int TIED_HASH = 2;
     public static final int READONLY_HASH = 3;
     // Static stack to store saved "local" states of RuntimeHash instances
-    private static final Stack<RuntimeHash> dynamicStateStack = new Stack<>();
+    private static Stack<RuntimeHash> dynamicStateStack() {
+        return PerlRuntime.current().executionState().hashDynamicStates;
+    }
     private static final RuntimeArray EMPTY_KEYS = new RuntimeArray();
 
     static {
@@ -1459,7 +1461,7 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
         currentState.blessId = this.blessId;
         currentState.byteKeys = this.byteKeys != null ? new HashSet<>(this.byteKeys) : null;
         currentState.type = this.type;
-        dynamicStateStack.push(currentState);
+        dynamicStateStack().push(currentState);
         // Clear the hash
         this.elements.clear();
         this.byteKeys = null;
@@ -1473,6 +1475,7 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
      */
     @Override
     public void dynamicRestoreState() {
+        Stack<RuntimeHash> dynamicStateStack = dynamicStateStack();
         if (!dynamicStateStack.isEmpty()) {
             // Restore the elements map and blessId from the most recent saved state
             RuntimeHash previousState = dynamicStateStack.pop();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHashProxyEntry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHashProxyEntry.java
@@ -8,7 +8,9 @@ import java.util.Stack;
  * when they are accessed.
  */
 public class RuntimeHashProxyEntry extends RuntimeBaseProxy {
-    private static final Stack<RuntimeScalar> dynamicStateStack = new Stack<>();
+    private static Stack<RuntimeScalar> dynamicStateStack() {
+        return PerlRuntime.current().executionState().hashProxyStates;
+    }
 
     // Reference to the parent RuntimeHash
     private final RuntimeHash parent;
@@ -104,7 +106,7 @@ public class RuntimeHashProxyEntry extends RuntimeBaseProxy {
     public void dynamicSaveState() {
         // Create a new RuntimeScalar to save the current state
         if (this.lvalue == null) {
-            dynamicStateStack.push(null);
+            dynamicStateStack().push(null);
             vivify();
         } else {
             RuntimeScalar currentState = new RuntimeScalar();
@@ -112,7 +114,7 @@ public class RuntimeHashProxyEntry extends RuntimeBaseProxy {
             currentState.type = this.lvalue.type;
             currentState.value = this.lvalue.value;
             currentState.blessId = this.lvalue.blessId;
-            dynamicStateStack.push(currentState);
+            dynamicStateStack().push(currentState);
             // Clear the current type and value
             this.undefine();
         }
@@ -126,6 +128,7 @@ public class RuntimeHashProxyEntry extends RuntimeBaseProxy {
      */
     @Override
     public void dynamicRestoreState() {
+        Stack<RuntimeScalar> dynamicStateStack = dynamicStateStack();
         if (!dynamicStateStack.isEmpty()) {
             // Pop the most recent saved state from the stack
             RuntimeScalar previousState = dynamicStateStack.pop();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimePosLvalue.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimePosLvalue.java
@@ -1,6 +1,5 @@
 package org.perlonjava.runtime.runtimetypes;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -10,21 +9,9 @@ import java.util.Map;
  */
 public class RuntimePosLvalue {
 
-    // Maximum size of the cache to prevent excessive memory usage
-    private static final int MAX_CACHE_SIZE = 1000;
-
-    /**
-     * A cache that stores the position of {@code RuntimeScalar} values and their hashes.
-     * It uses a LinkedHashMap to maintain insertion order and automatically remove the eldest entry
-     * when the cache exceeds the maximum size. This ensures that the cache does not grow indefinitely.
-     */
-    private static final Map<RuntimeScalar, CacheEntry> positionCache = new LinkedHashMap<>(MAX_CACHE_SIZE, 0.75f, true) {
-        @Override
-        protected boolean removeEldestEntry(Map.Entry<RuntimeScalar, CacheEntry> eldest) {
-            // Remove the eldest entry if the cache size exceeds the maximum limit
-            return size() > MAX_CACHE_SIZE;
-        }
-    };
+    private static Map<RuntimeScalar, CacheEntry> positionCache() {
+        return PerlRuntime.current().regexState.positionCache;
+    }
 
     /**
      * Retrieves the position of the given {@code RuntimeScalar} value from the cache.
@@ -42,7 +29,7 @@ public class RuntimePosLvalue {
         RuntimeScalar position;
 
         // Retrieve the cached entry for the given value
-        CacheEntry cachedEntry = positionCache.get(perlVariable);
+        CacheEntry cachedEntry = positionCache().get(perlVariable);
 
         // Check if the value is missing or it has changed
         int code = perlVariable.value == null ? 0 : perlVariable.value.hashCode();
@@ -51,7 +38,7 @@ public class RuntimePosLvalue {
             // create a new undefined RuntimeScalar to represent the position
             position = new PosLvalueScalar(perlVariable);
             // Cache the new position with the current hash of the value
-            positionCache.put(perlVariable, new CacheEntry(code, position));
+            positionCache().put(perlVariable, new CacheEntry(code, position));
         } else {
             // Use the cached position if the value has not changed
             position = cachedEntry.regexPosition;
@@ -62,8 +49,8 @@ public class RuntimePosLvalue {
     /** Copy pos() and zero-length /g bookkeeping between equivalent scalar views. */
     public static void copyPositionState(RuntimeScalar source, RuntimeScalar target) {
         RuntimeScalar targetPosition = pos(target);
-        CacheEntry sourceEntry = positionCache.get(source);
-        CacheEntry targetEntry = positionCache.get(target);
+        CacheEntry sourceEntry = positionCache().get(source);
+        CacheEntry targetEntry = positionCache().get(target);
         if (sourceEntry == null || sourceEntry.regexPosition.type == RuntimeScalarType.UNDEF) {
             targetPosition.type = RuntimeScalarType.UNDEF;
             targetPosition.value = null;
@@ -87,13 +74,13 @@ public class RuntimePosLvalue {
      * @param perlVariable the scalar whose pos should be invalidated
      */
     public static void invalidatePos(RuntimeScalar perlVariable) {
-        if (perlVariable == null) {
+        if (perlVariable == null || PerlRuntime.currentOrNull() == null) {
             return;
         }
         // Reset the canonical pos lvalue in place. Removing the cache entry orphans the
         // PosLvalueScalar that matchRegexDirect may already hold (local posScalar), breaking
         // /g and \\G after (?{ }) or other mid-match assignments to the target scalar.
-        CacheEntry cachedEntry = positionCache.get(perlVariable);
+        CacheEntry cachedEntry = positionCache().get(perlVariable);
         if (cachedEntry != null) {
             int code = perlVariable.value == null ? 0 : perlVariable.value.hashCode();
             cachedEntry.valueHash = code;
@@ -108,7 +95,7 @@ public class RuntimePosLvalue {
     }
 
     private static void clearZeroLengthMatchTracking(RuntimeScalar perlVariable) {
-        CacheEntry cachedEntry = positionCache.get(perlVariable);
+        CacheEntry cachedEntry = positionCache().get(perlVariable);
         if (cachedEntry != null) {
             cachedEntry.lastMatchWasZeroLength = false;
             cachedEntry.lastMatchPosition = -1;
@@ -121,7 +108,7 @@ public class RuntimePosLvalue {
      * This is used to prevent infinite loops in global regex matches.
      */
     public static boolean hadZeroLengthMatchAt(RuntimeScalar perlVariable, int position, String patternKey) {
-        CacheEntry cachedEntry = positionCache.get(perlVariable);
+        CacheEntry cachedEntry = positionCache().get(perlVariable);
         if (cachedEntry == null) {
             return false;
         }
@@ -134,7 +121,7 @@ public class RuntimePosLvalue {
      * Record that a zero-length match occurred at the given position with the given pattern.
      */
     public static void recordZeroLengthMatch(RuntimeScalar perlVariable, int position, String patternKey) {
-        CacheEntry cachedEntry = positionCache.get(perlVariable);
+        CacheEntry cachedEntry = positionCache().get(perlVariable);
         if (cachedEntry != null) {
             cachedEntry.lastMatchWasZeroLength = true;
             cachedEntry.lastMatchPosition = position;
@@ -146,7 +133,7 @@ public class RuntimePosLvalue {
      * Clear the zero-length match tracking (called after successful non-zero-length match).
      */
     public static void recordNonZeroLengthMatch(RuntimeScalar perlVariable) {
-        CacheEntry cachedEntry = positionCache.get(perlVariable);
+        CacheEntry cachedEntry = positionCache().get(perlVariable);
         if (cachedEntry != null) {
             cachedEntry.lastMatchWasZeroLength = false;
             cachedEntry.lastMatchPattern = null;
@@ -202,7 +189,7 @@ public class RuntimePosLvalue {
      * A cache entry that stores the hash of a {@code RuntimeScalar} value and its regex position.
      * This helps in determining if the cached position is still valid for the given scalar.
      */
-    private static class CacheEntry {
+    static final class CacheEntry {
         int valueHash; // Hash of the RuntimeScalar value to detect changes
         RuntimeScalar regexPosition; // Cached position of the regex match
         boolean lastMatchWasZeroLength; // Track if last match was zero-length
@@ -233,7 +220,7 @@ public class RuntimePosLvalue {
             return false;
         }
         
-        CacheEntry cachedEntry = positionCache.get(perlVariable);
+        CacheEntry cachedEntry = positionCache().get(perlVariable);
         // Use the same hash calculation as pos() for consistency
         int code = perlVariable.value == null ? 0 : perlVariable.value.hashCode();
         
@@ -261,7 +248,7 @@ public class RuntimePosLvalue {
             RuntimeScalar position = new PosLvalueScalar(perlVariable);
             cachedEntry = new CacheEntry(code, position);
             cachedEntry.hasUnicodeChars = result;
-            positionCache.put(perlVariable, cachedEntry);
+            positionCache().put(perlVariable, cachedEntry);
         }
         
         return result;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeRegexState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeRegexState.java
@@ -1,0 +1,87 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.perlonjava.runtime.regex.RegexMatcher;
+import org.perlonjava.runtime.regex.RuntimeRegex;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mutable regular-expression state owned by one {@link PerlRuntime}.
+ *
+ * <p>Compiled patterns and Perl-visible match state live here so two runtimes
+ * may match concurrently without sharing captures, {@code pos()}, match-once,
+ * or {@code /o} state.</p>
+ */
+public final class RuntimeRegexState {
+    public static final int MAX_REGEX_CACHE_SIZE = 1000;
+    static final int MAX_POSITION_CACHE_SIZE = 1000;
+
+    public RegexMatcher globalMatcher;
+    public String globalMatchString;
+    public String lastMatchedString;
+    public int lastMatchStart = -1;
+    public int lastMatchEnd = -1;
+    public String lastSuccessfulMatchedString;
+    public int lastSuccessfulMatchStart = -1;
+    public int lastSuccessfulMatchEnd = -1;
+    public String lastSuccessfulMatchString;
+    public RuntimeRegex lastSuccessfulPattern;
+    public boolean lastMatchUsedPFlag;
+    public boolean lastMatchUsedBackslashK;
+    public String[] lastCaptureGroups;
+    public Map<String, List<String>> lastNamedCaptureGroups;
+    public boolean lastMatchWasByteString;
+    public boolean lastMatchResultsTainted;
+    public int[] manualCaptureStarts;
+    public int[] manualCaptureEnds;
+
+    /** Per-runtime callsite state for {@code /o} and {@code m?PAT?}. */
+    public final Map<Integer, RuntimeScalar> optimizedRegexCache = new LinkedHashMap<>();
+
+    /**
+     * Per-runtime compiled templates. Some templates support deferred runtime
+     * properties, so keeping the cache local also prevents cross-runtime
+     * recompilation and invalidation.
+     */
+    public final Map<String, RuntimeRegex> compiledRegexCache =
+            new LinkedHashMap<String, RuntimeRegex>(MAX_REGEX_CACHE_SIZE, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, RuntimeRegex> eldest) {
+                    return size() > MAX_REGEX_CACHE_SIZE;
+                }
+            };
+
+    /** Per-runtime {@code pos()} values and zero-length-match bookkeeping. */
+    final Map<RuntimeScalar, RuntimePosLvalue.CacheEntry> positionCache =
+            new LinkedHashMap<RuntimeScalar, RuntimePosLvalue.CacheEntry>(
+                    MAX_POSITION_CACHE_SIZE, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(
+                        Map.Entry<RuntimeScalar, RuntimePosLvalue.CacheEntry> eldest) {
+                    return size() > MAX_POSITION_CACHE_SIZE;
+                }
+            };
+
+    public void clearMatchState() {
+        globalMatcher = null;
+        globalMatchString = null;
+        lastMatchedString = null;
+        lastMatchStart = -1;
+        lastMatchEnd = -1;
+        lastSuccessfulMatchedString = null;
+        lastSuccessfulMatchStart = -1;
+        lastSuccessfulMatchEnd = -1;
+        lastSuccessfulMatchString = null;
+        lastSuccessfulPattern = null;
+        lastMatchUsedPFlag = false;
+        lastMatchUsedBackslashK = false;
+        lastCaptureGroups = null;
+        lastNamedCaptureGroups = null;
+        lastMatchWasByteString = false;
+        lastMatchResultsTainted = false;
+        manualCaptureStarts = null;
+        manualCaptureEnds = null;
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -61,7 +61,9 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     }
 
     // Static stack to store saved "local" states of RuntimeScalar instances
-    private static final Stack<RuntimeScalar> dynamicStateStack = new Stack<>();
+    private static Stack<RuntimeScalar> dynamicStateStack() {
+        return PerlRuntime.current().executionState().scalarDynamicStates;
+    }
 
     // Pre-compiled regex pattern for decimal numification fast-path
     // INTEGER_PATTERN replaced with isIntegerString() for better performance
@@ -3984,7 +3986,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         currentState.firstClassRegexScalar = this.firstClassRegexScalar;
         currentState.formatPictureTainted = this.formatPictureTainted;
         // Push the current state onto the stack
-        dynamicStateStack.push(currentState);
+        dynamicStateStack().push(currentState);
         // Clear the current type and value
         this.type = UNDEF;
         this.value = null;
@@ -4005,6 +4007,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
      */
     @Override
     public void dynamicRestoreState() {
+        Stack<RuntimeScalar> dynamicStateStack = dynamicStateStack();
         if (!dynamicStateStack.isEmpty()) {
             // Pop the most recent saved state from the stack
             RuntimeScalar previousState = dynamicStateStack.pop();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStash.java
@@ -9,7 +9,9 @@ import java.util.*;
  */
 public class RuntimeStash extends RuntimeHash {
     // Static stack to store saved "local" states of RuntimeStash instances
-    private static final Stack<RuntimeStash> dynamicStateStack = new Stack<>();
+    private static Stack<RuntimeStash> dynamicStateStack() {
+        return PerlRuntime.current().executionState().stashDynamicStates;
+    }
     // Map to store the elements of the hash
     public Map<String, RuntimeScalar> elements;
     public String namespace;
@@ -489,7 +491,7 @@ public class RuntimeStash extends RuntimeHash {
         currentState.elements = new HashMap<>(this.elements);
         ((RuntimeHash) currentState).elements = currentState.elements;
         currentState.blessId = this.blessId;
-        dynamicStateStack.push(currentState);
+        dynamicStateStack().push(currentState);
         // Clear the hash
         this.elements.clear();
         super.elements = this.elements;
@@ -502,6 +504,7 @@ public class RuntimeStash extends RuntimeHash {
      */
     @Override
     public void dynamicRestoreState() {
+        Stack<RuntimeStash> dynamicStateStack = dynamicStateStack();
         if (!dynamicStateStack.isEmpty()) {
             // Restore the elements map and blessId from the most recent saved state
             RuntimeStash previousState = dynamicStateStack.pop();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeTiedHashProxyEntry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeTiedHashProxyEntry.java
@@ -7,7 +7,11 @@ import java.util.Stack;
  * It delegates all operations to the tied object's FETCH and STORE methods.
  */
 public class RuntimeTiedHashProxyEntry extends TiedVariableBase {
-    private static final Stack<SavedState> dynamicStateStack = new Stack<>();
+    @SuppressWarnings("unchecked")
+    private static Stack<SavedState> dynamicStateStack() {
+        return (Stack<SavedState>) (Stack<?>)
+                PerlRuntime.current().executionState().tiedHashProxyStates;
+    }
 
     // Reference to the parent RuntimeHash (which is tied)
     private final RuntimeHash parent;
@@ -68,11 +72,12 @@ public class RuntimeTiedHashProxyEntry extends TiedVariableBase {
     public void dynamicSaveState() {
         boolean existed = TieHash.tiedExists(parent, key).getBoolean();
         RuntimeScalar saved = existed ? new RuntimeScalar(TieHash.tiedFetch(parent, key)) : null;
-        dynamicStateStack.push(new SavedState(existed, saved));
+        dynamicStateStack().push(new SavedState(existed, saved));
     }
 
     @Override
     public void dynamicRestoreState() {
+        Stack<SavedState> dynamicStateStack = dynamicStateStack();
         if (dynamicStateStack.isEmpty()) {
             return;
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarSpecialVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarSpecialVariable.java
@@ -23,7 +23,11 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.PROXY;
  */
 public class ScalarSpecialVariable extends RuntimeBaseProxy {
 
-    private static final Stack<InputLineState> inputLineStateStack = new Stack<>();
+    @SuppressWarnings("unchecked")
+    private static Stack<InputLineState> inputLineStateStack() {
+        return (Stack<InputLineState>) (Stack<?>)
+                PerlRuntime.current().executionState().inputLineStates;
+    }
     // The type of special variable, represented by an enum.
     final Id variableId;
     // The position of the capture group, used only for CAPTURE type variables.
@@ -115,7 +119,7 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
             if (symbolTable != null) {
                 String bits = value.toString();
                 WarningFlags.setWarningBitsFromString(symbolTable, bits);
-                if (RuntimeCode.evalDepth > 0) {
+                if (RuntimeCode.getEvalDepth() > 0) {
                     org.perlonjava.runtime.WarningBitsRegistry.setRuntimeWarningBits(bits);
                 }
             }
@@ -164,17 +168,17 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
                     yield postmatch != null ? makeRegexResultScalar(postmatch) : scalarUndef;
                 }
                 case P_PREMATCH -> {
-                    if (!RuntimeRegex.lastMatchUsedPFlag) yield scalarUndef;
+                    if (!PerlRuntime.current().regexState.lastMatchUsedPFlag) yield scalarUndef;
                     String prematch = RuntimeRegex.preMatchString();
                     yield prematch != null ? makeRegexResultScalar(prematch) : scalarUndef;
                 }
                 case P_MATCH -> {
-                    if (!RuntimeRegex.lastMatchUsedPFlag) yield scalarUndef;
+                    if (!PerlRuntime.current().regexState.lastMatchUsedPFlag) yield scalarUndef;
                     String match = RuntimeRegex.matchString();
                     yield match != null ? makeRegexResultScalar(match) : scalarUndef;
                 }
                 case P_POSTMATCH -> {
-                    if (!RuntimeRegex.lastMatchUsedPFlag) yield scalarUndef;
+                    if (!PerlRuntime.current().regexState.lastMatchUsedPFlag) yield scalarUndef;
                     String postmatch = RuntimeRegex.postMatchString();
                     yield postmatch != null ? makeRegexResultScalar(postmatch) : scalarUndef;
                 }
@@ -223,13 +227,13 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
                     String lastCapture = RuntimeRegex.lastCaptureString();
                     yield lastCapture != null ? makeRegexResultScalar(lastCapture) : scalarUndef;
                 }
-                case LAST_SUCCESSFUL_PATTERN -> RuntimeRegex.lastSuccessfulPattern != null
-                        ? new RuntimeScalar(RuntimeRegex.lastSuccessfulPattern) : scalarUndef;
+                case LAST_SUCCESSFUL_PATTERN -> PerlRuntime.current().regexState.lastSuccessfulPattern != null
+                        ? new RuntimeScalar(PerlRuntime.current().regexState.lastSuccessfulPattern) : scalarUndef;
                 case LAST_REGEXP_CODE_RESULT -> {
                     // $^R - Result of last (?{...}) code block
                     // Get the last matched regex and retrieve its code block result
-                    if (RuntimeRegex.lastSuccessfulPattern != null) {
-                        RuntimeScalar codeBlockResult = RuntimeRegex.lastSuccessfulPattern.getLastCodeBlockResult();
+                    if (PerlRuntime.current().regexState.lastSuccessfulPattern != null) {
+                        RuntimeScalar codeBlockResult = PerlRuntime.current().regexState.lastSuccessfulPattern.getLastCodeBlockResult();
                         yield codeBlockResult != null ? codeBlockResult : scalarUndef;
                     }
                     yield scalarUndef;
@@ -279,7 +283,7 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
                         // During BEGIN/UNITCHECK blocks = compilation phase
                         yield scalarUndef;
                     }
-                    yield getScalarInt(RuntimeCode.evalDepth > 0 ? 1 : 0);
+                    yield getScalarInt(RuntimeCode.getEvalDepth() > 0 ? 1 : 0);
                 }
             };
             return result;
@@ -433,7 +437,7 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
             RuntimeIO handle = RuntimeIO.getLastAccessedHandle();
             int lineNumber = handle != null ? handle.currentLineNumber : (lvalue != null ? lvalue.getInt() : 0);
             RuntimeScalar localValue = lvalue != null ? new RuntimeScalar(lvalue) : null;
-            inputLineStateStack.push(new InputLineState(handle, lineNumber, localValue));
+            inputLineStateStack().push(new InputLineState(handle, lineNumber, localValue));
             return;
         }
         super.dynamicSaveState();
@@ -448,6 +452,7 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
     @Override
     public void dynamicRestoreState() {
         if (variableId == Id.INPUT_LINE_NUMBER) {
+            Stack<InputLineState> inputLineStateStack = inputLineStateStack();
             if (!inputLineStateStack.isEmpty()) {
                 InputLineState previous = inputLineStateStack.pop();
                 RuntimeIO.setLastAccessedHandle(previous.lastHandle);
@@ -497,10 +502,10 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
      */
     private static RuntimeScalar makeRegexResultScalar(String value) {
         RuntimeScalar scalar = new RuntimeScalar(value);
-        if (RuntimeRegex.lastMatchWasByteString) {
+        if (PerlRuntime.current().regexState.lastMatchWasByteString) {
             scalar.type = RuntimeScalarType.BYTE_STRING;
         }
-        scalar.tainted = RuntimeRegex.lastMatchResultsTainted;
+        scalar.tainted = PerlRuntime.current().regexState.lastMatchResultsTainted;
         return scalar;
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/SpecialBlock.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/SpecialBlock.java
@@ -15,9 +15,17 @@ import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalVariab
 public class SpecialBlock {
 
     // Arrays to store different types of blocks
-    public static RuntimeArray endBlocks = new RuntimeArray();
-    public static RuntimeArray initBlocks = new RuntimeArray();
-    public static RuntimeArray checkBlocks = new RuntimeArray();
+    public static RuntimeArray getEndBlocks() {
+        return PerlRuntime.current().executionState().endBlocks;
+    }
+
+    public static RuntimeArray getInitBlocks() {
+        return PerlRuntime.current().executionState().initBlocks;
+    }
+
+    public static RuntimeArray getCheckBlocks() {
+        return PerlRuntime.current().executionState().checkBlocks;
+    }
 
     /**
      * Saves a code reference to the endBlocks array.
@@ -29,7 +37,7 @@ public class SpecialBlock {
      * @param codeRef the code reference to be saved
      */
     public static void saveEndBlock(RuntimeScalar codeRef) {
-        RuntimeArray.unshift(endBlocks, codeRef);
+        RuntimeArray.unshift(getEndBlocks(), codeRef);
     }
 
     /**
@@ -39,7 +47,7 @@ public class SpecialBlock {
      * @param codeRef the code reference to be saved
      */
     public static void saveInitBlock(RuntimeScalar codeRef) {
-        RuntimeArray.unshift(initBlocks, codeRef);
+        RuntimeArray.unshift(getInitBlocks(), codeRef);
     }
 
     /**
@@ -49,7 +57,7 @@ public class SpecialBlock {
      * @param codeRef the code reference to be saved
      */
     public static void saveCheckBlock(RuntimeScalar codeRef) {
-        RuntimeArray.push(checkBlocks, codeRef);
+        RuntimeArray.push(getCheckBlocks(), codeRef);
     }
 
     /**
@@ -65,6 +73,7 @@ public class SpecialBlock {
             getGlobalVariable("main::?").set(0);
         }
         
+        RuntimeArray endBlocks = getEndBlocks();
         while (!endBlocks.isEmpty()) {
             RuntimeScalar block = RuntimeArray.shift(endBlocks);
             if (block.getDefinedBoolean()) {
@@ -85,6 +94,7 @@ public class SpecialBlock {
      * Executes all code blocks stored in the initBlocks array in FIFO order.
      */
     public static void runInitBlocks() {
+        RuntimeArray initBlocks = getInitBlocks();
         while (!initBlocks.isEmpty()) {
             RuntimeScalar block = RuntimeArray.pop(initBlocks);
             if (block.getDefinedBoolean()) {
@@ -97,6 +107,7 @@ public class SpecialBlock {
      * Executes all code blocks stored in the checkBlocks array in LIFO order.
      */
     public static void runCheckBlocks() {
+        RuntimeArray checkBlocks = getCheckBlocks();
         while (!checkBlocks.isEmpty()) {
             RuntimeScalar block = RuntimeArray.pop(checkBlocks);
             if (block.getDefinedBoolean()) {

--- a/src/test/java/org/perlonjava/ErrorMessageUtilTest.java
+++ b/src/test/java/org/perlonjava/ErrorMessageUtilTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * or wrapped exceptions where raw Java toString() would otherwise surface.
  */
 @Tag("unit")
-public class ErrorMessageUtilTest {
+public class ErrorMessageUtilTest extends PerlRuntimeTestBase {
 
     @Test
     void stripJavaExceptionPrefix_stripsFullyQualifiedJavaException() {

--- a/src/test/java/org/perlonjava/backend/bytecode/BytecodeCompilerEvalContextTest.java
+++ b/src/test/java/org/perlonjava/backend/bytecode/BytecodeCompilerEvalContextTest.java
@@ -2,6 +2,7 @@ package org.perlonjava.backend.bytecode;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.perlonjava.PerlRuntimeTestBase;
 import org.perlonjava.backend.jvm.EmitterContext;
 import org.perlonjava.runtime.runtimetypes.RuntimeBase;
 import org.perlonjava.runtime.runtimetypes.RuntimeCode;
@@ -12,7 +13,7 @@ import java.lang.reflect.Method;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 @Tag("unit")
-public class BytecodeCompilerEvalContextTest {
+public class BytecodeCompilerEvalContextTest extends PerlRuntimeTestBase {
 
     @Test
     void evalRuntimeContextLookupUsesPackedRuntimeValueIndex() throws Exception {

--- a/src/test/java/org/perlonjava/runtime/mro/MroRuntimeIsolationTest.java
+++ b/src/test/java/org/perlonjava/runtime/mro/MroRuntimeIsolationTest.java
@@ -1,0 +1,136 @@
+package org.perlonjava.runtime.mro;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.runtime.perlmodule.Mro;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
+import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class MroRuntimeIsolationTest {
+
+    @Test
+    void mroPolicyAutoloadAndDerivedCachesBelongToTheBoundRuntime() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        RuntimeScalar firstMethod = new RuntimeScalar("first-method");
+        RuntimeScalar secondMethod = new RuntimeScalar("second-method");
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            InheritanceResolver.setDefaultMRO(InheritanceResolver.MROAlgorithm.C3);
+            InheritanceResolver.setPackageMRO("Same::Package", InheritanceResolver.MROAlgorithm.C3);
+            InheritanceResolver.setAutoloadEnabled(false);
+            InheritanceResolver.cacheMethod("Same::Package::method", firstMethod);
+            first.mroState().linearizedClassesCache().put(
+                    "Same::Package", List.of("Same::Package", "First::Parent"));
+            first.mroState().isaRevCache().put("Base", Set.of("First::Child"));
+            Mro.incrementPackageGeneration("Same::Package");
+        }
+
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertEquals(InheritanceResolver.MROAlgorithm.DFS,
+                    InheritanceResolver.getPackageMRO("Same::Package"));
+            assertTrue(InheritanceResolver.isAutoloadEnabled());
+            assertNull(InheritanceResolver.getCachedMethod("Same::Package::method"));
+            assertFalse(second.mroState().linearizedClassesCache().containsKey("Same::Package"));
+            assertFalse(second.mroState().isaRevCache().containsKey("Base"));
+            assertEquals("1", Mro.get_pkg_gen(
+                    new org.perlonjava.runtime.runtimetypes.RuntimeArray(
+                            new RuntimeScalar("Same::Package")),
+                    RuntimeContextType.SCALAR).getFirst().toString());
+
+            InheritanceResolver.cacheMethod("Same::Package::method", secondMethod);
+        }
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            assertEquals(InheritanceResolver.MROAlgorithm.C3,
+                    InheritanceResolver.getPackageMRO("Same::Package"));
+            assertFalse(InheritanceResolver.isAutoloadEnabled());
+            assertSame(firstMethod,
+                    InheritanceResolver.getCachedMethod("Same::Package::method"));
+            assertEquals(List.of("Same::Package", "First::Parent"),
+                    first.mroState().linearizedClassesCache().get("Same::Package"));
+            assertEquals(Set.of("First::Child"), first.mroState().isaRevCache().get("Base"));
+            assertEquals("2", Mro.get_pkg_gen(
+                    new org.perlonjava.runtime.runtimetypes.RuntimeArray(
+                            new RuntimeScalar("Same::Package")),
+                    RuntimeContextType.SCALAR).getFirst().toString());
+        }
+
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertSame(secondMethod,
+                    InheritanceResolver.getCachedMethod("Same::Package::method"));
+        }
+    }
+
+    @Test
+    void runtimeLocalMroPolicyChangesDoNotInvalidateAnotherRuntime() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        RuntimeScalar cached = new RuntimeScalar("cached");
+
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            InheritanceResolver.cacheMethod("Shared::method", cached);
+        }
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            InheritanceResolver.setPackageMRO("Shared", InheritanceResolver.MROAlgorithm.C3);
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertSame(cached, InheritanceResolver.getCachedMethod("Shared::method"));
+            assertEquals(InheritanceResolver.MROAlgorithm.DFS,
+                    InheritanceResolver.getPackageMRO("Shared"));
+        }
+    }
+
+    @Test
+    void sharedSymbolMutationEpochLazilyInvalidatesEveryRuntime() {
+        PerlRuntime mutatingRuntime = new PerlRuntime();
+        PerlRuntime observingRuntime = new PerlRuntime();
+        RuntimeScalar stale = new RuntimeScalar("stale");
+
+        try (PerlRuntime.Binding ignored = observingRuntime.bind()) {
+            InheritanceResolver.cacheMethod("Epoch::target", stale);
+        }
+
+        try (PerlRuntime.Binding ignored = mutatingRuntime.bind()) {
+            InheritanceResolver.invalidateMethodLookupCachesForStashSubKey("Epoch::target");
+        }
+
+        // Observation is deliberately lazy: merely mutating another runtime does
+        // not require a registry of every live PerlRuntime.
+        assertSame(stale, observingRuntime.mroState().methodCache().get("Epoch::target"));
+        try (PerlRuntime.Binding ignored = observingRuntime.bind()) {
+            assertNull(InheritanceResolver.getCachedMethod("Epoch::target"));
+        }
+        assertFalse(observingRuntime.mroState().methodCache().containsKey("Epoch::target"));
+    }
+
+    @Test
+    void isaMutationGenerationIsObservedLazilyPerRuntime() {
+        PerlRuntime mutatingRuntime = new PerlRuntime();
+        PerlRuntime observingRuntime = new PerlRuntime();
+        long before;
+
+        try (PerlRuntime.Binding ignored = observingRuntime.bind()) {
+            before = InheritanceResolver.getIsaGeneration();
+            observingRuntime.mroState().isaRevCache().put("Base", Set.of("Old::Child"));
+            observingRuntime.mroState().setIsaRevGeneration(before);
+        }
+        try (PerlRuntime.Binding ignored = mutatingRuntime.bind()) {
+            InheritanceResolver.noteIsaMutation();
+        }
+
+        assertEquals(before, observingRuntime.mroState().isaGeneration());
+        try (PerlRuntime.Binding ignored = observingRuntime.bind()) {
+            assertTrue(InheritanceResolver.getIsaGeneration() > before);
+            assertTrue(observingRuntime.mroState().isaRevCache().isEmpty());
+            assertEquals(-1, observingRuntime.mroState().isaRevGeneration());
+        }
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/perlmodule/storable/BlessedTest.java
+++ b/src/test/java/org/perlonjava/runtime/perlmodule/storable/BlessedTest.java
@@ -1,5 +1,6 @@
 package org.perlonjava.runtime.perlmodule.storable;
 
+import org.perlonjava.PerlRuntimeTestBase;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.perlonjava.runtime.runtimetypes.NameNormalizer;
@@ -27,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * may not yet be implemented in parallel branches.
  */
 @Tag("unit")
-public class BlessedTest {
+public class BlessedTest extends PerlRuntimeTestBase {
 
     /**
      * Helper: append a 4-byte big-endian unsigned 32-bit integer to

--- a/src/test/java/org/perlonjava/runtime/perlmodule/storable/ContainersTest.java
+++ b/src/test/java/org/perlonjava/runtime/perlmodule/storable/ContainersTest.java
@@ -1,5 +1,6 @@
 package org.perlonjava.runtime.perlmodule.storable;
 
+import org.perlonjava.PerlRuntimeTestBase;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * other parallel agents (scalars, refs).
  */
 @Tag("unit")
-public class ContainersTest {
+public class ContainersTest extends PerlRuntimeTestBase {
 
     private static final Path FIXTURES =
             Paths.get("src/test/resources/storable_fixtures").toAbsolutePath();

--- a/src/test/java/org/perlonjava/runtime/perlmodule/storable/HooksTest.java
+++ b/src/test/java/org/perlonjava/runtime/perlmodule/storable/HooksTest.java
@@ -1,5 +1,6 @@
 package org.perlonjava.runtime.perlmodule.storable;
 
+import org.perlonjava.PerlRuntimeTestBase;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -40,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * </ul>
  */
 @Tag("unit")
-public class HooksTest {
+public class HooksTest extends PerlRuntimeTestBase {
 
     private static final Path FIXTURES =
             Paths.get("src/test/resources/storable_fixtures").toAbsolutePath();

--- a/src/test/java/org/perlonjava/runtime/perlmodule/storable/RefOfRefTest.java
+++ b/src/test/java/org/perlonjava/runtime/perlmodule/storable/RefOfRefTest.java
@@ -1,5 +1,6 @@
 package org.perlonjava.runtime.perlmodule.storable;
 
+import org.perlonjava.PerlRuntimeTestBase;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * type and the type/blessing of its referent).
  */
 @Tag("unit")
-public class RefOfRefTest {
+public class RefOfRefTest extends PerlRuntimeTestBase {
 
     /** Build a {@code "pst0"} file-style header for major=2, minor=11,
      *  netorder. Mirrors the helper in {@link RefsTest}. */

--- a/src/test/java/org/perlonjava/runtime/perlmodule/storable/RefsTest.java
+++ b/src/test/java/org/perlonjava/runtime/perlmodule/storable/RefsTest.java
@@ -1,5 +1,6 @@
 package org.perlonjava.runtime.perlmodule.storable;
 
+import org.perlonjava.PerlRuntimeTestBase;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * container readers haven't landed yet).
  */
 @Tag("unit")
-public class RefsTest {
+public class RefsTest extends PerlRuntimeTestBase {
 
     private static final Path FIXTURES =
             Paths.get("src/test/resources/storable_fixtures").toAbsolutePath();

--- a/src/test/java/org/perlonjava/runtime/perlmodule/storable/RegexpStorableTest.java
+++ b/src/test/java/org/perlonjava/runtime/perlmodule/storable/RegexpStorableTest.java
@@ -2,6 +2,7 @@ package org.perlonjava.runtime.perlmodule.storable;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.perlonjava.PerlRuntimeTestBase;
 import org.perlonjava.runtime.regex.RuntimeRegex;
 import org.perlonjava.runtime.runtimetypes.NameNormalizer;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
@@ -28,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@code retrieve_regexp} in upstream {@code Storable.xs}.
  */
 @Tag("unit")
-public class RegexpStorableTest {
+public class RegexpStorableTest extends PerlRuntimeTestBase {
 
     private static final Path FIXTURES =
             Paths.get("src/test/resources/storable_fixtures").toAbsolutePath();

--- a/src/test/java/org/perlonjava/runtime/perlmodule/storable/StorableReaderTest.java
+++ b/src/test/java/org/perlonjava/runtime/perlmodule/storable/StorableReaderTest.java
@@ -1,5 +1,6 @@
 package org.perlonjava.runtime.perlmodule.storable;
 
+import org.perlonjava.PerlRuntimeTestBase;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
@@ -40,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * "throws not-implemented" to "round-trips successfully".
  */
 @Tag("unit")
-public class StorableReaderTest {
+public class StorableReaderTest extends PerlRuntimeTestBase {
 
     private static final Path FIXTURES =
             Paths.get("src/test/resources/storable_fixtures").toAbsolutePath();

--- a/src/test/java/org/perlonjava/runtime/perlmodule/storable/TiedStorableTest.java
+++ b/src/test/java/org/perlonjava/runtime/perlmodule/storable/TiedStorableTest.java
@@ -1,5 +1,6 @@
 package org.perlonjava.runtime.perlmodule.storable;
 
+import org.perlonjava.PerlRuntimeTestBase;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.Tag;
@@ -41,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * package, which is the integration-test layer.
  */
 @Tag("unit")
-public class TiedStorableTest {
+public class TiedStorableTest extends PerlRuntimeTestBase {
 
     /** Build a blessed empty hash ref to act as the "tying object". The
      *  test never invokes its tie methods; it only round-trips its

--- a/src/test/java/org/perlonjava/runtime/perlmodule/storable/VStringStorableTest.java
+++ b/src/test/java/org/perlonjava/runtime/perlmodule/storable/VStringStorableTest.java
@@ -1,5 +1,6 @@
 package org.perlonjava.runtime.perlmodule.storable;
 
+import org.perlonjava.PerlRuntimeTestBase;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
@@ -24,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@link VStringEncoder}.
  */
 @Tag("unit")
-public class VStringStorableTest {
+public class VStringStorableTest extends PerlRuntimeTestBase {
 
     /** Convert encoded char-string back to a real byte array. */
     private static byte[] toBytes(String encoded) {

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/ExecutionRuntimeStateTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/ExecutionRuntimeStateTest.java
@@ -1,0 +1,103 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.backend.bytecode.InterpreterState;
+
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class ExecutionRuntimeStateTest {
+    @Test
+    void nestedBindingsKeepCallerDynamicAndEvalStateIndependent() {
+        PerlRuntime outer = new PerlRuntime();
+        PerlRuntime inner = new PerlRuntime();
+        RuntimeScalar outerValue = new RuntimeScalar("outer");
+        RuntimeScalar innerValue = new RuntimeScalar("inner");
+
+        try (PerlRuntime.Binding ignored = outer.bind()) {
+            CallerStack.push("Outer", "outer.pl", 10);
+            DynamicVariableManager.pushLocalVariable(outerValue);
+            outerValue.set("outer-local");
+            RuntimeCode.incrementEvalDepth();
+            InterpreterState.currentPackage.get().set("Outer");
+
+            try (PerlRuntime.Binding nested = inner.bind()) {
+                assertNull(CallerStack.peek(0));
+                assertEquals(0, DynamicVariableManager.getLocalLevel());
+                assertEquals(0, RuntimeCode.getEvalDepth());
+                assertEquals("main", InterpreterState.currentPackage.get().toString());
+
+                CallerStack.push("Inner", "inner.pl", 20);
+                DynamicVariableManager.pushLocalVariable(innerValue);
+                innerValue.set("inner-local");
+                RuntimeCode.incrementEvalDepth();
+                InterpreterState.currentPackage.get().set("Inner");
+                DynamicVariableManager.popToLocalLevel(0);
+                assertEquals("inner", innerValue.toString());
+                assertEquals("Inner", CallerStack.pop().packageName());
+                RuntimeCode.decrementEvalDepth();
+            }
+
+            assertEquals("Outer", CallerStack.peek(0).packageName());
+            assertEquals(1, DynamicVariableManager.getLocalLevel());
+            assertEquals(1, RuntimeCode.getEvalDepth());
+            assertEquals("Outer", InterpreterState.currentPackage.get().toString());
+            DynamicVariableManager.popToLocalLevel(0);
+            assertEquals("outer", outerValue.toString());
+            CallerStack.pop();
+            RuntimeCode.decrementEvalDepth();
+        }
+    }
+
+    @Test
+    void outputSeparatorsAndSpecialQueuesBelongToRuntime() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            new OutputFieldSeparator().set("first-field");
+            new OutputRecordSeparator().set("first-record");
+            SpecialBlock.saveEndBlock(new RuntimeScalar());
+            assertEquals(1, SpecialBlock.getEndBlocks().size());
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertEquals("", OutputFieldSeparator.getInternalOFS());
+            assertEquals("", OutputRecordSeparator.getInternalORS());
+            assertTrue(SpecialBlock.getEndBlocks().isEmpty());
+            new OutputFieldSeparator().set("second-field");
+        }
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            assertEquals("first-field", OutputFieldSeparator.getInternalOFS());
+            assertEquals("first-record", OutputRecordSeparator.getInternalORS());
+            assertEquals(1, SpecialBlock.getEndBlocks().size());
+        }
+    }
+
+    @Test
+    void boundJavaCallbackRestoresRuntimeOnForeignThread() throws Exception {
+        PerlRuntime runtime = new PerlRuntime();
+        RuntimeCode callback;
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            callback = new RuntimeCode((args, context) -> {
+                assertSame(runtime, PerlRuntime.current());
+                return new RuntimeList(new RuntimeScalar(42));
+            }, null).bindCallbackTo(runtime);
+        }
+
+        FutureTask<Integer> task = new FutureTask<>(() -> {
+            assertNull(PerlRuntime.currentOrNull());
+            int result = callback.apply(new RuntimeArray(), RuntimeContextType.SCALAR).scalar().getInt();
+            assertNull(PerlRuntime.currentOrNull());
+            return result;
+        });
+        Thread worker = new Thread(task, "phase5-callback-test");
+        worker.start();
+        assertEquals(42, task.get(10, TimeUnit.SECONDS));
+        worker.join(10_000);
+        assertFalse(worker.isAlive());
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeRegexIsolationTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeRegexIsolationTest.java
@@ -1,0 +1,193 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.runtime.operators.Time;
+import org.perlonjava.runtime.regex.RuntimeRegex;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class PerlRuntimeRegexIsolationTest {
+
+    @Test
+    void concurrentMatchesKeepCapturesAndOffsetsInTheirRuntime() throws Exception {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        FutureTask<MatchSignature> firstTask = matchTask(
+                first, "alpha-17", ready, start);
+        FutureTask<MatchSignature> secondTask = matchTask(
+                second, "beta-2048", ready, start);
+        Thread firstThread = Thread.ofPlatform().name("perl-regex-first").start(firstTask);
+        Thread secondThread = Thread.ofPlatform().name("perl-regex-second").start(secondTask);
+
+        try {
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+        } finally {
+            start.countDown();
+            firstThread.join(TimeUnit.SECONDS.toMillis(10));
+            secondThread.join(TimeUnit.SECONDS.toMillis(10));
+        }
+        assertFalse(firstThread.isAlive());
+        assertFalse(secondThread.isAlive());
+        assertEquals(new MatchSignature("alpha", "17", "alpha-17", 0, 8),
+                firstTask.get(1, TimeUnit.SECONDS));
+        assertEquals(new MatchSignature("beta", "2048", "beta-2048", 0, 9),
+                secondTask.get(1, TimeUnit.SECONDS));
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void positionAndZeroLengthBookkeepingArePerRuntimeEvenForSameScalar() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        RuntimeScalar shared = new RuntimeScalar("abc");
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            RuntimePosLvalue.pos(shared).set(1);
+            RuntimePosLvalue.recordZeroLengthMatch(shared, 1, "a*");
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertFalse(RuntimePosLvalue.pos(shared).getDefinedBoolean());
+            assertFalse(RuntimePosLvalue.hadZeroLengthMatchAt(shared, 1, "a*"));
+            RuntimePosLvalue.pos(shared).set(2);
+        }
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            assertEquals(1, RuntimePosLvalue.pos(shared).getInt());
+            assertTrue(RuntimePosLvalue.hadZeroLengthMatchAt(shared, 1, "a*"));
+        }
+    }
+
+    @Test
+    void optimizedAndMatchOnceCallsitesArePerRuntime() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        RuntimeScalar firstRegex;
+        RuntimeScalar secondRegex;
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            firstRegex = RuntimeRegex.getQuotedRegex(
+                    new RuntimeScalar("a"), new RuntimeScalar("?"), 73);
+            assertTrue(matches(firstRegex, "a"));
+            assertFalse(matches(firstRegex, "a"));
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            secondRegex = RuntimeRegex.getQuotedRegex(
+                    new RuntimeScalar("b"), new RuntimeScalar("?"), 73);
+            assertTrue(matches(secondRegex, "b"));
+            assertFalse(matches(secondRegex, "b"));
+        }
+
+        assertNotSame(firstRegex, secondRegex);
+    }
+
+    @Test
+    void resetOnlyClearsMatchOnceStateInTheBoundRuntime() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        RuntimeScalar firstRegex;
+        RuntimeScalar secondRegex;
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            firstRegex = RuntimeRegex.getQuotedRegex(
+                    new RuntimeScalar("x"), new RuntimeScalar("?"), 91);
+            assertTrue(matches(firstRegex, "x"));
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            secondRegex = RuntimeRegex.getQuotedRegex(
+                    new RuntimeScalar("x"), new RuntimeScalar("?"), 91);
+            assertTrue(matches(secondRegex, "x"));
+        }
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            RuntimeRegex.reset();
+            assertTrue(matches(firstRegex, "x"));
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertFalse(matches(secondRegex, "x"));
+        }
+    }
+
+    @Test
+    void dynamicSnapshotRestoresEveryMatchMetadataField() {
+        PerlRuntime runtime = new PerlRuntime();
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            RuntimeRegexState state = runtime.regexState;
+            state.lastMatchUsedBackslashK = true;
+            state.lastMatchResultsTainted = true;
+            state.lastNamedCaptureGroups = java.util.Map.of("name", List.of("outer"));
+            state.manualCaptureStarts = new int[]{4};
+            state.manualCaptureEnds = new int[]{9};
+            RegexState snapshot = new RegexState();
+
+            state.lastMatchUsedBackslashK = false;
+            state.lastMatchResultsTainted = false;
+            state.lastNamedCaptureGroups = null;
+            state.manualCaptureStarts = null;
+            state.manualCaptureEnds = null;
+            snapshot.restore();
+
+            assertTrue(state.lastMatchUsedBackslashK);
+            assertTrue(state.lastMatchResultsTainted);
+            assertEquals(List.of("outer"), state.lastNamedCaptureGroups.get("name"));
+            assertArrayEquals(new int[]{4}, state.manualCaptureStarts);
+            assertArrayEquals(new int[]{9}, state.manualCaptureEnds);
+        }
+    }
+
+    @Test
+    void alarmMediatedMatchRunsInTheOwningRuntime() {
+        assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+            PerlRuntime runtime = new PerlRuntime();
+            try (PerlRuntime.Binding ignored = runtime.bind()) {
+                RuntimeScalar regex = RuntimeRegex.getQuotedRegex(
+                        new RuntimeScalar("version-(?<major>\\d+)"), new RuntimeScalar(""));
+                Time.alarm(RuntimeContextType.SCALAR, new RuntimeScalar(5));
+                try {
+                    assertTrue(matches(regex, "version-42"));
+                    assertEquals("42", RuntimeRegex.captureString(1));
+                    assertEquals(List.of("42"), runtime.regexState.lastNamedCaptureGroups.get("major"));
+                } finally {
+                    Time.alarm(RuntimeContextType.SCALAR, new RuntimeScalar(0));
+                }
+            }
+        });
+    }
+
+    private static FutureTask<MatchSignature> matchTask(
+            PerlRuntime runtime, String input, CountDownLatch ready, CountDownLatch start) {
+        return new FutureTask<>(() -> {
+            try (PerlRuntime.Binding ignored = runtime.bind()) {
+                RuntimeScalar regex = RuntimeRegex.getQuotedRegex(
+                        new RuntimeScalar("(?<word>[a-z]+)-(\\d+)"), new RuntimeScalar(""));
+                ready.countDown();
+                assertTrue(start.await(10, TimeUnit.SECONDS));
+                assertTrue(matches(regex, input));
+                assertEquals(List.of(RuntimeRegex.captureString(1)),
+                        runtime.regexState.lastNamedCaptureGroups.get("word"));
+                return new MatchSignature(
+                        RuntimeRegex.captureString(1),
+                        RuntimeRegex.captureString(2),
+                        RuntimeRegex.matchString(),
+                        RuntimeRegex.matcherStart(0).getInt(),
+                        RuntimeRegex.matcherEnd(0).getInt());
+            }
+        });
+    }
+
+    private static boolean matches(RuntimeScalar regex, String input) {
+        return RuntimeRegex.matchRegex(regex, new RuntimeScalar(input), RuntimeContextType.SCALAR)
+                .scalar().getBoolean();
+    }
+
+    private record MatchSignature(String first, String second, String whole, int start, int end) {
+    }
+}


### PR DESCRIPTION
## Summary

This is the maintainer-requested combined PR for Perl threads plan Phases 5,
6, and 7. `Config` continues to report threads as disabled; no partial Perl
threads API is exposed.

- move execution, dynamic-scope, localization, interpreter/eval, cleanup, and
  `CHECK`/`INIT`/`END` state into each `PerlRuntime`
- bind asynchronous Future resumptions to their originating runtime
- move complete regex match/capture state, `/g`, `/o`, match-once, compiled
  regex, and position caches into each runtime
- bind and harden regex timeout workers in the same change as regex state
- move MRO policy, method/overload/ISA caches, package generations, reverse-ISA
  state, and AUTOLOAD policy into each runtime
- use temporary process-wide symbol/ISA mutation epochs to invalidate derived
  per-runtime caches until Phase 8 migrates the shared symbol tables
- add deterministic concurrency/isolation tests and update the implementation
  plan and next steps

## Deliberate phase boundaries

- package-global values and conflicting package definitions remain shared until
  the Phase 8 subphases
- mortal/weak-reference/`DESTROY` sweep machinery remains coupled for atomic
  migration in Phase 11
- process-wide alarm/signal ownership remains Phase 11; the known sequential
  alarm-mediated regex worker path is covered here
- `useithreads` remains false

## Validation

- `make` — passed on the exact implementation tree
- `make test-all` — completed at core 82.9% and bundled modules 81.0%
- 38 focused Perl runs across JVM and interpreter backends — passed except the
  interpreter `caller_wantarray_context.t` failure, reproduced identically on
  exact base `1ee08c0a2`
- Scalar::Util 1.70 and Moo 2.005005 — loaded successfully on both backends
- method and closure benchmarks improved against the same base
- eight Phase-7-relevant Perl core MRO outputs were byte-for-byte identical to
  exact base `1ee08c0a2`
- regex benchmark is approximately 10% slower because every match now resolves
  its bound runtime; the design records this measured debt for Phase 13's
  dedicated performance-recovery work

## Review notes

Existing Storable test assertions were not changed; affected low-level Java
fixtures now establish the runtime binding required by the isolated caches.

Generated with [Codex](https://openai.com/codex)
