### PR TITLE
feat: isolate runtime global state

### DIFF
--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -15,8 +15,8 @@ unless their storage was explicitly marked shared.
 Each numbered phase below normally forms an independent pull request. A phase
 may be split further when its audit shows that it cannot be reviewed or reverted
 safely. Phases 3 and 4 were combined at the maintainer's request, as were
-Phases 5 through 7; both combined changesets preserve the same green-boundary
-requirements. At every merge boundary:
+Phases 5 through 7 and Phases 8a through 8c; each combined changeset preserves
+the same green-boundary requirements. At every merge boundary:
 
 - the compiler and both execution backends remain functional;
 - `make` passes;
@@ -282,15 +282,22 @@ after the Phase 8 symbol-table migrations.
 
 ### Phase 8a — Core global values
 
-Move global scalar, array, and hash storage.
+Move global scalar, array, and hash storage, foreach alias bookkeeping, stash
+enumeration invalidation, and per-runtime core-global initialization. Keep
+`CompilerOptions` detached until its provider binds the owning runtime and
+installs that exact argument array as `@ARGV`.
 
 ### Phase 8b — Code and subroutine globals
 
-Move code references, pinned code, prototypes, and `is_sub` state.
+Move code references, pseudo constants, pinned/deleted pins, compiled-reference
+IDs, localization bookkeeping, prototypes, imported-sub state, and operator
+override flags. Preserve a declared-but-undefined CODE slot after `undef &name`.
 
 ### Phase 8c — IO and format globals
 
-Move global IO slots and formats, reconciling them with Phase 4 ownership.
+Move named global IO slots, hidden-after-stash-delete state, and formats,
+reconciling them with Phase 4's runtime-owned standard handles/globs. Glob and
+stash alias tables remain Phase 8d state.
 
 ### Phase 8d — Globs, aliases, and stashes
 
@@ -301,9 +308,12 @@ Move glob tables, stash/package objects, and alias maps.
 Move declared-global sets, package-existence caches, class-loader ownership, and
 remaining symbol-table runtime state.
 
-Each Phase 8 subphase is its own PR. Acceptance for each: conflicting global
-state in two runtimes remains isolated on JVM and interpreter backends; global,
-lexical, and eval benchmarks meet the budget.
+Each remaining Phase 8 subphase normally forms its own PR; 8a through 8c are a
+maintainer-requested combined exception. Acceptance for each: conflicting
+in-scope global state in two runtimes remains isolated on JVM and interpreter
+backends; global, lexical, and eval benchmarks meet the budget. No phase claims
+alias/stash isolation before 8d or declaration/package-service isolation before
+8e.
 
 ### Phase 9 — RuntimeCode and eval caches
 
@@ -455,7 +465,7 @@ measured benefit over platform threads/full clone.
 
 ## 7. Progress Tracking
 
-### Current Status: Phases 5 through 7 complete; combined PR ready for review
+### Current Status: Phases 8a through 8c complete; combined PR ready for review
 
 ### Completed Phases
 
@@ -568,6 +578,34 @@ measured benefit over platform threads/full clone.
     closure benchmarks improved; regex matching is approximately 10% slower
     from the required runtime lookup and is recorded for Phase 13 recovery.
     The comprehensive gate completed at core 82.9% and bundled modules 81.0%.
+- [x] Phases 8a-8c: Runtime-owned globals, CODE, IO, and formats (2026-08-11)
+  - Added `GlobalRuntimeState` and moved scalar, array, hash, foreach-alias,
+    CODE, pseudo-constant, pin, compiled-CV, named IO, hidden-IO, and format
+    storage behind the existing `GlobalVariable` facades.
+  - Made core-global initialization and stash-enumeration invalidation
+    runtime-owned. `CompilerOptions` now builds a detached argument array and
+    installs that exact object as the bound runtime's `@ARGV` during global
+    initialization.
+  - Preserved CODE identity and Perl's declared-but-undefined semantics across
+    `undef &name`, including package/subroutine metadata and pin behavior.
+  - Added nested-binding, simultaneous-runtime, reset, JSR-223, JVM, and
+    interpreter coverage for conflicting global values, named subs/prototypes,
+    named filehandles, and formats. New Perl semantic tests pass first under
+    system Perl and then under both PerlOnJava backends.
+  - Repaired the `re/pat.t` regression discovered after PR #921: regex-worker
+    cancellation now unwinds silently instead of reporting the internal
+    ten-second deadline, and the alarm scheduler binds its captured runtime
+    before reading `%SIG` and queuing `ALRM`. The exact pre-PR result is restored
+    at 1098/1302, including test 1149 on both compiler backends' reproducer.
+  - Validation: exact-tree `make` passed; Scalar::Util 1.70 and Moo 2.005005
+    loaded on both backends; the comprehensive gate completed at core 83.0%
+    and bundled modules 80.8%.
+  - Same-base three-run medians: lexical improved about 1%; global access is
+    about 34% slower and eval-string about 15% slower from the required bound-
+    runtime lookup. These exceed the normal 5% budget and are explicitly
+    presented for review as a temporary exception, with generated-code runtime
+    caching deferred to the dedicated performance-recovery phase. Thread
+    compatibility flags remain disabled.
 
 ### Phase 1 Work Completed (2026-08-10)
 
@@ -586,10 +624,13 @@ measured benefit over platform threads/full clone.
 
 ### Next Steps
 
-1. Review and merge the combined Phase 5-7 runtime-state PR while `Config`
-   thread flags remain disabled.
-2. Start Phase 8a from updated `master`: migrate core global scalar, array, and
-   hash storage without combining it with the later Phase 8 subphases.
+1. Review and merge the combined Phase 8a-8c runtime-global PR while `Config`
+   thread flags remain disabled, including the documented temporary benchmark
+   exception.
+2. Start Phase 8d from updated `master`: migrate glob tables, aliases, and
+   stashes as one atomic symbol-identity change.
+3. Keep Phase 8e declarations, package services, and class-loader ownership in
+   its own independently green PR.
 
 ### Open Questions
 

--- a/src/main/java/org/perlonjava/app/cli/CompilerOptions.java
+++ b/src/main/java/org/perlonjava/app/cli/CompilerOptions.java
@@ -1,6 +1,5 @@
 package org.perlonjava.app.cli;
 
-import org.perlonjava.runtime.runtimetypes.GlobalVariable;
 import org.perlonjava.runtime.runtimetypes.RuntimeArray;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 import org.perlonjava.runtime.runtimetypes.ScalarUtils;
@@ -59,7 +58,9 @@ public class CompilerOptions implements Cloneable {
     public boolean autoSplit = false; // For -a
     public boolean useVersion = false; // For -E
     // Initialize @ARGV
-    public RuntimeArray argumentList = GlobalVariable.getGlobalArray("main::ARGV");
+    // Kept detached until a provider entry point binds its owning PerlRuntime.
+    // GlobalContext installs this exact array as that runtime's @ARGV.
+    public RuntimeArray argumentList = new RuntimeArray();
     public RuntimeArray inc = new RuntimeArray();
     public String splitPattern = "' '"; // Default split pattern for -a
     public boolean lineEndingProcessing = false; // For -l

--- a/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
+++ b/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
@@ -93,12 +93,10 @@ public class PerlLanguageProvider {
         }
     }
 
-    private static boolean globalInitialized = false;
-
     public static void resetAll() {
         try (PerlRuntime.Binding runtimeBinding = PerlRuntime.bindCurrentOrNew();
              CompilationLockGuard ignored = acquireCompilationLock()) {
-            globalInitialized = false;
+            PerlRuntime.current().globalState().resetCoreGlobalsInitialization();
             GlobalContext.setThreadTaintMode(false);
             resetAllGlobals();
             WeakRefRegistry.resetState();
@@ -219,8 +217,8 @@ public class PerlLanguageProvider {
                 new RuntimeArray()
         );
 
-        if (!globalInitialized) {
-            globalInitialized = true;
+        if (!PerlRuntime.current().globalState().coreGlobalsInitialized()) {
+            PerlRuntime.current().globalState().markCoreGlobalsInitialized();
             GlobalContext.initializeGlobals(compilerOptions);
         }
 
@@ -421,8 +419,8 @@ public class PerlLanguageProvider {
                 new RuntimeArray()
         );
 
-        if (!globalInitialized) {
-            globalInitialized = true;
+        if (!PerlRuntime.current().globalState().coreGlobalsInitialized()) {
+            PerlRuntime.current().globalState().markCoreGlobalsInitialized();
             GlobalContext.initializeGlobals(compilerOptions);
         }
 
@@ -838,8 +836,8 @@ public class PerlLanguageProvider {
                 new RuntimeArray()
         );
 
-        if (!globalInitialized) {
-            globalInitialized = true;
+        if (!PerlRuntime.current().globalState().coreGlobalsInitialized()) {
+            PerlRuntime.current().globalState().markCoreGlobalsInitialized();
             GlobalContext.initializeGlobals(compilerOptions);
         }
 

--- a/src/main/java/org/perlonjava/runtime/operators/Time.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Time.java
@@ -366,18 +366,25 @@ public class Time {
         alarmStartTime = System.currentTimeMillis();
         alarmDuration = seconds;
         alarmTargetThread = Thread.currentThread();
+        PerlRuntime alarmOwner = PerlRuntime.current();
+        Thread targetThread = alarmTargetThread;
 
-        currentAlarmTask = alarmScheduler.schedule(() -> {
+        currentAlarmTask = alarmScheduler.schedule(
+                () -> dispatchAlarm(alarmOwner, targetThread), seconds, TimeUnit.SECONDS);
+
+        return new RuntimeScalar(remainingTime);
+    }
+
+    static void dispatchAlarm(PerlRuntime owner, Thread targetThread) {
+        try (PerlRuntime.Binding ignored = owner.bind()) {
             RuntimeScalar sig = getGlobalHash("main::SIG").get("ALRM");
             if (sig.getDefinedBoolean()) {
                 // Queue the signal for processing in the target thread
                 PerlSignalQueue.enqueue("ALRM", sig);
                 // Interrupt the target thread to break out of blocking operations
-                alarmTargetThread.interrupt();
+                targetThread.interrupt();
             }
-        }, seconds, TimeUnit.SECONDS);
-
-        return new RuntimeScalar(remainingTime);
+        }
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/regex/RegexTimeoutCharSequence.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexTimeoutCharSequence.java
@@ -1,5 +1,7 @@
 package org.perlonjava.runtime.regex;
 
+import java.util.concurrent.CancellationException;
+
 public class RegexTimeoutCharSequence implements CharSequence {
     private static final long DEFAULT_TIMEOUT_MS = 10_000;
     private static final int CHECK_INTERVAL = 4096;
@@ -24,8 +26,14 @@ public class RegexTimeoutCharSequence implements CharSequence {
 
     @Override
     public char charAt(int index) {
-        if (++checkCount % CHECK_INTERVAL == 0
-                && (Thread.currentThread().isInterrupted() || System.nanoTime() > deadlineNanos)) {
+        if (++checkCount % CHECK_INTERVAL == 0 && Thread.currentThread().isInterrupted()) {
+            // An active alarm runs the match in a worker and cancels that worker
+            // before dispatching SIGALRM on the owning Perl thread.  Cancellation
+            // is not Perl's built-in catastrophic-backtracking timeout and must
+            // not emit that timeout warning before the signal handler runs.
+            throw new CancellationException("Regex matching cancelled");
+        }
+        if (checkCount % CHECK_INTERVAL == 0 && System.nanoTime() > deadlineNanos) {
             throw new RegexTimeoutException(
                     "Regex matching timed out after " + DEFAULT_TIMEOUT_MS + "ms (catastrophic backtracking detected)");
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
@@ -218,6 +218,10 @@ public class GlobalContext {
         // @_ is implemented as a call-frame lexical, but its main-package glob
         // still has an ARRAY slot for symbol-table introspection.
         GlobalVariable.getGlobalArray("main::_");
+        // CompilerOptions can be constructed by an unbound embedding caller.
+        // Once the provider binds the owning runtime, install its detached
+        // argument array as this runtime's @ARGV slot.
+        GlobalVariable.globalArrays.put("main::ARGV", compilerOptions.argumentList);
 
         // Initialize default formats
         // Create a default STDOUT format to prevent "Undefined format" errors

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeState.java
@@ -1,0 +1,163 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Runtime-owned Perl global state.
+ *
+ * <p>Phases 8a through 8c own scalar/array/hash values, CODE-slot state, and
+ * named IO/format slots. Globs, stashes, aliases, declarations, and package
+ * services move in later Phase 8 changes.</p>
+ */
+public final class GlobalRuntimeState {
+    private final Map<String, RuntimeScalar> scalarValues = new HashMap<>();
+    private final Map<String, RuntimeArray> arrayValues = new HashMap<>();
+    private final Map<String, RuntimeHash> hashValues = new HashMap<>();
+    private final Map<String, RuntimeScalar> foreachScalarAliases = new HashMap<>();
+    private final Map<String, Boolean> importedSubs = new HashMap<>();
+    private final Map<String, Boolean> operatorOverrideGlobs = new HashMap<>();
+    private final Map<String, RuntimeScalar> codeRefs = new HashMap<>();
+    private final Map<String, RuntimeScalar> pseudoConstants = new HashMap<>();
+    private final Map<String, RuntimeScalar> pinnedCodeRefs = new HashMap<>();
+    private final Set<String> deletedCodeRefPins = new HashSet<>();
+    private final Map<Integer, RuntimeScalar> compiledCodeRefs = new HashMap<>();
+    private final Map<String, Integer> localizedCodeRefDepth = new HashMap<>();
+    private final IdentityHashMap<RuntimeScalar, String> displacedLocalizedCodeRefs =
+            new IdentityHashMap<>();
+    private final Map<String, RuntimeGlob> ioSlots = new HashMap<>();
+    private final Map<String, RuntimeFormat> formatSlots = new HashMap<>();
+    private final Set<String> hiddenIoSlotsAfterStashDelete = new HashSet<>();
+    private int nextCompiledCodeRefId = 1;
+    private long stashEnumerationVersion;
+    private boolean coreGlobalsInitialized;
+
+    /** Core package scalar slots owned by this runtime. */
+    public Map<String, RuntimeScalar> scalarValues() {
+        return scalarValues;
+    }
+
+    /** Core package array slots owned by this runtime. */
+    public Map<String, RuntimeArray> arrayValues() {
+        return arrayValues;
+    }
+
+    /** Core package hash slots owned by this runtime. */
+    public Map<String, RuntimeHash> hashValues() {
+        return hashValues;
+    }
+
+    Map<String, RuntimeScalar> foreachScalarAliases() {
+        return foreachScalarAliases;
+    }
+
+    public Map<String, RuntimeScalar> codeRefs() {
+        return codeRefs;
+    }
+
+    Map<String, Boolean> importedSubs() {
+        return importedSubs;
+    }
+
+    Map<String, Boolean> operatorOverrideGlobs() {
+        return operatorOverrideGlobs;
+    }
+
+    Map<String, RuntimeScalar> pseudoConstants() {
+        return pseudoConstants;
+    }
+
+    Map<String, RuntimeScalar> pinnedCodeRefs() {
+        return pinnedCodeRefs;
+    }
+
+    Set<String> deletedCodeRefPins() {
+        return deletedCodeRefPins;
+    }
+
+    Map<Integer, RuntimeScalar> compiledCodeRefs() {
+        return compiledCodeRefs;
+    }
+
+    Map<String, Integer> localizedCodeRefDepth() {
+        return localizedCodeRefDepth;
+    }
+
+    IdentityHashMap<RuntimeScalar, String> displacedLocalizedCodeRefs() {
+        return displacedLocalizedCodeRefs;
+    }
+
+    Map<String, RuntimeGlob> ioSlots() {
+        return ioSlots;
+    }
+
+    Map<String, RuntimeFormat> formatSlots() {
+        return formatSlots;
+    }
+
+    Set<String> hiddenIoSlotsAfterStashDelete() {
+        return hiddenIoSlotsAfterStashDelete;
+    }
+
+    synchronized int registerCompiledCodeRef(RuntimeScalar ref) {
+        int id = nextCompiledCodeRefId++;
+        compiledCodeRefs.put(id, ref);
+        return id;
+    }
+
+    long stashEnumerationVersion() {
+        return stashEnumerationVersion;
+    }
+
+    void invalidateStashEnumeration() {
+        stashEnumerationVersion++;
+    }
+
+    /** Return whether this runtime already installed its core globals. */
+    public boolean coreGlobalsInitialized() {
+        return coreGlobalsInitialized;
+    }
+
+    /** Record that this runtime installed its core globals. */
+    public void markCoreGlobalsInitialized() {
+        coreGlobalsInitialized = true;
+    }
+
+    /** Make the next top-level compilation initialize this runtime again. */
+    public void resetCoreGlobalsInitialization() {
+        coreGlobalsInitialized = false;
+    }
+
+    void clearCoreValues() {
+        scalarValues.clear();
+        arrayValues.clear();
+        hashValues.clear();
+        foreachScalarAliases.clear();
+        coreGlobalsInitialized = false;
+        invalidateStashEnumeration();
+    }
+
+    void clearCodeValues() {
+        importedSubs.clear();
+        operatorOverrideGlobs.clear();
+        codeRefs.clear();
+        pseudoConstants.clear();
+        pinnedCodeRefs.clear();
+        deletedCodeRefPins.clear();
+        compiledCodeRefs.clear();
+        localizedCodeRefDepth.clear();
+        displacedLocalizedCodeRefs.clear();
+        nextCompiledCodeRefId = 1;
+        invalidateStashEnumeration();
+    }
+
+    void clearIoAndFormatValues() {
+        ioSlots.clear();
+        formatSlots.clear();
+        hiddenIoSlotsAfterStashDelete.clear();
+        invalidateStashEnumeration();
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
@@ -6,11 +6,16 @@ import org.perlonjava.frontend.parser.ParserTables;
 import org.perlonjava.runtime.mro.InheritanceResolver;
 
 import java.util.ArrayList;
+import java.util.AbstractMap;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.AbstractSet;
+import java.util.Iterator;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -24,32 +29,28 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarTrue;
  */
 public class GlobalVariable {
     // Global variables and subroutines
-    public static final Map<String, RuntimeScalar> globalVariables = new PackageRootMap<>();
-    public static final Map<String, RuntimeArray> globalArrays = new PackageRootMap<>();
-    public static final Map<String, RuntimeHash> globalHashes = new PackageRootMap<>();
+    public static final Map<String, RuntimeScalar> globalVariables =
+            new CurrentRuntimeMap<>(state -> state.scalarValues());
+    public static final Map<String, RuntimeArray> globalArrays =
+            new CurrentRuntimeMap<>(state -> state.arrayValues());
+    public static final Map<String, RuntimeHash> globalHashes =
+            new CurrentRuntimeMap<>(state -> state.hashValues());
     // Cache for package existence checks
     public static final Map<String, Boolean> packageExistsCache = new HashMap<>();
     // isSubs: Tracks subroutines declared via 'use subs' pragma (e.g., use subs 'hex')
     // Maps fully-qualified names (package::subname) to indicate they should be called
     // as user-defined subroutines instead of built-in operators
-    public static final Map<String, Boolean> isSubs = new HashMap<>();
+    public static final Map<String, Boolean> isSubs =
+            new CurrentRuntimePlainMap<>(state -> state.importedSubs());
     public static final Map<String, RuntimeScalar> globalCodeRefs = new GlobalCodeRefMap();
-    private static final Map<String, RuntimeScalar> globalPseudoConstants = new HashMap<>();
-    static final Map<String, RuntimeGlob> globalIORefs = new StashSlotMap<>();
-    static final Map<String, RuntimeFormat> globalFormatRefs = new StashSlotMap<>();
-    private static final Map<String, Integer> localizedCodeRefDepth = new HashMap<>();
-    private static final IdentityHashMap<RuntimeScalar, String> displacedLocalizedCodeRefs =
-            new IdentityHashMap<>();
-    private static final Set<String> hiddenIORefsAfterStashDelete = new HashSet<>();
+    static final Map<String, RuntimeGlob> globalIORefs =
+            new StashSlotMap<>(state -> state.ioSlots());
+    static final Map<String, RuntimeFormat> globalFormatRefs =
+            new StashSlotMap<>(state -> state.formatSlots());
 
     // Pinned code references: RuntimeScalars that were accessed at compile time
     // and should survive stash deletion. This matches Perl's behavior where
     // compiled bytecode holds direct references to CVs that survive stash deletion.
-    private static final Map<String, RuntimeScalar> pinnedCodeRefs = new HashMap<>();
-    private static final Set<String> deletedCodeRefPins = new HashSet<>();
-    private static final Map<Integer, RuntimeScalar> compiledCodeRefs = new HashMap<>();
-    private static int nextCompiledCodeRefId = 1;
-
     // Stash aliasing: `*{Dst::} = *{Src::}` effectively makes Dst:: symbol table
     // behave like Src:: for method lookup and stash operations.
     // We keep this separate from globalCodeRefs/globalVariables so existing references
@@ -60,12 +61,12 @@ public class GlobalVariable {
     // Maps glob names to their canonical (target) name.
     // When looking up or assigning to glob slots, we resolve through this map.
     static final Map<String, String> globAliases = new HashMap<>();
-    private static final Map<String, RuntimeScalar> foreachGlobalAliases = new HashMap<>();
 
     // Flags used by operator override
     // globalGlobs: Tracks typeglob assignments (e.g., *CORE::GLOBAL::hex = sub {...})
     // Used to detect when built-in operators have been globally overridden
-    static final Map<String, Boolean> globalGlobs = new HashMap<>();
+    static final Map<String, Boolean> globalGlobs =
+            new CurrentRuntimePlainMap<>(state -> state.operatorOverrideGlobs());
     // Global class loader for all generated classes - not final so we can replace it
     public static CustomClassLoader globalClassLoader =
             new CustomClassLoader(GlobalVariable.class.getClassLoader());
@@ -80,23 +81,121 @@ public class GlobalVariable {
     private static final Set<String> declaredGlobalVariables = new HashSet<>();
     private static final Set<String> declaredGlobalArrays = new HashSet<>();
     private static final Set<String> declaredGlobalHashes = new HashSet<>();
-    private static long stashEnumerationVersion = 0;
-
     static long stashEnumerationVersion() {
-        return stashEnumerationVersion;
+        return globalState().stashEnumerationVersion();
     }
 
     static void invalidateStashEnumerationCache() {
-        stashEnumerationVersion++;
+        globalState().invalidateStashEnumeration();
     }
 
-    private static final class PackageRootMap<T extends RuntimeBase> extends HashMap<String, T> {
+    private static GlobalRuntimeState globalState() {
+        return PerlRuntime.current().globalState;
+    }
+
+    private static Map<String, RuntimeScalar> foreachGlobalAliases() {
+        return globalState().foreachScalarAliases();
+    }
+
+    private static Map<String, RuntimeScalar> globalPseudoConstants() {
+        return globalState().pseudoConstants();
+    }
+
+    private static Map<String, RuntimeScalar> pinnedCodeRefs() {
+        return globalState().pinnedCodeRefs();
+    }
+
+    private static Set<String> deletedCodeRefPins() {
+        return globalState().deletedCodeRefPins();
+    }
+
+    private static Map<Integer, RuntimeScalar> compiledCodeRefs() {
+        return globalState().compiledCodeRefs();
+    }
+
+    private static Map<String, Integer> localizedCodeRefDepth() {
+        return globalState().localizedCodeRefDepth();
+    }
+
+    private static IdentityHashMap<RuntimeScalar, String> displacedLocalizedCodeRefs() {
+        return globalState().displacedLocalizedCodeRefs();
+    }
+
+    private static Set<String> hiddenIORefsAfterStashDelete() {
+        return globalState().hiddenIoSlotsAfterStashDelete();
+    }
+
+    /** Stable facade for runtime-owned maps that do not need package-root hooks. */
+    private static final class CurrentRuntimePlainMap<T> extends AbstractMap<String, T> {
+        private final Function<GlobalRuntimeState, Map<String, T>> table;
+
+        private CurrentRuntimePlainMap(Function<GlobalRuntimeState, Map<String, T>> table) {
+            this.table = table;
+        }
+
+        private Map<String, T> delegate() {
+            return table.apply(globalState());
+        }
+
+        @Override public T get(Object key) { return delegate().get(key); }
+        @Override public boolean containsKey(Object key) { return delegate().containsKey(key); }
+        @Override public int size() { return delegate().size(); }
+        @Override public boolean isEmpty() { return delegate().isEmpty(); }
+        @Override public T put(String key, T value) { return delegate().put(key, value); }
+        @Override public T putIfAbsent(String key, T value) { return delegate().putIfAbsent(key, value); }
+        @Override public T remove(Object key) { return delegate().remove(key); }
+        @Override public void clear() { delegate().clear(); }
+        @Override public Set<Entry<String, T>> entrySet() { return delegate().entrySet(); }
+        @Override public Set<String> keySet() { return delegate().keySet(); }
+        @Override public Collection<T> values() { return delegate().values(); }
+    }
+
+    /**
+     * Stable facade retained for source and generated-bytecode compatibility.
+     * Each operation resolves the table from the currently bound runtime.
+     */
+    private static final class CurrentRuntimeMap<T extends RuntimeBase> extends AbstractMap<String, T> {
+        private final Function<GlobalRuntimeState, Map<String, T>> table;
+
+        private CurrentRuntimeMap(Function<GlobalRuntimeState, Map<String, T>> table) {
+            this.table = table;
+        }
+
+        private Map<String, T> delegate() {
+            return table.apply(globalState());
+        }
+
+        @Override
+        public T get(Object key) {
+            return delegate().get(key);
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return delegate().containsKey(key);
+        }
+
+        @Override
+        public boolean containsValue(Object value) {
+            return delegate().containsValue(value);
+        }
+
+        @Override
+        public int size() {
+            return delegate().size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return delegate().isEmpty();
+        }
+
         @Override
         public T put(String key, T value) {
-            boolean newKey = !containsKey(key);
+            boolean newKey = !delegate().containsKey(key);
             markStashEntryVisible(key);
             markPackageGlobalRoot(value);
-            T previous = super.put(key, value);
+            T previous = delegate().put(key, value);
             if (newKey) {
                 invalidateStashEnumerationCache();
             }
@@ -106,21 +205,17 @@ public class GlobalVariable {
 
         @Override
         public T putIfAbsent(String key, T value) {
-            markStashEntryVisible(key);
-            markPackageGlobalRoot(value);
-            T previous = super.putIfAbsent(key, value);
-            if (previous == null) {
-                invalidateStashEnumerationCache();
-                invalidatePackageRootSnapshot();
-            } else {
+            T previous = delegate().get(key);
+            if (previous != null) {
                 markPackageGlobalRoot(previous);
+                return previous;
             }
-            return previous;
+            return put(key, value);
         }
 
         @Override
         public T remove(Object key) {
-            T previous = super.remove(key);
+            T previous = delegate().remove(key);
             if (previous != null) {
                 invalidateStashEnumerationCache();
                 invalidatePackageRootSnapshot();
@@ -130,11 +225,54 @@ public class GlobalVariable {
 
         @Override
         public void clear() {
-            if (!isEmpty()) {
+            if (!delegate().isEmpty()) {
                 invalidateStashEnumerationCache();
                 invalidatePackageRootSnapshot();
             }
-            super.clear();
+            delegate().clear();
+        }
+
+        @Override
+        public Set<Entry<String, T>> entrySet() {
+            Map<String, T> entries = delegate();
+            return new AbstractSet<>() {
+                @Override
+                public Iterator<Entry<String, T>> iterator() {
+                    Iterator<Entry<String, T>> iterator = entries.entrySet().iterator();
+                    return new Iterator<>() {
+                        private boolean canRemove;
+
+                        @Override public boolean hasNext() { return iterator.hasNext(); }
+
+                        @Override
+                        public Entry<String, T> next() {
+                            Entry<String, T> current = iterator.next();
+                            canRemove = true;
+                            String key = current.getKey();
+                            return new SimpleEntry<>(key, current.getValue()) {
+                                @Override
+                                public T setValue(T value) {
+                                    T previous = CurrentRuntimeMap.this.put(key, value);
+                                    super.setValue(value);
+                                    return previous;
+                                }
+                            };
+                        }
+
+                        @Override
+                        public void remove() {
+                            if (!canRemove) throw new IllegalStateException("next() has not been called");
+                            iterator.remove();
+                            canRemove = false;
+                            invalidateStashEnumerationCache();
+                            invalidatePackageRootSnapshot();
+                        }
+                    };
+                }
+
+                @Override public int size() { return entries.size(); }
+                @Override public void clear() { CurrentRuntimeMap.this.clear(); }
+            };
         }
     }
 
@@ -143,7 +281,11 @@ public class GlobalVariable {
      * lines that depend on the sub's leaf name when the map entry is meaningfully
      * created or replaced (see {@link InheritanceResolver#invalidateMethodLookupCachesForStashSubKey}).
      */
-    private static final class GlobalCodeRefMap extends HashMap<String, RuntimeScalar> {
+    private static final class GlobalCodeRefMap extends AbstractMap<String, RuntimeScalar> {
+        private Map<String, RuntimeScalar> delegate() {
+            return globalState().codeRefs();
+        }
+
         private static void maybeInvalidateMethodCacheForCodeRefPut(String key, RuntimeScalar previous, RuntimeScalar value) {
             if (key == null || value == null) {
                 return;
@@ -157,10 +299,10 @@ public class GlobalVariable {
 
         @Override
         public RuntimeScalar put(String key, RuntimeScalar value) {
-            boolean newKey = !containsKey(key);
+            boolean newKey = !delegate().containsKey(key);
             markStashEntryVisible(key);
             markPackageGlobalRoot(value);
-            RuntimeScalar old = super.put(key, value);
+            RuntimeScalar old = delegate().put(key, value);
             if (newKey) {
                 invalidateStashEnumerationCache();
             }
@@ -187,7 +329,7 @@ public class GlobalVariable {
 
         @Override
         public RuntimeScalar remove(Object key) {
-            RuntimeScalar prev = super.remove(key);
+            RuntimeScalar prev = delegate().remove(key);
             if (prev != null) {
                 invalidateStashEnumerationCache();
                 invalidatePackageRootSnapshot();
@@ -203,22 +345,92 @@ public class GlobalVariable {
         public void clear() {
             if (!isEmpty()) {
                 invalidateStashEnumerationCache();
-                for (RuntimeScalar s : values()) {
+                for (Map.Entry<String, RuntimeScalar> entry : delegate().entrySet()) {
+                    RuntimeScalar s = entry.getValue();
                     if (s != null) {
                         s.globalCodeRefFqn = null;
                     }
+                    InheritanceResolver.invalidateMethodLookupCachesForStashSubKey(entry.getKey());
                 }
                 invalidatePackageRootSnapshot();
             }
-            super.clear();
+            delegate().clear();
+        }
+
+        @Override public RuntimeScalar get(Object key) { return delegate().get(key); }
+        @Override public boolean containsKey(Object key) { return delegate().containsKey(key); }
+        @Override public int size() { return delegate().size(); }
+        @Override public boolean isEmpty() { return delegate().isEmpty(); }
+        @Override
+        public Set<Entry<String, RuntimeScalar>> entrySet() {
+            Map<String, RuntimeScalar> entries = delegate();
+            return new AbstractSet<>() {
+                @Override
+                public Iterator<Entry<String, RuntimeScalar>> iterator() {
+                    Iterator<Entry<String, RuntimeScalar>> iterator = entries.entrySet().iterator();
+                    return new Iterator<>() {
+                        private Entry<String, RuntimeScalar> current;
+                        private boolean canRemove;
+
+                        @Override public boolean hasNext() { return iterator.hasNext(); }
+
+                        @Override
+                        public Entry<String, RuntimeScalar> next() {
+                            current = iterator.next();
+                            canRemove = true;
+                            String key = current.getKey();
+                            return new SimpleEntry<>(key, current.getValue()) {
+                                @Override
+                                public RuntimeScalar setValue(RuntimeScalar value) {
+                                    RuntimeScalar previous = GlobalCodeRefMap.this.put(key, value);
+                                    super.setValue(value);
+                                    return previous;
+                                }
+                            };
+                        }
+
+                        @Override
+                        public void remove() {
+                            if (!canRemove) throw new IllegalStateException("next() has not been called");
+                            String key = current.getKey();
+                            RuntimeScalar value = current.getValue();
+                            iterator.remove();
+                            canRemove = false;
+                            if (value != null) value.globalCodeRefFqn = null;
+                            invalidateStashEnumerationCache();
+                            invalidatePackageRootSnapshot();
+                            InheritanceResolver.invalidateMethodLookupCachesForStashSubKey(key);
+                        }
+                    };
+                }
+
+                @Override public int size() { return entries.size(); }
+                @Override public void clear() { GlobalCodeRefMap.this.clear(); }
+            };
         }
     }
 
-    private static final class StashSlotMap<T> extends HashMap<String, T> {
+    /** Runtime-selecting facade for named IO and FORMAT stash slots. */
+    private static final class StashSlotMap<T> extends AbstractMap<String, T> {
+        private final Function<GlobalRuntimeState, Map<String, T>> table;
+
+        private StashSlotMap(Function<GlobalRuntimeState, Map<String, T>> table) {
+            this.table = table;
+        }
+
+        private Map<String, T> delegate() {
+            return table.apply(globalState());
+        }
+
+        @Override public T get(Object key) { return delegate().get(key); }
+        @Override public boolean containsKey(Object key) { return delegate().containsKey(key); }
+        @Override public int size() { return delegate().size(); }
+        @Override public boolean isEmpty() { return delegate().isEmpty(); }
+
         @Override
         public T put(String key, T value) {
-            boolean newKey = !containsKey(key);
-            T previous = super.put(key, value);
+            boolean newKey = !delegate().containsKey(key);
+            T previous = delegate().put(key, value);
             if (newKey) {
                 invalidateStashEnumerationCache();
             }
@@ -227,7 +439,7 @@ public class GlobalVariable {
 
         @Override
         public T putIfAbsent(String key, T value) {
-            T previous = super.putIfAbsent(key, value);
+            T previous = delegate().putIfAbsent(key, value);
             if (previous == null) {
                 invalidateStashEnumerationCache();
             }
@@ -236,7 +448,7 @@ public class GlobalVariable {
 
         @Override
         public T remove(Object key) {
-            T previous = super.remove(key);
+            T previous = delegate().remove(key);
             if (previous != null) {
                 invalidateStashEnumerationCache();
             }
@@ -248,7 +460,50 @@ public class GlobalVariable {
             if (!isEmpty()) {
                 invalidateStashEnumerationCache();
             }
-            super.clear();
+            delegate().clear();
+        }
+
+        @Override
+        public Set<Entry<String, T>> entrySet() {
+            Map<String, T> entries = delegate();
+            return new AbstractSet<>() {
+                @Override
+                public Iterator<Entry<String, T>> iterator() {
+                    Iterator<Entry<String, T>> iterator = entries.entrySet().iterator();
+                    return new Iterator<>() {
+                        private Entry<String, T> current;
+                        private boolean canRemove;
+
+                        @Override public boolean hasNext() { return iterator.hasNext(); }
+
+                        @Override
+                        public Entry<String, T> next() {
+                            current = iterator.next();
+                            canRemove = true;
+                            String key = current.getKey();
+                            return new SimpleEntry<>(key, current.getValue()) {
+                                @Override
+                                public T setValue(T value) {
+                                    T previous = StashSlotMap.this.put(key, value);
+                                    super.setValue(value);
+                                    return previous;
+                                }
+                            };
+                        }
+
+                        @Override
+                        public void remove() {
+                            if (!canRemove) throw new IllegalStateException("next() has not been called");
+                            iterator.remove();
+                            canRemove = false;
+                            invalidateStashEnumerationCache();
+                        }
+                    };
+                }
+
+                @Override public int size() { return entries.size(); }
+                @Override public void clear() { StashSlotMap.this.clear(); }
+            };
         }
     }
 
@@ -362,19 +617,17 @@ public class GlobalVariable {
         globalVariables.clear();
         globalArrays.clear();
         globalHashes.clear();
+        globalState().clearCoreValues();
         globalCodeRefs.clear();
-        globalPseudoConstants.clear();
-        pinnedCodeRefs.clear();
-        deletedCodeRefPins.clear();
-        compiledCodeRefs.clear();
-        nextCompiledCodeRefId = 1;
+        globalState().clearCodeValues();
         globalIORefs.clear();
-        hiddenIORefsAfterStashDelete.clear();
+        hiddenIORefsAfterStashDelete().clear();
         PerlRuntime runtime = PerlRuntime.currentOrNull();
         if (runtime != null) {
             runtime.resetStandardIOGlobVisibility();
         }
         globalFormatRefs.clear();
+        globalState().clearIoAndFormatValues();
         globalGlobs.clear();
         isSubs.clear();
         stashAliases.clear();
@@ -561,8 +814,8 @@ public class GlobalVariable {
                 String newKey = srcNs + key.substring(dstLen);
                 RuntimeGlob value = globalIORefs.remove(key);
                 if (value != null) globalIORefs.putIfAbsent(newKey, value);
-                if (hiddenIORefsAfterStashDelete.remove(key)) {
-                    hiddenIORefsAfterStashDelete.add(newKey);
+                if (hiddenIORefsAfterStashDelete().remove(key)) {
+                    hiddenIORefsAfterStashDelete().add(newKey);
                 }
             }
         }
@@ -576,7 +829,7 @@ public class GlobalVariable {
             return;
         }
         if (key != null && globalIORefs.containsKey(key)) {
-            if (hiddenIORefsAfterStashDelete.add(key)) {
+            if (hiddenIORefsAfterStashDelete().add(key)) {
                 invalidateStashEnumerationCache();
             }
         }
@@ -589,7 +842,7 @@ public class GlobalVariable {
                 runtime.showStandardIOGlob(key);
                 invalidateStashEnumerationCache();
             }
-            if (hiddenIORefsAfterStashDelete.remove(key)) {
+            if (hiddenIORefsAfterStashDelete().remove(key)) {
                 invalidateStashEnumerationCache();
             }
         }
@@ -600,7 +853,7 @@ public class GlobalVariable {
         if (runtime != null && runtime.standardIOGlob(key) != null) {
             return !runtime.isStandardIOGlobVisible(key);
         }
-        return key != null && hiddenIORefsAfterStashDelete.contains(key);
+        return key != null && hiddenIORefsAfterStashDelete().contains(key);
     }
 
     static boolean isVisibleGlobalIORef(String key) {
@@ -610,7 +863,7 @@ public class GlobalVariable {
         }
         return key != null
                 && globalIORefs.containsKey(key)
-                && !hiddenIORefsAfterStashDelete.contains(key);
+                && !hiddenIORefsAfterStashDelete().contains(key);
     }
 
     static boolean containsVisibleGlobalIORefWithPrefix(String prefix) {
@@ -623,7 +876,7 @@ public class GlobalVariable {
             }
         }
         for (String key : globalIORefs.keySet()) {
-            if (key.startsWith(prefix) && !hiddenIORefsAfterStashDelete.contains(key)) {
+            if (key.startsWith(prefix) && !hiddenIORefsAfterStashDelete().contains(key)) {
                 return true;
             }
         }
@@ -641,7 +894,7 @@ public class GlobalVariable {
             }
         }
         for (String key : globalIORefs.keySet()) {
-            if (!hiddenIORefsAfterStashDelete.contains(key)) {
+            if (!hiddenIORefsAfterStashDelete().contains(key)) {
                 keys.add(key);
             }
         }
@@ -649,7 +902,7 @@ public class GlobalVariable {
     }
 
     static void clearHiddenIORefsForNamespace(String prefix) {
-        if (hiddenIORefsAfterStashDelete.removeIf(k -> k.startsWith(prefix))) {
+        if (hiddenIORefsAfterStashDelete().removeIf(k -> k.startsWith(prefix))) {
             invalidateStashEnumerationCache();
         }
     }
@@ -784,14 +1037,14 @@ public class GlobalVariable {
     public static void aliasForeachGlobalVariable(String key, RuntimeScalar var) {
         clearForeachGlobalAlias(key);
         retainForeachAlias(var);
-        foreachGlobalAliases.put(key, var);
+        foreachGlobalAliases().put(key, var);
         markPackageGlobalRoot(var);
         globalVariables.put(key, var);
         invalidatePackageRootSnapshot();
     }
 
     public static void clearForeachGlobalAlias(String key) {
-        RuntimeScalar previous = foreachGlobalAliases.remove(key);
+        RuntimeScalar previous = foreachGlobalAliases().remove(key);
         if (previous != null) {
             releaseForeachAlias(previous);
         }
@@ -883,9 +1136,9 @@ public class GlobalVariable {
         }
         String resolvedKey = resolveAliasedFqn(key);
         markPackageGlobalRoot(scalar);
-        globalPseudoConstants.put(resolvedKey, scalar);
+        globalPseudoConstants().put(resolvedKey, scalar);
         if (resolvedKey != key) {
-            globalPseudoConstants.remove(key);
+            globalPseudoConstants().remove(key);
         }
     }
 
@@ -893,10 +1146,10 @@ public class GlobalVariable {
         if (key == null) {
             return;
         }
-        globalPseudoConstants.remove(key);
+        globalPseudoConstants().remove(key);
         String resolvedKey = resolveAliasedFqn(key);
         if (resolvedKey != key) {
-            globalPseudoConstants.remove(resolvedKey);
+            globalPseudoConstants().remove(resolvedKey);
         }
     }
 
@@ -904,18 +1157,18 @@ public class GlobalVariable {
         if (childPrefix == null || childPrefix.isEmpty()) {
             return;
         }
-        globalPseudoConstants.keySet().removeIf(key -> key.startsWith(childPrefix));
+        globalPseudoConstants().keySet().removeIf(key -> key.startsWith(childPrefix));
     }
 
     public static boolean hasGlobalPseudoConstant(String key) {
         if (key == null) {
             return false;
         }
-        if (globalPseudoConstants.containsKey(key)) {
+        if (globalPseudoConstants().containsKey(key)) {
             return true;
         }
         String resolvedKey = resolveAliasedFqn(key);
-        return resolvedKey != key && globalPseudoConstants.containsKey(resolvedKey);
+        return resolvedKey != key && globalPseudoConstants().containsKey(resolvedKey);
     }
 
     /**
@@ -1179,13 +1432,13 @@ public class GlobalVariable {
         if (!stashAliases.isEmpty()) {
             String resolvedKey = resolveAliasedFqn(key);
             if (resolvedKey != key) {
-                RuntimeScalar resolvedPinned = pinnedCodeRefs.get(resolvedKey);
+                RuntimeScalar resolvedPinned = pinnedCodeRefs().get(resolvedKey);
                 if (resolvedPinned != null) {
                     return resolvedPinned;
                 }
                 RuntimeScalar resolvedVar = globalCodeRefs.get(resolvedKey);
                 if (resolvedVar != null) {
-                    pinnedCodeRefs.put(resolvedKey, resolvedVar);
+                    pinnedCodeRefs().put(resolvedKey, resolvedVar);
                     return resolvedVar;
                 }
             }
@@ -1193,7 +1446,7 @@ public class GlobalVariable {
         // First check if we have a pinned reference that survives stash deletion.
         // Runtime lookups emitted into already-compiled code use this path so
         // those call sites keep their original CV even after delete $Pkg::{sub}.
-        RuntimeScalar pinned = pinnedCodeRefs.get(key);
+        RuntimeScalar pinned = pinnedCodeRefs().get(key);
         if (pinned != null) {
             return pinned;
         }
@@ -1209,7 +1462,7 @@ public class GlobalVariable {
         }
 
         // Pin the RuntimeScalar so it survives stash deletion
-        pinnedCodeRefs.put(key, var);
+        pinnedCodeRefs().put(key, var);
 
         return var;
     }
@@ -1238,11 +1491,11 @@ public class GlobalVariable {
     }
 
     public static RuntimeScalar createPseudoConstantCodeRef(String key) {
-        RuntimeScalar scalar = globalPseudoConstants.get(key);
+        RuntimeScalar scalar = globalPseudoConstants().get(key);
         if (scalar == null) {
             String resolvedKey = resolveAliasedFqn(key);
             if (resolvedKey != key) {
-                scalar = globalPseudoConstants.get(resolvedKey);
+                scalar = globalPseudoConstants().get(resolvedKey);
                 key = resolvedKey;
             }
         }
@@ -1271,8 +1524,8 @@ public class GlobalVariable {
             if (resolvedKey != key) {
                 RuntimeScalar resolvedVar = globalCodeRefs.get(resolvedKey);
                 if (resolvedVar != null) {
-                    if (!deletedCodeRefPins.contains(resolvedKey)) {
-                        pinnedCodeRefs.put(resolvedKey, resolvedVar);
+                    if (!deletedCodeRefPins().contains(resolvedKey)) {
+                        pinnedCodeRefs().put(resolvedKey, resolvedVar);
                     }
                     return resolvedVar;
                 }
@@ -1288,8 +1541,8 @@ public class GlobalVariable {
         } else {
             markPackageGlobalRoot(var);
         }
-        if (!deletedCodeRefPins.contains(key)) {
-            pinnedCodeRefs.put(key, var);
+        if (!deletedCodeRefPins().contains(key)) {
+            pinnedCodeRefs().put(key, var);
         }
         return var;
     }
@@ -1309,7 +1562,7 @@ public class GlobalVariable {
         String resolvedKey = resolveAliasedFqn(key);
         RuntimeScalar ref = globalCodeRefs.get(resolvedKey);
         if (ref == null) {
-            RuntimeScalar pinned = pinnedCodeRefs.get(resolvedKey);
+            RuntimeScalar pinned = pinnedCodeRefs().get(resolvedKey);
             if (pinned != null
                     && pinned.type == RuntimeScalarType.CODE
                     && pinned.value instanceof RuntimeCode pinnedCode
@@ -1335,19 +1588,17 @@ public class GlobalVariable {
         } else {
             markPackageGlobalRoot(ref);
         }
-        deletedCodeRefPins.remove(resolvedKey);
-        pinnedCodeRefs.put(resolvedKey, ref);
+        deletedCodeRefPins().remove(resolvedKey);
+        pinnedCodeRefs().put(resolvedKey, ref);
         return ref;
     }
 
-    public static synchronized int registerCompiledCodeRef(RuntimeScalar ref) {
-        int id = nextCompiledCodeRefId++;
-        compiledCodeRefs.put(id, ref);
-        return id;
+    public static int registerCompiledCodeRef(RuntimeScalar ref) {
+        return globalState().registerCompiledCodeRef(ref);
     }
 
     public static RuntimeScalar getCompiledCodeRef(int id) {
-        RuntimeScalar ref = compiledCodeRefs.get(id);
+        RuntimeScalar ref = compiledCodeRefs().get(id);
         return ref != null ? ref : new RuntimeScalar();
     }
 
@@ -1376,38 +1627,38 @@ public class GlobalVariable {
      * @param codeRef The new RuntimeScalar to pin (typically a new empty one).
      */
     static void replacePinnedCodeRef(String key, RuntimeScalar codeRef) {
-        if (pinnedCodeRefs.containsKey(key)) {
-            pinnedCodeRefs.put(key, codeRef);
+        if (pinnedCodeRefs().containsKey(key)) {
+            pinnedCodeRefs().put(key, codeRef);
         }
     }
 
     static void enterLocalizedCodeRef(String key, RuntimeScalar displacedCodeRef) {
-        localizedCodeRefDepth.merge(key, 1, Integer::sum);
+        localizedCodeRefDepth().merge(key, 1, Integer::sum);
         if (displacedCodeRef != null) {
-            displacedLocalizedCodeRefs.put(displacedCodeRef, key);
+            displacedLocalizedCodeRefs().put(displacedCodeRef, key);
         }
     }
 
     static void exitLocalizedCodeRef(String key, RuntimeScalar displacedCodeRef) {
         if (displacedCodeRef != null) {
-            displacedLocalizedCodeRefs.remove(displacedCodeRef);
+            displacedLocalizedCodeRefs().remove(displacedCodeRef);
         }
-        Integer depth = localizedCodeRefDepth.get(key);
+        Integer depth = localizedCodeRefDepth().get(key);
         if (depth == null) {
             return;
         }
         if (depth <= 1) {
-            localizedCodeRefDepth.remove(key);
+            localizedCodeRefDepth().remove(key);
         } else {
-            localizedCodeRefDepth.put(key, depth - 1);
+            localizedCodeRefDepth().put(key, depth - 1);
         }
     }
 
     public static RuntimeScalar getLocalizedCodeRefForDirectCall(String key, RuntimeScalar fallback) {
         if ((key == null || key.isEmpty()) && fallback != null) {
-            key = displacedLocalizedCodeRefs.get(fallback);
+            key = displacedLocalizedCodeRefs().get(fallback);
         }
-        if (key == null || key.isEmpty() || !localizedCodeRefDepth.containsKey(key)) {
+        if (key == null || key.isEmpty() || !localizedCodeRefDepth().containsKey(key)) {
             return fallback;
         }
         RuntimeScalar localized = globalCodeRefs.get(key);
@@ -1528,8 +1779,8 @@ public class GlobalVariable {
 
     public static RuntimeScalar removeGlobalCodeRefForStashDelete(String key) {
         RuntimeScalar deleted = globalCodeRefs.remove(key);
-        if (deleted != null || pinnedCodeRefs.containsKey(key)) {
-            deletedCodeRefPins.add(key);
+        if (deleted != null || pinnedCodeRefs().containsKey(key)) {
+            deletedCodeRefPins().add(key);
             clearPackageCache();
             invalidatePackageRootSnapshot();
         }
@@ -1574,8 +1825,8 @@ public class GlobalVariable {
      * @param prefix The namespace prefix (e.g., "Foo::") to clear.
      */
     public static void clearPinnedCodeRefsForNamespace(String prefix) {
-        pinnedCodeRefs.keySet().removeIf(k -> k.startsWith(prefix));
-        deletedCodeRefPins.removeIf(k -> k.startsWith(prefix));
+        pinnedCodeRefs().keySet().removeIf(k -> k.startsWith(prefix));
+        deletedCodeRefPins().removeIf(k -> k.startsWith(prefix));
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -25,6 +25,7 @@ public final class PerlRuntime {
     public final ExecutionRuntimeState executionState = new ExecutionRuntimeState();
     public final RuntimeRegexState regexState = new RuntimeRegexState();
     public final MroRuntimeState mroState = new MroRuntimeState();
+    public final GlobalRuntimeState globalState = new GlobalRuntimeState();
 
     RuntimeIO ioStdout;
     RuntimeIO ioStderr;
@@ -117,6 +118,10 @@ public final class PerlRuntime {
 
     public MroRuntimeState mroState() {
         return mroState;
+    }
+
+    public GlobalRuntimeState globalState() {
+        return globalState;
     }
 
     RuntimeGlob standardIOGlob(String name) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -3068,8 +3068,21 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                     releasedCode = true;
                 }
             }
-            // Clear the code value but keep the type as CODE
-            this.value = new RuntimeCode((String) null, null);
+            // Clear the body but keep a declared CODE slot. Perl preserves the
+            // glob's CODE entry after both `undef &existing` and
+            // `undef &previously_unknown`: exists(&name) remains true while
+            // defined(&name) becomes false.
+            RuntimeCode undefinedCode = new RuntimeCode((String) null, null);
+            undefinedCode.isDeclared = true;
+            int separator = globalCodeRefFqn.lastIndexOf("::");
+            if (separator > 0) {
+                undefinedCode.packageName = globalCodeRefFqn.substring(0, separator);
+                undefinedCode.subName = globalCodeRefFqn.substring(separator + 2);
+            } else {
+                undefinedCode.packageName = "main";
+                undefinedCode.subName = globalCodeRefFqn;
+            }
+            this.value = undefinedCode;
             this.tainted = false;
             this.numericLiteralText = null;
             this.numericContextSeen = false;

--- a/src/test/java/org/perlonjava/app/scriptengine/PerlScriptEngineGlobalValueIsolationTest.java
+++ b/src/test/java/org/perlonjava/app/scriptengine/PerlScriptEngineGlobalValueIsolationTest.java
@@ -1,0 +1,59 @@
+package org.perlonjava.app.scriptengine;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("unit")
+class PerlScriptEngineGlobalValueIsolationTest {
+
+    @Test
+    void jsr223EnginesKeepGlobalValuesIndependent() throws Exception {
+        PerlScriptEngine first = (PerlScriptEngine) new PerlScriptEngineFactory().getScriptEngine();
+        PerlScriptEngine second = (PerlScriptEngine) new PerlScriptEngineFactory().getScriptEngine();
+
+        assertEquals("first:array:hash", first.eval(
+                "$Phase8a::scalar='first'; @Phase8a::array=('array'); "
+                        + "$Phase8a::hash{key}='hash'; "
+                        + "join(':', $Phase8a::scalar, $Phase8a::array[0], $Phase8a::hash{key})"));
+        assertEquals("0:0:0", second.eval(
+                "join(':', defined($Phase8a::scalar) ? 1 : 0, "
+                        + "scalar(@Phase8a::array), scalar(keys %Phase8a::hash))"));
+        assertEquals("first:array:hash", first.eval(
+                "join(':', $Phase8a::scalar, $Phase8a::array[0], $Phase8a::hash{key})"));
+    }
+
+    @Test
+    void jvmAndInterpreterBothResolveGlobalsThroughRuntimeFacade() throws Exception {
+        for (boolean interpreter : new boolean[]{false, true}) {
+            PerlRuntime first = new PerlRuntime();
+            PerlRuntime second = new PerlRuntime();
+            assertEquals("first:one:hash", execute(first,
+                    "$Phase8a::scalar='first'; @Phase8a::array=('one'); "
+                            + "$Phase8a::hash{key}='hash'; "
+                            + "join(':', $Phase8a::scalar, $Phase8a::array[0], $Phase8a::hash{key})",
+                    interpreter));
+            assertEquals("0:0:0", execute(second,
+                    "join(':', defined($Phase8a::scalar) ? 1 : 0, "
+                            + "scalar(@Phase8a::array), scalar(keys %Phase8a::hash))",
+                    interpreter));
+            assertEquals("first:one:hash", execute(first,
+                    "join(':', $Phase8a::scalar, $Phase8a::array[0], $Phase8a::hash{key})",
+                    interpreter));
+        }
+    }
+
+    private static String execute(PerlRuntime runtime, String source, boolean interpreter)
+            throws Exception {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            CompilerOptions options = new CompilerOptions();
+            options.fileName = "<phase8a-global-isolation>";
+            options.code = source;
+            options.useInterpreter = interpreter;
+            return PerlLanguageProvider.executePerlCode(options, false).scalar().toString();
+        }
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/operators/TimeAlarmRuntimeBindingTest.java
+++ b/src/test/java/org/perlonjava/runtime/operators/TimeAlarmRuntimeBindingTest.java
@@ -1,0 +1,46 @@
+package org.perlonjava.runtime.operators;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.runtime.runtimetypes.GlobalVariable;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
+import org.perlonjava.runtime.runtimetypes.PerlSignalQueue;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unit")
+class TimeAlarmRuntimeBindingTest {
+
+    @Test
+    void alarmCallbackUsesOwningRuntimeAndRestoresWorkerBinding() throws Exception {
+        PerlRuntime owner = new PerlRuntime();
+        RuntimeScalar handler = new RuntimeScalar("handler");
+        try (PerlRuntime.Binding ignored = owner.bind()) {
+            GlobalVariable.getGlobalHash("main::SIG").put("ALRM", handler);
+        }
+
+        PerlSignalQueue.clearSignals();
+        Thread target = new Thread(() -> { });
+        FutureTask<PerlRuntime> callback = new FutureTask<>(() -> {
+            Time.dispatchAlarm(owner, target);
+            return PerlRuntime.currentOrNull();
+        });
+        Thread worker = Thread.ofPlatform().name("alarm-binding-test").start(callback);
+
+        try {
+            assertNull(callback.get(10, TimeUnit.SECONDS));
+            worker.join(TimeUnit.SECONDS.toMillis(10));
+            assertFalse(worker.isAlive());
+            assertTrue(PerlSignalQueue.hasPendingSignals());
+            assertTrue(target.isInterrupted());
+        } finally {
+            PerlSignalQueue.clearSignals();
+        }
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/regex/RegexTimeoutCharSequenceTest.java
+++ b/src/test/java/org/perlonjava/runtime/regex/RegexTimeoutCharSequenceTest.java
@@ -1,0 +1,27 @@
+package org.perlonjava.runtime.regex;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CancellationException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("unit")
+class RegexTimeoutCharSequenceTest {
+
+    @Test
+    void interruptedMatchIsCancellationRatherThanRegexTimeout() {
+        RegexTimeoutCharSequence input = new RegexTimeoutCharSequence("x", 60_000);
+        Thread.currentThread().interrupt();
+        try {
+            assertThrows(CancellationException.class, () -> {
+                for (int i = 0; i < 4096; i++) {
+                    input.charAt(0);
+                }
+            });
+        } finally {
+            Thread.interrupted();
+        }
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/GlobalCodeRuntimeIsolationTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/GlobalCodeRuntimeIsolationTest.java
@@ -1,0 +1,125 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class GlobalCodeRuntimeIsolationTest {
+
+    @Test
+    void codeSlotsPinsCompiledIdsAndImportedSubFlagsBelongToTheBoundRuntime() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        String name = "Phase8bLowLevel::same_name";
+        RuntimeScalar firstCode = codeScalar("first", "$", name);
+        RuntimeScalar secondCode = codeScalar("second", "$$", name);
+        RuntimeScalar firstPinned;
+        int firstCompiledId;
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            firstPinned = GlobalVariable.getGlobalCodeRef(name);
+            firstPinned.set(firstCode);
+            GlobalVariable.isSubs.put(name, true);
+            GlobalVariable.globalGlobs.put(name, true);
+            firstCompiledId = GlobalVariable.registerCompiledCodeRef(firstPinned);
+
+            firstPinned.undefine();
+            assertTrue(GlobalVariable.existsGlobalCodeRefAsScalar(name).getBoolean());
+            assertFalse(GlobalVariable.definedGlobalCodeRefAsScalar(name).getBoolean());
+            RuntimeCode undefinedCode = (RuntimeCode) firstPinned.value;
+            assertTrue(undefinedCode.isDeclared);
+            assertEquals("Phase8bLowLevel", undefinedCode.packageName);
+            assertEquals("same_name", undefinedCode.subName);
+
+            firstPinned.set(firstCode);
+            GlobalVariable.removeGlobalCodeRefForStashDelete(name);
+
+            assertSame(firstPinned, GlobalVariable.getGlobalCodeRef(name));
+            assertEquals("$", ((RuntimeCode) firstPinned.value).prototype);
+        }
+
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertFalse(GlobalVariable.existsGlobalCodeRef(name));
+            assertFalse(GlobalVariable.isSubs.getOrDefault(name, false));
+            assertFalse(GlobalVariable.globalGlobs.getOrDefault(name, false));
+            assertFalse(GlobalVariable.getCompiledCodeRef(firstCompiledId).getDefinedBoolean());
+
+            RuntimeScalar secondPinned = GlobalVariable.getGlobalCodeRef(name);
+            secondPinned.set(secondCode);
+            GlobalVariable.isSubs.put(name, true);
+            GlobalVariable.globalGlobs.put(name, true);
+            int secondCompiledId = GlobalVariable.registerCompiledCodeRef(secondPinned);
+
+            assertEquals(firstCompiledId, secondCompiledId,
+                    "compiled-code identifiers are allocated by each runtime");
+            assertSame(secondPinned, GlobalVariable.getCompiledCodeRef(secondCompiledId));
+            assertEquals("$$", ((RuntimeCode) secondPinned.value).prototype);
+            assertNotSame(firstPinned, secondPinned);
+        }
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            assertSame(firstPinned, GlobalVariable.getCompiledCodeRef(firstCompiledId));
+            assertTrue(GlobalVariable.isSubs.getOrDefault(name, false));
+            assertTrue(GlobalVariable.globalGlobs.getOrDefault(name, false));
+            assertEquals("$", ((RuntimeCode) GlobalVariable.getGlobalCodeRef(name).value).prototype);
+        }
+    }
+
+    @Test
+    void conflictingNamedSubsAndRedefinitionStayIsolatedOnJvmAndInterpreter() throws Exception {
+        for (boolean interpreter : new boolean[]{false, true}) {
+            PerlRuntime first = new PerlRuntime();
+            PerlRuntime second = new PerlRuntime();
+            String pkg = interpreter ? "Phase8bInterpreter" : "Phase8bJvm";
+
+            run(first, "package " + pkg
+                    + "; sub value ($) { 'first:' . $_[0] }"
+                    + " sub method { 'first-method' } 1", interpreter);
+            run(second, "package " + pkg
+                    + "; sub value ($$) { 'second:' . $_[0] . ':' . $_[1] }"
+                    + " sub method { 'second-method' } 1", interpreter);
+
+            assertEquals("first:x:$:first-method", run(first,
+                    pkg + "::value('x') . ':' . prototype('" + pkg + "::value')"
+                            + " . ':' . " + pkg + "->method", interpreter));
+            assertEquals("second:y:z:$$:second-method", run(second,
+                    pkg + "::value('y', 'z') . ':' . prototype('" + pkg + "::value')"
+                            + " . ':' . " + pkg + "->method", interpreter));
+
+            run(first, "package " + pkg + "; no warnings qw(redefine prototype);"
+                    + " sub value () { 'first-redefined' }"
+                    + " sub method { 'first-method-redefined' } 1", interpreter);
+
+            assertEquals("first-redefined::first-method-redefined", run(first,
+                    pkg + "::value() . ':' . prototype('" + pkg + "::value')"
+                            + " . ':' . " + pkg + "->method", interpreter));
+            assertEquals("second:y:z:$$:second-method", run(second,
+                    pkg + "::value('y', 'z') . ':' . prototype('" + pkg + "::value')"
+                            + " . ':' . " + pkg + "->method", interpreter));
+        }
+    }
+
+    private static RuntimeScalar codeScalar(String value, String prototype, String fullName) {
+        RuntimeCode code = new RuntimeCode(
+                (args, context) -> new RuntimeScalar(value).getList(), prototype);
+        int separator = fullName.lastIndexOf("::");
+        code.packageName = fullName.substring(0, separator);
+        code.subName = fullName.substring(separator + 2);
+        return new RuntimeScalar(code);
+    }
+
+    private static String run(PerlRuntime runtime, String source, boolean interpreter)
+            throws Exception {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            CompilerOptions options = new CompilerOptions();
+            options.fileName = "<global-code-runtime-isolation>";
+            options.code = source;
+            options.useInterpreter = interpreter;
+            return PerlLanguageProvider.executePerlCode(options, false).scalar().toString();
+        }
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/GlobalIORuntimeIsolationTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/GlobalIORuntimeIsolationTest.java
@@ -1,0 +1,186 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+import org.perlonjava.runtime.io.StandardIO;
+
+import java.io.ByteArrayOutputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class GlobalIORuntimeIsolationTest {
+
+    @Test
+    void namedIoAndFormatSlotsFollowNestedRuntimeBindings() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        RuntimeIO firstIo = output();
+        RuntimeIO secondIo = output();
+        RuntimeGlob firstGlob;
+        RuntimeFormat firstFormat;
+        RuntimeGlob secondGlob;
+        RuntimeFormat secondFormat;
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            firstGlob = GlobalVariable.getGlobalIO("Phase8::FH").setIO(firstIo);
+            firstFormat = GlobalVariable.getGlobalFormatRef("Phase8::REPORT").setTemplate("first");
+            assertSame(firstGlob, GlobalVariable.peekGlobalIO("Phase8::FH"));
+            assertSame(firstFormat, GlobalVariable.getGlobalFormatRef("Phase8::REPORT"));
+
+            try (PerlRuntime.Binding nested = second.bind()) {
+                assertNull(GlobalVariable.peekGlobalIO("Phase8::FH"));
+                assertFalse(GlobalVariable.existsGlobalFormat("Phase8::REPORT"));
+                secondGlob = GlobalVariable.getGlobalIO("Phase8::FH").setIO(secondIo);
+                secondFormat = GlobalVariable.getGlobalFormatRef("Phase8::REPORT").setTemplate("second");
+                assertNotSame(firstGlob, secondGlob);
+                assertNotSame(firstFormat, secondFormat);
+            }
+
+            assertSame(firstGlob, GlobalVariable.peekGlobalIO("Phase8::FH"));
+            assertSame(firstIo, firstGlob.getRuntimeIO());
+            assertSame(firstFormat, GlobalVariable.getGlobalFormatRef("Phase8::REPORT"));
+            assertEquals("first", firstFormat.getTemplate());
+        }
+
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertSame(secondIo, GlobalVariable.peekGlobalIO("Phase8::FH").getRuntimeIO());
+            assertEquals("second", GlobalVariable.getGlobalFormatRef("Phase8::REPORT").getTemplate());
+        }
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void simultaneousNamedIoAndFormatMutationDoesNotCrossRuntimes() throws Exception {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        FutureTask<SlotSnapshot> firstTask = slotTask(first, "first", ready, start);
+        FutureTask<SlotSnapshot> secondTask = slotTask(second, "second", ready, start);
+        Thread firstThread = Thread.ofPlatform().name("phase8-io-first").start(firstTask);
+        Thread secondThread = Thread.ofPlatform().name("phase8-io-second").start(secondTask);
+
+        try {
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+        } finally {
+            start.countDown();
+            firstThread.join(TimeUnit.SECONDS.toMillis(10));
+            secondThread.join(TimeUnit.SECONDS.toMillis(10));
+        }
+        assertFalse(firstThread.isAlive());
+        assertFalse(secondThread.isAlive());
+
+        SlotSnapshot firstResult = firstTask.get(1, TimeUnit.SECONDS);
+        SlotSnapshot secondResult = secondTask.get(1, TimeUnit.SECONDS);
+        assertNotSame(firstResult.glob, secondResult.glob);
+        assertNotSame(firstResult.format, secondResult.format);
+        assertEquals("first", firstResult.format.getTemplate());
+        assertEquals("second", secondResult.format.getTemplate());
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void resetClearsOnlyTheBoundRuntimesNamedIoAndFormats() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+
+        installSlots(first, "first");
+        SlotSnapshot secondBefore = installSlots(second, "second");
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            GlobalVariable.resetAllGlobals();
+            assertNull(GlobalVariable.peekGlobalIO("Phase8::FH"));
+            assertFalse(GlobalVariable.existsGlobalFormat("Phase8::REPORT"));
+        }
+
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertSame(secondBefore.glob, GlobalVariable.peekGlobalIO("Phase8::FH"));
+            assertSame(secondBefore.format, GlobalVariable.getGlobalFormatRef("Phase8::REPORT"));
+            assertEquals("second", secondBefore.format.getTemplate());
+        }
+    }
+
+    @Test
+    void namedIoAndFormatsStayIsolatedOnJvmAndInterpreter() throws Exception {
+        for (boolean interpreter : new boolean[]{false, true}) {
+            PerlRuntime first = new PerlRuntime();
+            PerlRuntime second = new PerlRuntime();
+
+            assertEquals("first", run(first,
+                    "open Phase8c::FH, '>', \\$Phase8c::sink; "
+                            + "print Phase8c::FH 'first'; close Phase8c::FH; $Phase8c::sink",
+                    interpreter));
+            assertEquals("second", run(second,
+                    "open Phase8c::FH, '>', \\$Phase8c::sink; "
+                            + "print Phase8c::FH 'second'; close Phase8c::FH; $Phase8c::sink",
+                    interpreter));
+            RuntimeGlob firstGlob;
+            RuntimeFormat firstFormat;
+            try (PerlRuntime.Binding ignored = first.bind()) {
+                firstGlob = GlobalVariable.peekGlobalIO("Phase8c::FH");
+                assertNotNull(firstGlob);
+                firstFormat = GlobalVariable.getGlobalFormatRef("Phase8c::REPORT")
+                        .setTemplate("FIRST");
+                assertTrue(firstFormat.isFormatDefined());
+                assertEquals("FIRST", firstFormat.getTemplate());
+            }
+            try (PerlRuntime.Binding ignored = second.bind()) {
+                assertNotSame(firstGlob, GlobalVariable.peekGlobalIO("Phase8c::FH"));
+                RuntimeFormat secondFormat = GlobalVariable.getGlobalFormatRef("Phase8c::REPORT")
+                        .setTemplate("SECOND");
+                assertNotSame(firstFormat, secondFormat);
+                assertTrue(secondFormat.isFormatDefined());
+                assertEquals("SECOND", secondFormat.getTemplate());
+            }
+        }
+    }
+
+    private static FutureTask<SlotSnapshot> slotTask(
+            PerlRuntime runtime, String marker, CountDownLatch ready, CountDownLatch start) {
+        return new FutureTask<>(() -> {
+            try (PerlRuntime.Binding ignored = runtime.bind()) {
+                ready.countDown();
+                assertTrue(start.await(10, TimeUnit.SECONDS));
+                RuntimeGlob glob = GlobalVariable.getGlobalIO("Phase8::FH").setIO(output());
+                RuntimeFormat format = GlobalVariable.getGlobalFormatRef("Phase8::REPORT")
+                        .setTemplate(marker);
+                assertSame(glob, GlobalVariable.peekGlobalIO("Phase8::FH"));
+                assertSame(format, GlobalVariable.getGlobalFormatRef("Phase8::REPORT"));
+                return new SlotSnapshot(glob, format);
+            }
+        });
+    }
+
+    private static SlotSnapshot installSlots(PerlRuntime runtime, String marker) {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            RuntimeGlob glob = GlobalVariable.getGlobalIO("Phase8::FH").setIO(output());
+            RuntimeFormat format = GlobalVariable.getGlobalFormatRef("Phase8::REPORT")
+                    .setTemplate(marker);
+            return new SlotSnapshot(glob, format);
+        }
+    }
+
+    private static RuntimeIO output() {
+        return new RuntimeIO(new StandardIO(new ByteArrayOutputStream(), true));
+    }
+
+    private static String run(PerlRuntime runtime, String source, boolean interpreter)
+            throws Exception {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            CompilerOptions options = new CompilerOptions();
+            options.fileName = "<global-io-format-runtime-isolation>";
+            options.code = source;
+            options.useInterpreter = interpreter;
+            return PerlLanguageProvider.executePerlCode(options, false).scalar().toString();
+        }
+    }
+
+    private record SlotSnapshot(RuntimeGlob glob, RuntimeFormat format) {
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeGlobalValueIsolationTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeGlobalValueIsolationTest.java
@@ -1,0 +1,141 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class PerlRuntimeGlobalValueIsolationTest {
+
+    @Test
+    void scalarArrayAndHashSlotsBelongToTheBoundRuntime() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            GlobalVariable.getGlobalVariable("Phase8a::value").set("first");
+            GlobalVariable.getGlobalArray("Phase8a::values").push(new RuntimeScalar("a"));
+            GlobalVariable.getGlobalHash("Phase8a::values").put("key", new RuntimeScalar("h1"));
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertFalse(GlobalVariable.existsGlobalVariable("Phase8a::value"));
+            assertFalse(GlobalVariable.existsGlobalArray("Phase8a::values"));
+            assertFalse(GlobalVariable.existsGlobalHash("Phase8a::values"));
+            GlobalVariable.getGlobalVariable("Phase8a::value").set("second");
+        }
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            assertEquals("first", GlobalVariable.getGlobalVariable("Phase8a::value").toString());
+            assertEquals("a", GlobalVariable.getGlobalArray("Phase8a::values").get(0).toString());
+            assertEquals("h1", GlobalVariable.getGlobalHash("Phase8a::values").get("key").toString());
+        }
+    }
+
+    @Test
+    void aliasesAndLocalizationRestoreOnlyTheOwningRuntime() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            GlobalVariable.getGlobalVariable("Phase8a::source").set("outer");
+            GlobalVariable.aliasGlobalVariable("Phase8a::alias", "Phase8a::source");
+            int level = DynamicVariableManager.getLocalLevel();
+            GlobalRuntimeScalar.makeLocal("Phase8a::source").set("local");
+            assertEquals("local", GlobalVariable.getGlobalVariable("Phase8a::source").toString());
+            DynamicVariableManager.popToLocalLevel(level);
+            assertEquals("outer", GlobalVariable.getGlobalVariable("Phase8a::source").toString());
+            assertSame(GlobalVariable.getGlobalVariable("Phase8a::source"),
+                    GlobalVariable.getGlobalVariable("Phase8a::alias"));
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertFalse(GlobalVariable.existsGlobalVariable("Phase8a::source"));
+            assertFalse(GlobalVariable.existsGlobalVariable("Phase8a::alias"));
+        }
+    }
+
+    @Test
+    void arrayAndHashLocalizationUseRuntimeOwnedSlots() {
+        PerlRuntime runtime = new PerlRuntime();
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            GlobalVariable.getGlobalArray("Phase8a::array").push(new RuntimeScalar("outer"));
+            GlobalVariable.getGlobalHash("Phase8a::hash").put("key", new RuntimeScalar("outer"));
+            int level = DynamicVariableManager.getLocalLevel();
+            GlobalRuntimeArray.makeLocal("Phase8a::array").push(new RuntimeScalar("local"));
+            GlobalRuntimeHash.makeLocal("Phase8a::hash").put("key", new RuntimeScalar("local"));
+            assertEquals("local", GlobalVariable.getGlobalArray("Phase8a::array").get(0).toString());
+            assertEquals("local", GlobalVariable.getGlobalHash("Phase8a::hash").get("key").toString());
+            DynamicVariableManager.popToLocalLevel(level);
+            assertEquals("outer", GlobalVariable.getGlobalArray("Phase8a::array").get(0).toString());
+            assertEquals("outer", GlobalVariable.getGlobalHash("Phase8a::hash").get("key").toString());
+        }
+    }
+
+    @Test
+    void resetAndMapViewMutationAffectOnlyTheBoundRuntime() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        long firstVersion;
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            GlobalVariable.globalVariables.put("Phase8a::value", new RuntimeScalar("first"));
+            firstVersion = GlobalVariable.stashEnumerationVersion();
+            assertTrue(GlobalVariable.globalVariables.keySet().remove("Phase8a::value"));
+            assertTrue(GlobalVariable.stashEnumerationVersion() > firstVersion);
+            GlobalVariable.getGlobalVariable("Phase8a::value").set("first-again");
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            GlobalVariable.getGlobalVariable("Phase8a::value").set("second");
+        }
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            GlobalVariable.resetAllGlobals();
+            assertFalse(GlobalVariable.existsGlobalVariable("Phase8a::value"));
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertEquals("second", GlobalVariable.getGlobalVariable("Phase8a::value").toString());
+        }
+    }
+
+    @Test
+    void concurrentRuntimeBindingsDoNotCrossGlobalSlots() throws Exception {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        FutureTask<String> firstTask = globalTask(first, "first", ready, start);
+        FutureTask<String> secondTask = globalTask(second, "second", ready, start);
+        Thread firstThread = Thread.ofPlatform().start(firstTask);
+        Thread secondThread = Thread.ofPlatform().start(secondTask);
+
+        try {
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+        } finally {
+            start.countDown();
+            firstThread.join(TimeUnit.SECONDS.toMillis(10));
+            secondThread.join(TimeUnit.SECONDS.toMillis(10));
+        }
+        assertFalse(firstThread.isAlive());
+        assertFalse(secondThread.isAlive());
+        assertEquals("first:first:first", firstTask.get(1, TimeUnit.SECONDS));
+        assertEquals("second:second:second", secondTask.get(1, TimeUnit.SECONDS));
+    }
+
+    private static FutureTask<String> globalTask(
+            PerlRuntime runtime, String value, CountDownLatch ready, CountDownLatch start) {
+        return new FutureTask<>(() -> {
+            try (PerlRuntime.Binding ignored = runtime.bind()) {
+                ready.countDown();
+                assertTrue(start.await(10, TimeUnit.SECONDS));
+                GlobalVariable.getGlobalVariable("Phase8a::shared").set(value);
+                GlobalVariable.getGlobalArray("Phase8a::shared").push(new RuntimeScalar(value));
+                GlobalVariable.getGlobalHash("Phase8a::shared").put("key", new RuntimeScalar(value));
+                return GlobalVariable.getGlobalVariable("Phase8a::shared") + ":"
+                        + GlobalVariable.getGlobalArray("Phase8a::shared").get(0) + ":"
+                        + GlobalVariable.getGlobalHash("Phase8a::shared").get("key");
+            }
+        });
+    }
+}

--- a/src/test/resources/unit/global_code_runtime_semantics.t
+++ b/src/test/resources/unit/global_code_runtime_semantics.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More tests => 8;
+
+package RuntimeCodePhase8b;
+
+sub value ($) { "first:$_[0]" }
+
+package main;
+
+is(prototype('RuntimeCodePhase8b::value'), '$',
+    'named sub exposes its installed prototype');
+is(RuntimeCodePhase8b::value('one'), 'first:one',
+    'qualified direct call resolves the installed code slot');
+ok(exists &RuntimeCodePhase8b::value,
+    'exists observes the installed code slot');
+ok(defined &RuntimeCodePhase8b::value,
+    'defined observes the installed subroutine');
+
+{
+    no warnings qw(redefine prototype);
+    *RuntimeCodePhase8b::value = sub ($$) { "second:$_[0]:$_[1]" };
+}
+
+is(prototype('RuntimeCodePhase8b::value'), '$$',
+    'glob assignment replaces the code slot prototype');
+is(eval q{ RuntimeCodePhase8b::value('two', 'args') }, 'second:two:args',
+    'qualified call observes the replacement code slot');
+
+undef &RuntimeCodePhase8b::value;
+ok(exists &RuntimeCodePhase8b::value,
+    'undef leaves a declared code slot');
+ok(!defined &RuntimeCodePhase8b::value,
+    'undef clears the installed subroutine body');

--- a/src/test/resources/unit/global_value_runtime_semantics.t
+++ b/src/test/resources/unit/global_value_runtime_semantics.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use Test::More tests => 12;
+
+$Phase8a::scalar = 'outer';
+@Phase8a::array = qw(outer array);
+%Phase8a::hash = (key => 'outer');
+
+is($Phase8a::scalar, 'outer', 'package scalar stores a value');
+is_deeply(\@Phase8a::array, [qw(outer array)], 'package array stores values');
+is_deeply(\%Phase8a::hash, {key => 'outer'}, 'package hash stores values');
+
+*Phase8a::scalar_alias = *Phase8a::scalar;
+$Phase8a::scalar_alias = 'aliased';
+is($Phase8a::scalar, 'aliased', 'scalar glob alias shares its value slot');
+
+{
+    local $Phase8a::scalar = 'local';
+    local @Phase8a::array = qw(local array);
+    local %Phase8a::hash = (key => 'local');
+    is($Phase8a::scalar, 'local', 'localized scalar uses temporary slot');
+    is_deeply(\@Phase8a::array, [qw(local array)], 'localized array uses temporary slot');
+    is_deeply(\%Phase8a::hash, {key => 'local'}, 'localized hash uses temporary slot');
+    is($Phase8a::scalar_alias, 'local', 'scalar alias observes localization');
+}
+
+is($Phase8a::scalar, 'aliased', 'localized scalar restores original slot');
+is_deeply(\@Phase8a::array, [qw(outer array)], 'localized array restores original slot');
+is_deeply(\%Phase8a::hash, {key => 'outer'}, 'localized hash restores original slot');
+is($Phase8a::scalar_alias, 'aliased', 'scalar alias observes restored slot');


### PR DESCRIPTION
## Summary

- implement Perl threads plan phases 8a-8c as the approved combined PR
- move core scalar/array/hash globals, CODE state, named IO, and formats into `PerlRuntime`
- preserve existing `GlobalVariable` facades and Perl CODE-slot behavior across `undef &name`
- make core initialization and `@ARGV` ownership runtime-local
- add low-level, concurrent, JSR-223, JVM, and interpreter isolation coverage
- restore the `re/pat.t` result regressed by PR #921
- update the design progress ledger with Phase 8d as the next independent PR

## Regression fix

`re/pat.t` test 1149 failed because cancellation of an alarm-controlled regex worker was reported as PerlOnJava's internal ten-second regex deadline. Phase 8 global isolation also exposed that the scheduled alarm callback read `%SIG` without binding its owning runtime.

This PR makes worker cancellation unwind silently and binds scheduled `ALRM` dispatch to the captured runtime. The full result is restored exactly from 1097/1302 to 1098/1302, with test 1149 passing.

## Validation

- `make`: passed
- `make test-all`: core 83.0%, bundled modules 80.8%
- `re/pat.t`: 1098/1302, exact pre-PR #921 result
- new Perl semantic tests: system Perl, JVM, and interpreter passed
- Scalar::Util 1.70: JVM and interpreter passed
- Moo 2.005005: JVM and interpreter passed
- focused local/glob/stash/format/filehandle tests: JVM and interpreter passed

## Performance exception for review

Three-run CPU-time medians against exact base `ff98585b1`:

| Benchmark | Base | This PR | Delta |
|---|---:|---:|---:|
| lexical | 8.41s | 8.33s | -1% |
| global | 14.94s | 20.04s | +34% |
| eval string | 57.30s | 65.84s | +15% |

Global and eval exceed the normal 5% budget because each hot lookup now resolves the explicitly bound runtime. The design document records this transparently as a temporary exception candidate; generated-code runtime caching remains assigned to the dedicated performance-recovery phase. Thread compatibility flags remain disabled.
