### PR TITLE
Fix jcpan tooling for packed arrays and Git::Crypt

### DIFF
--- a/dev/design/jcpan-packed-crypto-tooling.md
+++ b/dev/design/jcpan-packed-crypto-tooling.md
@@ -1,0 +1,76 @@
+# jcpan packed-array and crypto dependency compatibility
+
+## Goal
+
+Fix reusable compiler, runtime, and CPAN-tooling failures encountered while
+testing `Tie::Array::Packed`, `Image::Heatmap`,
+`Log::Any::Adapter::Catalyst`, and `Git::Crypt`. Prefer shared fixes and
+Java replacements for genuine XS boundaries over distribution preferences.
+Ignore a target only when its unchanged suite also fails under system Perl.
+
+## Progress Tracking
+
+### Current Status: complete (2026-08-11)
+
+### Completed Phases
+
+- [x] Phase 1: Initial target and system-Perl baseline (2026-08-11)
+  - `Image::Heatmap` passes its fresh isolated `jcpan -t` run: 1 file,
+    7 assertions.
+  - `Tie::Array::Packed` fails only at its unsupported XS load boundary under
+    PerlOnJava; its unchanged upstream suite passes system Perl: 2 files,
+    223 assertions.
+  - The new focused packed-array regression passes system Perl: 44 assertions.
+  - The new Blowfish vector regression passes system Perl: 13 assertions.
+
+- [x] Phase 2: Java XS replacements (2026-08-11)
+  - Added `TieArrayPacked.java` and the upstream-compatible Perl facade for
+    packed tied-array storage, mutation, splicing, ordering, and search.
+  - Added `CryptBlowfish.java` and its Perl facade. The native block operation
+    reuses the BouncyCastle dependency already shipped by PerlOnJava.
+  - Added bundled module regression suites for both ports.
+
+- [x] Phase 3: Shared tooling and byte-semantics fixes (2026-08-11)
+  - Fixed simplified MakeMaker's broad package-tree scan so test helpers below
+    `t/` or `xt/` cannot overwrite production modules in `blib`. This restores
+    IO-All's real `IO::All::Filesys` instead of staging `t/IO_Dumper.pm` over it.
+  - Fixed `pack` H/h nibble folding and field padding to match system Perl,
+    including non-hex input used by `Git::Crypt` salt construction.
+  - Fixed raw `Digest::MD5` results to retain byte-string semantics, allowing
+    Crypt::CBC to derive an eight-octet Blowfish IV under `use bytes`.
+  - Added a Java `Proc::ProcessTable` bridge backed by `ProcessHandle` for the
+    CLI process lookup used by `Git::Crypt`.
+  - Files: `ExtUtils/MakeMaker.pm`, `PackWriter.java`, `DigestMD5.java`,
+    `ProcProcessTable.java`, and their focused regression tests.
+
+- [x] Phase 4: Target validation (2026-08-11)
+  - `Tie::Array::Packed`: forced upstream suite passes, 2 files and 223 tests.
+  - `Image::Heatmap`: fresh isolated suite passes, 1 file and 7 tests.
+  - `Log::Any::Adapter::Catalyst`: isolated suite passes, 2 files and 75 tests.
+  - `Git::Crypt`: isolated suite passes, 5 files and 71 tests.
+  - Full `make` gate passes after the final runtime changes.
+
+### Next Steps
+
+1. No implementation work remains for these four targets.
+2. Treat executable regex callbacks as a separate compiler project if an
+   independently required distribution reaches that capability.
+
+### Open Questions
+
+- `ExtUtils::ParseXS` 3.64 uses executable `(??{ ... })` regex callbacks.
+  That capability is deliberately tracked by
+  `dev/design/executable-regex-callbacks.md`; it surfaced only through
+  HTTP::Message's optional Brotli recommendation during the Catalyst run and
+  must not be papered over with a source patch.
+- `Proc::ProcessTable`'s native upstream suite still fails under system Perl in
+  this sandbox because `sysctl` and process/fork access are denied. The Java
+  bridge deliberately implements the portable fields available through
+  `ProcessHandle`; platform-specific native metrics remain outside this work.
+
+## Related documentation and skills
+
+- `dev/design/executable-regex-callbacks.md`
+- `docs/guides/module-porting.md`
+- `.agents/skills/debug-perlonjava/SKILL.md`
+- `.agents/skills/port-cpan-module/SKILL.md`

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -4,6 +4,11 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 
 ## Work in progress
 
+- CPAN: add Java-backed `Tie::Array::Packed`, BouncyCastle-backed
+  `Crypt::Blowfish`, and ProcessHandle-backed `Proc::ProcessTable` XS
+  replacements. Fix MakeMaker test-helper staging, H/h pack semantics, and raw
+  MD5 byte flags so `Tie::Array::Packed` and `Git::Crypt` pass without new
+  distribution preferences.
 - CPAN: add a Java-backed `Digest::JHash` XS replacement for CHI and
   `TimeZone::TimeZoneDB` dependency chains, and make CPAN's generated
   Makefile fallback work when a distribution ships a read-only Makefile.PL.

--- a/docs/reference/bundled-modules.md
+++ b/docs/reference/bundled-modules.md
@@ -20,6 +20,9 @@ Recent CPAN compatibility additions include:
 | `Devel::LexAlias` | Perl facade over Java lexical cells | Rebinds local and captured scalar, array, and hash lexicals |
 | `Encode::Locale` | Pure Perl facade over bundled locale support | Provides LWP and XML::Parser with locale encoding aliases; includes `Encode::Alias` |
 | `Crypt::Twofish2` | Java XS bridge | BouncyCastle Twofish engine with ECB, CBC, and CFB1 compatibility |
+| `Crypt::Blowfish` | Java XS bridge | BouncyCastle Blowfish engine used by `Crypt::CBC` and `Git::Crypt` |
+| `Proc::ProcessTable` | Perl + Java XS bridge | Portable process enumeration and common fields via Java `ProcessHandle` |
+| `Tie::Array::Packed` | Perl + Java XS bridge | Packed scalar storage for the upstream tied-array API and pack formats |
 | `Digest::JHash` | Java XS bridge | Jenkins 32-bit hash used by CHI and TimeZone::TimeZoneDB |
 | `B::Flags` | Pure Perl over portable `B` objects | Named OP/SV flags without access to Perl C structures |
 

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -758,8 +758,15 @@ The `:encoding()` layer supports all encodings provided by Java's `Charset.forNa
 - ❌  **Safe** module.
 
 ### Non-core modules
+- ✅  **Crypt::Blowfish**: Java XS replacement backed by the bundled
+  BouncyCastle engine, including the variable key sizes and 8-byte block API
+  required by `Crypt::CBC`.
+- ✅  **Proc::ProcessTable**: Java XS replacement for portable process
+  enumeration and common process fields through `ProcessHandle`.
 - ✅  **Crypt::Twofish2**: Java XS replacement backed by BouncyCastle, with
   upstream-compatible ECB, CBC, and CFB1 modes.
+- ✅  **Tie::Array::Packed**: Java XS replacement for packed tied-array
+  storage, mutation, splicing, rotation, and binary search.
 - 🟡 **B::Flags**: portable OP/SV flag names over the bundled partial `B`
   model; host-Perl allocation flags are intentionally unavailable.
 - ✅  **Scalar::Type** module backed by PerlOnJava scalar metadata (replaces native XS).

--- a/src/main/java/org/perlonjava/runtime/operators/pack/PackWriter.java
+++ b/src/main/java/org/perlonjava/runtime/operators/pack/PackWriter.java
@@ -50,6 +50,7 @@ public class PackWriter {
      * @param format The format character indicating the hex string type ('h' for low nybble first, 'H' for high nybble first).
      */
     public static void writeHexString(PackBuffer output, String str, int count, char format) {
+        int initialSize = output.size();
         int nulPos = str.indexOf('\0');
         int effectiveLen = nulPos >= 0 ? nulPos : str.length();
         int hexDigitsToProcess = Math.min(effectiveLen, count);
@@ -59,13 +60,11 @@ public class PackWriter {
         for (i = 0; i + 1 < hexDigitsToProcess; i += 2) {
             // Get first nybble
             char c1 = str.charAt(i);
-            int nybble1 = Character.digit(c1, 16);
-            if (nybble1 == -1) nybble1 = 0; // Default to 0 for invalid hex digit
+            int nybble1 = perlHexNybble(c1);
 
             // Get second nybble
             char c2 = str.charAt(i + 1);
-            int nybble2 = Character.digit(c2, 16);
-            if (nybble2 == -1) nybble2 = 0; // Default to 0 for invalid hex digit
+            int nybble2 = perlHexNybble(c2);
 
             int byteValue;
             if (format == 'h') {
@@ -82,8 +81,7 @@ public class PackWriter {
         // Handle the last hex digit if we have an odd count from input string
         if (i < hexDigitsToProcess) {
             char c = str.charAt(i);
-            int nybble = Character.digit(c, 16);
-            if (nybble == -1) nybble = 0;
+            int nybble = perlHexNybble(c);
 
             int byteValue;
             if (format == 'h') {
@@ -98,16 +96,19 @@ public class PackWriter {
             i++;
         }
 
-        // Zero-pad if count is larger than available hex digits
-        // Each pair of hex digits produces one byte, so we need (count - hexDigitsToProcess) / 2 more bytes
-        int remainingHexDigits = count - hexDigitsToProcess;
-        if (remainingHexDigits > 0) {
-            // Write zero bytes for the remaining hex digit pairs
-            int zeroBytesToWrite = (remainingHexDigits + 1) / 2; // Round up for odd counts
-            for (int j = 0; j < zeroBytesToWrite; j++) {
-                output.write(0);
-            }
+        // The requested nibble width rounds up once for the whole field.  An
+        // odd input nibble already occupies half of its output byte, so do not
+        // round the remaining padding independently (H16 with "0" is 8 bytes,
+        // not 9).
+        int targetBytes = (count + 1) / 2;
+        while (output.size() - initialSize < targetBytes) {
+            output.write(0);
         }
+    }
+
+    /** Perl folds every input character into a nibble, not just [0-9A-Fa-f]. */
+    private static int perlHexNybble(char value) {
+        return ((value & 0x0f) + (value > '9' ? 9 : 0)) & 0x0f;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/perlmodule/CryptBlowfish.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/CryptBlowfish.java
@@ -1,0 +1,70 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.bouncycastle.crypto.engines.BlowfishEngine;
+import org.bouncycastle.crypto.params.KeyParameter;
+import org.perlonjava.frontend.parser.StringParser;
+import org.perlonjava.runtime.runtimetypes.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/** Crypt::Blowfish's two XS functions, backed by BouncyCastle. */
+public final class CryptBlowfish extends PerlModuleBase {
+    private static final String MODULE = "Crypt::Blowfish";
+
+    private record KeySchedule(byte[] key) {
+        private KeySchedule {
+            key = Arrays.copyOf(key, key.length);
+        }
+    }
+
+    public CryptBlowfish() {
+        super(MODULE, false);
+    }
+
+    public static void initialize() {
+        CryptBlowfish module = new CryptBlowfish();
+        try {
+            module.registerMethod("init", null);
+            module.registerMethod("crypt", null);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Unable to initialize " + MODULE, e);
+        }
+    }
+
+    public static RuntimeList init(RuntimeArray args, int ctx) {
+        if (args.isEmpty()) throw new PerlCompilerException("Invalid length key");
+        String keyString = args.get(0).toString();
+        StringParser.assertNoWideCharacters(keyString, "Crypt::Blowfish::init");
+        byte[] key = keyString.getBytes(StandardCharsets.ISO_8859_1);
+        if (key.length < 8 || key.length > 56) {
+            throw new PerlCompilerException("Invalid length key");
+        }
+        return new RuntimeScalar(new KeySchedule(key)).getList();
+    }
+
+    public static RuntimeList crypt(RuntimeArray args, int ctx) {
+        if (args.size() < 4) {
+            throw new PerlCompilerException("Usage: Crypt::Blowfish::crypt(input, output, key, direction)");
+        }
+        String inputString = args.get(0).toString();
+        StringParser.assertNoWideCharacters(inputString, "Crypt::Blowfish::crypt");
+        byte[] input = inputString.getBytes(StandardCharsets.ISO_8859_1);
+        if (input.length != 8) throw new PerlCompilerException("input must be 8 bytes long");
+
+        RuntimeScalar scheduleArg = args.get(2);
+        if (scheduleArg.type != RuntimeScalarType.JAVAOBJECT
+                || !(scheduleArg.value instanceof KeySchedule schedule)) {
+            throw new PerlCompilerException("Invalid Blowfish key schedule");
+        }
+
+        boolean encrypt = args.get(3).getInt() == 0;
+        BlowfishEngine engine = new BlowfishEngine();
+        engine.init(encrypt, new KeyParameter(schedule.key()));
+        byte[] output = new byte[8];
+        engine.processBlock(input, 0, output, 0);
+        RuntimeScalar result = new RuntimeScalar(output);
+        args.get(1).set(result);
+        return result.getList();
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/DigestMD5.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/DigestMD5.java
@@ -210,14 +210,15 @@ public class DigestMD5 extends PerlModuleBase {
             MessageDigest mdClone = (MessageDigest) md.clone();
             byte[] digestBytes = mdClone.digest();
 
-            // Convert bytes to string (ISO-8859-1 to preserve byte values)
-            String digestStr = new String(digestBytes, StandardCharsets.ISO_8859_1);
-
             // Reset for next use
             md.reset();
             self.put(BLOCK_COUNT_KEY, scalarZero);
 
-            return new RuntimeScalar(digestStr).getList();
+            // The raw digest is an octet string (SvUTF8 off), even when it
+            // contains bytes above 0x7f.  Constructing from a Java String
+            // incorrectly marked it UTF-8 and made `use bytes; length` exceed
+            // 16, breaking Crypt::CBC key/IV derivation.
+            return new RuntimeScalar(digestBytes).getList();
 
         } catch (Exception e) {
             throw new RuntimeException("Digest::MD5 digest failed: " + e.getMessage(), e);

--- a/src/main/java/org/perlonjava/runtime/perlmodule/ProcProcessTable.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/ProcProcessTable.java
@@ -1,0 +1,68 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.runtime.operators.ReferenceOperators;
+import org.perlonjava.runtime.runtimetypes.*;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/** Portable subset of Proc::ProcessTable backed by Java ProcessHandle. */
+public final class ProcProcessTable extends PerlModuleBase {
+    public static final String XS_VERSION = "0.637";
+    private static final String MODULE = "Proc::ProcessTable";
+
+    public ProcProcessTable() {
+        super(MODULE, false);
+    }
+
+    public static void initialize() {
+        ProcProcessTable module = new ProcProcessTable();
+        try {
+            module.registerMethod("table", null);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Unable to initialize " + MODULE, e);
+        }
+    }
+
+    public static RuntimeList table(RuntimeArray args, int ctx) {
+        RuntimeArray table = new RuntimeArray();
+        ProcessHandle.allProcesses().forEach(process -> {
+            try {
+                RuntimeHash fields = processFields(process);
+                RuntimeScalar object = ReferenceOperators.bless(
+                        fields.createReference(),
+                        new RuntimeScalar("Proc::ProcessTable::Process"));
+                RuntimeArray.push(table, object);
+            } catch (RuntimeException ignored) {
+                // Processes can disappear or become inaccessible while the
+                // operating system's process table is being enumerated.
+            }
+        });
+        return table.createReference().getList();
+    }
+
+    private static RuntimeHash processFields(ProcessHandle process) {
+        ProcessHandle.Info info = process.info();
+        RuntimeHash fields = new RuntimeHash();
+        fields.put("pid", new RuntimeScalar(process.pid()));
+        fields.put("ppid", new RuntimeScalar(process.parent().map(ProcessHandle::pid).orElse(0L)));
+
+        String command = info.command().orElse("");
+        String commandLine = info.commandLine().orElseGet(() -> {
+            String[] arguments = info.arguments().orElse(new String[0]);
+            return arguments.length == 0 ? command : command + " " + String.join(" ", arguments);
+        });
+        String filename = command;
+        int separator = Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\'));
+        if (separator >= 0) filename = filename.substring(separator + 1);
+
+        fields.put("fname", new RuntimeScalar(filename));
+        fields.put("cmndline", new RuntimeScalar(commandLine));
+        fields.put("start", new RuntimeScalar(
+                info.startInstant().map(Instant::getEpochSecond).orElse(0L)));
+        fields.put("time", new RuntimeScalar(
+                info.totalCpuDuration().map(Duration::toMillis).orElse(0L) / 1000.0));
+        fields.put("state", new RuntimeScalar(process.isAlive() ? "run" : "defunct"));
+        return fields;
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/TieArrayPacked.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/TieArrayPacked.java
@@ -1,0 +1,301 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.runtime.operators.Pack;
+import org.perlonjava.runtime.operators.ReferenceOperators;
+import org.perlonjava.runtime.operators.Unpack;
+import org.perlonjava.runtime.runtimetypes.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Java replacement for the XS storage engine used by Tie::Array::Packed. */
+public final class TieArrayPacked extends PerlModuleBase {
+    private static final String MODULE = "Tie::Array::Packed";
+
+    /** The XS implementation attaches the pack format as scalar magic. */
+    private static final class PackedScalar extends RuntimeScalar {
+        private final String packer;
+        private final int elementSize;
+
+        private PackedScalar(String packer, String initial) {
+            super(initial.getBytes(StandardCharsets.ISO_8859_1));
+            this.packer = packer;
+            this.elementSize = packOne(packer, new RuntimeScalar(0)).length();
+            if (elementSize == 0) {
+                throw new PerlCompilerException("invalid/unsupported packing type " + packer);
+            }
+        }
+    }
+
+    public TieArrayPacked() {
+        super(MODULE, false);
+    }
+
+    public static void initialize() {
+        TieArrayPacked module = new TieArrayPacked();
+        try {
+            for (String method : new String[] {
+                    "TIEARRAY", "STORE", "FETCH", "FETCHSIZE", "STORESIZE", "EXTEND",
+                    "EXISTS", "DELETE", "CLEAR", "PUSH", "POP", "SHIFT", "UNSHIFT",
+                    "SPLICE", "packer", "element_size", "reverse", "rotate", "bsearch"
+            }) {
+                module.registerMethod(method, null);
+            }
+            module.registerMethod("bsearch_le", "bsearchLe", null);
+            module.registerMethod("bsearch_ge", "bsearchGe", null);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Unable to initialize " + MODULE, e);
+        }
+    }
+
+    public static RuntimeList TIEARRAY(RuntimeArray args, int ctx) {
+        if (args.size() < 3) {
+            throw new PerlCompilerException("Usage: Tie::Array::Packed::TIEARRAY(class, type, initial)");
+        }
+        String packer = normalizePacker(args.get(1).toString());
+        String initial = args.get(2).toString();
+        PackedScalar data = new PackedScalar(packer, initial);
+        RuntimeScalar self = data.createReference();
+        ReferenceOperators.bless(self, args.get(0));
+        return self.getList();
+    }
+
+    public static RuntimeList STORE(RuntimeArray args, int ctx) {
+        PackedScalar data = data(args);
+        int index = checkedIndex(args.get(1));
+        List<RuntimeScalar> values = values(data);
+        while (values.size() <= index) values.add(new RuntimeScalar(0));
+        values.set(index, coerce(data, args.get(2)));
+        storeValues(data, values);
+        return new RuntimeList();
+    }
+
+    public static RuntimeList FETCH(RuntimeArray args, int ctx) {
+        PackedScalar data = data(args);
+        int index = checkedIndex(args.get(1));
+        List<RuntimeScalar> values = values(data);
+        return (index < values.size() ? values.get(index) : RuntimeScalarCache.scalarUndef).getList();
+    }
+
+    public static RuntimeList FETCHSIZE(RuntimeArray args, int ctx) {
+        PackedScalar data = data(args);
+        return new RuntimeScalar(data.toString().length() / data.elementSize).getList();
+    }
+
+    public static RuntimeList STORESIZE(RuntimeArray args, int ctx) {
+        PackedScalar data = data(args);
+        int size = checkedIndex(args.get(1));
+        List<RuntimeScalar> values = values(data);
+        while (values.size() < size) values.add(new RuntimeScalar(0));
+        if (values.size() > size) values = new ArrayList<>(values.subList(0, size));
+        storeValues(data, values);
+        return new RuntimeList();
+    }
+
+    public static RuntimeList EXTEND(RuntimeArray args, int ctx) {
+        checkedIndex(args.get(1));
+        return new RuntimeList();
+    }
+
+    public static RuntimeList EXISTS(RuntimeArray args, int ctx) {
+        PackedScalar data = data(args);
+        int index = checkedIndex(args.get(1));
+        return (index < data.toString().length() / data.elementSize
+                ? RuntimeScalarCache.scalarTrue : RuntimeScalarCache.scalarUndef).getList();
+    }
+
+    public static RuntimeList DELETE(RuntimeArray args, int ctx) {
+        PackedScalar data = data(args);
+        int index = checkedIndex(args.get(1));
+        List<RuntimeScalar> values = values(data);
+        if (index >= values.size()) return RuntimeScalarCache.scalarUndef.getList();
+        RuntimeScalar old = values.get(index);
+        values.set(index, new RuntimeScalar(0));
+        storeValues(data, values);
+        return old.getList();
+    }
+
+    public static RuntimeList CLEAR(RuntimeArray args, int ctx) {
+        data(args).set(new RuntimeScalar(new byte[0]));
+        return new RuntimeList();
+    }
+
+    public static RuntimeList PUSH(RuntimeArray args, int ctx) {
+        PackedScalar data = data(args);
+        List<RuntimeScalar> values = values(data);
+        for (int i = 1; i < args.size(); i++) values.add(coerce(data, args.get(i)));
+        storeValues(data, values);
+        return new RuntimeList();
+    }
+
+    public static RuntimeList POP(RuntimeArray args, int ctx) {
+        PackedScalar data = data(args);
+        List<RuntimeScalar> values = values(data);
+        if (values.isEmpty()) return RuntimeScalarCache.scalarUndef.getList();
+        RuntimeScalar value = values.removeLast();
+        storeValues(data, values);
+        return value.getList();
+    }
+
+    public static RuntimeList SHIFT(RuntimeArray args, int ctx) {
+        PackedScalar data = data(args);
+        List<RuntimeScalar> values = values(data);
+        if (values.isEmpty()) return RuntimeScalarCache.scalarUndef.getList();
+        RuntimeScalar value = values.removeFirst();
+        storeValues(data, values);
+        return value.getList();
+    }
+
+    public static RuntimeList UNSHIFT(RuntimeArray args, int ctx) {
+        PackedScalar data = data(args);
+        List<RuntimeScalar> values = values(data);
+        for (int i = args.size() - 1; i >= 1; i--) values.addFirst(coerce(data, args.get(i)));
+        storeValues(data, values);
+        return new RuntimeList();
+    }
+
+    public static RuntimeList SPLICE(RuntimeArray args, int ctx) {
+        PackedScalar data = data(args);
+        List<RuntimeScalar> values = values(data);
+        int offset = Math.min(checkedIndex(args.get(1)), values.size());
+        int length = Math.min(checkedIndex(args.get(2)), values.size() - offset);
+        List<RuntimeScalar> removed = new ArrayList<>(values.subList(offset, offset + length));
+        values.subList(offset, offset + length).clear();
+        for (int i = 3; i < args.size(); i++) {
+            values.add(offset++, coerce(data, args.get(i)));
+        }
+        storeValues(data, values);
+        if (ctx == RuntimeContextType.LIST) return new RuntimeList(removed.toArray(new RuntimeBase[0]));
+        if (ctx == RuntimeContextType.SCALAR) {
+            return (removed.isEmpty() ? RuntimeScalarCache.scalarUndef : removed.getLast()).getList();
+        }
+        return new RuntimeList();
+    }
+
+    public static RuntimeList packer(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(data(args).packer).getList();
+    }
+
+    public static RuntimeList element_size(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(data(args).elementSize).getList();
+    }
+
+    public static RuntimeList reverse(RuntimeArray args, int ctx) {
+        PackedScalar data = data(args);
+        List<RuntimeScalar> values = values(data);
+        Collections.reverse(values);
+        storeValues(data, values);
+        return new RuntimeList();
+    }
+
+    public static RuntimeList rotate(RuntimeArray args, int ctx) {
+        PackedScalar data = data(args);
+        List<RuntimeScalar> values = values(data);
+        if (values.isEmpty()) return new RuntimeList();
+        int amount = args.size() > 1 ? args.get(1).getInt() : 1;
+        amount %= values.size();
+        if (amount < 0) amount += values.size();
+        Collections.rotate(values, -amount);
+        storeValues(data, values);
+        return new RuntimeList();
+    }
+
+    public static RuntimeList bsearch(RuntimeArray args, int ctx) {
+        return search(args, 0);
+    }
+
+    public static RuntimeList bsearchLe(RuntimeArray args, int ctx) {
+        return search(args, -1);
+    }
+
+    public static RuntimeList bsearchGe(RuntimeArray args, int ctx) {
+        return search(args, 1);
+    }
+
+    private static RuntimeList search(RuntimeArray args, int fallback) {
+        PackedScalar data = data(args);
+        List<RuntimeScalar> values = values(data);
+        double wanted = coerce(data, args.get(1)).getDouble();
+        int low = 0;
+        int high = values.size();
+        while (low < high) {
+            int pivot = (low + high) >>> 1;
+            double value = values.get(pivot).getDouble();
+            if (value < wanted) low = pivot + 1;
+            else if (value > wanted) high = pivot;
+            else return new RuntimeScalar(pivot).getList();
+        }
+        int index = fallback < 0 ? low - 1 : low;
+        if (fallback == 0 || index < 0 || index >= values.size()) {
+            return RuntimeScalarCache.scalarUndef.getList();
+        }
+        return new RuntimeScalar(index).getList();
+    }
+
+    private static PackedScalar data(RuntimeArray args) {
+        if (args.isEmpty()) throw new PerlCompilerException("Tie::Array::Packed method called without an object");
+        RuntimeScalar scalar = args.get(0).scalarDeref();
+        if (!(scalar instanceof PackedScalar packed)) {
+            throw new PerlCompilerException("invalid Tie::Array::Packed object");
+        }
+        return packed;
+    }
+
+    private static int checkedIndex(RuntimeScalar scalar) {
+        long value = scalar.getLong();
+        if (value < 0 || value > Integer.MAX_VALUE) {
+            throw new PerlCompilerException("Modification of non-creatable array value attempted");
+        }
+        return (int) value;
+    }
+
+    private static String normalizePacker(String packer) {
+        if (packer.length() == 1 && "cChFfdiIjJnNvVqQeE".contains(packer)) return packer;
+        if (packer.length() == 2 && packer.charAt(1) == '!' && "sSlL".indexOf(packer.charAt(0)) >= 0) {
+            return packer;
+        }
+        throw new PerlCompilerException("invalid/unsupported packing type " + packer);
+    }
+
+    private static RuntimeScalar coerce(PackedScalar data, RuntimeScalar value) {
+        return unpackOne(data.packer, packOne(data.packer, value));
+    }
+
+    private static String packOne(String packer, RuntimeScalar value) {
+        if (packer.equals("h")) {
+            int nibble = value.getInt() & 15;
+            return Character.toString(Character.forDigit(nibble, 16));
+        }
+        RuntimeList packArgs = new RuntimeList(new RuntimeScalar(packer), value);
+        return Pack.pack(packArgs).toString();
+    }
+
+    private static RuntimeScalar unpackOne(String packer, String bytes) {
+        if (packer.equals("h")) {
+            int value = Character.digit(bytes.isEmpty() ? '0' : bytes.charAt(0), 16);
+            return new RuntimeScalar(Math.max(value, 0));
+        }
+        RuntimeList unpacked = Unpack.unpack(RuntimeContextType.LIST,
+                new RuntimeScalar(packer), new RuntimeScalar(bytes.getBytes(StandardCharsets.ISO_8859_1)));
+        return unpacked.isEmpty() ? RuntimeScalarCache.scalarUndef : unpacked.getFirst();
+    }
+
+    private static List<RuntimeScalar> values(PackedScalar data) {
+        String raw = data.toString();
+        int count = raw.length() / data.elementSize;
+        List<RuntimeScalar> values = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            int offset = i * data.elementSize;
+            values.add(unpackOne(data.packer, raw.substring(offset, offset + data.elementSize)));
+        }
+        return values;
+    }
+
+    private static void storeValues(PackedScalar data, List<RuntimeScalar> values) {
+        StringBuilder raw = new StringBuilder(values.size() * data.elementSize);
+        for (RuntimeScalar value : values) raw.append(packOne(data.packer, value));
+        data.set(new RuntimeScalar(raw.toString().getBytes(StandardCharsets.ISO_8859_1)));
+    }
+}

--- a/src/main/perl/lib/Crypt/Blowfish.pm
+++ b/src/main/perl/lib/Crypt/Blowfish.pm
@@ -1,0 +1,63 @@
+package Crypt::Blowfish;
+
+require Exporter;
+use strict;
+use warnings;
+use Carp;
+
+our $VERSION = '2.14';
+our @ISA = qw(Exporter);
+our @EXPORT = ();
+our @EXPORT_OK = qw(blocksize keysize min_keysize max_keysize new encrypt decrypt);
+
+require XSLoader;
+XSLoader::load(__PACKAGE__, $VERSION);
+
+sub usage {
+    my (undef, undef, undef, $subroutine) = caller(1);
+    local $Carp::CarpLevel = 2;
+    croak "Usage: $subroutine(@_)";
+}
+
+sub blocksize   { 8 }
+sub keysize     { 0 }
+sub min_keysize { 8 }
+sub max_keysize { 56 }
+
+sub new {
+    usage('new Blowfish key') unless @_ == 2;
+    my ($type, $key) = @_;
+    return bless { ks => init($key) }, $type;
+}
+
+sub encrypt {
+    usage('encrypt data[8 bytes]') unless @_ == 2;
+    my ($self, $data) = @_;
+    Crypt::Blowfish::crypt($data, $data, $self->{ks}, 0);
+    return $data;
+}
+
+sub decrypt {
+    usage('decrypt data[8 bytes]') unless @_ == 2;
+    my ($self, $data) = @_;
+    Crypt::Blowfish::crypt($data, $data, $self->{ks}, 1);
+    return $data;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Crypt::Blowfish - Blowfish encryption using PerlOnJava's BouncyCastle runtime
+
+=head1 COPYRIGHT
+
+Parts Copyright (C) 1995, 1996 Systemics Ltd.
+New parts Copyright (C) 1999-2010 W3Works, LLC.
+
+The original implementation and interface are distributed under the same terms
+as Perl itself.  PerlOnJava replaces only the native XS block operation.
+
+=cut

--- a/src/main/perl/lib/ExtUtils/MakeMaker.pm
+++ b/src/main/perl/lib/ExtUtils/MakeMaker.pm
@@ -460,6 +460,11 @@ sub _install_pure_perl {
             if ($root_dh) {
                 while (my $entry = readdir($root_dh)) {
                     next if $entry =~ /^\.{1,2}$/ || $entry eq 'lib' || $entry eq 'blib';
+                    # Test helpers sometimes reopen a production package to
+                    # install fixture-only methods (IO-All's t/IO_Dumper.pm
+                    # reopens IO::All::Filesys).  They are not PMLIBDIRS and
+                    # must not overwrite the real library file in blib.
+                    next if $entry eq 't' || $entry eq 'xt';
                     next unless -d $entry;
                     find({
                         wanted => sub {

--- a/src/main/perl/lib/Proc/ProcessTable.pm
+++ b/src/main/perl/lib/Proc/ProcessTable.pm
@@ -1,0 +1,30 @@
+package Proc::ProcessTable;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.637';
+
+require XSLoader;
+XSLoader::load(__PACKAGE__, $VERSION);
+require Proc::ProcessTable::Process;
+
+sub new {
+    my ($class, %args) = @_;
+    return bless { %args }, ref($class) || $class;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Proc::ProcessTable - portable process table access for PerlOnJava
+
+=head1 DESCRIPTION
+
+This compatibility facade preserves the CPAN object interface while the table
+enumeration is supplied by Java's ProcessHandle API.
+
+=cut

--- a/src/main/perl/lib/Proc/ProcessTable/Process.pm
+++ b/src/main/perl/lib/Proc/ProcessTable/Process.pm
@@ -1,0 +1,26 @@
+package Proc::ProcessTable::Process;
+
+use strict;
+use warnings;
+use Carp qw(croak);
+
+our $VERSION = '0.02';
+our $AUTOLOAD;
+
+sub AUTOLOAD {
+    my $self = shift;
+    my $type = ref($self) or croak "$self is not an object";
+    (my $name = $AUTOLOAD) =~ s/.*://;
+    croak "Can't access `$name' field in class $type"
+        unless exists $self->{$name};
+    return @_ ? ($self->{$name} = shift) : $self->{$name};
+}
+
+sub kill {
+    my ($self, $signal) = @_;
+    return CORE::kill($signal, $self->{pid});
+}
+
+sub DESTROY { }
+
+1;

--- a/src/main/perl/lib/Tie/Array/Packed.pm
+++ b/src/main/perl/lib/Tie/Array/Packed.pm
@@ -1,0 +1,128 @@
+package Tie::Array::Packed;
+
+our $VERSION = '0.13';
+
+use strict;
+use warnings;
+use Carp;
+
+require XSLoader;
+XSLoader::load(__PACKAGE__, $VERSION);
+
+my @short = qw(c C F f d i I j J s! S! l! L! n N v V q Q e E);
+my %map = (
+    Char => 'c', UnsignedChar => 'C', Hex => 'h', NV => 'F', Number => 'F',
+    FloatNative => 'f', DoubleNative => 'd', Integer => 'j', UnsignedInteger => 'J',
+    IntegerPerl => 'j', IV => 'j', UnsignedIntegerPerl => 'J', UV => 'J',
+    IntegerNative => 'i', UnsignedIntegerNative => 'I', ShortNative => 's!',
+    UnsignedShortNative => 'S!', LongNative => 'l!', UnsignedLongNative => 'L!',
+    UnsignedShortNet => 'n', UnsignedShortBE => 'n', UnsignedLongNet => 'N',
+    UnsignedLongBE => 'N', UnsignedShortVax => 'v', UnsignedShortLE => 'v',
+    UnsignedLongVax => 'V', UnsignedLongLE => 'V', Quad => 'q', UnsignedQuad => 'Q',
+    LongLong => 'q', UnsignedLongLong => 'Q', Int64 => 'q', UInt64 => 'Q',
+    Int128 => 'e', UInt128 => 'E',
+);
+@map{@short} = @short;
+
+for my $name (keys %map) {
+    my $type = $map{$name};
+    no strict 'refs';
+    @{"Tie::Array::Packed::${name}::ISA"} = __PACKAGE__;
+    *{"Tie::Array::Packed::${name}::TIEARRAY"} = sub {
+        my $class = shift;
+        my $self = TIEARRAY($class, $type, defined $_[0] ? $_[0] : '');
+        if (@_ > 1) {
+            shift;
+            $self->SPLICE(0, scalar(@_), @_);
+        }
+        return $self;
+    };
+}
+
+sub make {
+    my $class = shift;
+    tie my @self, $class, '', @_;
+    return \@self;
+}
+
+sub make_with_packed {
+    my $class = shift;
+    tie my @self, $class, @_;
+    return \@self;
+}
+
+sub make_clone {
+    my $self = shift;
+    tie my @clone, ref($self), $$self;
+    return \@clone;
+}
+
+sub string { ${$_[0]} }
+
+my $sort_packed_loaded;
+sub _load_sort_packed {
+    eval { require Sort::Packed };
+    croak __PACKAGE__ . '::sort requires package Sort::Packed'
+        if $@ or !$Sort::Packed::VERSION;
+    $sort_packed_loaded++;
+}
+
+sub sort {
+    @_ > 2 and croak 'Usage: tied(@parray)->sort([sub { CMP($a, $b) }])';
+    $sort_packed_loaded or _load_sort_packed();
+    my $self = shift;
+    my $packer = $self->packer;
+    return @_ ? Sort::Packed::sort_packed_custom(shift, $packer, $$self)
+              : Sort::Packed::sort_packed($packer, $$self);
+}
+
+sub shuffle {
+    @_ == 1 or croak 'Usage: tied(@parray)->shuffle';
+    $sort_packed_loaded or _load_sort_packed();
+    my $self = shift;
+    return Sort::Packed::shuffle_packed($self->packer, $$self);
+}
+
+sub grep {
+    @_ == 2 or croak 'Usage: tied(@parray)->grep(sub { SELECT($_) })';
+    my ($self, $select) = @_;
+    my $last = $self->FETCHSIZE - 1;
+    my $slow = 0;
+    for my $i (0 .. $last) {
+        for ($self->FETCH($i)) {
+            my $copy = $_;
+            if (&$select) {
+                $self->STORE($slow, $copy) if $slow < $i;
+                $slow++;
+            }
+        }
+    }
+    $self->STORESIZE($slow);
+    return $slow;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Tie::Array::Packed - store arrays efficiently as packed strings
+
+=head1 DESCRIPTION
+
+This is the PerlOnJava port of Tie::Array::Packed 0.13.  The original Perl
+interface is retained and its XS storage operations are implemented in Java.
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2006-2008, 2011-2013 by Salvador Fandino
+(sfandino@yahoo.com).
+
+Some parts copied from Tie::Array::PackedC (C) 2003-2006 by Yves Orton.
+
+This library is free software; you can redistribute it and/or modify it under
+the same terms as Perl itself, either Perl version 5.8.8 or, at your option,
+any later version of Perl 5 you may have available.
+
+=cut

--- a/src/test/resources/module/Crypt-Blowfish/t/vectors.t
+++ b/src/test/resources/module/Crypt-Blowfish/t/vectors.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More;
+use Crypt::Blowfish;
+
+my @vectors = (
+    ['0000000000000000', '0000000000000000', '4ef997456198dd78'],
+    ['ffffffffffffffff', 'ffffffffffffffff', '51866fd5b85ecb8a'],
+    ['3000000000000000', '1000000000000001', '7d856f9a613063f2'],
+    ['1111111111111111', '1111111111111111', '2466dd878b963c9d'],
+    ['0101010101010101', '0123456789abcdef', 'fa34ec4847b268b2'],
+);
+
+for my $vector (@vectors) {
+    my ($key_hex, $plain_hex, $cipher_hex) = @$vector;
+    my $cipher = Crypt::Blowfish->new(pack('H*', $key_hex));
+    my $encrypted = $cipher->encrypt(pack('H*', $plain_hex));
+    is(unpack('H*', $encrypted), $cipher_hex, "encrypt $plain_hex");
+    is(unpack('H*', $cipher->decrypt($encrypted)), $plain_hex, "decrypt $cipher_hex");
+}
+
+is(Crypt::Blowfish::blocksize(), 8, 'block size');
+is(Crypt::Blowfish::min_keysize(), 8, 'minimum key size');
+is(Crypt::Blowfish::max_keysize(), 56, 'maximum key size');
+
+done_testing;

--- a/src/test/resources/module/Proc-ProcessTable/t/basic.t
+++ b/src/test/resources/module/Proc-ProcessTable/t/basic.t
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Proc::ProcessTable;
+
+my $table = Proc::ProcessTable->new(enable_ttys => 0)->table;
+ok(ref($table) eq 'ARRAY', 'table returns an array reference');
+
+my ($current) = grep { $_->pid == $$ } @$table;
+ok($current, 'table contains the current process');
+is($current->pid, $$, 'process pid accessor matches Perl pid');
+ok(defined($current->cmndline), 'process command line is available');
+
+done_testing;

--- a/src/test/resources/module/Tie-Array-Packed/t/basic.t
+++ b/src/test/resources/module/Tie-Array-Packed/t/basic.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More;
+use Tie::Array::Packed;
+
+for my $type (qw(c C F f d i I j J s! S! l! L! n N v V)) {
+    my $array = "Tie::Array::Packed::$type"->make(1 .. 5);
+    is("@$array", '1 2 3 4 5', "$type initial values");
+    push @$array, 6;
+    is(pop @$array, 6, "$type push and pop");
+}
+
+my $array = Tie::Array::Packed::Integer->make(1, 3, 5, 7);
+is_deeply([splice(@$array, 1, 2, 2, 4, 6)], [3, 5], 'splice returns removed values');
+is_deeply([@$array], [1, 2, 4, 6, 7], 'splice replaces values');
+
+my $object = tied(@$array);
+is($object->bsearch(4), 2, 'binary search exact match');
+is($object->bsearch_le(5), 2, 'binary search lower bound');
+is($object->bsearch_ge(5), 3, 'binary search upper bound');
+
+$object->reverse;
+is_deeply([@$array], [7, 6, 4, 2, 1], 'reverse');
+$object->rotate(2);
+is_deeply([@$array], [4, 2, 1, 7, 6], 'rotate left');
+$object->rotate(-1);
+is_deeply([@$array], [6, 4, 2, 1, 7], 'rotate right');
+
+my $packed = pack('n*', 10, 20, 30);
+my $network = Tie::Array::Packed::UnsignedShortNet->make_with_packed($packed);
+is_deeply([@$network], [10, 20, 30], 'packed initializer');
+is(tied(@$network)->string, $packed, 'packed storage string');
+
+done_testing;

--- a/src/test/resources/unit/digest_md5_byte_flag.t
+++ b/src/test/resources/unit/digest_md5_byte_flag.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+
+use Digest::MD5 qw(md5);
+use Encode qw(is_utf8);
+use Test::More;
+
+for my $digest (
+    md5('x'),
+    Digest::MD5->new->add('x')->digest,
+) {
+    ok(!is_utf8($digest), 'raw MD5 digest has the UTF-8 flag off');
+    is(length($digest), 16, 'raw MD5 digest contains 16 characters');
+    {
+        use bytes;
+        is(length($digest), 16, 'raw MD5 digest contains 16 octets');
+    }
+}
+
+done_testing;

--- a/src/test/resources/unit/makemaker_ignores_test_helpers.t
+++ b/src/test/resources/unit/makemaker_ignores_test_helpers.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+
+use Cwd qw(getcwd);
+use ExtUtils::MakeMaker;
+use File::Path qw(make_path);
+use File::Temp qw(tempdir);
+use Test::More;
+
+my $original = getcwd();
+my $dist = tempdir(CLEANUP => 1);
+
+END {
+    chdir $original if defined $original;
+}
+
+chdir $dist or die "chdir $dist: $!";
+make_path('lib/IO/All', 't');
+
+open my $module, '>', 'lib/IO/All/Filesys.pm'
+    or die "create library module: $!";
+print {$module} "package IO::All::Filesys; sub set_lock { 1 } 1;\n";
+close $module or die "close library module: $!";
+
+# IO-All has a test helper with this shape: it starts in its own package but
+# later reopens a production package to add test-only methods.  It is not a
+# library payload and must never overwrite lib/IO/All/Filesys.pm in blib.
+open my $helper, '>', 't/IO_Dumper.pm' or die "create test helper: $!";
+print {$helper} <<'HELPER';
+package IO_Dumper;
+sub io { 1 }
+package IO::All::Filesys;
+sub dump { 1 }
+1;
+HELPER
+close $helper or die "close test helper: $!";
+
+WriteMakefile(NAME => 'IO::All', VERSION => '0.001');
+
+open my $makefile_fh, '<', 'Makefile' or die "open generated Makefile: $!";
+my $makefile = do { local $/; <$makefile_fh> };
+close $makefile_fh or die "close generated Makefile: $!";
+
+like(
+    $makefile,
+    qr{lib/IO/All/Filesys\.pm},
+    'production module is staged',
+);
+unlike(
+    $makefile,
+    qr{t/IO_Dumper\.pm},
+    'test helper is not treated as a library payload',
+);
+
+done_testing;

--- a/src/test/resources/unit/pack_hex_string_regressions.t
+++ b/src/test/resources/unit/pack_hex_string_regressions.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+sub packed_hex {
+    my ($template, $value) = @_;
+    my $packed = pack($template, $value);
+    return (length($packed), unpack('H*', $packed));
+}
+
+is_deeply([packed_hex('H16', 0)], [8, '0000000000000000'],
+    'fixed-width H padding shares the final partial byte');
+is_deeply([packed_hex('H4', 'f')], [2, 'f000'],
+    'H pads a short odd-nibble input to the requested width');
+is_deeply([packed_hex('H3', '')], [2, '0000'],
+    'H pads an empty input to a rounded-up odd width');
+is_deeply([packed_hex('H16', 'very very very very loooong salt')],
+    [8, 'feb20feb20feb20f'],
+    'H uses Perl nibble folding for non-hex characters');
+is_deeply([packed_hex('h16', 'very very very very loooong salt')],
+    [8, 'ef2bf0be02ef2bf0'],
+    'h uses the same folded nibbles in low-first order');
+is_deeply([packed_hex('H*', 'very')], [2, 'feb2'],
+    'star width consumes all folded input nibbles');
+
+done_testing;


### PR DESCRIPTION
## Summary

- add JVM-backed `Tie::Array::Packed`, `Crypt::Blowfish`, and `Proc::ProcessTable` compatibility modules
- reuse the bundled BouncyCastle provider for Blowfish instead of introducing another Java dependency
- fix shared MakeMaker package scanning, packed-hex decoding, and Digest::MD5 byte handling exposed by the target CPAN dependency trees
- document the implementation and bundled-module coverage without adding distribution preferences

## Validation

- `make` — `BUILD SUCCESSFUL` (all five unit-test shards)
- `./jcpan -t Tie::Array::Packed` — 223 tests pass with the upstream distribution forced
- `./jcpan -t Image::Heatmap` — 7 tests pass from a fresh install
- `./jcpan -t Log::Any::Adapter::Catalyst` — 75 tests pass
- `./jcpan -t Git::Crypt` — 71 tests pass
- new regression tests also pass under system Perl where applicable

## Notes

`Proc::ProcessTable` cannot be validated with system Perl in this sandbox because its native implementation calls restricted `sysctl`; this is within the requested system-Perl exception.
