### PR TITLE
feat: isolate symbol and eval runtime state

### DIFF
--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -16,7 +16,8 @@ Each numbered phase below normally forms an independent pull request. A phase
 may be split further when its audit shows that it cannot be reviewed or reverted
 safely. Phases 3 and 4 were combined at the maintainer's request, as were
 Phases 5 through 7 and Phases 8a through 8c; each combined changeset preserves
-the same green-boundary requirements. At every merge boundary:
+the same green-boundary requirements. Phases 8d, 8e, and 9 form one further
+maintainer-requested combined PR. At every merge boundary:
 
 - the compiler and both execution backends remain functional;
 - `make` passes;
@@ -308,12 +309,12 @@ Move glob tables, stash/package objects, and alias maps.
 Move declared-global sets, package-existence caches, class-loader ownership, and
 remaining symbol-table runtime state.
 
-Each remaining Phase 8 subphase normally forms its own PR; 8a through 8c are a
-maintainer-requested combined exception. Acceptance for each: conflicting
-in-scope global state in two runtimes remains isolated on JVM and interpreter
-backends; global, lexical, and eval benchmarks meet the budget. No phase claims
-alias/stash isolation before 8d or declaration/package-service isolation before
-8e.
+Each remaining Phase 8 subphase normally forms its own PR; 8a through 8c and
+the 8d-through-9 group are maintainer-requested combined exceptions. Acceptance
+for each: conflicting in-scope global state in two runtimes remains isolated on
+JVM and interpreter backends; global, lexical, and eval benchmarks meet the
+budget. No phase claims alias/stash isolation before 8d or declaration/package-
+service isolation before 8e.
 
 ### Phase 9 — RuntimeCode and eval caches
 
@@ -465,172 +466,34 @@ measured benefit over platform threads/full clone.
 
 ## 7. Progress Tracking
 
-### Current Status: Phases 8a through 8c complete; combined PR ready for review
+### Current Status: Phases 8d through 9 complete; combined PR ready for review
 
-### Completed Phases
+Runtime-owned state now includes glob/stash aliases and enumeration caches;
+declarations, package/class/field/version services, and generated classloaders;
+and RuntimeCode eval registries, caches, callsites, inline caches, and backend
+selection flags. `Config` thread flags remain disabled. The paired six-benchmark
+matrix is within budget after batching hot-path runtime lookups. Exact-tree
+`make` passes; the comprehensive gate is core 83.0% and bundled modules 80.8%.
+Scalar::Util 1.70, Moo 2.005005, and focused stash/glob/strict/eval tests pass
+on both backends, apart from one interpreter eval/goto miss reproduced exactly
+on merged master. Three-run CPU medians versus the same base improved by about
+9% global, 14% lexical, 14% method, 3% closure, 2% regex, and 4% eval-string.
 
-- [x] Phase 1: Import health and compiler identity safety (2026-08-10)
-  - Made the 208-entry Perl 5 import replay idempotent.
-  - Preserved CPAN provider/prerequisite/heap adaptations as importer patches.
-  - Repaired malformed Data::Dumper and stale manifest-test patches.
-  - Made compiler-generated identifiers atomic and control-flow analysis local.
-  - Added concurrent generated-class-name coverage.
-  - Validation: `make` passed; `make test-all` completed with the recorded
-    compatibility baseline (core 82.9%, bundled modules 80.8%).
-  - Merged as PR #915 on 2026-08-11.
-- [x] Phase 2: Serialized compilation (2026-08-11)
-  - Added one reentrant compilation lock with an idempotent, one-hold guard.
-  - Serialized initial source/AST compilation, both interpreter eval roots,
-    JVM eval compilation, lazy named-sub materialization, reset, and verifier
-    fallback compilation.
-  - Kept ordinary program/eval execution outside each entry point's own hold;
-    compile-time `BEGIN` wrapper execution remains inside the enclosing hold.
-  - Restored compiler scope, eval aliases, and hint state under the lock and
-    made lexer/parser failures release their exact acquisition.
-  - Added deterministic queueing, reentrancy, failure-cleanup, mixed-backend
-    concurrency, nested `BEGIN`/eval, and unlocked-execution tests.
-  - Files: `PerlLanguageProvider.java`, `EvalStringHandler.java`,
-    `RuntimeCode.java`, `SubroutineParser.java`, and `CompilationLockTest.java`.
-  - Validation: `make` passed; focused eval regressions passed under system
-    Perl and both PerlOnJava backends; Scalar::Util 1.70 and Moo 2.005005 loaded
-    successfully on both backends; `make test-all` completed at core 83.0% and
-    bundled modules 80.8%.
-  - Audit delta: no runtime state moved and no production worker was added; the
-    new lock is the only mutable static and covers the newly identified lazy-sub
-    and verifier-fallback compiler escape paths.
-  - Merged as PR #918 on 2026-08-11.
-- [x] Phase 3: `PerlRuntime` shell and scoped binding (2026-08-11)
-  - Added an empty runtime identity object backed by an ordinary, non-inherited
-    `ThreadLocal` binding-frame stack; no mutable interpreter state moved.
-  - Scoped bindings restore exact nested state, remove absent bindings, and
-    reject cross-thread or out-of-order closure.
-  - Bound CLI lifetime, provider ownership roots, JSR-223 engines and compiled
-    scripts, require/do, and both eval compilation/execution families.
-  - Public provider calls temporarily create a shell only when invoked by an
-    unbound embedding caller; nested require/eval paths require the existing
-    runtime so missing worker propagation fails clearly.
-  - Added absence, nesting, exception, ownership, non-inheritance, executor
-    reuse, two-thread isolation, provider, nested require/eval, and JSR-223
-    lifecycle tests.
-  - Deliberately deferred regex timeout and alarm worker binding until the same
-    PR that migrates the state each worker uses. I/O router, process, and Netty
-    callback bindings land with Phase 4 in this combined PR.
-  - `globalInitialized` and all other runtime state remain static by design in
-    this shell-only phase; `Config` thread flags remain disabled.
-- [x] Phase 4: I/O state isolation (2026-08-11)
-  - Moved standard input/output/error handles, the selected/last-used handle
-    bookkeeping, and the open-handle cache into `PerlRuntime` behind stable
-    `RuntimeIO` accessors.
-  - Routed uppercase and lowercase standard-handle globs through the bound
-    runtime, including glob localization/restoration and generated JVM readline
-    bookkeeping.
-  - Captured and scoped the originating runtime in pipe routers, system-process
-    routers, IPC::Open3 copying, PerlOnJava::Process output, and Netty request
-    and streaming callbacks.
-  - Added independent-default, nested-state, simultaneous low-level write,
-    reset isolation, generated-readline bookkeeping, deterministic router
-    propagation, standard-glob lifecycle, and JSR-223 engine ownership tests.
-    Concurrent full Perl execution remains intentionally deferred because
-    Phase 5 stack state is still process-global.
-  - Kept fileno, child-process, phantom-handle, terminal-service, regex, and
-    alarm state explicitly deferred to their inventory phases.
-  - Validation: `make` passed; the final exact-tree `make test-all` completed
-    at core 83.2% and bundled modules 80.8%. Twenty-four focused I/O runs
-    passed across JVM and interpreter backends, as did IPC::Open3 and the
-    Scalar::Util 1.70/Moo 2.005005 smoke tests on both backends.
-  - The interpreter-only TAP miss in `nonblocking_pipe_syswrite.t` assertion 8
-    was reproduced on the exact PR #918 base and is therefore pre-existing;
-    the JVM backend and the remaining focused assertions pass.
-- [x] Phase 5: Execution stacks and special blocks (2026-08-11)
-  - Added per-runtime execution state for caller/dynamic scope, interpreter and
-    eval frames, argument/context/lexical stacks, recursion tracking, control
-    flow, lexical cleanup registrations, and every current localization stack.
-  - Moved live output separators and `CHECK`/`INIT`/`END` queues with their
-    reset and `Internals::B::end_av` consumers, preserving current ordering.
-  - Captured the owning runtime for asynchronous Future callbacks before they
-    resume Perl execution on an arbitrary Java thread.
-  - Kept package-global values shared until Phase 8 and kept the coupled
-    mortal/weak/`DESTROY` sweep machinery together for Phase 11.
-- [x] Phase 6: Regex state and timeout binding (2026-08-11)
-  - Moved all match/capture metadata, offsets, `/g` positions, compiled-regex
-    caches, `/o`, and match-once state into the bound runtime.
-  - Made regex snapshots restore the complete state and reject cross-runtime
-    restoration.
-  - Captured and scoped the runtime in timeout workers, made those workers
-    daemon and cancellation-aware, and serialized the remaining compile-only
-    regex-preprocessor scratch behind the compilation boundary.
-  - Deferred process-wide alarm/signal ownership to Phase 11 while covering
-    the sequential alarm-mediated regex path that regressed PR #480.
-- [x] Phase 7: Inheritance and method caches (2026-08-11)
-  - Moved MRO policy, method/overload/ISA caches, package generations,
-    reverse-ISA data, and AUTOLOAD policy into each runtime.
-  - Added temporary process-wide symbol and ISA mutation epochs so a runtime
-    cannot retain stale derived entries while symbol tables remain shared.
-  - Kept conflicting package/method declarations explicitly deferred to the
-    Phase 8 symbol-table migrations.
-  - Added deterministic low-level isolation tests for all three phases and
-    retained existing Storable assertions while giving affected fixtures an
-    explicit runtime binding.
-  - Validation: the exact-tree `make` completed successfully; 38 focused Perl
-    runs passed across JVM and interpreter backends except one interpreter
-    caller-context failure reproduced identically on PR #920's merge base.
-    Scalar::Util 1.70 and Moo 2.005005 loaded on both backends. Method and
-    closure benchmarks improved; regex matching is approximately 10% slower
-    from the required runtime lookup and is recorded for Phase 13 recovery.
-    The comprehensive gate completed at core 82.9% and bundled modules 81.0%.
-- [x] Phases 8a-8c: Runtime-owned globals, CODE, IO, and formats (2026-08-11)
-  - Added `GlobalRuntimeState` and moved scalar, array, hash, foreach-alias,
-    CODE, pseudo-constant, pin, compiled-CV, named IO, hidden-IO, and format
-    storage behind the existing `GlobalVariable` facades.
-  - Made core-global initialization and stash-enumeration invalidation
-    runtime-owned. `CompilerOptions` now builds a detached argument array and
-    installs that exact object as the bound runtime's `@ARGV` during global
-    initialization.
-  - Preserved CODE identity and Perl's declared-but-undefined semantics across
-    `undef &name`, including package/subroutine metadata and pin behavior.
-  - Added nested-binding, simultaneous-runtime, reset, JSR-223, JVM, and
-    interpreter coverage for conflicting global values, named subs/prototypes,
-    named filehandles, and formats. New Perl semantic tests pass first under
-    system Perl and then under both PerlOnJava backends.
-  - Repaired the `re/pat.t` regression discovered after PR #921: regex-worker
-    cancellation now unwinds silently instead of reporting the internal
-    ten-second deadline, and the alarm scheduler binds its captured runtime
-    before reading `%SIG` and queuing `ALRM`. The exact pre-PR result is restored
-    at 1098/1302, including test 1149 on both compiler backends' reproducer.
-  - Validation: exact-tree `make` passed; Scalar::Util 1.70 and Moo 2.005005
-    loaded on both backends; the comprehensive gate completed at core 83.0%
-    and bundled modules 80.8%.
-  - Same-base three-run medians: lexical improved about 1%; global access is
-    about 34% slower and eval-string about 15% slower from the required bound-
-    runtime lookup. These exceed the normal 5% budget and are explicitly
-    presented for review as a temporary exception, with generated-code runtime
-    caching deferred to the dedicated performance-recovery phase. Thread
-    compatibility flags remain disabled.
+### Implementation History
 
-### Phase 1 Work Completed (2026-08-10)
-
-- [x] Audited the four files changed by `dev/import-perl5/sync.pl`.
-- [x] Identified lost PerlOnJava adaptations and a malformed Data::Dumper patch.
-- [x] Added replayable CPAN script/module/queue patches and repaired Data::Dumper.
-- [x] Repaired the stale manifest-test patch against the current Perl 5 source.
-- [x] Verified affected filtered sync operations are idempotent.
-- [x] Converted current compiler-generated ID allocation to atomic operations.
-- [x] Removed shared mutable control-flow visitor state.
-- [x] Added a concurrent generated-class-name uniqueness test.
-- [x] Ran full import replay twice with zero diff.
-- [x] Ran targeted system-Perl/JVM/interpreter tests.
-- [x] Ran full `make` and the available comprehensive gate.
-- [x] Prepared the final Phase 1 commit for review.
+Completed phase history is intentionally kept out of this living design
+document. The implementation record, validation details, regressions, and
+review decisions can be recovered from the phase commit messages and pull-
+request history.
 
 ### Next Steps
 
-1. Review and merge the combined Phase 8a-8c runtime-global PR while `Config`
-   thread flags remain disabled, including the documented temporary benchmark
-   exception.
-2. Start Phase 8d from updated `master`: migrate glob tables, aliases, and
-   stashes as one atomic symbol-identity change.
-3. Keep Phase 8e declarations, package services, and class-loader ownership in
-   its own independently green PR.
+1. Finish validation and review the combined Phase 8d-through-9 PR while
+   `Config` thread flags remain disabled.
+2. Start Phase 10 from updated `master`: classify compile-only versus runtime
+   hints, warnings, filters, and source maps before migrating runtime state.
+3. Re-audit and split Phase 11's lifecycle/miscellaneous inventory into atomic,
+   independently green ownership domains before implementation.
 
 ### Open Questions
 

--- a/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
+++ b/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
@@ -144,7 +144,7 @@ public class PerlLanguageProvider {
 
         // The compiler options are also the source of truth for nested loads.
         // ModuleOperators creates fresh CompilerOptions instances for require/use
-        // and reads RuntimeCode.USE_INTERPRETER when choosing their backend.  If
+        // and reads the bound runtime's interpreter option when choosing their backend. If
         // an embedding caller sets useInterpreter directly (rather than using the
         // CLI, which updates that runtime flag), the top-level program would run
         // in the interpreter while its modules were still compiled as JVM code.

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -2982,7 +2982,7 @@ public class BytecodeCompiler implements Visitor {
                     boolean isDeclaredReference = node.annotations != null &&
                             Boolean.TRUE.equals(node.annotations.get("isDeclaredReference"));
 
-                    Integer beginId = RuntimeCode.evalBeginIds.get(sigilOp);
+                    Integer beginId = RuntimeCode.evalBeginIds().get(sigilOp);
                     if (beginId != null) {
                         // BEGIN-captured variable: use RETRIEVE_BEGIN_* (destructive removal from global storage)
                         int persistId = beginId;
@@ -3399,7 +3399,7 @@ public class BytecodeCompiler implements Visitor {
                                 continue;
                             }
 
-                            Integer beginId2 = RuntimeCode.evalBeginIds.get(sigilOp);
+                            Integer beginId2 = RuntimeCode.evalBeginIds().get(sigilOp);
                             if (beginId2 != null || op.equals("state")) {
                                 int persistId = beginId2 != null ? beginId2 : sigilOp.id;
                                 int reg = allocateRegister();
@@ -5713,7 +5713,7 @@ public class BytecodeCompiler implements Visitor {
         copySignatureMetadata(subCode, node.block);
         attachDeparseSourceSpan(subCode, node);
 
-        if (RuntimeCode.DISASSEMBLE) {
+        if (RuntimeCode.isDisassemble()) {
             System.out.println(Disassemble.disassemble(subCode));
         }
 
@@ -5860,7 +5860,7 @@ public class BytecodeCompiler implements Visitor {
             subCode.isMapGrepBlock = true;
         }
 
-        if (RuntimeCode.DISASSEMBLE) {
+        if (RuntimeCode.isDisassemble()) {
             System.out.println(Disassemble.disassemble(subCode));
         }
 

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
@@ -17,7 +17,7 @@ public class CompileAssignment {
 
     private static boolean compileForwardCodeGlobAlias(
             BytecodeCompiler bc, Node lhs, Node rhs) {
-        if (!RuntimeCode.USE_INTERPRETER
+        if (!RuntimeCode.isUseInterpreter()
                 || !(lhs instanceof OperatorNode globOp) || !globOp.operator.equals("*")
                 || !(rhs instanceof OperatorNode refOp) || !refOp.operator.equals("\\")
                 || !(refOp.operand instanceof OperatorNode codeOp) || !codeOp.operator.equals("&")
@@ -456,7 +456,7 @@ public class CompileAssignment {
                         if (sigilOp.operator.equals("$") && sigilOp.operand instanceof IdentifierNode) {
                             String varName = "$" + ((IdentifierNode) sigilOp.operand).name;
 
-                            Integer beginIdObj = RuntimeCode.evalBeginIds.get(sigilOp);
+                            Integer beginIdObj = RuntimeCode.evalBeginIds().get(sigilOp);
                             if (beginIdObj != null) {
                                 int beginId = beginIdObj;
                                 int nameIdx = bytecodeCompiler.addToStringPool(varName);
@@ -558,7 +558,7 @@ public class CompileAssignment {
                             // Handle my @array = ...
                             String varName = "@" + ((IdentifierNode) sigilOp.operand).name;
 
-                            Integer beginIdArr = RuntimeCode.evalBeginIds.get(sigilOp);
+                            Integer beginIdArr = RuntimeCode.evalBeginIds().get(sigilOp);
                             if (beginIdArr != null) {
                                 int beginId = beginIdArr;
                                 int nameIdx = bytecodeCompiler.addToStringPool(varName);
@@ -633,7 +633,7 @@ public class CompileAssignment {
                             // Handle my %hash = ...
                             String varName = "%" + ((IdentifierNode) sigilOp.operand).name;
 
-                            Integer beginIdHash = RuntimeCode.evalBeginIds.get(sigilOp);
+                            Integer beginIdHash = RuntimeCode.evalBeginIds().get(sigilOp);
                             if (beginIdHash != null) {
                                 int beginId = beginIdHash;
                                 int nameIdx = bytecodeCompiler.addToStringPool(varName);
@@ -763,7 +763,7 @@ public class CompileAssignment {
                                     String varName = sigil + ((IdentifierNode) sigilOp.operand).name;
                                     int varReg;
 
-                                    Integer beginIdList = RuntimeCode.evalBeginIds.get(sigilOp);
+                                    Integer beginIdList = RuntimeCode.evalBeginIds().get(sigilOp);
                                     if (beginIdList != null) {
                                         int beginId = beginIdList;
                                         int nameIdx = bytecodeCompiler.addToStringPool(varName);

--- a/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
@@ -439,7 +439,7 @@ public class EvalStringHandler {
 
             evalTrace("EvalStringHandler compiled bytecodeLen=" + (evalCode != null ? evalCode.bytecode.length : -1) +
                     " src=" + (evalCode != null ? evalCode.sourceName : "null"));
-            if (RuntimeCode.DISASSEMBLE) {
+            if (RuntimeCode.isDisassemble()) {
                 System.out.println(Disassemble.disassemble(evalCode));
             }
 
@@ -615,7 +615,7 @@ public class EvalStringHandler {
                     errorUtil
             );
             InterpretedCode evalCode = compiler.compile(ast, ctx);  // Pass ctx for context propagation
-            if (RuntimeCode.DISASSEMBLE) {
+            if (RuntimeCode.isDisassemble()) {
                 System.out.println(Disassemble.disassemble(evalCode));
             }
 

--- a/src/main/java/org/perlonjava/backend/jvm/EmitEval.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitEval.java
@@ -34,7 +34,7 @@ import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
  *       for each eval site. This tag links the runtime eval to its compile-time context</li>
  *   <li><b>Reflection for Instantiation:</b> We use Constructor.newInstance() rather than
  *       direct instantiation because class names are generated at runtime</li>
- *   <li><b>Global ClassLoader:</b> All eval classes use GlobalVariable.globalClassLoader
+ *   <li><b>Runtime ClassLoader:</b> Eval classes use GlobalVariable.getGlobalClassLoader()
  *       to ensure they can reference each other and share the same namespace</li>
  * </ul>
  *
@@ -169,7 +169,7 @@ public class EmitEval {
 
         // Store the context in a static map, indexed by evalTag
         // This allows the runtime compilation to access the compile-time environment
-        RuntimeCode.evalContext.put(evalTag, evalCtx);
+        RuntimeCode.putEvalContext(evalTag, evalCtx);
 
         // Generate bytecode to evaluate the eval string expression
         // This pushes the string value onto the stack

--- a/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
@@ -265,7 +265,8 @@ public class EmitSubroutine {
             String newClassNameDot = subCtx.javaClassInfo.javaClassName.replace('/', '.');
             if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("Generated class name: " + newClassNameDot + " internal " + subCtx.javaClassInfo.javaClassName);
             if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("Generated class env:  " + Arrays.toString(newEnv));
-            RuntimeCode.anonSubs.put(subCtx.javaClassInfo.javaClassName, generatedClass); // Cache the class
+            RuntimeCode.registerAnonymousSub(
+                    subCtx.javaClassInfo.javaClassName, generatedClass); // Cache the class
 
             String cvStartFile = "-e";
             int cvStartLine = 0;
@@ -310,7 +311,7 @@ public class EmitSubroutine {
             // Transfer pad constants (cached string literals referenced via \) from compile time
             // to a registry so makeCodeObject() can attach them to the RuntimeCode at runtime.
             if (subCtx.javaClassInfo.padConstants != null && !subCtx.javaClassInfo.padConstants.isEmpty()) {
-                RuntimeCode.padConstantsByClassName.put(subCtx.javaClassInfo.javaClassName,
+                RuntimeCode.registerPadConstants(subCtx.javaClassInfo.javaClassName,
                         subCtx.javaClassInfo.padConstants.toArray(new RuntimeBase[0]));
             }
 
@@ -382,19 +383,15 @@ public class EmitSubroutine {
             
             // Store the InterpretedCode in the interpretedSubs map with a unique key
             String fallbackKey = "interpreted_" + System.identityHashCode(fallback.interpretedCode);
-            RuntimeCode.interpretedSubs.put(fallbackKey, fallback.interpretedCode);
+            RuntimeCode.putInterpretedSub(fallbackKey, fallback.interpretedCode);
             
             // Generate bytecode to retrieve and configure the InterpretedCode
             // 1. Load the InterpretedCode from the map
-            mv.visitFieldInsn(Opcodes.GETSTATIC,
-                    "org/perlonjava/runtime/runtimetypes/RuntimeCode",
-                    "interpretedSubs",
-                    "Ljava/util/HashMap;");
             mv.visitLdcInsn(fallbackKey);
-            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
-                    "java/util/HashMap",
-                    "get",
-                    "(Ljava/lang/Object;)Ljava/lang/Object;",
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                    "org/perlonjava/runtime/runtimetypes/RuntimeCode",
+                    "getInterpretedSub",
+                    "(Ljava/lang/String;)Ljava/lang/Object;",
                     false);
             mv.visitTypeInsn(Opcodes.CHECKCAST, "org/perlonjava/backend/bytecode/InterpretedCode");
             
@@ -546,18 +543,14 @@ public class EmitSubroutine {
         if (compileTimeAttributeCodeRef != null) {
             String key = "compile_time_attr_"
                     + System.identityHashCode(compileTimeAttributeCodeRef);
-            RuntimeCode.interpretedSubs.put(key, compileTimeAttributeCodeRef);
+            RuntimeCode.putInterpretedSub(key, compileTimeAttributeCodeRef);
 
             // Stack: [compiledRef]
-            mv.visitFieldInsn(Opcodes.GETSTATIC,
-                    "org/perlonjava/runtime/runtimetypes/RuntimeCode",
-                    "interpretedSubs",
-                    "Ljava/util/HashMap;");
             mv.visitLdcInsn(key);
-            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
-                    "java/util/HashMap",
-                    "get",
-                    "(Ljava/lang/Object;)Ljava/lang/Object;",
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                    "org/perlonjava/runtime/runtimetypes/RuntimeCode",
+                    "getInterpretedSub",
+                    "(Ljava/lang/String;)Ljava/lang/Object;",
                     false);
             mv.visitTypeInsn(Opcodes.CHECKCAST,
                     "org/perlonjava/runtime/runtimetypes/RuntimeScalar");

--- a/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
@@ -1489,7 +1489,7 @@ public class EmitVariable {
                     String className = EmitterMethodCreator.getVariableClassName(sigil);
 
                     if (operator.equals("my")) {
-                        Integer beginId = RuntimeCode.evalBeginIds.get(sigilNode);
+                        Integer beginId = RuntimeCode.evalBeginIds().get(sigilNode);
                         if (beginId == null) {
                             ctx.mv.visitTypeInsn(Opcodes.NEW, className);
                             ctx.mv.visitInsn(Opcodes.DUP);

--- a/src/main/java/org/perlonjava/backend/jvm/EmitterMethodCreator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitterMethodCreator.java
@@ -1454,7 +1454,7 @@ public class EmitterMethodCreator implements Opcodes {
                     PrintWriter verifyPw = new PrintWriter(System.err);
                     String thisClassNameDot = className.replace('/', '.');
                     final byte[] verifyClassData = classData;
-                    ClassLoader verifyLoader = new ClassLoader(GlobalVariable.globalClassLoader) {
+                    ClassLoader verifyLoader = new ClassLoader(GlobalVariable.getGlobalClassLoader()) {
                         @Override
                         protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
                             if (name.equals(thisClassNameDot)) {
@@ -1496,7 +1496,7 @@ public class EmitterMethodCreator implements Opcodes {
                     PrintWriter verifyPw = new PrintWriter(System.err);
                     String thisClassNameDot = className.replace('/', '.');
                     final byte[] verifyClassData = classData;
-                    ClassLoader verifyLoader = new ClassLoader(GlobalVariable.globalClassLoader) {
+                    ClassLoader verifyLoader = new ClassLoader(GlobalVariable.getGlobalClassLoader()) {
                         @Override
                         protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
                             if (name.equals(thisClassNameDot)) {
@@ -1546,7 +1546,7 @@ public class EmitterMethodCreator implements Opcodes {
                     PrintWriter verifyPw = new PrintWriter(System.err);
                     String thisClassNameDot = className.replace('/', '.');
                     final byte[] verifyClassData = classData;
-                    ClassLoader verifyLoader = new ClassLoader(GlobalVariable.globalClassLoader) {
+                    ClassLoader verifyLoader = new ClassLoader(GlobalVariable.getGlobalClassLoader()) {
                         @Override
                         protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
                             if (name.equals(thisClassNameDot)) {
@@ -1704,8 +1704,8 @@ public class EmitterMethodCreator implements Opcodes {
      * @return The loaded Class object
      */
     public static Class<?> loadBytecode(EmitterContext ctx, byte[] classData) {
-        // Use the global class loader to ensure all generated classes are in the same namespace
-        CustomClassLoader loader = GlobalVariable.globalClassLoader;
+        // Use the runtime's class loader so its generated classes share one namespace.
+        CustomClassLoader loader = GlobalVariable.getGlobalClassLoader();
 
         // Create a "Java" class name with dots instead of slashes
         String javaClassNameDot = ctx.javaClassInfo.javaClassName.replace('/', '.');

--- a/src/main/java/org/perlonjava/frontend/parser/FieldRegistry.java
+++ b/src/main/java/org/perlonjava/frontend/parser/FieldRegistry.java
@@ -1,30 +1,32 @@
 package org.perlonjava.frontend.parser;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
+
 /**
- * Global registry for tracking field declarations across class hierarchy at parse time.
+ * Runtime-owned registry for tracking field declarations across class hierarchy at parse time.
  * This works when parent classes are parsed before child classes (common case).
  * <p>
- * Unlike the symbol table which is scoped, this is a global registry that persists
+ * Unlike the symbol table which is scoped, this registry persists within a runtime
  * across class boundaries, allowing child classes to look up parent fields.
  */
 public class FieldRegistry {
-    // Map from class name to set of field names defined in that class
-    private static final Map<String, Set<String>> classFields = new HashMap<>();
+    private static Map<String, Set<String>> classFields() {
+        return PerlRuntime.current().globalState().classFields();
+    }
 
-    // Map from class name to its parent class (from :isa attribute)
-    // This is populated at parse time when we see :isa(Parent)
-    private static final Map<String, String> classParents = new HashMap<>();
+    private static Map<String, String> classParents() {
+        return PerlRuntime.current().globalState().classParents();
+    }
 
     /**
      * Register a field declaration in a class
      */
     public static void registerField(String className, String fieldName) {
-        classFields.computeIfAbsent(className, k -> new HashSet<>()).add(fieldName);
+        classFields().computeIfAbsent(className, k -> new HashSet<>()).add(fieldName);
     }
 
     /**
@@ -32,21 +34,21 @@ public class FieldRegistry {
      * Called when we parse :isa(Parent) at parse time
      */
     public static void registerParentClass(String childClass, String parentClass) {
-        classParents.put(childClass, parentClass);
+        classParents().put(childClass, parentClass);
     }
 
     /**
      * Get all fields from a class (not including inherited fields)
      */
     public static Set<String> getClassFields(String className) {
-        return classFields.getOrDefault(className, new HashSet<>());
+        return classFields().getOrDefault(className, new HashSet<>());
     }
 
     /**
      * Get the parent class of a given class
      */
     public static String getParentClass(String className) {
-        return classParents.get(className);
+        return classParents().get(className);
     }
 
     /**
@@ -65,13 +67,13 @@ public class FieldRegistry {
         visited.add(className);
 
         // Check if field exists in current class
-        Set<String> fields = classFields.get(className);
+        Set<String> fields = classFields().get(className);
         if (fields != null && fields.contains(fieldName)) {
             return true;
         }
 
         // Check parent class recursively (if it was parsed)
-        String parentClass = classParents.get(className);
+        String parentClass = classParents().get(className);
         if (parentClass != null) {
             return hasFieldInHierarchyHelper(parentClass, fieldName, visited);
         }
@@ -83,7 +85,7 @@ public class FieldRegistry {
      * Clear the registry (useful for testing)
      */
     public static void clear() {
-        classParents.clear();
-        classFields.clear();
+        classParents().clear();
+        classFields().clear();
     }
 }

--- a/src/main/java/org/perlonjava/frontend/parser/SpecialBlockParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SpecialBlockParser.java
@@ -279,8 +279,8 @@ public class SpecialBlockParser {
                                     new IdentifierNode(packageName, tokenIndex), tokenIndex));
                 } else {
                     OperatorNode ast = entry.ast();
-                    isFromOuterScope = RuntimeCode.evalBeginIds.containsKey(ast);
-                    int beginId = RuntimeCode.evalBeginIds.computeIfAbsent(
+                    isFromOuterScope = RuntimeCode.evalBeginIds().containsKey(ast);
+                    int beginId = RuntimeCode.evalBeginIds().computeIfAbsent(
                             ast,
                             k -> EmitterMethodCreator.classCounter.getAndIncrement());
                     packageName = PersistentVariable.beginPackage(beginId);

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -1485,9 +1485,9 @@ public class SubroutineParser {
                     int beginId;
                     if ("state".equals(entry.decl()) && ast != null && ast.id != 0) {
                         beginId = ast.id;
-                        RuntimeCode.evalBeginIds.putIfAbsent(ast, beginId);
+                        RuntimeCode.evalBeginIds().putIfAbsent(ast, beginId);
                     } else {
-                        beginId = RuntimeCode.evalBeginIds.computeIfAbsent(
+                        beginId = RuntimeCode.evalBeginIds().computeIfAbsent(
                                 ast,
                                 k -> EmitterMethodCreator.classCounter.getAndIncrement());
                     }

--- a/src/main/java/org/perlonjava/frontend/semantic/ScopedSymbolTable.java
+++ b/src/main/java/org/perlonjava/frontend/semantic/ScopedSymbolTable.java
@@ -3,6 +3,7 @@ package org.perlonjava.frontend.semantic;
 import org.perlonjava.frontend.astnode.OperatorNode;
 import org.perlonjava.runtime.runtimetypes.FeatureFlags;
 import org.perlonjava.runtime.runtimetypes.PerlCompilerException;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 import org.perlonjava.runtime.runtimetypes.WarningFlags;
 
 import java.util.*;
@@ -17,8 +18,9 @@ public class ScopedSymbolTable {
     // Mapping of warning and feature names to bit positions
     private static final Map<String, Integer> warningBitPositions = new HashMap<>();
     private static final Map<String, Integer> featureBitPositions = new HashMap<>();
-    // Global package version storage (static so it persists across all symbol table instances)
-    private static final Map<String, String> packageVersions = new HashMap<>();
+    private static Map<String, String> packageVersions() {
+        return PerlRuntime.current().globalState().packageVersions();
+    }
 
     static {
         // Initialize warning bit positions
@@ -161,7 +163,7 @@ public class ScopedSymbolTable {
      * Clears all package versions. Called during global initialization.
      */
     public static void clearPackageVersions() {
-        packageVersions.clear();
+        packageVersions().clear();
     }
 
     /**
@@ -663,7 +665,7 @@ public class ScopedSymbolTable {
      */
     public void setPackageVersion(String packageName, String version) {
         // Store in global map so version persists across scopes
-        packageVersions.put(packageName, version);
+        packageVersions().put(packageName, version);
 
         // Also update the current package on the stack if it matches
         if (!packageStack.isEmpty()) {
@@ -683,7 +685,7 @@ public class ScopedSymbolTable {
      */
     public String getPackageVersion(String packageName) {
         // First check the global map
-        return packageVersions.get(packageName);
+        return packageVersions().get(packageName);
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
@@ -636,8 +636,8 @@ public class ModuleOperators {
         parsedArgs.fileName = actualFileName;
         parsedArgs.incHook = incHookRef;
         parsedArgs.applySourceFilters = shouldApplyFilters;  // Enable source filter preprocessing if needed
-        parsedArgs.disassembleEnabled = RuntimeCode.DISASSEMBLE;
-        parsedArgs.useInterpreter = RuntimeCode.USE_INTERPRETER;
+        parsedArgs.disassembleEnabled = RuntimeCode.isDisassemble();
+        parsedArgs.useInterpreter = RuntimeCode.isUseInterpreter();
         if (jarPrefetchedBytes != null) {
             code = FileUtils.decodePerlSourceBytes(jarPrefetchedBytes, parsedArgs);
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ClassRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ClassRegistry.java
@@ -1,14 +1,15 @@
 package org.perlonjava.runtime.runtimetypes;
 
-import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Registry to track which packages are Perl 5.38+ classes (not just regular packages).
+ * Runtime-owned registry of packages that are Perl 5.38+ classes (not just regular packages).
  * This is used to determine whether blessed objects should stringify as OBJECT or HASH.
  */
 public class ClassRegistry {
-    private static final Set<String> classNames = new HashSet<>();
+    private static Set<String> classNames() {
+        return PerlRuntime.current().globalState().classNames();
+    }
 
     /**
      * Register a package name as a Perl 5.38+ class.
@@ -17,7 +18,7 @@ public class ClassRegistry {
      * @param className The name of the class
      */
     public static void registerClass(String className) {
-        classNames.add(className);
+        classNames().add(className);
     }
 
     /**
@@ -27,13 +28,13 @@ public class ClassRegistry {
      * @return true if this is a class, false if it's a regular package
      */
     public static boolean isClass(String packageName) {
-        return classNames.contains(packageName);
+        return classNames().contains(packageName);
     }
 
     /**
      * Clear all registered classes (useful for testing).
      */
     public static void clear() {
-        classNames.clear();
+        classNames().clear();
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeState.java
@@ -1,17 +1,20 @@
 package org.perlonjava.runtime.runtimetypes;
 
+import org.perlonjava.backend.jvm.CustomClassLoader;
+
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
  * Runtime-owned Perl global state.
  *
- * <p>Phases 8a through 8c own scalar/array/hash values, CODE-slot state, and
- * named IO/format slots. Globs, stashes, aliases, declarations, and package
- * services move in later Phase 8 changes.</p>
+ * <p>Phases 8a through 8e own scalar/array/hash values, CODE-slot state,
+ * named IO/format slots, glob/stash identity, declarations, and package
+ * services.</p>
  */
 public final class GlobalRuntimeState {
     private final Map<String, RuntimeScalar> scalarValues = new HashMap<>();
@@ -31,8 +34,24 @@ public final class GlobalRuntimeState {
     private final Map<String, RuntimeGlob> ioSlots = new HashMap<>();
     private final Map<String, RuntimeFormat> formatSlots = new HashMap<>();
     private final Set<String> hiddenIoSlotsAfterStashDelete = new HashSet<>();
+    private final Map<String, String> stashAliases = new HashMap<>();
+    private final Map<String, String> resolvedStashAliases = new HashMap<>();
+    private final Map<String, String> globAliases = new HashMap<>();
+    private final Map<String, List<HashSpecialVariable.StashEntryName>> stashEntryCache =
+            new HashMap<>();
+    private final Map<String, Boolean> packageExistsCache = new HashMap<>();
+    private final Set<String> declaredGlobalVariables = new HashSet<>();
+    private final Set<String> declaredGlobalArrays = new HashSet<>();
+    private final Set<String> declaredGlobalHashes = new HashSet<>();
+    private final Set<String> classNames = new HashSet<>();
+    private final Map<String, Set<String>> classFields = new HashMap<>();
+    private final Map<String, String> classParents = new HashMap<>();
+    private final Map<String, String> packageVersions = new HashMap<>();
+    private CustomClassLoader generatedClassLoader =
+            new CustomClassLoader(GlobalVariable.class.getClassLoader());
     private int nextCompiledCodeRefId = 1;
     private long stashEnumerationVersion;
+    private long cachedStashEnumerationVersion = -1;
     private boolean coreGlobalsInitialized;
 
     /** Core package scalar slots owned by this runtime. */
@@ -102,6 +121,74 @@ public final class GlobalRuntimeState {
         return hiddenIoSlotsAfterStashDelete;
     }
 
+    Map<String, String> stashAliases() {
+        return stashAliases;
+    }
+
+    Map<String, String> resolvedStashAliases() {
+        return resolvedStashAliases;
+    }
+
+    Map<String, String> globAliases() {
+        return globAliases;
+    }
+
+    Map<String, List<HashSpecialVariable.StashEntryName>> stashEntryCache() {
+        return stashEntryCache;
+    }
+
+    Map<String, Boolean> packageExistsCache() {
+        return packageExistsCache;
+    }
+
+    Set<String> declaredGlobalVariables() {
+        return declaredGlobalVariables;
+    }
+
+    Set<String> declaredGlobalArrays() {
+        return declaredGlobalArrays;
+    }
+
+    Set<String> declaredGlobalHashes() {
+        return declaredGlobalHashes;
+    }
+
+    /** Perl 5.38+ class declarations owned by this runtime. */
+    public Set<String> classNames() {
+        return classNames;
+    }
+
+    /** Field declarations keyed by their owning Perl class. */
+    public Map<String, Set<String>> classFields() {
+        return classFields;
+    }
+
+    /** Parent declarations used by the class-field parser. */
+    public Map<String, String> classParents() {
+        return classParents;
+    }
+
+    /** Package versions visible to later compilation units in this runtime. */
+    public Map<String, String> packageVersions() {
+        return packageVersions;
+    }
+
+    CustomClassLoader generatedClassLoader() {
+        return generatedClassLoader;
+    }
+
+    void generatedClassLoader(CustomClassLoader loader) {
+        generatedClassLoader = loader;
+    }
+
+    long cachedStashEnumerationVersion() {
+        return cachedStashEnumerationVersion;
+    }
+
+    void cachedStashEnumerationVersion(long version) {
+        cachedStashEnumerationVersion = version;
+    }
+
     synchronized int registerCompiledCodeRef(RuntimeScalar ref) {
         int id = nextCompiledCodeRefId++;
         compiledCodeRefs.put(id, ref);
@@ -159,5 +246,26 @@ public final class GlobalRuntimeState {
         formatSlots.clear();
         hiddenIoSlotsAfterStashDelete.clear();
         invalidateStashEnumeration();
+    }
+
+    void clearGlobAndStashValues() {
+        stashAliases.clear();
+        resolvedStashAliases.clear();
+        globAliases.clear();
+        stashEntryCache.clear();
+        cachedStashEnumerationVersion = -1;
+        invalidateStashEnumeration();
+    }
+
+    void clearDeclarationsAndPackageServices() {
+        packageExistsCache.clear();
+        declaredGlobalVariables.clear();
+        declaredGlobalArrays.clear();
+        declaredGlobalHashes.clear();
+        classNames.clear();
+        classFields.clear();
+        classParents.clear();
+        packageVersions.clear();
+        generatedClassLoader = new CustomClassLoader(GlobalVariable.class.getClassLoader());
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
@@ -36,7 +35,8 @@ public class GlobalVariable {
     public static final Map<String, RuntimeHash> globalHashes =
             new CurrentRuntimeMap<>(state -> state.hashValues());
     // Cache for package existence checks
-    public static final Map<String, Boolean> packageExistsCache = new HashMap<>();
+    public static final Map<String, Boolean> packageExistsCache =
+            new CurrentRuntimePlainMap<>(state -> state.packageExistsCache());
     // isSubs: Tracks subroutines declared via 'use subs' pragma (e.g., use subs 'hex')
     // Maps fully-qualified names (package::subname) to indicate they should be called
     // as user-defined subroutines instead of built-in operators
@@ -55,32 +55,22 @@ public class GlobalVariable {
     // behave like Src:: for method lookup and stash operations.
     // We keep this separate from globalCodeRefs/globalVariables so existing references
     // to Dst:: symbols can still point to their original objects.
-    static final Map<String, String> stashAliases = new HashMap<>();
+    static final Map<String, String> stashAliases =
+            new CurrentRuntimePlainMap<>(state -> state.stashAliases());
 
     // Glob aliasing: `*a = *b` makes a and b share the same glob.
     // Maps glob names to their canonical (target) name.
     // When looking up or assigning to glob slots, we resolve through this map.
-    static final Map<String, String> globAliases = new HashMap<>();
+    static final Map<String, String> globAliases =
+            new CurrentRuntimePlainMap<>(state -> state.globAliases());
 
     // Flags used by operator override
     // globalGlobs: Tracks typeglob assignments (e.g., *CORE::GLOBAL::hex = sub {...})
     // Used to detect when built-in operators have been globally overridden
     static final Map<String, Boolean> globalGlobs =
             new CurrentRuntimePlainMap<>(state -> state.operatorOverrideGlobs());
-    // Global class loader for all generated classes - not final so we can replace it
-    public static CustomClassLoader globalClassLoader =
-            new CustomClassLoader(GlobalVariable.class.getClassLoader());
-
     // Regular expression for regex variables like $main::1
     static Pattern regexVariablePattern = Pattern.compile("^main::(\\d+)$");
-
-    // Track explicitly declared global variables (via use vars, our, Exporter glob assignment).
-    // Separate from globalVariables/globalArrays/globalHashes to distinguish intentional
-    // declarations from auto-vivification under 'no strict'. Used by strict vars check
-    // for single-letter variable names like $A-$Z (excluding $a/$b).
-    private static final Set<String> declaredGlobalVariables = new HashSet<>();
-    private static final Set<String> declaredGlobalArrays = new HashSet<>();
-    private static final Set<String> declaredGlobalHashes = new HashSet<>();
     static long stashEnumerationVersion() {
         return globalState().stashEnumerationVersion();
     }
@@ -91,6 +81,16 @@ public class GlobalVariable {
 
     private static GlobalRuntimeState globalState() {
         return PerlRuntime.current().globalState;
+    }
+
+    /** Return the generated-class loader owned by the bound runtime. */
+    public static CustomClassLoader getGlobalClassLoader() {
+        return globalState().generatedClassLoader();
+    }
+
+    /** Replace the generated-class loader owned by the bound runtime. */
+    public static void setGlobalClassLoader(CustomClassLoader loader) {
+        globalState().generatedClassLoader(loader);
     }
 
     private static Map<String, RuntimeScalar> foreachGlobalAliases() {
@@ -569,28 +569,28 @@ public class GlobalVariable {
      * Marks a global variable as explicitly declared (e.g., via use vars, Exporter import).
      */
     public static void declareGlobalVariable(String key) {
-        declaredGlobalVariables.add(key);
+        globalState().declaredGlobalVariables().add(key);
     }
 
     /**
      * Marks a global array as explicitly declared.
      */
     public static void declareGlobalArray(String key) {
-        declaredGlobalArrays.add(key);
+        globalState().declaredGlobalArrays().add(key);
     }
 
     /**
      * Marks a global hash as explicitly declared.
      */
     public static void declareGlobalHash(String key) {
-        declaredGlobalHashes.add(key);
+        globalState().declaredGlobalHashes().add(key);
     }
 
     /**
      * Checks if a global variable was explicitly declared (not just auto-vivified).
      */
     public static boolean isDeclaredGlobalVariable(String key) {
-        return declaredGlobalVariables.contains(key)
+        return globalState().declaredGlobalVariables().contains(key)
                 || key.endsWith("::a") || key.endsWith("::b");
     }
 
@@ -598,14 +598,14 @@ public class GlobalVariable {
      * Checks if a global array was explicitly declared.
      */
     public static boolean isDeclaredGlobalArray(String key) {
-        return declaredGlobalArrays.contains(key);
+        return globalState().declaredGlobalArrays().contains(key);
     }
 
     /**
      * Checks if a global hash was explicitly declared.
      */
     public static boolean isDeclaredGlobalHash(String key) {
-        return declaredGlobalHashes.contains(key);
+        return globalState().declaredGlobalHashes().contains(key);
     }
 
     /**
@@ -630,13 +630,8 @@ public class GlobalVariable {
         globalState().clearIoAndFormatValues();
         globalGlobs.clear();
         isSubs.clear();
-        stashAliases.clear();
-        resolvedStashAliasCache.clear();
-        globAliases.clear();
-        declaredGlobalVariables.clear();
-        declaredGlobalArrays.clear();
-        declaredGlobalHashes.clear();
-        clearPackageCache();
+        globalState().clearGlobAndStashValues();
+        globalState().clearDeclarationsAndPackageServices();
 
         org.perlonjava.runtime.WarningBitsRegistry.clear();
         WarningFlags.resetRuntimeState();
@@ -666,9 +661,6 @@ public class GlobalVariable {
         // Reset lib module static state (ORIG_INC)
         org.perlonjava.runtime.perlmodule.Lib.resetState();
 
-        // Destroy the old classloader and create a new one
-        // This allows the old generated classes to be garbage collected
-        globalClassLoader = new CustomClassLoader(GlobalVariable.class.getClassLoader());
         MortalList.invalidateAllRootSnapshots();
     }
 
@@ -719,7 +711,8 @@ public class GlobalVariable {
      * non-alias hit without allocating. Cleared whenever {@link #stashAliases}
      * is mutated.
      */
-    private static final Map<String, String> resolvedStashAliasCache = new HashMap<>();
+    private static final Map<String, String> resolvedStashAliasCache =
+            new CurrentRuntimePlainMap<>(state -> state.resolvedStashAliases());
 
     /** Hop cap for cycle detection in {@link #resolvePackageAliasCached}. */
     private static final int STASH_ALIAS_HOP_CAP = 16;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/HashSpecialVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/HashSpecialVariable.java
@@ -5,7 +5,6 @@ import org.perlonjava.runtime.regex.RuntimeRegex;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -32,10 +31,7 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
 
     // Namespace for the stash, if any
     private String namespace = null;
-    private static long stashEntryCacheVersion = -1;
-    private static final Map<String, List<StashEntryName>> stashEntryCache = new HashMap<>();
-
-    private static final class StashEntryName {
+    static final class StashEntryName {
         final String entryKey;
         final String globName;
 
@@ -186,10 +182,12 @@ public class HashSpecialVariable extends AbstractMap<String, RuntimeScalar> {
     }
 
     private static List<StashEntryName> cachedStashEntries(String namespace) {
+        GlobalRuntimeState state = PerlRuntime.current().globalState();
         long version = GlobalVariable.stashEnumerationVersion();
-        if (stashEntryCacheVersion != version) {
+        Map<String, List<StashEntryName>> stashEntryCache = state.stashEntryCache();
+        if (state.cachedStashEnumerationVersion() != version) {
             stashEntryCache.clear();
-            stashEntryCacheVersion = version;
+            state.cachedStashEnumerationVersion(version);
         }
         List<StashEntryName> cached = stashEntryCache.get(namespace);
         if (cached != null) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -26,6 +26,7 @@ public final class PerlRuntime {
     public final RuntimeRegexState regexState = new RuntimeRegexState();
     public final MroRuntimeState mroState = new MroRuntimeState();
     public final GlobalRuntimeState globalState = new GlobalRuntimeState();
+    public final RuntimeCodeRuntimeState runtimeCodeState = new RuntimeCodeRuntimeState();
 
     RuntimeIO ioStdout;
     RuntimeIO ioStderr;
@@ -122,6 +123,10 @@ public final class PerlRuntime {
 
     public GlobalRuntimeState globalState() {
         return globalState;
+    }
+
+    public RuntimeCodeRuntimeState runtimeCodeState() {
+        return runtimeCodeState;
     }
 
     RuntimeGlob standardIOGlob(String name) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -63,7 +63,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     // Lookup object for performing method handle operations
     public static final MethodHandles.Lookup lookup = MethodHandles.lookup();
 
-    public static final IdentityHashMap<OperatorNode, Integer> evalBeginIds = new IdentityHashMap<>();
+    public static IdentityHashMap<OperatorNode, Integer> evalBeginIds() {
+        return PerlRuntime.current().runtimeCodeState().evalBeginIds;
+    }
 
     /**
      * Flag to control whether eval STRING should use the interpreter backend.
@@ -118,22 +120,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     private static ArrayDeque<ArrayList<String>> syntheticCallerFrames() {
         return PerlRuntime.current().executionState().syntheticCallerFrames;
     }
-    // Cache for memoization of evalStringHelper results
-    private static final int CLASS_CACHE_SIZE = 100;
-    private static final Map<String, Class<?>> evalCache = new LinkedHashMap<String, Class<?>>(CLASS_CACHE_SIZE, 0.75f, true) {
-        @Override
-        protected boolean removeEldestEntry(Map.Entry<String, Class<?>> eldest) {
-            return size() > CLASS_CACHE_SIZE;
-        }
-    };
-    // Cache for method handles with eviction policy
-    private static final int METHOD_HANDLE_CACHE_SIZE = 100;
-    private static final Map<Class<?>, MethodHandle> methodHandleCache = new LinkedHashMap<Class<?>, MethodHandle>(METHOD_HANDLE_CACHE_SIZE, 0.75f, true) {
-        @Override
-        protected boolean removeEldestEntry(Map.Entry<Class<?>, MethodHandle> eldest) {
-            return size() > METHOD_HANDLE_CACHE_SIZE;
-        }
-    };
+    private static Map<String, Class<?>> evalCache() {
+        return PerlRuntime.current().runtimeCodeState().evalCache;
+    }
     /**
      * Flag to enable disassembly of eval STRING bytecode.
      * When set, prints the interpreter bytecode for each eval STRING compilation.
@@ -141,13 +130,10 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * Set environment variable JPERL_DISASSEMBLE=1 to enable, or use --disassemble CLI flag.
      * The --disassemble flag sets this via setDisassemble().
      */
-    public static boolean DISASSEMBLE =
-            System.getenv("JPERL_DISASSEMBLE") != null;
-    public static boolean USE_INTERPRETER =
-            System.getenv("JPERL_INTERPRETER") != null;
     public static final boolean FORCE_INTERPRETER =
             System.getenv("JPERL_INTERPRETER") != null;
-    public static MethodType methodType = MethodType.methodType(RuntimeList.class, RuntimeArray.class, int.class);
+    public static final MethodType methodType =
+            MethodType.methodType(RuntimeList.class, RuntimeArray.class, int.class);
 
     /**
      * Tracks the current eval nesting depth for $^S support.
@@ -191,12 +177,15 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         return PerlRuntime.current().executionState().activeCodeStack;
     }
 
+    private static Deque<RuntimeCode> activeCodeStack(ExecutionRuntimeState executionState) {
+        return executionState.activeCodeStack;
+    }
+
     private record ActiveLexicalFrame(RuntimeCode code, Map<String, RuntimeBase> cells) {}
-    private static volatile boolean lexicalAliasSupportEnabled;
     @SuppressWarnings("unchecked")
-    private static Deque<ActiveLexicalFrame> activeLexicalFrames() {
-        return (Deque<ActiveLexicalFrame>) (Deque<?>)
-                PerlRuntime.current().executionState().activeLexicalFrames;
+    private static Deque<ActiveLexicalFrame> activeLexicalFrames(
+            ExecutionRuntimeState executionState) {
+        return (Deque<ActiveLexicalFrame>) (Deque<?>) executionState.activeLexicalFrames;
     }
 
     /**
@@ -271,22 +260,27 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     public static void pushActiveCode(RuntimeCode code) {
-        activeCodeStack().push(code);
-        if (lexicalAliasSupportEnabled) {
-            activeLexicalFrames().push(new ActiveLexicalFrame(code, new HashMap<>()));
+        PerlRuntime runtime = PerlRuntime.current();
+        ExecutionRuntimeState executionState = runtime.executionState();
+        activeCodeStack(executionState).push(code);
+        if (runtime.runtimeCodeState().lexicalAliasSupportEnabled) {
+            activeLexicalFrames(executionState).push(
+                    new ActiveLexicalFrame(code, new HashMap<>()));
         }
     }
 
     public static void popActiveCode(RuntimeCode code) {
-        if (lexicalAliasSupportEnabled) {
-            Deque<ActiveLexicalFrame> frames = activeLexicalFrames();
+        PerlRuntime runtime = PerlRuntime.current();
+        ExecutionRuntimeState executionState = runtime.executionState();
+        if (runtime.runtimeCodeState().lexicalAliasSupportEnabled) {
+            Deque<ActiveLexicalFrame> frames = activeLexicalFrames(executionState);
             if (!frames.isEmpty() && frames.peek().code() == code) {
                 frames.pop();
             } else {
                 frames.removeIf(frame -> frame.code() == code);
             }
         }
-        Deque<RuntimeCode> stack = activeCodeStack();
+        Deque<RuntimeCode> stack = activeCodeStack(executionState);
         if (!stack.isEmpty() && stack.peek() == code) {
             stack.pop();
             return;
@@ -318,7 +312,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     public static void enableLexicalAliasSupport() {
-        lexicalAliasSupportEnabled = true;
+        PerlRuntime.current().runtimeCodeState().lexicalAliasSupportEnabled = true;
     }
 
     private static boolean sameLogicalCode(RuntimeCode left, RuntimeCode right) {
@@ -329,8 +323,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
 
     private static void registerActiveLexical(
             RuntimeCode code, String variableName, RuntimeBase cell) {
-        if (!lexicalAliasSupportEnabled) return;
-        for (ActiveLexicalFrame frame : activeLexicalFrames()) {
+        PerlRuntime runtime = PerlRuntime.current();
+        if (!runtime.runtimeCodeState().lexicalAliasSupportEnabled) return;
+        for (ActiveLexicalFrame frame : activeLexicalFrames(runtime.executionState())) {
             if (sameLogicalCode(frame.code(), code)) {
                 frame.cells().put(variableName, cell);
                 return;
@@ -339,8 +334,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     public static RuntimeBase findActiveLexical(RuntimeCode code, String variableName) {
-        if (!lexicalAliasSupportEnabled) return null;
-        for (ActiveLexicalFrame frame : activeLexicalFrames()) {
+        PerlRuntime runtime = PerlRuntime.current();
+        if (!runtime.runtimeCodeState().lexicalAliasSupportEnabled) return null;
+        for (ActiveLexicalFrame frame : activeLexicalFrames(runtime.executionState())) {
             if (sameLogicalCode(frame.code(), code)) {
                 RuntimeBase cell = frame.cells().get(variableName);
                 if (cell != null) return cell;
@@ -526,23 +522,15 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * This optimization provides ~50% speedup for method-heavy code like:
      *   while ($i < 10000) { $obj->method($arg); $i++ }
      */
-    private static final int METHOD_CALL_CACHE_SIZE = 4096;
-    private static final int[] inlineCacheBlessId = new int[METHOD_CALL_CACHE_SIZE];
-    private static final int[] inlineCacheMethodHash = new int[METHOD_CALL_CACHE_SIZE];
-    private static final RuntimeCode[] inlineCacheCode = new RuntimeCode[METHOD_CALL_CACHE_SIZE];
-    private static int nextCallsiteId = 0;
-    
     public static int allocateMethodCallsiteId() {
-        return nextCallsiteId++ % METHOD_CALL_CACHE_SIZE;
+        return PerlRuntime.current().runtimeCodeState().allocateMethodCallsiteId();
     }
     
     /**
      * Clear the inline method cache. Should be called when method definitions change.
      */
     public static void clearInlineMethodCache() {
-        java.util.Arrays.fill(inlineCacheBlessId, 0);
-        java.util.Arrays.fill(inlineCacheMethodHash, 0);
-        java.util.Arrays.fill(inlineCacheCode, null);
+        PerlRuntime.current().runtimeCodeState().clearInlineMethodCache();
     }
 
     public static int effectiveCallContext(int callContext) {
@@ -782,12 +770,29 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         return result.cloneScalars();
     }
     
-    // Temporary storage for anonymous subroutines and eval string compiler context
-    public static HashMap<String, Class<?>> anonSubs = new HashMap<>(); // temp storage for makeCodeObject()
-    public static HashMap<String, Object> interpretedSubs = new HashMap<>(); // storage for interpreter fallback closures
-    public static HashMap<String, EmitterContext> evalContext = new HashMap<>(); // storage for eval string compiler context
-    // Runtime eval counter for generating unique filenames when $^P is set
-    private static int runtimeEvalCounter = 1;
+    public static void registerAnonymousSub(String className, Class<?> generatedClass) {
+        PerlRuntime.current().runtimeCodeState().anonymousSubs.put(className, generatedClass);
+    }
+
+    public static void putInterpretedSub(String key, Object code) {
+        PerlRuntime.current().runtimeCodeState().interpretedSubs.put(key, code);
+    }
+
+    public static Object getInterpretedSub(String key) {
+        return PerlRuntime.current().runtimeCodeState().interpretedSubs.get(key);
+    }
+
+    public static void putEvalContext(String evalTag, EmitterContext context) {
+        PerlRuntime.current().runtimeCodeState().evalContexts.put(evalTag, context);
+    }
+
+    private static EmitterContext getEvalContext(String evalTag) {
+        return PerlRuntime.current().runtimeCodeState().evalContexts.get(evalTag);
+    }
+
+    public static void registerPadConstants(String className, RuntimeBase[] constants) {
+        PerlRuntime.current().runtimeCodeState().padConstantsByClassName.put(className, constants);
+    }
     // Method object representing the compiled subroutine (legacy - used by PerlModuleBase)
     public MethodHandle methodHandle;
     // Functional interface for direct subroutine invocation (preferred for generated classes)
@@ -909,10 +914,6 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     // tail calls don't consume real Java stack, so a depth warning for
     // them is misleading anyway. Nested tail-call trampolines use an int
     // counter so re-entries only skip tracking for the outermost trampoline.
-    private static int tailCallTrampolineDepth() {
-        return PerlRuntime.current().executionState().tailCallTrampolineDepth;
-    }
-
     /**
      * Increment the recursion depth counter and, if we've just crossed the
      * "Deep recursion on subroutine" threshold for the first time in this
@@ -927,11 +928,12 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         if (isMapGrepBlock || isEvalBlock || isBuiltin) {
             return;
         }
-        if (tailCallTrampolineDepth() > 0) {
+        ExecutionRuntimeState executionState = PerlRuntime.current().executionState();
+        if (executionState.tailCallTrampolineDepth > 0) {
             return;
         }
         ExecutionRuntimeState.CallDepthState callState =
-                PerlRuntime.current().executionState().callDepth(this);
+                executionState.callDepth(this);
         int depth = ++callState.depth;
         if (depth > DEEP_RECURSION_WARN_DEPTH && !callState.warned) {
             callState.warned = true;
@@ -950,15 +952,16 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         if (isMapGrepBlock || isEvalBlock || isBuiltin) {
             return;
         }
-        if (tailCallTrampolineDepth() > 0) {
+        ExecutionRuntimeState executionState = PerlRuntime.current().executionState();
+        if (executionState.tailCallTrampolineDepth > 0) {
             return;
         }
         ExecutionRuntimeState.CallDepthState callState =
-                PerlRuntime.current().executionState().callDepth(this);
+                executionState.callDepth(this);
         if (--callState.depth <= 0) {
             callState.depth = 0;
             callState.warned = false;
-            PerlRuntime.current().executionState().releaseCallDepth(this);
+            executionState.releaseCallDepth(this);
         }
     }
     // State variables
@@ -1061,9 +1064,6 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * Registry mapping generated class names to their pad constants.
      * Used to transfer pad constants from compile time to runtime for anonymous subs.
      */
-    public static final java.util.concurrent.ConcurrentHashMap<String, RuntimeBase[]> padConstantsByClassName =
-            new java.util.concurrent.ConcurrentHashMap<>();
-
     /**
      * Clears weak references to this subroutine's pad constants.
      * Called when the CODE slot of a glob is replaced, emulating Perl 5's
@@ -1240,11 +1240,19 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * Called by CLI argument parser when --disassemble is set.
      */
     public static void setDisassemble(boolean value) {
-        DISASSEMBLE = value;
+        PerlRuntime.current().runtimeCodeState().disassemble = value;
+    }
+
+    public static boolean isDisassemble() {
+        return PerlRuntime.current().runtimeCodeState().disassemble;
     }
 
     public static void setUseInterpreter(boolean value) {
-        USE_INTERPRETER = value;
+        PerlRuntime.current().runtimeCodeState().useInterpreter = value;
+    }
+
+    public static boolean isUseInterpreter() {
+        return PerlRuntime.current().runtimeCodeState().useInterpreter;
     }
 
     /**
@@ -1714,18 +1722,15 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      *
      * @return Filename like "(eval 1)", "(eval 2)", etc.
      */
-    public static synchronized String getNextEvalFilename() {
-        return "(eval " + runtimeEvalCounter++ + ")";
+    public static String getNextEvalFilename() {
+        return PerlRuntime.current().runtimeCodeState().nextEvalFilename();
     }
 
     // Add a method to clear caches when globals are reset
     public static void clearCaches() {
-        evalCache.clear();
-        methodHandleCache.clear();
-        anonSubs.clear();
-        interpretedSubs.clear();
-        evalContext.clear();
-        evalRuntimeContextStack().clear();
+        PerlRuntime runtime = PerlRuntime.current();
+        runtime.runtimeCodeState().clearCaches();
+        runtime.executionState().evalRuntimeContexts.clear();
     }
 
     public static void copy(RuntimeCode code, RuntimeCode codeFrom) {
@@ -1884,7 +1889,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         rejectTaintedEval(code);
 
         // Retrieve the eval context that was saved at program compile-time
-        EmitterContext ctx = RuntimeCode.evalContext.get(evalTag);
+        EmitterContext ctx = getEvalContext(evalTag);
 
         // Handle missing eval context - this can happen when compiled code (e.g., INIT blocks
         // with eval) is executed after the runtime has been reset. In JUnit parallel tests,
@@ -1980,9 +1985,10 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             String cacheKey = evalString + '\0' + evalTag + '\0' + hasUnicode + '\0' + ctx.isEvalbytes + '\0' + evalbytesUtf8Source + '\0' + isByteStringSource + '\0' + featureFlags + '\0' + currentPackage;
             Class<?> cachedClass = null;
             if (!isDebugging) {
-                synchronized (evalCache) {
-                    if (evalCache.containsKey(cacheKey)) {
-                        cachedClass = evalCache.get(cacheKey);
+                Map<String, Class<?>> runtimeEvalCache = evalCache();
+                synchronized (runtimeEvalCache) {
+                    if (runtimeEvalCache.containsKey(cacheKey)) {
+                        cachedClass = runtimeEvalCache.get(cacheKey);
                     }
                 }
 
@@ -2048,7 +2054,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                             // variable reinitialization in loops.
                             OperatorNode ast = entry.ast();
                             if (ast != null) {
-                                int beginId = evalBeginIds.computeIfAbsent(
+                                int beginId = evalBeginIds().computeIfAbsent(
                                         ast,
                                         k -> EmitterMethodCreator.classCounter.getAndIncrement());
                                 String packageName = PersistentVariable.beginPackage(beginId);
@@ -2248,8 +2254,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
 
             // Cache the result (unless debugging is enabled)
             if (!isDebugging) {
-                synchronized (evalCache) {
-                    evalCache.put(cacheKey, generatedClass);
+                Map<String, Class<?>> runtimeEvalCache = evalCache();
+                synchronized (runtimeEvalCache) {
+                    runtimeEvalCache.put(cacheKey, generatedClass);
                 }
             }
 
@@ -2411,7 +2418,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 " codeType=" + code.type + " codeLen=" + (code.toString() != null ? code.toString().length() : -1));
 
         // Retrieve the eval context that was saved at program compile-time
-        EmitterContext ctx = RuntimeCode.evalContext.get(evalTag);
+        EmitterContext ctx = getEvalContext(evalTag);
 
         // Handle missing eval context - this can happen when compiled code (e.g., INIT blocks
         // with eval) is executed after the runtime has been reset. In JUnit parallel tests,
@@ -2509,7 +2516,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                         if (runtimeValue != null) {
                             OperatorNode operatorAst = entry.ast();
                             if (operatorAst != null) {
-                                int beginId = evalBeginIds.computeIfAbsent(
+                                int beginId = evalBeginIds().computeIfAbsent(
                                         operatorAst,
                                         k -> EmitterMethodCreator.classCounter.getAndIncrement());
                                 String packageName = PersistentVariable.beginPackage(beginId);
@@ -2662,7 +2669,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 evalTrace("evalStringWithInterpreter compiled tag=" + evalTag +
                         " bytecodeLen=" + (interpretedCode != null ? interpretedCode.bytecode.length : -1) +
                         " src=" + (interpretedCode != null ? interpretedCode.sourceName : "null"));
-                if (DISASSEMBLE) {
+                if (isDisassemble()) {
                     System.out.println(Disassemble.disassemble(interpretedCode));
                 }
 
@@ -3015,7 +3022,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         // These track cached string literals referenced via \ inside the sub,
         // needed for optree reaping (clearing weak refs when sub is replaced).
         String internalClassName = clazz.getName().replace('.', '/');
-        RuntimeBase[] padConsts = padConstantsByClassName.remove(internalClassName);
+        RuntimeBase[] padConsts = PerlRuntime.current().runtimeCodeState()
+                .padConstantsByClassName.remove(internalClassName);
         if (padConsts != null) {
             code.padConstants = padConsts;
         }
@@ -3168,13 +3176,14 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 int blessId = ((RuntimeBase) invocant.value).blessId;
                 if (blessId != 0) {
                     int methodHash = System.identityHashCode(method.value);
-                    int cacheIndex = callsiteId & (METHOD_CALL_CACHE_SIZE - 1);
-                    
+                    RuntimeCodeRuntimeState runtimeCodeState =
+                            PerlRuntime.current().runtimeCodeState();
+
                     // Check if cache hit
-                    if (inlineCacheBlessId[cacheIndex] == blessId && 
-                        inlineCacheMethodHash[cacheIndex] == methodHash) {
-                        RuntimeCode cachedCode = inlineCacheCode[cacheIndex];
-                        if (cachedCode != null && (cachedCode.subroutine != null || cachedCode.methodHandle != null)) {
+                    RuntimeCode cachedCode = runtimeCodeState.cachedInlineMethod(
+                            callsiteId, blessId, methodHash);
+                    if (cachedCode != null
+                            && (cachedCode.subroutine != null || cachedCode.methodHandle != null)) {
                             // Cache hit: skip method lookup, but still enter through
                             // RuntimeCode.apply() so caller(), next::method, warnings,
                             // recursion tracking, and scope cleanup see a real Perl frame.
@@ -3214,7 +3223,6 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                                 if (e instanceof RuntimeException) throw (RuntimeException) e;
                                 throw new RuntimeException(e);
                             }
-                        }
                     }
                     
                     // Cache miss - do full lookup and update cache
@@ -3234,9 +3242,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                             // Only cache if method is defined and has a subroutine or method handle
                             if (code.subroutine != null || code.methodHandle != null) {
                                 // Update cache
-                                inlineCacheBlessId[cacheIndex] = blessId;
-                                inlineCacheMethodHash[cacheIndex] = methodHash;
-                                inlineCacheCode[cacheIndex] = code;
+                                runtimeCodeState.cacheInlineMethod(
+                                        callsiteId, blessId, methodHash, code);
                             }
                             
                             // Call the method with function-scoped mortal boundary

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCodeRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCodeRuntimeState.java
@@ -1,0 +1,88 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.perlonjava.backend.jvm.EmitterContext;
+import org.perlonjava.frontend.astnode.OperatorNode;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Runtime-owned compilation handoff, eval, and method-dispatch cache state. */
+public final class RuntimeCodeRuntimeState {
+    static final int METHOD_CALL_CACHE_SIZE = 4096;
+    private static final int EVAL_CACHE_SIZE = 100;
+    private static final int METHOD_HANDLE_CACHE_SIZE = 100;
+
+    final IdentityHashMap<OperatorNode, Integer> evalBeginIds = new IdentityHashMap<>();
+    final Map<String, Class<?>> evalCache = lruMap(EVAL_CACHE_SIZE);
+    final Map<Class<?>, MethodHandle> methodHandleCache = lruMap(METHOD_HANDLE_CACHE_SIZE);
+    final HashMap<String, Class<?>> anonymousSubs = new HashMap<>();
+    final HashMap<String, Object> interpretedSubs = new HashMap<>();
+    final HashMap<String, EmitterContext> evalContexts = new HashMap<>();
+    final ConcurrentHashMap<String, RuntimeBase[]> padConstantsByClassName =
+            new ConcurrentHashMap<>();
+
+    final int[] inlineCacheBlessId = new int[METHOD_CALL_CACHE_SIZE];
+    final int[] inlineCacheMethodHash = new int[METHOD_CALL_CACHE_SIZE];
+    final RuntimeCode[] inlineCacheCode = new RuntimeCode[METHOD_CALL_CACHE_SIZE];
+
+    private int nextMethodCallsiteId;
+    private int nextRuntimeEvalId = 1;
+    boolean disassemble = System.getenv("JPERL_DISASSEMBLE") != null;
+    boolean useInterpreter = System.getenv("JPERL_INTERPRETER") != null;
+    boolean lexicalAliasSupportEnabled;
+
+    private static <K, V> Map<K, V> lruMap(int maximumSize) {
+        return new LinkedHashMap<K, V>(maximumSize, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+                return size() > maximumSize;
+            }
+        };
+    }
+
+    synchronized int allocateMethodCallsiteId() {
+        return nextMethodCallsiteId++ % METHOD_CALL_CACHE_SIZE;
+    }
+
+    synchronized String nextEvalFilename() {
+        return "(eval " + nextRuntimeEvalId++ + ")";
+    }
+
+    RuntimeCode cachedInlineMethod(int callsiteId, int blessId, int methodHash) {
+        int index = callsiteId & (METHOD_CALL_CACHE_SIZE - 1);
+        return inlineCacheBlessId[index] == blessId
+                && inlineCacheMethodHash[index] == methodHash
+                ? inlineCacheCode[index]
+                : null;
+    }
+
+    void cacheInlineMethod(int callsiteId, int blessId, int methodHash, RuntimeCode code) {
+        int index = callsiteId & (METHOD_CALL_CACHE_SIZE - 1);
+        inlineCacheBlessId[index] = blessId;
+        inlineCacheMethodHash[index] = methodHash;
+        inlineCacheCode[index] = code;
+    }
+
+    void clearInlineMethodCache() {
+        Arrays.fill(inlineCacheBlessId, 0);
+        Arrays.fill(inlineCacheMethodHash, 0);
+        Arrays.fill(inlineCacheCode, null);
+    }
+
+    void clearCaches() {
+        evalBeginIds.clear();
+        evalCache.clear();
+        methodHandleCache.clear();
+        anonymousSubs.clear();
+        interpretedSubs.clear();
+        evalContexts.clear();
+        padConstantsByClassName.clear();
+        nextMethodCallsiteId = 0;
+        clearInlineMethodCache();
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/GlobalGlobStashRuntimeIsolationTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/GlobalGlobStashRuntimeIsolationTest.java
@@ -1,0 +1,190 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class GlobalGlobStashRuntimeIsolationTest {
+
+    @Test
+    void stashObjectsAliasesAndEnumerationCachesFollowNestedRuntimeBindings() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        RuntimeHash firstStash;
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            firstStash = GlobalVariable.getGlobalHash("Phase8dIdentity::");
+            GlobalVariable.setStashAlias("Phase8dAlias", "Phase8dFirst");
+            GlobalVariable.setGlobAlias("Phase8dGlobAlias", "Phase8dFirst::slot");
+            GlobalVariable.getGlobalVariable("Phase8dCache::first").set("first");
+
+            assertEquals("Phase8dFirst", GlobalVariable.resolveStashAlias("Phase8dAlias"));
+            assertEquals("Phase8dFirst::slot",
+                    GlobalVariable.resolveGlobAlias("Phase8dGlobAlias"));
+            assertEquals(Set.of("first"), stashKeys("Phase8dCache::"));
+
+            try (PerlRuntime.Binding nested = second.bind()) {
+                RuntimeHash secondStash = GlobalVariable.getGlobalHash("Phase8dIdentity::");
+                assertNotSame(firstStash, secondStash);
+                assertEquals("Phase8dAlias", GlobalVariable.resolveStashAlias("Phase8dAlias"));
+                assertEquals("Phase8dGlobAlias",
+                        GlobalVariable.resolveGlobAlias("Phase8dGlobAlias"));
+
+                GlobalVariable.setStashAlias("Phase8dAlias", "Phase8dSecond");
+                GlobalVariable.setGlobAlias("Phase8dGlobAlias", "Phase8dSecond::slot");
+                GlobalVariable.getGlobalVariable("Phase8dCache::second").set("second");
+
+                // Both runtimes deliberately have the same mutation-version value.
+                // A process-wide cache would return the first runtime's key here.
+                assertEquals(Set.of("second"), stashKeys("Phase8dCache::"));
+            }
+
+            assertEquals("Phase8dFirst", GlobalVariable.resolveStashAlias("Phase8dAlias"));
+            assertEquals("Phase8dFirst::slot",
+                    GlobalVariable.resolveGlobAlias("Phase8dGlobAlias"));
+            assertEquals(Set.of("first"), stashKeys("Phase8dCache::"));
+        }
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void simultaneousAliasMutationDoesNotCrossRuntimes() throws Exception {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        FutureTask<AliasSnapshot> firstTask = aliasTask(first, "First", ready, start);
+        FutureTask<AliasSnapshot> secondTask = aliasTask(second, "Second", ready, start);
+        Thread firstThread = Thread.ofPlatform().name("phase8d-alias-first").start(firstTask);
+        Thread secondThread = Thread.ofPlatform().name("phase8d-alias-second").start(secondTask);
+
+        try {
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+        } finally {
+            start.countDown();
+            firstThread.join(TimeUnit.SECONDS.toMillis(10));
+            secondThread.join(TimeUnit.SECONDS.toMillis(10));
+        }
+        assertFalse(firstThread.isAlive());
+        assertFalse(secondThread.isAlive());
+
+        assertEquals(new AliasSnapshot("Phase8dFirst::", "Phase8dFirst::slot"),
+                firstTask.get(1, TimeUnit.SECONDS));
+        assertEquals(new AliasSnapshot("Phase8dSecond::", "Phase8dSecond::slot"),
+                secondTask.get(1, TimeUnit.SECONDS));
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void resetClearsOnlyTheBoundRuntimesGlobAndStashIdentity() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        installAliases(first, "First");
+        installAliases(second, "Second");
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            GlobalVariable.resetAllGlobals();
+            assertEquals("Phase8dAlias::", GlobalVariable.resolveStashAlias("Phase8dAlias::"));
+            assertEquals("Phase8dGlobAlias",
+                    GlobalVariable.resolveGlobAlias("Phase8dGlobAlias"));
+        }
+
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertEquals("Phase8dSecond::",
+                    GlobalVariable.resolveStashAlias("Phase8dAlias::"));
+            assertEquals("Phase8dSecond::slot",
+                    GlobalVariable.resolveGlobAlias("Phase8dGlobAlias"));
+        }
+    }
+
+    @Test
+    void conflictingGlobAndStashAliasesStayIsolatedOnJvmAndInterpreter() throws Exception {
+        for (boolean interpreter : new boolean[]{false, true}) {
+            PerlRuntime first = new PerlRuntime();
+            PerlRuntime second = new PerlRuntime();
+
+            installPerlAliases(first, "First", "first", interpreter);
+            installPerlAliases(second, "Second", "second", interpreter);
+
+            assertEquals("first:glob-first", readPerlAliases(first, interpreter));
+            assertEquals("second:glob-second", readPerlAliases(second, interpreter));
+
+            try (PerlRuntime.Binding ignored = first.bind()) {
+                RuntimeHash firstAliasStash = GlobalVariable.getGlobalHash("Phase8dAlias::");
+                try (PerlRuntime.Binding nested = second.bind()) {
+                    assertNotSame(firstAliasStash,
+                            GlobalVariable.getGlobalHash("Phase8dAlias::"));
+                }
+            }
+        }
+    }
+
+    private static Set<String> stashKeys(String namespace) {
+        return new HashSpecialVariable(HashSpecialVariable.Id.STASH, namespace).keySet();
+    }
+
+    private static FutureTask<AliasSnapshot> aliasTask(
+            PerlRuntime runtime, String target, CountDownLatch ready, CountDownLatch start) {
+        return new FutureTask<>(() -> {
+            try (PerlRuntime.Binding ignored = runtime.bind()) {
+                ready.countDown();
+                assertTrue(start.await(10, TimeUnit.SECONDS));
+                installAliasesInCurrentRuntime(target);
+                return new AliasSnapshot(
+                        GlobalVariable.resolveStashAlias("Phase8dAlias::"),
+                        GlobalVariable.resolveGlobAlias("Phase8dGlobAlias"));
+            }
+        });
+    }
+
+    private static void installAliases(PerlRuntime runtime, String target) {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            installAliasesInCurrentRuntime(target);
+        }
+    }
+
+    private static void installAliasesInCurrentRuntime(String target) {
+        GlobalVariable.setStashAlias("Phase8dAlias::", "Phase8d" + target + "::");
+        GlobalVariable.setGlobAlias("Phase8dGlobAlias", "Phase8d" + target + "::slot");
+    }
+
+    private static void installPerlAliases(
+            PerlRuntime runtime, String target, String value, boolean interpreter) throws Exception {
+        run(runtime,
+                "$Phase8d" + target + "::value = '" + value + "';"
+                        + " $Phase8d" + target + "::glob = 'glob-" + value + "';"
+                        + " *Phase8dAlias:: = *Phase8d" + target + "::;"
+                        + " *Phase8dGlobAlias = *Phase8d" + target + "::glob; 1",
+                interpreter);
+    }
+
+    private static String readPerlAliases(PerlRuntime runtime, boolean interpreter)
+            throws Exception {
+        return run(runtime,
+                "no strict 'refs'; ${'Phase8dAlias::value'} . ':' . $Phase8dGlobAlias",
+                interpreter);
+    }
+
+    private static String run(PerlRuntime runtime, String source, boolean interpreter)
+            throws Exception {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            CompilerOptions options = new CompilerOptions();
+            options.fileName = "<global-glob-stash-runtime-isolation>";
+            options.code = source;
+            options.useInterpreter = interpreter;
+            return PerlLanguageProvider.executePerlCode(options, false).scalar().toString();
+        }
+    }
+
+    private record AliasSnapshot(String stash, String glob) {
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/GlobalPackageServicesRuntimeIsolationTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/GlobalPackageServicesRuntimeIsolationTest.java
@@ -1,0 +1,186 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+import org.perlonjava.backend.jvm.CustomClassLoader;
+import org.perlonjava.frontend.parser.FieldRegistry;
+import org.perlonjava.frontend.semantic.ScopedSymbolTable;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class GlobalPackageServicesRuntimeIsolationTest {
+
+    @Test
+    void declarationsPackageMetadataAndClassLoadersFollowNestedBindings() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        CustomClassLoader firstLoader;
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            installPackageServices("first");
+            firstLoader = GlobalVariable.getGlobalClassLoader();
+            assertPackageServices("first", firstLoader);
+
+            try (PerlRuntime.Binding nested = second.bind()) {
+                assertPackageServicesAbsent(firstLoader);
+                installPackageServices("second");
+                assertPackageServices("second", GlobalVariable.getGlobalClassLoader());
+            }
+
+            assertPackageServices("first", firstLoader);
+        }
+
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertPackageServices("second", GlobalVariable.getGlobalClassLoader());
+        }
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void simultaneousPackageServiceMutationDoesNotCrossRuntimes() throws Exception {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        FutureTask<PackageSnapshot> firstTask = packageTask(first, "first", ready, start);
+        FutureTask<PackageSnapshot> secondTask = packageTask(second, "second", ready, start);
+        Thread firstThread = Thread.ofPlatform().name("phase8e-package-first").start(firstTask);
+        Thread secondThread = Thread.ofPlatform().name("phase8e-package-second").start(secondTask);
+
+        try {
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+        } finally {
+            start.countDown();
+            firstThread.join(TimeUnit.SECONDS.toMillis(10));
+            secondThread.join(TimeUnit.SECONDS.toMillis(10));
+        }
+        assertFalse(firstThread.isAlive());
+        assertFalse(secondThread.isAlive());
+
+        PackageSnapshot firstResult = firstTask.get(1, TimeUnit.SECONDS);
+        PackageSnapshot secondResult = secondTask.get(1, TimeUnit.SECONDS);
+        assertEquals("first", firstResult.marker);
+        assertEquals("second", secondResult.marker);
+        assertNotSame(firstResult.loader, secondResult.loader);
+        assertNull(PerlRuntime.currentOrNull());
+    }
+
+    @Test
+    void resetClearsOnlyTheBoundRuntimePackageServicesAndReplacesItsLoader() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        CustomClassLoader firstLoader;
+        CustomClassLoader secondLoader;
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            installPackageServices("first");
+            firstLoader = GlobalVariable.getGlobalClassLoader();
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            installPackageServices("second");
+            secondLoader = GlobalVariable.getGlobalClassLoader();
+        }
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            GlobalVariable.resetAllGlobals();
+            assertPackageServicesAbsent(firstLoader);
+            assertNotSame(firstLoader, GlobalVariable.getGlobalClassLoader());
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertPackageServices("second", secondLoader);
+        }
+    }
+
+    @Test
+    void declaredGlobalsAffectOnlyTheirRuntimeOnBothBackends() throws Exception {
+        for (boolean interpreter : new boolean[]{false, true}) {
+            PerlRuntime declared = new PerlRuntime();
+            PerlRuntime undeclared = new PerlRuntime();
+
+            try (PerlRuntime.Binding ignored = declared.bind()) {
+                GlobalVariable.declareGlobalVariable("Phase8eStrict::X");
+                // The strict-vars single-letter exception requires both an
+                // explicitly declared slot and the package scalar it names.
+                GlobalVariable.getGlobalVariable("Phase8eStrict::X");
+            }
+            assertEquals("42", run(declared,
+                    "package Phase8eStrict; use strict 'vars'; $X = 42; $X",
+                    interpreter));
+
+            Exception error = assertThrows(Exception.class, () -> run(undeclared,
+                    "package Phase8eStrict; use strict 'vars'; $X = 99; $X",
+                    interpreter));
+            assertTrue(error.getMessage().contains("Global symbol \"$X\""), error::getMessage);
+        }
+    }
+
+    private static void installPackageServices(String marker) {
+        GlobalVariable.packageExistsCache.put("Phase8e::Package", true);
+        GlobalVariable.declareGlobalVariable("Phase8e::scalar");
+        GlobalVariable.declareGlobalArray("Phase8e::array");
+        GlobalVariable.declareGlobalHash("Phase8e::hash");
+        ClassRegistry.registerClass("Phase8e::Class");
+        FieldRegistry.registerField("Phase8e::Class", marker);
+        FieldRegistry.registerParentClass("Phase8e::Class", marker + "::Parent");
+        new ScopedSymbolTable().setPackageVersion("Phase8e::Package", marker);
+    }
+
+    private static void assertPackageServices(String marker, CustomClassLoader loader) {
+        assertTrue(GlobalVariable.packageExistsCache.getOrDefault("Phase8e::Package", false));
+        assertTrue(GlobalVariable.isDeclaredGlobalVariable("Phase8e::scalar"));
+        assertTrue(GlobalVariable.isDeclaredGlobalArray("Phase8e::array"));
+        assertTrue(GlobalVariable.isDeclaredGlobalHash("Phase8e::hash"));
+        assertTrue(ClassRegistry.isClass("Phase8e::Class"));
+        assertEquals(marker + "::Parent", FieldRegistry.getParentClass("Phase8e::Class"));
+        assertTrue(FieldRegistry.getClassFields("Phase8e::Class").contains(marker));
+        assertEquals(marker, new ScopedSymbolTable().getPackageVersion("Phase8e::Package"));
+        assertSame(loader, GlobalVariable.getGlobalClassLoader());
+    }
+
+    private static void assertPackageServicesAbsent(CustomClassLoader otherLoader) {
+        assertFalse(GlobalVariable.packageExistsCache.containsKey("Phase8e::Package"));
+        assertFalse(GlobalVariable.isDeclaredGlobalVariable("Phase8e::scalar"));
+        assertFalse(GlobalVariable.isDeclaredGlobalArray("Phase8e::array"));
+        assertFalse(GlobalVariable.isDeclaredGlobalHash("Phase8e::hash"));
+        assertFalse(ClassRegistry.isClass("Phase8e::Class"));
+        assertNull(FieldRegistry.getParentClass("Phase8e::Class"));
+        assertTrue(FieldRegistry.getClassFields("Phase8e::Class").isEmpty());
+        assertNull(new ScopedSymbolTable().getPackageVersion("Phase8e::Package"));
+        assertNotSame(otherLoader, GlobalVariable.getGlobalClassLoader());
+    }
+
+    private static FutureTask<PackageSnapshot> packageTask(
+            PerlRuntime runtime, String marker, CountDownLatch ready, CountDownLatch start) {
+        return new FutureTask<>(() -> {
+            try (PerlRuntime.Binding ignored = runtime.bind()) {
+                ready.countDown();
+                assertTrue(start.await(10, TimeUnit.SECONDS));
+                installPackageServices(marker);
+                CustomClassLoader loader = GlobalVariable.getGlobalClassLoader();
+                assertPackageServices(marker, loader);
+                return new PackageSnapshot(marker, loader);
+            }
+        });
+    }
+
+    private static String run(PerlRuntime runtime, String source, boolean interpreter)
+            throws Exception {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            CompilerOptions options = new CompilerOptions();
+            options.fileName = "<global-package-services-runtime-isolation>";
+            options.code = source;
+            options.useInterpreter = interpreter;
+            return PerlLanguageProvider.executePerlCode(options, false).scalar().toString();
+        }
+    }
+
+    private record PackageSnapshot(String marker, CustomClassLoader loader) {
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/RuntimeCodeRuntimeIsolationTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/RuntimeCodeRuntimeIsolationTest.java
@@ -1,0 +1,214 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class RuntimeCodeRuntimeIsolationTest {
+
+    @Test
+    void evalRegistriesOptionsAndInlineCachesBelongToTheBoundRuntime() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        RuntimeCode firstMethod = codeReturning("first");
+        RuntimeCode secondMethod = codeReturning("second");
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            assertEquals("(eval 1)", RuntimeCode.getNextEvalFilename());
+            assertEquals(0, RuntimeCode.allocateMethodCallsiteId());
+            RuntimeCode.putInterpretedSub("same", firstMethod);
+            RuntimeCode.registerAnonymousSub("same", String.class);
+            RuntimeCode.registerPadConstants("same", new RuntimeBase[]{new RuntimeScalar("first")});
+            first.runtimeCodeState.evalCache.put("same", String.class);
+            first.runtimeCodeState.methodHandleCache.put(String.class, null);
+            first.runtimeCodeState.evalContexts.put("same", null);
+            first.runtimeCodeState.cacheInlineMethod(0, 17, 23, firstMethod);
+            RuntimeCode.setDisassemble(true);
+            RuntimeCode.setUseInterpreter(true);
+            RuntimeCode.enableLexicalAliasSupport();
+        }
+
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            RuntimeCode.setDisassemble(false);
+            RuntimeCode.setUseInterpreter(false);
+            assertEquals("(eval 1)", RuntimeCode.getNextEvalFilename());
+            assertEquals(0, RuntimeCode.allocateMethodCallsiteId());
+            assertNull(RuntimeCode.getInterpretedSub("same"));
+            assertFalse(second.runtimeCodeState.anonymousSubs.containsKey("same"));
+            assertFalse(second.runtimeCodeState.padConstantsByClassName.containsKey("same"));
+            assertFalse(second.runtimeCodeState.evalCache.containsKey("same"));
+            assertFalse(second.runtimeCodeState.methodHandleCache.containsKey(String.class));
+            assertFalse(second.runtimeCodeState.evalContexts.containsKey("same"));
+            assertNull(second.runtimeCodeState.cachedInlineMethod(0, 17, 23));
+            assertFalse(RuntimeCode.isDisassemble());
+            assertFalse(RuntimeCode.isUseInterpreter());
+            assertFalse(second.runtimeCodeState.lexicalAliasSupportEnabled);
+
+            RuntimeCode.putInterpretedSub("same", secondMethod);
+            second.runtimeCodeState.cacheInlineMethod(0, 17, 23, secondMethod);
+        }
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            assertSame(firstMethod, RuntimeCode.getInterpretedSub("same"));
+            assertSame(String.class, first.runtimeCodeState.anonymousSubs.get("same"));
+            assertEquals("first", first.runtimeCodeState.padConstantsByClassName
+                    .get("same")[0].toString());
+            assertSame(String.class, first.runtimeCodeState.evalCache.get("same"));
+            assertTrue(first.runtimeCodeState.methodHandleCache.containsKey(String.class));
+            assertTrue(first.runtimeCodeState.evalContexts.containsKey("same"));
+            assertSame(firstMethod, first.runtimeCodeState.cachedInlineMethod(0, 17, 23));
+            assertTrue(RuntimeCode.isDisassemble());
+            assertTrue(RuntimeCode.isUseInterpreter());
+            assertTrue(first.runtimeCodeState.lexicalAliasSupportEnabled);
+        }
+
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertSame(secondMethod, RuntimeCode.getInterpretedSub("same"));
+            assertSame(secondMethod, second.runtimeCodeState.cachedInlineMethod(0, 17, 23));
+        }
+    }
+
+    @Test
+    void resetClearsOnlyTheBoundRuntimeCodeCaches() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        Object firstCode = new Object();
+        Object secondCode = new Object();
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            RuntimeCode.putInterpretedSub("entry", firstCode);
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            RuntimeCode.putInterpretedSub("entry", secondCode);
+        }
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            RuntimeCode.clearCaches();
+            assertNull(RuntimeCode.getInterpretedSub("entry"));
+        }
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertSame(secondCode, RuntimeCode.getInterpretedSub("entry"));
+        }
+    }
+
+    @Test
+    void concurrentEvalIdentifiersDoNotShareASequence() throws Exception {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        FutureTask<String> firstTask = evalSequenceTask(first, ready, start);
+        FutureTask<String> secondTask = evalSequenceTask(second, ready, start);
+        Thread firstThread = Thread.ofPlatform().start(firstTask);
+        Thread secondThread = Thread.ofPlatform().start(secondTask);
+
+        try {
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+        } finally {
+            start.countDown();
+            firstThread.join(TimeUnit.SECONDS.toMillis(10));
+            secondThread.join(TimeUnit.SECONDS.toMillis(10));
+        }
+        assertFalse(firstThread.isAlive());
+        assertFalse(secondThread.isAlive());
+        assertEquals("(eval 1):(eval 2)", firstTask.get(1, TimeUnit.SECONDS));
+        assertEquals("(eval 1):(eval 2)", secondTask.get(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void concurrentMixedBackendEvalClosuresUseTheirOwningRegistry() throws Exception {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        FutureTask<String> firstTask = executionTask(
+                first, source("Phase9Concurrent", "first"), false, ready, start);
+        FutureTask<String> secondTask = executionTask(
+                second, source("Phase9Concurrent", "second"), true, ready, start);
+        Thread firstThread = Thread.ofPlatform().start(firstTask);
+        Thread secondThread = Thread.ofPlatform().start(secondTask);
+
+        try {
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+        } finally {
+            start.countDown();
+            firstThread.join(TimeUnit.SECONDS.toMillis(30));
+            secondThread.join(TimeUnit.SECONDS.toMillis(30));
+        }
+        assertFalse(firstThread.isAlive());
+        assertFalse(secondThread.isAlive());
+        assertEquals("first:first:first", firstTask.get(1, TimeUnit.SECONDS));
+        assertEquals("second:second:second", secondTask.get(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void evalClosuresAndMethodDispatchStayIsolatedOnBothBackends() throws Exception {
+        for (boolean interpreter : new boolean[]{false, true}) {
+            PerlRuntime first = new PerlRuntime();
+            PerlRuntime second = new PerlRuntime();
+            String pkg = interpreter ? "Phase9Interpreter" : "Phase9Jvm";
+
+            String firstSource = source(pkg, "first");
+            String secondSource = source(pkg, "second");
+            assertEquals("first:first:first", run(first, firstSource, interpreter));
+            assertEquals("second:second:second", run(second, secondSource, interpreter));
+            assertEquals("first:first", run(first,
+                    "$" + pkg + "::closure->() . ':' . " + pkg + "->value", interpreter));
+            assertEquals("second:second", run(second,
+                    "$" + pkg + "::closure->() . ':' . " + pkg + "->value", interpreter));
+        }
+    }
+
+    private static RuntimeCode codeReturning(String value) {
+        return new RuntimeCode((args, context) -> new RuntimeScalar(value).getList(), null);
+    }
+
+    private static FutureTask<String> evalSequenceTask(
+            PerlRuntime runtime, CountDownLatch ready, CountDownLatch start) {
+        return new FutureTask<>(() -> {
+            try (PerlRuntime.Binding ignored = runtime.bind()) {
+                ready.countDown();
+                assertTrue(start.await(10, TimeUnit.SECONDS));
+                return RuntimeCode.getNextEvalFilename() + ":"
+                        + RuntimeCode.getNextEvalFilename();
+            }
+        });
+    }
+
+    private static FutureTask<String> executionTask(
+            PerlRuntime runtime, String source, boolean interpreter,
+            CountDownLatch ready, CountDownLatch start) {
+        return new FutureTask<>(() -> {
+            ready.countDown();
+            assertTrue(start.await(10, TimeUnit.SECONDS));
+            return run(runtime, source, interpreter);
+        });
+    }
+
+    private static String source(String pkg, String value) {
+        return "package " + pkg + ";"
+                + " my $captured = '" + value + "';"
+                + " our $closure = sub { eval '$captured' };"
+                + " sub value { '" + value + "' }"
+                + " my $object = bless {}, '" + pkg + "';"
+                + " $closure->() . ':' . $object->value . ':' . $object->value";
+    }
+
+    private static String run(PerlRuntime runtime, String source, boolean interpreter)
+            throws Exception {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            CompilerOptions options = new CompilerOptions();
+            options.fileName = "<runtime-code-isolation>";
+            options.code = source;
+            options.useInterpreter = interpreter;
+            return PerlLanguageProvider.executePerlCode(options, false).scalar().toString();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- implement Perl threads plan phases 8d, 8e, and 9 as the requested combined PR
- isolate glob/stash aliases and stash enumeration caches per runtime
- isolate declarations, package/class/field/version services, and generated classloaders
- isolate RuntimeCode eval registries, caches, callsites, inline caches, and backend flags
- preserve existing static facades and generated-bytecode compatibility
- batch runtime lookup on hot call paths to keep the full benchmark matrix within budget
- simplify design progress tracking so completed history lives in commits and PRs

Thread compatibility flags remain disabled.

## Phase boundaries

Phase 8d includes stash aliases, resolved-alias caching, glob aliases, and the stash enumeration cache. Runtime stashes themselves already live in the runtime-owned global hash table.

Phase 8e includes declared global sets, package-existence caching, generated classloaders, `ClassRegistry`, `FieldRegistry`, and package-version storage. Warning/feature registries remain compile state for Phase 10. `NameNormalizer` bless identity remains deferred to the lifecycle/cloning phase.

Phase 9 adds `RuntimeCodeRuntimeState` for eval IDs/classes/method handles/contexts, anonymous and interpreted code, pad constants, method callsites, inline method caches, and runtime-dependent interpreter/disassembly/lexical-alias flags. Generated fallback bytecode uses a runtime-aware interpreted-code facade.

## Validation

- exact-tree `make`: passed
- `make test-all`: core 83.0%, bundled modules 80.8%
- Scalar::Util 1.70: JVM and interpreter passed
- Moo 2.005005: JVM and interpreter passed
- focused stash, glob, strict-vars, localization, and eval tests: JVM and interpreter passed
- one interpreter eval/goto miss reproduced identically on merged master and is pre-existing
- no PerlOnJava3 test workers remained after validation

## Performance

Three-run CPU-time medians against exact merged base `ff04a83a6`:

| Benchmark | Base | This PR | Delta |
|---|---:|---:|---:|
| global | 27.31s | 24.81s | -9% |
| lexical | 10.01s | 8.63s | -14% |
| method | 5.73s | 4.95s | -14% |
| closure | 153.45s | 149.59s | -3% |
| regex | 4.76s | 4.66s | -2% |
| eval string | 70.48s | 67.72s | -4% |

All six gates are within the 5% regression budget.
