### PR TITLE
feat: complete runtime isolation and cloning phases 10-16

### DIFF
--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -478,7 +478,7 @@ measured benefit over platform threads/full clone.
 
 ## 7. Progress Tracking
 
-### Current Status: Phases 10 through 12 implemented and validated
+### Current Status: Phase 13 implemented and validated
 
 Hints, warnings, filters, and source maps are runtime-owned while compiler-only
 scratch remains protected by the global compile lock. The Phase 11 inventory is
@@ -510,7 +510,8 @@ current/base rates were global 37030/35671 (+3.8%), lexical 127349/118820
 (+7.2%), method 91.45/94.40 (-3.1%), closure 34.68/32.37 (+7.1%), regex
 21657.60/22048.45 (-1.8%), and eval-string 15070.22/14910.07 (+1.1%). The
 runtime lookup batching and idle lifecycle fast paths used to recover these
-results preserve the runtime-owned state boundaries.
+results preserve the runtime-owned state boundaries. This satisfies Phase 13;
+no speculative optimization from the historical branches is required.
 
 ### Implementation History
 
@@ -521,12 +522,12 @@ request history.
 
 ### Next Steps
 
-1. Land the combined Phase 10-through-12 pull request while `Config` thread
-   flags remain disabled.
-2. Start Phase 13 performance recovery only from new measured profiles; retain
-   the global compilation lock and do not optimize already-green paths speculatively.
-3. Re-run the mutable-static and worker audit before beginning Phase 14's graph
-   cloner so newly introduced state cannot escape runtime ownership.
+1. Implement Phase 14's identity-preserving graph cloner with a single identity
+   map across every root, explicit tie/resource policies, and no source mutation.
+2. Add explicit JVM and interpreter capture metadata in Phase 15; do not infer
+   generated constructor order through reflection.
+3. Compose the cloner into a Phase 16 runtime snapshot, preflight `CLONE_SKIP`,
+   and invoke `CLONE` only after the child graph is installed.
 
 ### Open Questions
 

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -478,7 +478,7 @@ measured benefit over platform threads/full clone.
 
 ## 7. Progress Tracking
 
-### Current Status: Phase 15 implemented and validated
+### Current Status: Phase 16 implemented and validated
 
 Hints, warnings, filters, and source maps are runtime-owned while compiler-only
 scratch remains protected by the global compile lock. The Phase 11 inventory is
@@ -529,6 +529,14 @@ captures, state values, and recursive self references through the same identity
 map. Cross-backend tests prove scalar, array, and hash captures evolve independently
 after cloning.
 
+`PerlRuntime.snapshotClone()` now pre-materializes lazy clone hooks, evaluates
+`CLONE_SKIP` in the parent, copies package globals and CODE slots through one
+graph cloner, and invokes `CLONE` in deterministic package order after the child
+graph is installed. The child keeps fresh execution, lifecycle, signal/alarm,
+native, classloader, cache, and I/O state. Snapshot tests cover both backends,
+global alias isolation, skipped blessed objects, parent immutability, hook
+context, and empty child execution stacks. Thread capability flags remain off.
+
 ### Implementation History
 
 Completed phase history is intentionally kept out of this living design
@@ -538,8 +546,10 @@ request history.
 
 ### Next Steps
 
-1. Compose the cloner into a Phase 16 runtime snapshot, preflight `CLONE_SKIP`,
-   and invoke `CLONE` only after the child graph is installed.
+1. Implement Phase 17's internal platform-thread control block with explicit
+   ownership, completion/error state, join/detach transitions, and cleanup.
+2. Keep the public Perl `threads` stub and `Config` capability flags unchanged
+   until the Phase 18 compatibility tranche is green.
 
 ### Open Questions
 

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -17,7 +17,8 @@ may be split further when its audit shows that it cannot be reviewed or reverted
 safely. Phases 3 and 4 were combined at the maintainer's request, as were
 Phases 5 through 7 and Phases 8a through 8c; each combined changeset preserves
 the same green-boundary requirements. Phases 8d, 8e, and 9 form one further
-maintainer-requested combined PR. At every merge boundary:
+maintainer-requested combined PR, as do Phases 10 through 12. At every merge
+boundary:
 
 - the compiler and both execution backends remain functional;
 - `make` passes;
@@ -72,8 +73,12 @@ and remove an empty binding. Do not use `InheritableThreadLocal`: executor
 workers are reused and inherited state leaks between tasks. Every callback or
 worker that accesses Perl state must capture a runtime and bind it explicitly.
 
-One runtime may move between Java threads when idle, but it must never execute
-concurrently on two threads.
+One runtime may move between Java threads when idle, but managed Perl execution
+must never run concurrently on two threads. `execute` is the exclusive ownership
+boundary. A scoped `bind` may also be used by captured infrastructure workers
+that perform narrowly classified state delivery (for example, enqueuing an
+alarm or routing process bytes); it does not authorize arbitrary concurrent
+Perl execution.
 
 ### 3.2 Compilation boundary
 
@@ -344,6 +349,13 @@ finds unrelated ownership domains; document the split here before coding.
 Worker binding for alarms, pipes, system stream routers, and callbacks lands
 with the state each worker accesses.
 
+The implementation groups this inventory into explicit runtime-owned domains:
+lifecycle/reachability, signals/alarms, process and IO registries, filesystem
+environment/stat state, debugger state, parser data sections, random/state
+variables, native/module registries, and object-name/bless identity. Opaque
+Net::SSLeay handles and provider registries are interpreter-owned; cryptographic
+algorithms and native bindings remain immutable process services.
+
 Acceptance: the mutable-static/thread-spawn audit has no unclassified
 runtime-dependent state.
 
@@ -466,18 +478,39 @@ measured benefit over platform threads/full clone.
 
 ## 7. Progress Tracking
 
-### Current Status: Phases 8d through 9 complete; combined PR ready for review
+### Current Status: Phases 10 through 12 implemented and validated
 
-Runtime-owned state now includes glob/stash aliases and enumeration caches;
-declarations, package/class/field/version services, and generated classloaders;
-and RuntimeCode eval registries, caches, callsites, inline caches, and backend
-selection flags. `Config` thread flags remain disabled. The paired six-benchmark
-matrix is within budget after batching hot-path runtime lookups. Exact-tree
-`make` passes; the comprehensive gate is core 83.0% and bundled modules 80.8%.
-Scalar::Util 1.70, Moo 2.005005, and focused stash/glob/strict/eval tests pass
-on both backends, apart from one interpreter eval/goto miss reproduced exactly
-on merged master. Three-run CPU medians versus the same base improved by about
-9% global, 14% lexical, 14% method, 3% closure, 2% regex, and 4% eval-string.
+Hints, warnings, filters, and source maps are runtime-owned while compiler-only
+scratch remains protected by the global compile lock. The Phase 11 inventory is
+split internally into explicit state holders for lifecycle/reachability,
+signals/alarms, process and IO registries, filesystem/stat/random state,
+debugging, data sections, native/module registries, and bless identity. The
+mutable-static and spawned-worker audit classifies remaining statics as immutable
+caches/constants, synchronized process services, globally unique ID allocators,
+or compile-only state under the Phase 2 lock.
+
+`PerlRuntime` now provides idempotent initialization and close plus exclusive,
+reentrant managed execution. Closing releases alarms, signals, I/O and native
+registries, and lifecycle roots. Concurrent integration tests run conflicting
+JVM and interpreter programs in separate runtimes. `Config` thread flags remain
+disabled; no Perl `threads` API is exposed.
+
+Validation completed with the full unit build and the comprehensive compatibility
+gate. `make test-all` retained the established partial-support baseline while
+slightly improving the aggregate counts: Perl core reached 83.1% and bundled
+modules reached 81.0%. Focused JVM/interpreter checks covered warning and hint
+state, source locations, filters, CWD, alarms/signals, random and regex state,
+data sections, I/O registries, lifecycle/weak references, and runtime close.
+Scalar::Util reports 1.70 on both backends; the JVM Moo constructor smoke passes.
+The interpreter's pre-existing parser rejection of Moo attribute syntax remains
+outside this runtime-state migration.
+
+Three-run same-base benchmark medians are within the 5% gate. The measured
+current/base rates were global 37030/35671 (+3.8%), lexical 127349/118820
+(+7.2%), method 91.45/94.40 (-3.1%), closure 34.68/32.37 (+7.1%), regex
+21657.60/22048.45 (-1.8%), and eval-string 15070.22/14910.07 (+1.1%). The
+runtime lookup batching and idle lifecycle fast paths used to recover these
+results preserve the runtime-owned state boundaries.
 
 ### Implementation History
 
@@ -488,12 +521,12 @@ request history.
 
 ### Next Steps
 
-1. Finish validation and review the combined Phase 8d-through-9 PR while
-   `Config` thread flags remain disabled.
-2. Start Phase 10 from updated `master`: classify compile-only versus runtime
-   hints, warnings, filters, and source maps before migrating runtime state.
-3. Re-audit and split Phase 11's lifecycle/miscellaneous inventory into atomic,
-   independently green ownership domains before implementation.
+1. Land the combined Phase 10-through-12 pull request while `Config` thread
+   flags remain disabled.
+2. Start Phase 13 performance recovery only from new measured profiles; retain
+   the global compilation lock and do not optimize already-green paths speculatively.
+3. Re-run the mutable-static and worker audit before beginning Phase 14's graph
+   cloner so newly introduced state cannot escape runtime ownership.
 
 ### Open Questions
 

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -478,7 +478,7 @@ measured benefit over platform threads/full clone.
 
 ## 7. Progress Tracking
 
-### Current Status: Phase 14 implemented and validated
+### Current Status: Phase 15 implemented and validated
 
 Hints, warnings, filters, and source maps are runtime-owned while compiler-only
 scratch remains protected by the global compile lock. The Phase 11 inventory is
@@ -521,6 +521,14 @@ are rebuilt without invoking FETCH/STORE. Nonportable Java I/O resources follow
 the documented conservative policy and become `undef` in the clone. Focused
 tests prove source immutability and cross-root alias preservation.
 
+Generated JVM closures now implement `CloneablePerlSubroutine`, exposing their
+captures in constructor order and rebuilding themselves from an explicit capture
+array. The graph cloner uses that contract without reflecting over field order.
+Interpreter closures rebuild immutable bytecode metadata while cloning constants,
+captures, state values, and recursive self references through the same identity
+map. Cross-backend tests prove scalar, array, and hash captures evolve independently
+after cloning.
+
 ### Implementation History
 
 Completed phase history is intentionally kept out of this living design
@@ -530,9 +538,7 @@ request history.
 
 ### Next Steps
 
-1. Add explicit JVM and interpreter capture metadata in Phase 15; do not infer
-   generated constructor order through reflection.
-2. Compose the cloner into a Phase 16 runtime snapshot, preflight `CLONE_SKIP`,
+1. Compose the cloner into a Phase 16 runtime snapshot, preflight `CLONE_SKIP`,
    and invoke `CLONE` only after the child graph is installed.
 
 ### Open Questions

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -478,7 +478,7 @@ measured benefit over platform threads/full clone.
 
 ## 7. Progress Tracking
 
-### Current Status: Phase 13 implemented and validated
+### Current Status: Phase 14 implemented and validated
 
 Hints, warnings, filters, and source maps are runtime-owned while compiler-only
 scratch remains protected by the global compile lock. The Phase 11 inventory is
@@ -513,6 +513,14 @@ runtime lookup batching and idle lifecycle fast paths used to recover these
 results preserve the runtime-owned state boundaries. This satisfies Phase 13;
 no speculative optimization from the historical branches is required.
 
+`RuntimeGraphCloner` now clones non-code Perl graphs through one identity map.
+Container shells are registered before their contents, so aliases and cycles
+survive; blessings are translated by class name, weak edges are installed only
+after the strong graph exists, and readonly constants stay shared. Tie wrappers
+are rebuilt without invoking FETCH/STORE. Nonportable Java I/O resources follow
+the documented conservative policy and become `undef` in the clone. Focused
+tests prove source immutability and cross-root alias preservation.
+
 ### Implementation History
 
 Completed phase history is intentionally kept out of this living design
@@ -522,11 +530,9 @@ request history.
 
 ### Next Steps
 
-1. Implement Phase 14's identity-preserving graph cloner with a single identity
-   map across every root, explicit tie/resource policies, and no source mutation.
-2. Add explicit JVM and interpreter capture metadata in Phase 15; do not infer
+1. Add explicit JVM and interpreter capture metadata in Phase 15; do not infer
    generated constructor order through reflection.
-3. Compose the cloner into a Phase 16 runtime snapshot, preflight `CLONE_SKIP`,
+2. Compose the cloner into a Phase 16 runtime snapshot, preflight `CLONE_SKIP`,
    and invoke `CLONE` only after the child graph is installed.
 
 ### Open Questions

--- a/src/main/java/org/perlonjava/app/cli/ArgumentParser.java
+++ b/src/main/java/org/perlonjava/app/cli/ArgumentParser.java
@@ -551,8 +551,8 @@ public class ArgumentParser {
                     // Run under debugger
                     parsedArgs.runUnderDebugger = true;
                     parsedArgs.useInterpreter = true;  // Force interpreter mode for debugging
-                    DebugState.debugMode = true;       // Enable debug opcode emission
-                    DebugState.single = true;          // Start in single-step mode
+                    DebugState.setDebugMode(true);       // Enable debug opcode emission
+                    DebugState.current().single = true;  // Start in single-step mode
                     DebugHooks.initializeDebugVariables();  // Initialize $DB::single etc.
                     break;
                 case 't':
@@ -935,7 +935,7 @@ public class ArgumentParser {
         if (directory != null) {
             try {
                 // Change to the specified directory
-                System.setProperty("user.dir", directory);
+                org.perlonjava.runtime.runtimetypes.RuntimeEnvironment.setCurrentDirectory(directory);
             } catch (SecurityException e) {
                 System.err.println("Error: Unable to change directory to " + directory);
                 System.exit(1);

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -955,7 +955,7 @@ public class BytecodeCompiler implements Visitor {
         }
 
         // Populate debug source lines if in debug mode
-        if (DebugState.debugMode && errorUtil != null && sourceName != null) {
+        if (DebugState.isDebugMode() && errorUtil != null && sourceName != null) {
             String[] lines = errorUtil.extractSourceLines();
             if (lines.length > 0) {
                 DebugState.storeSourceLines(sourceName, lines);
@@ -1310,7 +1310,7 @@ public class BytecodeCompiler implements Visitor {
 
             // Emit DEBUG opcode for debugger support (only when -d flag is active)
             // Skip debug opcodes for internal/infrastructure nodes (marked with skipDebug)
-            if (DebugState.debugMode && stmtTokenIndex >= 0) {
+            if (DebugState.isDebugMode() && stmtTokenIndex >= 0) {
                 boolean skipDebug = (stmt instanceof AbstractNode an && an.getBooleanAnnotation("skipDebug"));
                 if (!skipDebug) {
                     // Use getLineNumberAccurate() because subroutine bodies may be compiled
@@ -5751,7 +5751,7 @@ public class BytecodeCompiler implements Visitor {
         emitReg(codeReg);
 
         // Step 7: Register subroutine location for %DB::sub (only in debug mode)
-        if (DebugState.debugMode && errorUtil != null) {
+        if (DebugState.isDebugMode() && errorUtil != null) {
             int startLine = errorUtil.getLineNumber(node.getIndex());
             // Use start line as end line for now (accurate end would require tracking block end)
             DebugState.registerSubroutine(fullName, sourceName, startLine, startLine);

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperatorHelper.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperatorHelper.java
@@ -477,10 +477,10 @@ public class CompileBinaryOperatorHelper {
                 // Flip-flop operator (.. and ...) - per-call-site state via unique ID
                 // Note: numeric range (..) is handled earlier in visitBinaryOperator for list context;
                 // this case handles scalar-context flip-flop.
-                int flipFlopId = org.perlonjava.runtime.operators.ScalarFlipFlopOperator.currentId++;
+                int flipFlopId = org.perlonjava.runtime.operators.ScalarFlipFlopOperator.allocateId();
                 org.perlonjava.runtime.operators.ScalarFlipFlopOperator op =
                         new org.perlonjava.runtime.operators.ScalarFlipFlopOperator(operator.equals("..."));
-                org.perlonjava.runtime.operators.ScalarFlipFlopOperator.flipFlops.putIfAbsent(flipFlopId, op);
+                org.perlonjava.runtime.operators.ScalarFlipFlopOperator.flipFlops().putIfAbsent(flipFlopId, op);
                 bytecodeCompiler.emit(Opcodes.FLIP_FLOP);
                 bytecodeCompiler.emitReg(rd);
                 bytecodeCompiler.emit(flipFlopId);

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -1600,7 +1600,7 @@ public class CompileOperator {
     }
 
     private static void visitGlob(BytecodeCompiler bc, OperatorNode node) {
-        int globId = ScalarGlobOperator.currentId++;
+        int globId = ScalarGlobOperator.allocateId();
         bc.compileNode(node.operand, -1, RuntimeContextType.SCALAR);
         int patternReg = bc.lastResultReg;
         int rd = bc.allocateOutputRegister();

--- a/src/main/java/org/perlonjava/backend/bytecode/FutureAsyncAwaitRuntime.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/FutureAsyncAwaitRuntime.java
@@ -3,18 +3,12 @@ package org.perlonjava.backend.bytecode;
 import org.perlonjava.runtime.WarningBitsRegistry;
 import org.perlonjava.runtime.runtimetypes.*;
 
-import java.util.ArrayDeque;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /** Runtime bridge to the Future::AsyncAwait::Awaitable method contract. */
 public final class FutureAsyncAwaitRuntime {
     private static final RuntimeScalar EMPTY_CURRENT_SUB = new RuntimeScalar("");
-    private static final ThreadLocal<ArrayDeque<Runnable>> RESUME_QUEUE =
-            ThreadLocal.withInitial(ArrayDeque::new);
-    private static final ThreadLocal<Boolean> DRAINING =
-            ThreadLocal.withInitial(() -> false);
-
     private FutureAsyncAwaitRuntime() {
     }
 
@@ -340,18 +334,19 @@ public final class FutureAsyncAwaitRuntime {
     }
 
     private static void enqueue(Runnable action) {
-        ArrayDeque<Runnable> queue = RESUME_QUEUE.get();
+        ExecutionRuntimeState state = PerlRuntime.current().executionState();
+        var queue = state.futureResumeQueue;
         queue.addLast(action);
-        if (DRAINING.get()) {
+        if (state.futureResumeDraining) {
             return;
         }
-        DRAINING.set(true);
+        state.futureResumeDraining = true;
         try {
             while (!queue.isEmpty()) {
                 queue.removeFirst().run();
             }
         } finally {
-            DRAINING.set(false);
+            state.futureResumeDraining = false;
             queue.clear();
         }
     }

--- a/src/main/java/org/perlonjava/backend/jvm/ByteCodeSourceMapper.java
+++ b/src/main/java/org/perlonjava/backend/jvm/ByteCodeSourceMapper.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 
 /**
  * Maps bytecode positions to their corresponding Perl source code locations.
@@ -13,32 +14,32 @@ import java.util.TreeMap;
  * resolution for stack traces at runtime.
  */
 public class ByteCodeSourceMapper {
-    // Maps source files to their debug information
-    private static final Map<Integer, SourceFileInfo> sourceFiles = new HashMap<>();
+    public static final class State {
+        final Map<Integer, SourceFileInfo> sourceFiles = new HashMap<>();
+        final ArrayList<String> packageNamePool = new ArrayList<>();
+        final Map<String, Integer> packageNameToId = new HashMap<>();
+        final ArrayList<String> fileNamePool = new ArrayList<>();
+        final Map<String, Integer> fileNameToId = new HashMap<>();
+        final ArrayList<String> subroutineNamePool = new ArrayList<>();
+        final Map<String, Integer> subroutineNameToId = new HashMap<>();
 
-    // Pool of package names to optimize memory usage
-    private static final ArrayList<String> packageNamePool = new ArrayList<>();
-    private static final Map<String, Integer> packageNameToId = new HashMap<>();
+        void clear() {
+            sourceFiles.clear();
+            packageNamePool.clear();
+            packageNameToId.clear();
+            fileNamePool.clear();
+            fileNameToId.clear();
+            subroutineNamePool.clear();
+            subroutineNameToId.clear();
+        }
+    }
 
-    // Pool of file names to optimize memory usage
-    private static final ArrayList<String> fileNamePool = new ArrayList<>();
-    private static final Map<String, Integer> fileNameToId = new HashMap<>();
-
-    // Pool of subroutine names to optimize memory usage
-    private static final ArrayList<String> subroutineNamePool = new ArrayList<>();
-    private static final Map<String, Integer> subroutineNameToId = new HashMap<>();
+    private static State state() {
+        return PerlRuntime.current().sourceMapperState;
+    }
 
     public static void resetAll() {
-        sourceFiles.clear();
-
-        packageNamePool.clear();
-        packageNameToId.clear();
-
-        fileNamePool.clear();
-        fileNameToId.clear();
-
-        subroutineNamePool.clear();
-        subroutineNameToId.clear();
+        state().clear();
     }
 
     /**
@@ -48,9 +49,10 @@ public class ByteCodeSourceMapper {
      * @return The unique identifier for the package
      */
     private static int getOrCreatePackageId(String packageName) {
-        return packageNameToId.computeIfAbsent(packageName, name -> {
-            packageNamePool.add(name);
-            return packageNamePool.size() - 1;
+        State state = state();
+        return state.packageNameToId.computeIfAbsent(packageName, name -> {
+            state.packageNamePool.add(name);
+            return state.packageNamePool.size() - 1;
         });
     }
 
@@ -61,9 +63,10 @@ public class ByteCodeSourceMapper {
      * @return The unique identifier for the file
      */
     private static int getOrCreateFileId(String fileName) {
-        return fileNameToId.computeIfAbsent(fileName, name -> {
-            fileNamePool.add(name);
-            return fileNamePool.size() - 1;
+        State state = state();
+        return state.fileNameToId.computeIfAbsent(fileName, name -> {
+            state.fileNamePool.add(name);
+            return state.fileNamePool.size() - 1;
         });
     }
 
@@ -74,9 +77,10 @@ public class ByteCodeSourceMapper {
      * @return The unique identifier for the subroutine name
      */
     private static int getOrCreateSubroutineId(String subroutineName) {
-        return subroutineNameToId.computeIfAbsent(subroutineName, name -> {
-            subroutineNamePool.add(name);
-            return subroutineNamePool.size() - 1;
+        State state = state();
+        return state.subroutineNameToId.computeIfAbsent(subroutineName, name -> {
+            state.subroutineNamePool.add(name);
+            return state.subroutineNamePool.size() - 1;
         });
     }
 
@@ -87,7 +91,7 @@ public class ByteCodeSourceMapper {
      */
     static void setDebugInfoFileName(EmitterContext ctx) {
         int fileId = getOrCreateFileId(ctx.compilerOptions.fileName);
-        sourceFiles.computeIfAbsent(fileId, SourceFileInfo::new);
+        state().sourceFiles.computeIfAbsent(fileId, SourceFileInfo::new);
         ctx.cw.visitSource(ctx.compilerOptions.fileName, null);
     }
 
@@ -126,13 +130,14 @@ public class ByteCodeSourceMapper {
      * @param tokenIndex The index of the token in the source code
      */
     public static void saveSourceLocation(EmitterContext ctx, int tokenIndex) {
+        State state = state();
         // Use the ORIGINAL filename (compile-time) for the key, not the #line-adjusted one.
         // This is because JVM stack traces report the original filename from visitSource().
         // The #line-adjusted filename is stored separately in LineInfo for caller() reporting.
         int fileId = getOrCreateFileId(ctx.compilerOptions.fileName);
 
         // Get or create the SourceFileInfo object for the file
-        SourceFileInfo info = sourceFiles.computeIfAbsent(fileId, SourceFileInfo::new);
+        SourceFileInfo info = state.sourceFiles.computeIfAbsent(fileId, SourceFileInfo::new);
 
         // Get current subroutine name (empty string for main code)
         String subroutineName = ctx.symbolTable.getCurrentSubroutine();
@@ -174,7 +179,7 @@ public class ByteCodeSourceMapper {
             // Look for nearby entry (within 50 tokens) that has #line-adjusted filename
             var nearbyEntry = info.tokenToLineInfo.floorEntry(tokenIndex);
             if (nearbyEntry != null && (tokenIndex - nearbyEntry.getKey()) < 50) {
-                String nearbySourceFile = fileNamePool.get(nearbyEntry.getValue().sourceFileNameId());
+                String nearbySourceFile = state.fileNamePool.get(nearbyEntry.getValue().sourceFileNameId());
                 if (!nearbySourceFile.equals(ctx.compilerOptions.fileName)) {
                     // Nearby entry has #line-adjusted filename - inherit it
                     sourceFileName = nearbySourceFile;
@@ -208,12 +213,13 @@ public class ByteCodeSourceMapper {
      * @return The package name at that location, or null if not found
      */
     public static String getPackageAtLocation(String fileName, int tokenIndex) {
-        int fileId = fileNameToId.getOrDefault(fileName, -1);
+        State state = state();
+        int fileId = state.fileNameToId.getOrDefault(fileName, -1);
         if (fileId == -1) {
             return null;
         }
 
-        SourceFileInfo info = sourceFiles.get(fileId);
+        SourceFileInfo info = state.sourceFiles.get(fileId);
         if (info == null) {
             return null;
         }
@@ -223,7 +229,7 @@ public class ByteCodeSourceMapper {
             return null;
         }
 
-        String pkg = packageNamePool.get(entry.getValue().packageNameId());
+        String pkg = state.packageNamePool.get(entry.getValue().packageNameId());
         return pkg;
     }
 
@@ -234,10 +240,11 @@ public class ByteCodeSourceMapper {
      * @return The corresponding source code location
      */
     public static SourceLocation parseStackTraceElement(StackTraceElement element, HashMap<ByteCodeSourceMapper.SourceLocation, String> locationToClassName) {
-        int fileId = fileNameToId.getOrDefault(element.getFileName(), -1);
+        State state = state();
+        int fileId = state.fileNameToId.getOrDefault(element.getFileName(), -1);
         int tokenIndex = element.getLineNumber();
 
-        SourceFileInfo info = sourceFiles.get(fileId);
+        SourceFileInfo info = state.sourceFiles.get(fileId);
         if (info == null) {
             return new SourceLocation(element.getFileName(), "", tokenIndex, null);
         }
@@ -251,9 +258,9 @@ public class ByteCodeSourceMapper {
         LineInfo lineInfo = entry.getValue();
         
         // Get the #line directive-adjusted source filename for caller() reporting
-        String sourceFileName = fileNamePool.get(lineInfo.sourceFileNameId());
+        String sourceFileName = state.fileNamePool.get(lineInfo.sourceFileNameId());
         int lineNumber = lineInfo.lineNumber();
-        String packageName = packageNamePool.get(lineInfo.packageNameId());
+        String packageName = state.packageNamePool.get(lineInfo.packageNameId());
         
         // FIX: If the found entry's sourceFile equals the original file (no #line applied),
         // check for nearby entries that have a #line-adjusted filename.
@@ -266,7 +273,7 @@ public class ByteCodeSourceMapper {
             boolean foundLineDirective = false;
             
             while (lowerEntry != null && (entry.getKey() - lowerEntry.getKey()) < 300) {
-                String lowerSourceFile = fileNamePool.get(lowerEntry.getValue().sourceFileNameId());
+                String lowerSourceFile = state.fileNamePool.get(lowerEntry.getValue().sourceFileNameId());
                 if (!lowerSourceFile.equals(element.getFileName())) {
                     // Found an entry with #line-adjusted filename
                     // Calculate the offset: the difference between the original line and the #line-adjusted line
@@ -293,7 +300,7 @@ public class ByteCodeSourceMapper {
                     int estimatedExtraLines = tokenDistFromLineDirective / 6;
                     lineNumber = lowerEntry.getValue().lineNumber() + estimatedExtraLines;
                     
-                    packageName = packageNamePool.get(lowerEntry.getValue().packageNameId());
+                    packageName = state.packageNamePool.get(lowerEntry.getValue().packageNameId());
                     break;
                 }
                 // This lower entry still has the original file, keep looking
@@ -305,14 +312,14 @@ public class ByteCodeSourceMapper {
                 int currentKey = entry.getKey();
                 var higherEntry = info.tokenToLineInfo.higherEntry(currentKey);
                 while (higherEntry != null && (higherEntry.getKey() - entry.getKey()) < 50) {
-                    String higherSourceFile = fileNamePool.get(higherEntry.getValue().sourceFileNameId());
+                    String higherSourceFile = state.fileNamePool.get(higherEntry.getValue().sourceFileNameId());
                     if (!higherSourceFile.equals(element.getFileName())) {
                         // Higher entry has #line-adjusted filename - use it
                         sourceFileName = higherSourceFile;
                         lineNumber = higherEntry.getValue().lineNumber() - 
                             (higherEntry.getKey() - entry.getKey());  // Approximate adjustment
                         if (lineNumber < 1) lineNumber = 1;
-                        packageName = packageNamePool.get(higherEntry.getValue().packageNameId());
+                        packageName = state.packageNamePool.get(higherEntry.getValue().packageNameId());
                         break;
                     }
                     // This higher entry still has the original file, keep looking
@@ -324,7 +331,7 @@ public class ByteCodeSourceMapper {
         
 
         // Retrieve subroutine name
-        String subroutineName = subroutineNamePool.get(lineInfo.subroutineNameId());
+        String subroutineName = state.subroutineNamePool.get(lineInfo.subroutineNameId());
         // If subroutine name is empty string (main code), convert to null
         if (subroutineName != null && subroutineName.isEmpty()) {
             subroutineName = null;

--- a/src/main/java/org/perlonjava/backend/jvm/EmitLogicalOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitLogicalOperator.java
@@ -19,7 +19,6 @@ import org.perlonjava.runtime.operators.ScalarFlipFlopOperator;
 import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
-import static org.perlonjava.runtime.operators.ScalarFlipFlopOperator.flipFlops;
 
 /**
  * The EmitLogicalOperator class is responsible for handling logical operators
@@ -47,11 +46,11 @@ public class EmitLogicalOperator {
         MethodVisitor mv = ctx.mv;
 
         // Generate unique IDs for this flip-flop instance
-        int flipFlopId = ScalarFlipFlopOperator.currentId++;
+        int flipFlopId = ScalarFlipFlopOperator.allocateId();
 
         // Constructor to initialize the flip-flop operator with a unique identifier
         ScalarFlipFlopOperator op = new ScalarFlipFlopOperator(node.operator.equals("..."));
-        flipFlops.putIfAbsent(flipFlopId, op);   // Initialize to false state
+        ScalarFlipFlopOperator.flipFlops().putIfAbsent(flipFlopId, op);   // Initialize to false state
 
         // Emit bytecode to evaluate the flip-flop operator
         int flipFlopIdSlot = ctx.symbolTable.allocateLocalVariable();

--- a/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
@@ -685,7 +685,7 @@ public class EmitOperator {
         MethodVisitor mv = emitterVisitor.ctx.mv;
 
         // Generate unique IDs for this glob instance
-        int globId = ScalarGlobOperator.currentId++;
+        int globId = ScalarGlobOperator.allocateId();
 
         int globIdSlot = emitterVisitor.ctx.symbolTable.allocateLocalVariable();
         mv.visitLdcInsn(globId);

--- a/src/main/java/org/perlonjava/backend/jvm/EmitterMethodCreator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitterMethodCreator.java
@@ -462,7 +462,7 @@ public class EmitterMethodCreator implements Opcodes {
             // Define the class with version, access flags, name, signature, superclass, and interfaces
             // Implement PerlSubroutine interface for direct method calls (no MethodHandle conversion needed)
             cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, className, null, "java/lang/Object",
-                    new String[]{"org/perlonjava/runtime/runtimetypes/PerlSubroutine"});
+                    new String[]{"org/perlonjava/runtime/runtimetypes/CloneablePerlSubroutine"});
             if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("Create class: " + className);
 
             // Add instance fields to the class for closure variables
@@ -536,6 +536,8 @@ public class EmitterMethodCreator implements Opcodes {
             mv.visitInsn(Opcodes.RETURN); // Return void
             mv.visitMaxs(0, 0); // Automatically computed
             mv.visitEnd();
+
+            emitClosureCloneMetadata(cw, className, env, constructorDescriptor.toString());
 
             // Create the public "apply" method for the generated class
             if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("Create the method");
@@ -1684,6 +1686,73 @@ public class EmitterMethodCreator implements Opcodes {
                     e);
         }
 
+    }
+
+    private static void emitClosureCloneMetadata(
+            ClassWriter cw, String className, String[] env, String constructorDescriptor) {
+        String base = "org/perlonjava/runtime/runtimetypes/RuntimeBase";
+        String scalar = "org/perlonjava/runtime/runtimetypes/RuntimeScalar";
+        String cloneable = "org/perlonjava/runtime/runtimetypes/CloneablePerlSubroutine";
+        int captureCount = Math.max(0, env.length - skipVariables);
+
+        MethodVisitor values = cw.visitMethod(Opcodes.ACC_PUBLIC, "capturedValues",
+                "()[L" + base + ";", null, null);
+        values.visitCode();
+        pushInt(values, captureCount);
+        values.visitTypeInsn(Opcodes.ANEWARRAY, base);
+        for (int i = skipVariables; i < env.length; i++) {
+            values.visitInsn(Opcodes.DUP);
+            pushInt(values, i - skipVariables);
+            if (env[i] == null || env[i].isEmpty()) {
+                values.visitInsn(Opcodes.ACONST_NULL);
+            } else {
+                values.visitVarInsn(Opcodes.ALOAD, 0);
+                values.visitFieldInsn(Opcodes.GETFIELD, className, env[i], getVariableDescriptor(env[i]));
+            }
+            values.visitInsn(Opcodes.AASTORE);
+        }
+        values.visitInsn(Opcodes.ARETURN);
+        values.visitMaxs(0, 0);
+        values.visitEnd();
+
+        MethodVisitor clone = cw.visitMethod(Opcodes.ACC_PUBLIC, "cloneWithCaptures",
+                "([L" + base + ";)L" + cloneable + ";", null, null);
+        clone.visitCode();
+        clone.visitTypeInsn(Opcodes.NEW, className);
+        clone.visitInsn(Opcodes.DUP);
+        for (int i = skipVariables; i < env.length; i++) {
+            clone.visitVarInsn(Opcodes.ALOAD, 1);
+            pushInt(clone, i - skipVariables);
+            clone.visitInsn(Opcodes.AALOAD);
+            String descriptor = getVariableDescriptor(env[i]);
+            clone.visitTypeInsn(Opcodes.CHECKCAST, descriptor.substring(1, descriptor.length() - 1));
+        }
+        clone.visitMethodInsn(Opcodes.INVOKESPECIAL, className, "<init>", constructorDescriptor, false);
+        clone.visitInsn(Opcodes.ARETURN);
+        clone.visitMaxs(0, 0);
+        clone.visitEnd();
+
+        MethodVisitor self = cw.visitMethod(Opcodes.ACC_PUBLIC, "setSelfReference",
+                "(L" + scalar + ";)V", null, null);
+        self.visitCode();
+        self.visitVarInsn(Opcodes.ALOAD, 0);
+        self.visitVarInsn(Opcodes.ALOAD, 1);
+        self.visitFieldInsn(Opcodes.PUTFIELD, className, "__SUB__", "L" + scalar + ";");
+        self.visitInsn(Opcodes.RETURN);
+        self.visitMaxs(0, 0);
+        self.visitEnd();
+    }
+
+    private static void pushInt(MethodVisitor mv, int value) {
+        if (value >= -1 && value <= 5) {
+            mv.visitInsn(Opcodes.ICONST_0 + value);
+        } else if (value <= Byte.MAX_VALUE) {
+            mv.visitIntInsn(Opcodes.BIPUSH, value);
+        } else if (value <= Short.MAX_VALUE) {
+            mv.visitIntInsn(Opcodes.SIPUSH, value);
+        } else {
+            mv.visitLdcInsn(value);
+        }
     }
 
     /**

--- a/src/main/java/org/perlonjava/frontend/parser/DataSection.java
+++ b/src/main/java/org/perlonjava/frontend/parser/DataSection.java
@@ -6,6 +6,7 @@ import org.perlonjava.frontend.lexer.LexerToken;
 import org.perlonjava.frontend.lexer.LexerTokenType;
 import org.perlonjava.runtime.io.ScalarBackedIO;
 import org.perlonjava.runtime.runtimetypes.GlobalVariable;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 import org.perlonjava.runtime.runtimetypes.RuntimeIO;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
@@ -21,20 +22,22 @@ public class DataSection {
     /**
      * Set of package names that have already processed their DATA section
      */
-    private static final Set<String> processedPackages = new HashSet<>();
+    public static final class State {
+        final Set<String> processedPackages = new HashSet<>();
+        final Set<String> placeholderCreated = new HashSet<>();
+    }
 
-    /**
-     * Set of package names that have already created placeholder DATA handles
-     */
-    private static final Set<String> placeholderCreated = new HashSet<>();
+    private static State state() {
+        return PerlRuntime.current().dataSectionState;
+    }
 
     /**
      * Resets all static state for DataSection.
      * Called between test runs to prevent stale state from interfering.
      */
     public static void reset() {
-        processedPackages.clear();
-        placeholderCreated.clear();
+        state().processedPackages.clear();
+        state().placeholderCreated.clear();
     }
 
     /**
@@ -46,11 +49,11 @@ public class DataSection {
     public static void createPlaceholderDataHandle(Parser parser) {
         String handleName = parser.ctx.symbolTable.getCurrentPackage() + "::DATA";
 
-        if (placeholderCreated.contains(handleName)) {
+        if (state().placeholderCreated.contains(handleName)) {
             return; // Already created placeholder for this package
         }
 
-        placeholderCreated.add(handleName);
+        state().placeholderCreated.add(handleName);
 
         if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("Creating placeholder DATA handle for package: " + handleName);
 
@@ -186,18 +189,19 @@ public class DataSection {
         // However, allow re-processing if the DATA handle was closed (e.g., module
         // was re-required after delete $INC{...}). This is needed because modules
         // like ConfigData.pm close DATA after reading and expect a fresh handle on reload.
-        if (processedPackages.contains(handleName)) {
+        State state = state();
+        if (state.processedPackages.contains(handleName)) {
             RuntimeIO existingIO = GlobalVariable.getGlobalIO(handleName).getRuntimeIO();
             if (existingIO != null && !(existingIO.ioHandle instanceof org.perlonjava.runtime.io.ClosedIOHandle)) {
                 return tokens.size();
             }
             // Handle was closed — allow re-processing
-            processedPackages.remove(handleName);
-            placeholderCreated.remove(handleName);
+            state.processedPackages.remove(handleName);
+            state.placeholderCreated.remove(handleName);
         }
 
         if (token.text.equals("__DATA__") || token.text.equals("__END__")) {
-            processedPackages.add(handleName);
+            state.processedPackages.add(handleName);
 
             // __END__ should always stop parsing, but only top-level scripts (and __DATA__) should
             // populate the DATA handle content.

--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -31,7 +31,6 @@ import static org.perlonjava.frontend.parser.SpecialBlockParser.runSpecialBlock;
 import static org.perlonjava.frontend.parser.SpecialBlockParser.setCurrentScope;
 import static org.perlonjava.frontend.parser.StringParser.parseVstring;
 import static org.perlonjava.runtime.operators.VersionHelper.normalizeVersion;
-import static org.perlonjava.runtime.perlmodule.Feature.featureManager;
 import static org.perlonjava.runtime.perlmodule.Strict.useStrict;
 import static org.perlonjava.runtime.runtimetypes.WarningFlags.getLastScopeId;
 import static org.perlonjava.runtime.runtimetypes.WarningFlags.clearLastScopeId;
@@ -795,7 +794,7 @@ public class StatementParser {
                         String closestVersion = minorVersion < 10
                                 ? ":default"
                                 : ":" + majorVersion + "." + minorVersion;
-                        featureManager.enableFeatureBundle(closestVersion);
+                        org.perlonjava.runtime.perlmodule.Feature.getFeatureManager().enableFeatureBundle(closestVersion);
 
                         if (minorVersion >= 12) {
                             // If the specified Perl version is 5.12 or higher,

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -1346,7 +1346,7 @@ public class SubroutineParser {
         org.perlonjava.runtime.perlmodule.Mro.incrementPackageGeneration(definitionPackage);
 
         // Register subroutine location for %DB::sub (only in debug mode)
-        if (DebugState.debugMode && parser.ctx.errorUtil != null && block != null) {
+        if (DebugState.isDebugMode() && parser.ctx.errorUtil != null && block != null) {
             int startLine = parser.ctx.errorUtil.getLineNumber(block.tokenIndex);
             // Use current position as end for now (could track block end for accuracy)
             int endLine = parser.ctx.errorUtil.getLineNumber(parser.tokenIndex);

--- a/src/main/java/org/perlonjava/runtime/CompilationRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/CompilationRuntimeState.java
@@ -1,0 +1,74 @@
+package org.perlonjava.runtime;
+
+import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+import org.perlonjava.runtime.runtimetypes.FeatureFlags;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Runtime-owned lexical hint and warning state used across compilation and execution. */
+public final class CompilationRuntimeState {
+    public final Deque<Map<String, RuntimeScalar>> hintCompileTimeStack = new ArrayDeque<>();
+    public final Map<Integer, Map<String, String>> hintSnapshots = new ConcurrentHashMap<>();
+    public final AtomicInteger nextHintSnapshotId = new AtomicInteger();
+    public int callSiteHintHashId;
+    public final Deque<Integer> callerHintHashIdStack = new ArrayDeque<>();
+
+    public final ConcurrentHashMap<String, String> warningBitsByClass = new ConcurrentHashMap<>();
+    public final Deque<String> currentWarningBitsStack = new ArrayDeque<>();
+    public String callSiteWarningBits;
+    public String runtimeWarningBits;
+    public final Deque<String> callerWarningBitsStack = new ArrayDeque<>();
+    public int callSiteHints;
+    public final Deque<Integer> callerHintsStack = new ArrayDeque<>();
+    public Map<String, RuntimeScalar> callSiteHintHash = new HashMap<>();
+    public final Deque<Map<String, RuntimeScalar>> callerHintHashStack = new ArrayDeque<>();
+    public FeatureFlags featureManager = new FeatureFlags();
+    public final Set<String> customWarningCategories = ConcurrentHashMap.newKeySet();
+    public boolean globalWarningsEnabled;
+    public int commandLineWarningOverride;
+    public final AtomicInteger warningScopeIdCounter = new AtomicInteger();
+    public final Map<Integer, Set<String>> scopeDisabledWarnings = new HashMap<>();
+    public int lastWarningScopeId;
+    public final ConcurrentHashMap<String, Integer> userWarningCategoryOffsets =
+            new ConcurrentHashMap<>();
+    public final AtomicInteger nextUserWarningOffset = new AtomicInteger(128);
+    public final Map<String, Deque<RuntimeScalar>> endOfScopeFileCallbacks =
+            new ConcurrentHashMap<>();
+    public final Deque<String> loadingFileStack = new ArrayDeque<>();
+    public final Deque<Deque<RuntimeScalar>> compileScopes = new ArrayDeque<>();
+
+    public void clear() {
+        hintCompileTimeStack.clear();
+        hintSnapshots.clear();
+        nextHintSnapshotId.set(0);
+        callSiteHintHashId = 0;
+        callerHintHashIdStack.clear();
+        warningBitsByClass.clear();
+        currentWarningBitsStack.clear();
+        callSiteWarningBits = null;
+        runtimeWarningBits = null;
+        callerWarningBitsStack.clear();
+        callSiteHints = 0;
+        callerHintsStack.clear();
+        callSiteHintHash.clear();
+        callerHintHashStack.clear();
+        featureManager = new FeatureFlags();
+        customWarningCategories.clear();
+        globalWarningsEnabled = false;
+        commandLineWarningOverride = 0;
+        warningScopeIdCounter.set(0);
+        scopeDisabledWarnings.clear();
+        lastWarningScopeId = 0;
+        userWarningCategoryOffsets.clear();
+        nextUserWarningOffset.set(128);
+        endOfScopeFileCallbacks.clear();
+        loadingFileStack.clear();
+        compileScopes.clear();
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/ForkOpenState.java
+++ b/src/main/java/org/perlonjava/runtime/ForkOpenState.java
@@ -2,6 +2,7 @@ package org.perlonjava.runtime;
 
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 import org.perlonjava.runtime.runtimetypes.RuntimeCode;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 
 /**
  * Thread-local state for fork-open emulation.
@@ -47,8 +48,6 @@ public class ForkOpenState {
     /**
      * Thread-local storage for pending fork-open state.
      */
-    private static final ThreadLocal<PendingForkOpen> pendingState = new ThreadLocal<>();
-    
     /**
      * Represents a pending fork-open operation waiting for exec to complete it.
      */
@@ -85,8 +84,8 @@ public class ForkOpenState {
      * @param ioLayers Optional I/O layers (e.g., ":utf8")
      */
     public static void setPending(RuntimeScalar fileHandle, int tokenIndex, String ioLayers) {
-        pendingState.set(new PendingForkOpen(fileHandle, tokenIndex, ioLayers,
-                RuntimeCode.getActiveCodeAt(0)));
+        PerlRuntime.current().pendingForkOpen = new PendingForkOpen(fileHandle, tokenIndex, ioLayers,
+                RuntimeCode.getActiveCodeAt(0));
     }
     
     /**
@@ -95,7 +94,7 @@ public class ForkOpenState {
      * @return The pending state, or null if none
      */
     public static PendingForkOpen getPending() {
-        return pendingState.get();
+        return PerlRuntime.current().pendingForkOpen;
     }
     
     /**
@@ -110,7 +109,7 @@ public class ForkOpenState {
      * </ul>
      */
     public static void clear() {
-        pendingState.remove();
+        PerlRuntime.current().pendingForkOpen = null;
     }
     
     /**
@@ -119,6 +118,6 @@ public class ForkOpenState {
      * @return true if a fork-open is pending
      */
     public static boolean hasPending() {
-        return pendingState.get() != null;
+        return PerlRuntime.current().pendingForkOpen != null;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/HintHashRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/HintHashRegistry.java
@@ -2,12 +2,11 @@ package org.perlonjava.runtime;
 
 import org.perlonjava.runtime.runtimetypes.GlobalContext;
 import org.perlonjava.runtime.runtimetypes.GlobalVariable;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 import org.perlonjava.runtime.runtimetypes.RuntimeHash;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Registry for compile-time %^H (hints hash) scoping and per-call-site tracking.
@@ -28,24 +27,9 @@ public class HintHashRegistry {
     // Compile-time scope stack for %^H save/restore.
     // Each entry is a snapshot of %^H taken when entering a scope.
     // On scope exit, the global %^H is restored from this stack.
-    private static final Deque<Map<String, RuntimeScalar>> compileTimeStack =
-        new ArrayDeque<>();
-
-    // ---- Snapshot registry (compile-time -> runtime bridge) ----
-
-    // Maps snapshot IDs to frozen hint hash maps. ID 0 means empty/no hints.
-    private static final Map<Integer, Map<String, String>> snapshotRegistry =
-        new ConcurrentHashMap<>();
-    private static final AtomicInteger nextSnapshotId = new AtomicInteger(0);
-
-    // ThreadLocal tracking the current call site's snapshot ID.
-    // Updated at runtime from emitted bytecode.
-    private static final ThreadLocal<Integer> callSiteSnapshotId =
-        ThreadLocal.withInitial(() -> 0);
-
-    // ThreadLocal stack saving caller's snapshot ID across subroutine calls.
-    private static final ThreadLocal<Deque<Integer>> callerSnapshotIdStack =
-        ThreadLocal.withInitial(ArrayDeque::new);
+    private static CompilationRuntimeState state() {
+        return PerlRuntime.current().compilationState;
+    }
 
     // ---- Compile-time %^H scoping ----
 
@@ -60,7 +44,7 @@ public class HintHashRegistry {
         for (Map.Entry<String, RuntimeScalar> entry : hintHash.elements.entrySet()) {
             snapshot.put(entry.getKey(), new RuntimeScalar(entry.getValue()));
         }
-        compileTimeStack.push(snapshot);
+        state().hintCompileTimeStack.push(snapshot);
     }
 
     /**
@@ -68,8 +52,9 @@ public class HintHashRegistry {
      * Called at block exit during parsing.
      */
     public static void exitScope() {
-        if (!compileTimeStack.isEmpty()) {
-            Map<String, RuntimeScalar> savedState = compileTimeStack.pop();
+        Deque<Map<String, RuntimeScalar>> stack = state().hintCompileTimeStack;
+        if (!stack.isEmpty()) {
+            Map<String, RuntimeScalar> savedState = stack.pop();
             // Restore global %^H to the state saved when we entered this scope
             RuntimeHash hintHash = GlobalVariable.getGlobalHash(GlobalContext.encodeSpecialVar("H"));
             hintHash.elements.clear();
@@ -92,12 +77,13 @@ public class HintHashRegistry {
         if (hintHash.elements.isEmpty()) {
             return 0;
         }
-        int id = nextSnapshotId.incrementAndGet();
+        CompilationRuntimeState state = state();
+        int id = state.nextHintSnapshotId.incrementAndGet();
         Map<String, String> snapshot = new HashMap<>();
         for (Map.Entry<String, RuntimeScalar> entry : hintHash.elements.entrySet()) {
             snapshot.put(entry.getKey(), entry.getValue().toString());
         }
-        snapshotRegistry.put(id, snapshot);
+        state.hintSnapshots.put(id, snapshot);
         return id;
     }
 
@@ -110,7 +96,7 @@ public class HintHashRegistry {
      * @param id the snapshot ID (0 = empty/no hints)
      */
     public static void setCallSiteHintHashId(int id) {
-        callSiteSnapshotId.set(id);
+        state().callSiteHintHashId = id;
     }
 
     /**
@@ -120,11 +106,15 @@ public class HintHashRegistry {
      * Called by RuntimeCode.apply() before entering a subroutine.
      */
     public static void pushCallerHintHash() {
-        int currentId = callSiteSnapshotId.get();
-        callerSnapshotIdStack.get().push(currentId);
+        pushCallerHintHash(state());
+    }
+
+    public static void pushCallerHintHash(CompilationRuntimeState state) {
+        int currentId = state.callSiteHintHashId;
+        state.callerHintHashIdStack.push(currentId);
         // Reset callsite for the callee - it should not inherit the caller's hints.
         // The callee's own CompilerFlagNodes will set the correct ID if needed.
-        callSiteSnapshotId.set(0);
+        state.callSiteHintHashId = 0;
     }
 
     /**
@@ -133,12 +123,16 @@ public class HintHashRegistry {
      * Called by RuntimeCode.apply() after a subroutine returns.
      */
     public static void popCallerHintHash() {
-        Deque<Integer> stack = callerSnapshotIdStack.get();
+        popCallerHintHash(state());
+    }
+
+    public static void popCallerHintHash(CompilationRuntimeState state) {
+        Deque<Integer> stack = state.callerHintHashIdStack;
         if (!stack.isEmpty()) {
             int restoredId = stack.pop();
             // Restore the callsite ID so eval STRING and subsequent code
             // see the correct hint hash, not one clobbered by the callee.
-            callSiteSnapshotId.set(restoredId);
+            state.callSiteHintHashId = restoredId;
         }
     }
 
@@ -150,7 +144,8 @@ public class HintHashRegistry {
      * @return The hint hash map, or null if not available
      */
     public static Map<String, String> getCallerHintHashAtFrame(int frame) {
-        Deque<Integer> stack = callerSnapshotIdStack.get();
+        CompilationRuntimeState state = state();
+        Deque<Integer> stack = state.callerHintHashIdStack;
         if (stack.isEmpty()) {
             return null;
         }
@@ -158,7 +153,7 @@ public class HintHashRegistry {
         for (int id : stack) {
             if (index == frame) {
                 if (id == 0) return null;
-                return snapshotRegistry.get(id);
+                return state.hintSnapshots.get(id);
             }
             index++;
         }
@@ -172,9 +167,10 @@ public class HintHashRegistry {
      * @return the hint hash map, or null if empty/not set
      */
     public static Map<String, String> getCurrentCallSiteHintHash() {
-        int id = callSiteSnapshotId.get();
+        CompilationRuntimeState state = state();
+        int id = state.callSiteHintHashId;
         if (id == 0) return null;
-        return snapshotRegistry.get(id);
+        return state.hintSnapshots.get(id);
     }
 
     /**
@@ -182,10 +178,11 @@ public class HintHashRegistry {
      * Called by PerlLanguageProvider.resetAll() during reinitialization.
      */
     public static void clear() {
-        compileTimeStack.clear();
-        snapshotRegistry.clear();
-        nextSnapshotId.set(0);
-        callSiteSnapshotId.set(0);
-        callerSnapshotIdStack.get().clear();
+        CompilationRuntimeState state = state();
+        state.hintCompileTimeStack.clear();
+        state.hintSnapshots.clear();
+        state.nextHintSnapshotId.set(0);
+        state.callSiteHintHashId = 0;
+        state.callerHintHashIdStack.clear();
     }
 }

--- a/src/main/java/org/perlonjava/runtime/WarningBitsRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/WarningBitsRegistry.java
@@ -2,10 +2,9 @@ package org.perlonjava.runtime;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.perlonjava.runtime.runtimetypes.GlobalContext;
 import org.perlonjava.runtime.runtimetypes.GlobalVariable;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 import org.perlonjava.runtime.runtimetypes.RuntimeHash;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
@@ -25,52 +24,9 @@ import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
  */
 public class WarningBitsRegistry {
     
-    // Map from fully-qualified class name to warning bits string
-    private static final ConcurrentHashMap<String, String> registry = 
-        new ConcurrentHashMap<>();
-    
-    // ThreadLocal stack of warning bits for the current execution context
-    // This allows runtime code to find warning bits even at top-level (no subroutine frame)
-    private static final ThreadLocal<Deque<String>> currentBitsStack = 
-        ThreadLocal.withInitial(ArrayDeque::new);
-    
-    // ThreadLocal tracking the warning bits at the current call site.
-    // Updated at runtime when 'use warnings' / 'no warnings' pragmas are encountered.
-    // This provides per-statement warning bits (like Perl 5's per-COP bits).
-    private static final ThreadLocal<String> callSiteBits = 
-        ThreadLocal.withInitial(() -> null);
-
-    // Runtime override installed by ${^WARNING_BITS}; scoped by eval STRING.
-    private static final ThreadLocal<String> runtimeWarningBits =
-        ThreadLocal.withInitial(() -> null);
-    
-    // ThreadLocal stack saving caller's call-site bits across subroutine calls.
-    // Each apply() pushes the current callSiteBits before calling the subroutine,
-    // and pops it when the subroutine returns. This allows caller()[9] to return
-    // the correct per-call-site warning bits.
-    private static final ThreadLocal<Deque<String>> callerBitsStack = 
-        ThreadLocal.withInitial(ArrayDeque::new);
-    
-    // ThreadLocal tracking the compile-time $^H (hints) at the current call site.
-    // Updated at runtime when pragmas (use strict, etc.) are encountered.
-    // This provides per-statement hints for caller()[8].
-    private static final ThreadLocal<Integer> callSiteHints = 
-        ThreadLocal.withInitial(() -> 0);
-    
-    // ThreadLocal stack saving caller's $^H hints across subroutine calls.
-    // Mirrors callerBitsStack but for $^H instead of warning bits.
-    private static final ThreadLocal<Deque<Integer>> callerHintsStack = 
-        ThreadLocal.withInitial(ArrayDeque::new);
-    
-    // ThreadLocal tracking the compile-time %^H (hints hash) at the current call site.
-    // Updated at runtime when pragmas modify %^H.
-    // This provides per-statement hints hash for caller()[10].
-    private static final ThreadLocal<java.util.Map<String, org.perlonjava.runtime.runtimetypes.RuntimeScalar>> callSiteHintHash = 
-        ThreadLocal.withInitial(java.util.HashMap::new);
-    
-    // ThreadLocal stack saving caller's %^H across subroutine calls.
-    private static final ThreadLocal<Deque<java.util.Map<String, org.perlonjava.runtime.runtimetypes.RuntimeScalar>>> callerHintHashStack = 
-        ThreadLocal.withInitial(ArrayDeque::new);
+    private static CompilationRuntimeState state() {
+        return PerlRuntime.current().compilationState;
+    }
     
     /**
      * Registers the warning bits for a class.
@@ -82,7 +38,7 @@ public class WarningBitsRegistry {
      */
     public static void register(String className, String bits) {
         if (className != null && bits != null) {
-            registry.put(className, bits);
+            state().warningBitsByClass.put(className, bits);
         }
     }
     
@@ -97,7 +53,7 @@ public class WarningBitsRegistry {
         if (className == null) {
             return null;
         }
-        return registry.get(className);
+        return state().warningBitsByClass.get(className);
     }
     
     /**
@@ -107,8 +63,12 @@ public class WarningBitsRegistry {
      * @param bits The warning bits string
      */
     public static void pushCurrent(String bits) {
+        pushCurrent(bits, state());
+    }
+
+    public static void pushCurrent(String bits, CompilationRuntimeState state) {
         if (bits != null) {
-            currentBitsStack.get().push(bits);
+            state.currentWarningBitsStack.push(bits);
         }
     }
     
@@ -117,7 +77,11 @@ public class WarningBitsRegistry {
      * Called when exiting a subroutine or code block.
      */
     public static void popCurrent() {
-        Deque<String> stack = currentBitsStack.get();
+        popCurrent(state());
+    }
+
+    public static void popCurrent(CompilationRuntimeState state) {
+        Deque<String> stack = state.currentWarningBitsStack;
         if (!stack.isEmpty()) {
             stack.pop();
         }
@@ -130,7 +94,7 @@ public class WarningBitsRegistry {
      * @return The current warning bits string, or null if stack is empty
      */
     public static String getCurrent() {
-        Deque<String> stack = currentBitsStack.get();
+        Deque<String> stack = state().currentWarningBitsStack;
         return stack.isEmpty() ? null : stack.peek();
     }
     
@@ -139,15 +103,7 @@ public class WarningBitsRegistry {
      * Called by PerlLanguageProvider.resetAll() during reinitialization.
      */
     public static void clear() {
-        registry.clear();
-        currentBitsStack.get().clear();
-        callSiteBits.remove();
-        runtimeWarningBits.remove();
-        callerBitsStack.get().clear();
-        callSiteHints.remove();
-        callerHintsStack.get().clear();
-        callSiteHintHash.get().clear();
-        callerHintHashStack.get().clear();
+        state().clear();
     }
     
     /**
@@ -158,7 +114,7 @@ public class WarningBitsRegistry {
      * @param bits The warning bits string for the current call site
      */
     public static void setCallSiteBits(String bits) {
-        callSiteBits.set(bits);
+        state().callSiteWarningBits = bits;
     }
     
     /**
@@ -167,15 +123,15 @@ public class WarningBitsRegistry {
      * @return The current call-site warning bits, or null if not set
      */
     public static String getCallSiteBits() {
-        return callSiteBits.get();
+        return state().callSiteWarningBits;
     }
 
     public static void setRuntimeWarningBits(String bits) {
-        runtimeWarningBits.set(bits);
+        state().runtimeWarningBits = bits;
     }
 
     public static String getRuntimeWarningBits() {
-        return runtimeWarningBits.get();
+        return state().runtimeWarningBits;
     }
     
     /**
@@ -184,15 +140,20 @@ public class WarningBitsRegistry {
      * This preserves the caller's warning bits so caller()[9] can retrieve them.
      */
     public static void pushCallerBits() {
-        String bits = callSiteBits.get();
+        pushCallerBits(state());
+    }
+
+    public static void pushCallerBits(CompilationRuntimeState state) {
+        String bits = state.callSiteWarningBits;
         // The interpreter has no emitted runtime instruction for every
         // compile-time pragma node. When no per-call-site value is available,
         // the active caller code's bits are the correct fallback for
         // caller()[9] and eval-generated warning restoration.
         if (bits == null) {
-            bits = getCurrent();
+            Deque<String> current = state.currentWarningBitsStack;
+            bits = current.isEmpty() ? null : current.peek();
         }
-        callerBitsStack.get().push(bits != null ? bits : "");
+        state.callerWarningBitsStack.push(bits != null ? bits : "");
     }
     
     /**
@@ -200,7 +161,11 @@ public class WarningBitsRegistry {
      * Called by RuntimeCode.apply() after a subroutine returns.
      */
     public static void popCallerBits() {
-        Deque<String> stack = callerBitsStack.get();
+        popCallerBits(state());
+    }
+
+    public static void popCallerBits(CompilationRuntimeState state) {
+        Deque<String> stack = state.callerWarningBitsStack;
         if (!stack.isEmpty()) {
             stack.pop();
         }
@@ -215,7 +180,7 @@ public class WarningBitsRegistry {
      * @return The warning bits string, or null if not available
      */
     public static String getCallerBitsAtFrame(int frame) {
-        Deque<String> stack = callerBitsStack.get();
+        Deque<String> stack = state().callerWarningBitsStack;
         if (stack.isEmpty()) {
             return null;
         }
@@ -237,7 +202,7 @@ public class WarningBitsRegistry {
      * @return The number of registered class → bits mappings
      */
     public static int size() {
-        return registry.size();
+        return state().warningBitsByClass.size();
     }
     
     // ===== $^H (hints) support for caller()[8] =====
@@ -249,7 +214,7 @@ public class WarningBitsRegistry {
      * @param hints The $^H bitmask
      */
     public static void setCallSiteHints(int hints) {
-        callSiteHints.set(hints);
+        state().callSiteHints = hints;
     }
     
     /**
@@ -258,7 +223,7 @@ public class WarningBitsRegistry {
      * @return The current call-site $^H value
      */
     public static int getCallSiteHints() {
-        return callSiteHints.get();
+        return state().callSiteHints;
     }
     
     /**
@@ -266,7 +231,11 @@ public class WarningBitsRegistry {
      * Called by RuntimeCode.apply() before entering a subroutine.
      */
     public static void pushCallerHints() {
-        callerHintsStack.get().push(callSiteHints.get());
+        pushCallerHints(state());
+    }
+
+    public static void pushCallerHints(CompilationRuntimeState state) {
+        state.callerHintsStack.push(state.callSiteHints);
     }
     
     /**
@@ -274,7 +243,11 @@ public class WarningBitsRegistry {
      * Called by RuntimeCode.apply() after a subroutine returns.
      */
     public static void popCallerHints() {
-        Deque<Integer> stack = callerHintsStack.get();
+        popCallerHints(state());
+    }
+
+    public static void popCallerHints(CompilationRuntimeState state) {
+        Deque<Integer> stack = state.callerHintsStack;
         if (!stack.isEmpty()) {
             stack.pop();
         }
@@ -289,7 +262,7 @@ public class WarningBitsRegistry {
      * @return The $^H value, or -1 if not available
      */
     public static int getCallerHintsAtFrame(int frame) {
-        Deque<Integer> stack = callerHintsStack.get();
+        Deque<Integer> stack = state().callerHintsStack;
         if (stack.isEmpty()) {
             return -1;
         }
@@ -312,7 +285,7 @@ public class WarningBitsRegistry {
      * @param hintHash A snapshot of the %^H hash elements
      */
     public static void setCallSiteHintHash(java.util.Map<String, org.perlonjava.runtime.runtimetypes.RuntimeScalar> hintHash) {
-        callSiteHintHash.set(hintHash != null ? new java.util.HashMap<>(hintHash) : new java.util.HashMap<>());
+        state().callSiteHintHash = hintHash != null ? new java.util.HashMap<>(hintHash) : new java.util.HashMap<>();
     }
     
     /**
@@ -329,7 +302,8 @@ public class WarningBitsRegistry {
      * Called by RuntimeCode.apply() before entering a subroutine.
      */
     public static void pushCallerHintHash() {
-        callerHintHashStack.get().push(new java.util.HashMap<>(callSiteHintHash.get()));
+        CompilationRuntimeState state = state();
+        state.callerHintHashStack.push(new java.util.HashMap<>(state.callSiteHintHash));
     }
 
     /**
@@ -340,11 +314,12 @@ public class WarningBitsRegistry {
      */
     public static java.util.List<org.perlonjava.runtime.runtimetypes.RuntimeScalar> snapshotHintHashStackScalars() {
         java.util.ArrayList<org.perlonjava.runtime.runtimetypes.RuntimeScalar> out = new java.util.ArrayList<>();
-        Deque<java.util.Map<String, org.perlonjava.runtime.runtimetypes.RuntimeScalar>> stack = callerHintHashStack.get();
+        CompilationRuntimeState state = state();
+        Deque<java.util.Map<String, org.perlonjava.runtime.runtimetypes.RuntimeScalar>> stack = state.callerHintHashStack;
         for (java.util.Map<String, org.perlonjava.runtime.runtimetypes.RuntimeScalar> frame : stack) {
             out.addAll(frame.values());
         }
-        out.addAll(callSiteHintHash.get().values());
+        out.addAll(state.callSiteHintHash.values());
         return out;
     }
     
@@ -353,7 +328,7 @@ public class WarningBitsRegistry {
      * Called by RuntimeCode.apply() after a subroutine returns.
      */
     public static void popCallerHintHash() {
-        Deque<java.util.Map<String, org.perlonjava.runtime.runtimetypes.RuntimeScalar>> stack = callerHintHashStack.get();
+        Deque<java.util.Map<String, org.perlonjava.runtime.runtimetypes.RuntimeScalar>> stack = state().callerHintHashStack;
         if (!stack.isEmpty()) {
             stack.pop();
         }
@@ -368,7 +343,7 @@ public class WarningBitsRegistry {
      * @return A copy of the %^H hash elements, or null if not available
      */
     public static java.util.Map<String, org.perlonjava.runtime.runtimetypes.RuntimeScalar> getCallerHintHashAtFrame(int frame) {
-        Deque<java.util.Map<String, org.perlonjava.runtime.runtimetypes.RuntimeScalar>> stack = callerHintHashStack.get();
+        Deque<java.util.Map<String, org.perlonjava.runtime.runtimetypes.RuntimeScalar>> stack = state().callerHintHashStack;
         if (stack.isEmpty()) {
             return null;
         }

--- a/src/main/java/org/perlonjava/runtime/debugger/DebugHooks.java
+++ b/src/main/java/org/perlonjava/runtime/debugger/DebugHooks.java
@@ -32,19 +32,9 @@ public class DebugHooks {
 
     private static final BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
     
-    // Command counter for prompt (1-indexed like Perl)
-    private static int commandCounter = 1;
-    
-    // Current execution context for expression evaluation
-    private static InterpretedCode currentCode;
-    private static RuntimeBase[] currentRegisters;
-    private static int currentSiteIndex = -1;
-    
-    // Flag to track if PERL5DB was set (user wants custom debugger)
-    private static boolean hasCustomDebugger = false;
-    
-    // Flag to track if we've already tried to execute PERL5DB
-    private static boolean perl5dbExecuted = false;
+    private static DebugRuntimeState state() {
+        return DebugState.current();
+    }
 
     /**
      * Main debug hook called by DEBUG opcode.
@@ -58,15 +48,16 @@ public class DebugHooks {
      */
     public static void debug(String filename, int line, InterpretedCode code, RuntimeBase[] registers, int siteIndex) {
         // Execute PERL5DB on first call (defines user's DB::DB if set)
-        if (!perl5dbExecuted) {
-            perl5dbExecuted = true;
+        DebugRuntimeState state = state();
+        if (!state.perl5dbExecuted) {
+            state.perl5dbExecuted = true;
             executePERL5DB();
         }
         
         // Store context for expression evaluation
-        currentCode = code;
-        currentRegisters = registers;
-        currentSiteIndex = siteIndex;
+        state.currentCode = code;
+        state.currentRegisters = registers;
+        state.currentSiteIndex = siteIndex;
         
         // Sync from Perl $DB::single variable to DebugState
         syncFromPerlVariables();
@@ -75,8 +66,8 @@ public class DebugHooks {
         syncDbSub();
         
         // Update current location
-        DebugState.currentFile = filename;
-        DebugState.currentLine = line;
+        state.currentFile = filename;
+        state.currentLine = line;
         
         // Update Perl debug variables
         GlobalVariable.getGlobalVariable("DB::filename").set(filename);
@@ -88,7 +79,7 @@ public class DebugHooks {
         }
 
         // Check for quit flag
-        if (DebugState.quit) {
+        if (state.quit) {
             System.exit(0);
         }
 
@@ -102,7 +93,7 @@ public class DebugHooks {
         }
 
         // If user has defined custom DB::DB, call it instead of our interactive debugger
-        if (hasCustomDebugger) {
+        if (state().hasCustomDebugger) {
             callUserDbDb();
             return;
         }
@@ -151,22 +142,22 @@ public class DebugHooks {
             return;
         }
         
-        hasCustomDebugger = true;
+        state().hasCustomDebugger = true;
         
         // Execute PERL5DB code in DB package context
         try {
             // Temporarily disable debug mode to avoid infinite recursion
-            boolean savedDebugMode = DebugState.debugMode;
-            DebugState.debugMode = false;
+            boolean savedDebugMode = state().debugMode;
+            state().debugMode = false;
             
             // Wrap in package DB to ensure subs are defined there
             String wrappedCode = "package DB; " + perl5db;
             EvalStringHandler.evalString(wrappedCode, new RuntimeBase[0], "<DB>", 1);
             
-            DebugState.debugMode = savedDebugMode;
+            state().debugMode = savedDebugMode;
         } catch (Exception e) {
             // If PERL5DB execution fails, fall back to interactive debugger
-            hasCustomDebugger = false;
+            state().hasCustomDebugger = false;
             System.err.println("Warning: Error executing PERL5DB: " + e.getMessage());
         }
     }
@@ -191,7 +182,7 @@ public class DebugHooks {
      */
     private static void commandLoop() {
         while (true) {
-            System.out.printf("  DB<%d> ", commandCounter);
+            System.out.printf("  DB<%d> ", state().commandCounter);
             System.out.flush();
 
             String input;
@@ -199,13 +190,13 @@ public class DebugHooks {
                 input = reader.readLine();
             } catch (IOException e) {
                 // EOF or error - quit
-                DebugState.quit = true;
+                state().quit = true;
                 return;
             }
 
             if (input == null) {
                 // EOF - quit
-                DebugState.quit = true;
+                state().quit = true;
                 return;
             }
 
@@ -218,7 +209,7 @@ public class DebugHooks {
 
             // Parse and execute command
             if (executeCommand(input)) {
-                commandCounter++;  // Increment after command that resumes execution
+                state().commandCounter++;  // Increment after command that resumes execution
                 return;  // Command indicates we should resume execution
             }
         }
@@ -303,9 +294,9 @@ public class DebugHooks {
     private static boolean handleNext(String args) {
         // Set step-over depth to current depth
         // DEBUG hook will skip while callDepth > stepOverDepth
-        DebugState.stepOverDepth = DebugState.callDepth;
-        DebugState.stepOutDepth = -1;
-        DebugState.single = true;
+        state().stepOverDepth = state().callDepth;
+        state().stepOutDepth = -1;
+        state().single = true;
         syncToPerlVariables();
         return true;
     }
@@ -315,9 +306,9 @@ public class DebugHooks {
      */
     private static boolean handleStep(String args) {
         // Disable step-over/step-out, enable single-step
-        DebugState.stepOverDepth = -1;
-        DebugState.stepOutDepth = -1;
-        DebugState.single = true;
+        state().stepOverDepth = -1;
+        state().stepOutDepth = -1;
+        state().single = true;
         syncToPerlVariables();
         return true;
     }
@@ -328,9 +319,9 @@ public class DebugHooks {
     private static boolean handleReturn(String args) {
         // Set step-out depth to current depth
         // DEBUG hook will skip until callDepth < stepOutDepth
-        DebugState.stepOutDepth = DebugState.callDepth;
-        DebugState.stepOverDepth = -1;
-        DebugState.single = true;
+        state().stepOutDepth = state().callDepth;
+        state().stepOverDepth = -1;
+        state().single = true;
         syncToPerlVariables();
         return true;
     }
@@ -340,17 +331,17 @@ public class DebugHooks {
      */
     private static boolean handleContinue(String args) {
         // Disable single-step, step-over, step-out
-        DebugState.single = false;
-        DebugState.stepOverDepth = -1;
-        DebugState.stepOutDepth = -1;
+        state().single = false;
+        state().stepOverDepth = -1;
+        state().stepOutDepth = -1;
 
         // If argument provided, it's a line number for one-time breakpoint
         if (!args.isEmpty()) {
             try {
                 int targetLine = Integer.parseInt(args);
-                String key = DebugState.currentFile + ":" + targetLine;
+                String key = state().currentFile + ":" + targetLine;
                 // Use one-time breakpoint so it's removed after being hit
-                DebugState.oneTimeBreakpoints.add(key);
+                state().oneTimeBreakpoints.add(key);
             } catch (NumberFormatException e) {
                 System.out.println("Invalid line number: " + args);
                 return false;
@@ -374,8 +365,8 @@ public class DebugHooks {
      * Handle 'l' (list) command - show source code.
      */
     private static void handleList(String args) {
-        String file = DebugState.currentFile;
-        int centerLine = DebugState.currentLine;
+        String file = state().currentFile;
+        int centerLine = state().currentLine;
         int range = 5;  // Show 5 lines before and after
 
         // Parse args for line range
@@ -405,7 +396,7 @@ public class DebugHooks {
      * Show source lines from file.
      */
     private static void showLines(String file, int start, int end) {
-        String[] lines = DebugState.sourceLines.get(file);
+        String[] lines = state().sourceLines.get(file);
         if (lines == null) {
             System.out.println("No source available for: " + file);
             return;
@@ -413,8 +404,8 @@ public class DebugHooks {
 
         end = Math.min(end, lines.length - 1);
         for (int i = start; i <= end; i++) {
-            String marker = (i == DebugState.currentLine) ? "==>" : "   ";
-            String bpMarker = DebugState.breakpoints.contains(file + ":" + i) ? "b" : " ";
+            String marker = (i == state().currentLine) ? "==>" : "   ";
+            String bpMarker = state().breakpoints.contains(file + ":" + i) ? "b" : " ";
             String line = (i < lines.length && lines[i] != null) ? lines[i] : "";
             System.out.printf("%s%s%4d:\t%s%n", marker, bpMarker, i, line);
         }
@@ -424,10 +415,10 @@ public class DebugHooks {
      * Handle '.' command - show current line.
      */
     private static void handleShowCurrent() {
-        String sourceLine = DebugState.getSourceLine(DebugState.currentFile, DebugState.currentLine);
+        String sourceLine = DebugState.getSourceLine(state().currentFile, state().currentLine);
         System.out.printf("%s:%d:\t%s%n",
-                DebugState.currentFile,
-                DebugState.currentLine,
+                state().currentFile,
+                state().currentLine,
                 sourceLine);
     }
 
@@ -436,11 +427,11 @@ public class DebugHooks {
      */
     private static void handleBreakpoint(String args) {
         int line;
-        String file = DebugState.currentFile;
+        String file = state().currentFile;
 
         if (args.isEmpty()) {
             // Breakpoint at current line
-            line = DebugState.currentLine;
+            line = state().currentLine;
         } else if (args.contains(":")) {
             // file:line format
             String[] parts = args.split(":", 2);
@@ -462,7 +453,7 @@ public class DebugHooks {
         }
 
         String key = file + ":" + line;
-        DebugState.breakpoints.add(key);
+        state().breakpoints.add(key);
         System.out.println("Breakpoint set at " + key);
     }
 
@@ -472,16 +463,16 @@ public class DebugHooks {
     private static void handleDeleteBreakpoint(String args) {
         if (args.equals("*")) {
             // Delete all breakpoints
-            DebugState.breakpoints.clear();
+            state().breakpoints.clear();
             System.out.println("All breakpoints deleted");
             return;
         }
 
         int line;
-        String file = DebugState.currentFile;
+        String file = state().currentFile;
 
         if (args.isEmpty()) {
-            line = DebugState.currentLine;
+            line = state().currentLine;
         } else if (args.contains(":")) {
             String[] parts = args.split(":", 2);
             file = parts[0];
@@ -501,7 +492,7 @@ public class DebugHooks {
         }
 
         String key = file + ":" + line;
-        if (DebugState.breakpoints.remove(key)) {
+        if (state().breakpoints.remove(key)) {
             System.out.println("Breakpoint deleted at " + key);
         } else {
             System.out.println("No breakpoint at " + key);
@@ -512,13 +503,13 @@ public class DebugHooks {
      * Handle 'L' (list breakpoints) command.
      */
     private static void handleListBreakpoints() {
-        if (DebugState.breakpoints.isEmpty()) {
+        if (state().breakpoints.isEmpty()) {
             System.out.println("No breakpoints set");
             return;
         }
 
         System.out.println("Breakpoints:");
-        for (String bp : DebugState.breakpoints) {
+        for (String bp : state().breakpoints) {
             System.out.println("  " + bp);
         }
     }
@@ -586,24 +577,25 @@ public class DebugHooks {
         }
 
         // Temporarily disable debug mode during expression evaluation
-        boolean savedDebugMode = DebugState.debugMode;
-        DebugState.debugMode = false;
+        boolean savedDebugMode = state().debugMode;
+        state().debugMode = false;
         
         try {
             // Look up the site-specific variable registry for lexical variable access
             java.util.Map<String, Integer> siteRegistry = null;
-            if (currentSiteIndex >= 0 && currentCode.evalSiteRegistries != null
-                    && currentSiteIndex < currentCode.evalSiteRegistries.size()) {
-                siteRegistry = currentCode.evalSiteRegistries.get(currentSiteIndex);
+            DebugRuntimeState state = state();
+            if (state.currentSiteIndex >= 0 && state.currentCode.evalSiteRegistries != null
+                    && state.currentSiteIndex < state.currentCode.evalSiteRegistries.size()) {
+                siteRegistry = state.currentCode.evalSiteRegistries.get(state.currentSiteIndex);
             }
             
             // Evaluate the expression using eval in scalar context
             RuntimeScalar result = EvalStringHandler.evalString(
                     expr,
-                    currentCode,
-                    currentRegisters,
-                    DebugState.currentFile,
-                    DebugState.currentLine,
+                    state.currentCode,
+                    state.currentRegisters,
+                    state().currentFile,
+                    state().currentLine,
                     RuntimeContextType.SCALAR,
                     siteRegistry
             );
@@ -620,7 +612,7 @@ public class DebugHooks {
             System.out.println("Error evaluating expression: " + e.getMessage());
         } finally {
             // Restore debug mode
-            DebugState.debugMode = savedDebugMode;
+            state().debugMode = savedDebugMode;
         }
     }
 
@@ -634,15 +626,16 @@ public class DebugHooks {
         }
 
         // Temporarily disable debug mode during expression evaluation
-        boolean savedDebugMode = DebugState.debugMode;
-        DebugState.debugMode = false;
+        boolean savedDebugMode = state().debugMode;
+        state().debugMode = false;
         
         try {
             // Look up the site-specific variable registry for lexical variable access
             java.util.Map<String, Integer> siteRegistry = null;
-            if (currentSiteIndex >= 0 && currentCode.evalSiteRegistries != null
-                    && currentSiteIndex < currentCode.evalSiteRegistries.size()) {
-                siteRegistry = currentCode.evalSiteRegistries.get(currentSiteIndex);
+            DebugRuntimeState state = state();
+            if (state.currentSiteIndex >= 0 && state.currentCode.evalSiteRegistries != null
+                    && state.currentSiteIndex < state.currentCode.evalSiteRegistries.size()) {
+                siteRegistry = state.currentCode.evalSiteRegistries.get(state.currentSiteIndex);
             }
             
             // Wrap expression to use Data::Dumper-style output
@@ -651,10 +644,10 @@ public class DebugHooks {
             
             RuntimeScalar result = EvalStringHandler.evalString(
                     dumpExpr,
-                    currentCode,
-                    currentRegisters,
-                    DebugState.currentFile,
-                    DebugState.currentLine,
+                    state.currentCode,
+                    state.currentRegisters,
+                    state().currentFile,
+                    state().currentLine,
                     RuntimeContextType.SCALAR,
                     siteRegistry
             );
@@ -665,10 +658,10 @@ public class DebugHooks {
                 // Data::Dumper not available, fall back to simple output
                 result = EvalStringHandler.evalString(
                         expr,
-                        currentCode,
-                        currentRegisters,
-                        DebugState.currentFile,
-                        DebugState.currentLine,
+                        state.currentCode,
+                        state.currentRegisters,
+                        state().currentFile,
+                        state().currentLine,
                         RuntimeContextType.SCALAR,
                         siteRegistry
                 );
@@ -680,7 +673,7 @@ public class DebugHooks {
             System.out.println("Error evaluating expression: " + e.getMessage());
         } finally {
             // Restore debug mode
-            DebugState.debugMode = savedDebugMode;
+            state().debugMode = savedDebugMode;
         }
     }
 
@@ -690,7 +683,7 @@ public class DebugHooks {
      * @param subName The fully-qualified subroutine name (package::subname)
      */
     public static void enterSubroutine(String subName) {
-        DebugState.callDepth++;
+        state().callDepth++;
         DebugState.pushSubName(subName);
     }
 
@@ -699,9 +692,9 @@ public class DebugHooks {
      * Caller must check debugMode before calling.
      */
     public static void exitSubroutine() {
-        DebugState.callDepth--;
-        if (DebugState.callDepth < 0) {
-            DebugState.callDepth = 0;
+        state().callDepth--;
+        if (state().callDepth < 0) {
+            state().callDepth = 0;
         }
         DebugState.popSubName();
     }
@@ -715,9 +708,9 @@ public class DebugHooks {
         RuntimeScalar trace = GlobalVariable.getGlobalVariable("DB::trace");
         RuntimeScalar signal = GlobalVariable.getGlobalVariable("DB::signal");
         
-        DebugState.single = single.getBoolean();
-        DebugState.trace = trace.getBoolean();
-        DebugState.signal = signal.getBoolean();
+        state().single = single.getBoolean();
+        state().trace = trace.getBoolean();
+        state().signal = signal.getBoolean();
     }
     
     /**
@@ -725,9 +718,9 @@ public class DebugHooks {
      * Called after debugger commands that change stepping state.
      */
     private static void syncToPerlVariables() {
-        GlobalVariable.getGlobalVariable("DB::single").set(DebugState.single ? 1 : 0);
-        GlobalVariable.getGlobalVariable("DB::trace").set(DebugState.trace ? 1 : 0);
-        GlobalVariable.getGlobalVariable("DB::signal").set(DebugState.signal ? 1 : 0);
+        GlobalVariable.getGlobalVariable("DB::single").set(state().single ? 1 : 0);
+        GlobalVariable.getGlobalVariable("DB::trace").set(state().trace ? 1 : 0);
+        GlobalVariable.getGlobalVariable("DB::signal").set(state().signal ? 1 : 0);
     }
     
     /**
@@ -748,11 +741,11 @@ public class DebugHooks {
      * Called periodically to ensure Perl code can access subroutine locations.
      */
     public static void syncDbSub() {
-        if (!DebugState.debugMode) {
+        if (!state().debugMode) {
             return;
         }
         RuntimeHash dbSub = GlobalVariable.getGlobalHash("DB::sub");
-        for (var entry : DebugState.subLocations.entrySet()) {
+        for (var entry : state().subLocations.entrySet()) {
             dbSub.put(entry.getKey(), new RuntimeScalar(entry.getValue()));
         }
     }

--- a/src/main/java/org/perlonjava/runtime/debugger/DebugRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/debugger/DebugRuntimeState.java
@@ -1,0 +1,67 @@
+package org.perlonjava.runtime.debugger;
+
+import org.perlonjava.backend.bytecode.InterpretedCode;
+import org.perlonjava.runtime.runtimetypes.RuntimeArray;
+import org.perlonjava.runtime.runtimetypes.RuntimeBase;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Runtime-owned debugger controls, locations, breakpoints, and active evaluation context. */
+public final class DebugRuntimeState {
+    public boolean debugMode;
+    public volatile boolean single;
+    public volatile boolean trace;
+    public volatile boolean signal;
+    public volatile String currentFile = "";
+    public volatile int currentLine;
+    public final Set<String> breakpoints = ConcurrentHashMap.newKeySet();
+    public final Map<String, String> breakpointConditions = new ConcurrentHashMap<>();
+    public final Map<String, String[]> sourceLines = new ConcurrentHashMap<>();
+    public final Map<String, Set<Integer>> breakableLines = new ConcurrentHashMap<>();
+    public volatile int stepOverDepth = -1;
+    public volatile int stepOutDepth = -1;
+    public volatile int callDepth;
+    public final Deque<String> subNameStack = new ArrayDeque<>();
+    public final Set<String> oneTimeBreakpoints = ConcurrentHashMap.newKeySet();
+    public volatile boolean quit;
+    public final Map<String, String> subLocations = new ConcurrentHashMap<>();
+    public final Deque<RuntimeArray> argsStack = new ArrayDeque<>();
+
+    int commandCounter = 1;
+    InterpretedCode currentCode;
+    RuntimeBase[] currentRegisters;
+    int currentSiteIndex = -1;
+    boolean hasCustomDebugger;
+    boolean perl5dbExecuted;
+
+    void reset() {
+        debugMode = false;
+        single = false;
+        trace = false;
+        signal = false;
+        currentFile = "";
+        currentLine = 0;
+        breakpoints.clear();
+        breakpointConditions.clear();
+        sourceLines.clear();
+        breakableLines.clear();
+        stepOverDepth = -1;
+        stepOutDepth = -1;
+        callDepth = 0;
+        subNameStack.clear();
+        oneTimeBreakpoints.clear();
+        quit = false;
+        subLocations.clear();
+        argsStack.clear();
+        commandCounter = 1;
+        currentCode = null;
+        currentRegisters = null;
+        currentSiteIndex = -1;
+        hasCustomDebugger = false;
+        perl5dbExecuted = false;
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/debugger/DebugState.java
+++ b/src/main/java/org/perlonjava/runtime/debugger/DebugState.java
@@ -1,304 +1,95 @@
 package org.perlonjava.runtime.debugger;
 
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 import org.perlonjava.runtime.runtimetypes.RuntimeArray;
 
-import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * Global debug state for the Perl debugger.
- * <p>
- * This class holds all debug-related state:
- * - debugMode: set at startup, controls whether DEBUG opcodes are emitted
- * - single/trace/signal: runtime flags checked by DEBUG opcode
- * - breakpoints: set of "file:line" strings for active breakpoints
- * - sourceLines: stored source code for each file
- */
-public class DebugState {
+/** Runtime-selecting facade for debugger state. */
+public final class DebugState {
+    private static volatile boolean anyDebugMode;
 
-    /**
-     * Master debug mode flag - set at startup when -d is used.
-     * Controls whether DEBUG opcodes are emitted by BytecodeCompiler.
-     * Once set, cannot be changed (compile-time decision).
-     */
-    public static boolean debugMode = false;
+    private DebugState() {
+    }
 
-    /**
-     * Single-step mode ($DB::single in Perl).
-     * When true, DEBUG opcode will call DB::DB() on every statement.
-     * Set to true initially when debugging starts.
-     */
-    public static volatile boolean single = false;
+    public static DebugRuntimeState current() {
+        return PerlRuntime.current().debugState;
+    }
 
-    /**
-     * Trace mode ($DB::trace in Perl).
-     * When true, prints trace info for each statement.
-     */
-    public static volatile boolean trace = false;
+    public static boolean isDebugMode() {
+        if (!anyDebugMode) return false;
+        return current().debugMode;
+    }
 
-    /**
-     * Signal flag ($DB::signal in Perl).
-     * Set when a signal is received that should break into debugger.
-     */
-    public static volatile boolean signal = false;
+    public static void setDebugMode(boolean enabled) {
+        if (enabled) anyDebugMode = true;
+        current().debugMode = enabled;
+    }
 
-    /**
-     * Current filename being debugged ($DB::filename in Perl).
-     */
-    public static volatile String currentFile = "";
-
-    /**
-     * Current line number ($DB::line in Perl).
-     */
-    public static volatile int currentLine = 0;
-
-    /**
-     * Breakpoint table: "file:line" -> true.
-     * Fast O(1) lookup for checking if current location has a breakpoint.
-     */
-    public static final Set<String> breakpoints = ConcurrentHashMap.newKeySet();
-
-    /**
-     * Conditional breakpoints: "file:line" -> "condition_expr".
-     * If a breakpoint has a condition, it's stored here.
-     * The condition is eval'd and breakpoint only triggers if true.
-     */
-    public static final Map<String, String> breakpointConditions = new ConcurrentHashMap<>();
-
-    /**
-     * Source lines storage: filename -> String[] of source lines.
-     * Line numbers are 1-based, so lines[0] is unused.
-     * Populated by the lexer/parser during compilation.
-     */
-    public static final Map<String, String[]> sourceLines = new ConcurrentHashMap<>();
-
-    /**
-     * Breakable lines: filename -> Set<Integer> of line numbers that can have breakpoints.
-     * Non-breakable lines include comments, blank lines, and continuation lines.
-     */
-    public static final Map<String, Set<Integer>> breakableLines = new ConcurrentHashMap<>();
-
-    /**
-     * Step-over depth tracking.
-     * When >= 0, skip DEBUG calls until call depth returns to this level.
-     * Used to implement "n" (next) command - step over subroutine calls.
-     */
-    public static volatile int stepOverDepth = -1;
-
-    /**
-     * Step-out depth tracking.
-     * When >= 0, skip DEBUG calls until call depth is less than this level.
-     * Used to implement "r" (return) command - step out of current subroutine.
-     */
-    public static volatile int stepOutDepth = -1;
-
-    /**
-     * Current call depth for step-over/step-out tracking.
-     */
-    public static volatile int callDepth = 0;
-
-    /**
-     * Thread-local stack of subroutine names for debug display.
-     * Tracks the current subroutine being executed.
-     */
-    public static final ThreadLocal<Deque<String>> subNameStack =
-            ThreadLocal.withInitial(ArrayDeque::new);
-
-    /**
-     * Get the current subroutine name for debug display.
-     * Returns empty string if in main code (not inside a sub).
-     */
     public static String getCurrentSubName() {
-        Deque<String> stack = subNameStack.get();
+        Deque<String> stack = current().subNameStack;
         return stack.isEmpty() ? "" : stack.peek();
     }
 
-    /**
-     * Push a subroutine name onto the stack when entering a sub.
-     * Caller must check debugMode before calling.
-     */
     public static void pushSubName(String subName) {
-        subNameStack.get().push(subName != null ? subName : "");
+        current().subNameStack.push(subName != null ? subName : "");
     }
 
-    /**
-     * Pop a subroutine name from the stack when exiting a sub.
-     * Caller must check debugMode before calling.
-     */
     public static void popSubName() {
-        Deque<String> stack = subNameStack.get();
-        if (!stack.isEmpty()) {
-            stack.pop();
-        }
+        Deque<String> stack = current().subNameStack;
+        if (!stack.isEmpty()) stack.pop();
     }
 
-    /**
-     * One-time breakpoints: "file:line" strings that should be removed after being hit.
-     * Used by "c line" command to continue to a specific line once.
-     */
-    public static final Set<String> oneTimeBreakpoints = ConcurrentHashMap.newKeySet();
-
-    /**
-     * Flag to indicate debugger should quit.
-     */
-    public static volatile boolean quit = false;
-
-    /**
-     * Reset all debug state (for testing or restart).
-     */
     public static void reset() {
-        single = false;
-        trace = false;
-        signal = false;
-        currentFile = "";
-        currentLine = 0;
-        breakpoints.clear();
-        breakpointConditions.clear();
-        oneTimeBreakpoints.clear();
-        sourceLines.clear();
-        breakableLines.clear();
-        stepOverDepth = -1;
-        stepOutDepth = -1;
-        callDepth = 0;
-        subNameStack.get().clear();
-        quit = false;
+        current().reset();
     }
 
-    /**
-     * Check if we should stop at the current location.
-     * Fast path for common case (no debugging active).
-     *
-     * @param file Current filename
-     * @param line Current line number
-     * @return true if debugger should stop here
-     */
     public static boolean shouldStop(String file, int line) {
+        DebugRuntimeState state = current();
         String key = file + ":" + line;
-
-        // Check for one-time breakpoint first (and remove if hit)
-        if (oneTimeBreakpoints.remove(key)) {
-            // Also remove from regular breakpoints if it was added there
-            breakpoints.remove(key);
+        if (state.oneTimeBreakpoints.remove(key)) {
+            state.breakpoints.remove(key);
             return true;
         }
-
-        // Fast path: nothing active
-        if (!single && !trace && !signal) {
-            return breakpoints.contains(key);
+        if (!state.single && !state.trace && !state.signal) {
+            return state.breakpoints.contains(key);
         }
-
-        // Step-over mode: skip if we're deeper than target depth
-        if (stepOverDepth >= 0 && callDepth > stepOverDepth) {
-            return false;
-        }
-
-        // Step-out mode: skip until we're shallower than target depth
-        if (stepOutDepth >= 0 && callDepth >= stepOutDepth) {
-            return false;
-        }
-
+        if (state.stepOverDepth >= 0 && state.callDepth > state.stepOverDepth) return false;
+        if (state.stepOutDepth >= 0 && state.callDepth >= state.stepOutDepth) return false;
         return true;
     }
 
-    /**
-     * Store source lines for a file.
-     *
-     * @param filename The source filename
-     * @param lines    Array of source lines (1-based indexing)
-     */
     public static void storeSourceLines(String filename, String[] lines) {
-        sourceLines.put(filename, lines);
+        current().sourceLines.put(filename, lines);
     }
 
-    /**
-     * Get source line for display.
-     *
-     * @param filename The source filename
-     * @param line     Line number (1-based)
-     * @return The source line, or empty string if not available
-     */
     public static String getSourceLine(String filename, int line) {
-        String[] lines = sourceLines.get(filename);
-        if (lines != null && line > 0 && line < lines.length) {
-            return lines[line];
-        }
-        return "";
+        String[] lines = current().sourceLines.get(filename);
+        return lines != null && line > 0 && line < lines.length ? lines[line] : "";
     }
 
-    /**
-     * Subroutine location registry for %DB::sub.
-     * Maps "package::subname" -> "filename:startline-endline"
-     */
-    public static final Map<String, String> subLocations = new ConcurrentHashMap<>();
-
-    /**
-     * Register a subroutine's location for %DB::sub.
-     * Only registers if debugMode is enabled.
-     *
-     * @param fullName  Fully qualified subroutine name (package::subname)
-     * @param filename  Source filename
-     * @param startLine Starting line number (1-based)
-     * @param endLine   Ending line number (1-based)
-     */
     public static void registerSubroutine(String fullName, String filename, int startLine, int endLine) {
-        if (!debugMode) {
-            return;
+        DebugRuntimeState state = current();
+        if (state.debugMode) {
+            state.subLocations.put(fullName, filename + ":" + startLine + "-" + endLine);
         }
-        String location = filename + ":" + startLine + "-" + endLine;
-        subLocations.put(fullName, location);
     }
 
-    /**
-     * Thread-local stack of subroutine arguments for @DB::args support.
-     * Each frame stores a copy of the @_ array when the subroutine was called.
-     */
-    public static final ThreadLocal<Deque<RuntimeArray>> argsStack =
-            ThreadLocal.withInitial(ArrayDeque::new);
-
-    /**
-     * Push subroutine arguments onto the stack (called when entering a sub in debug mode).
-     *
-     * @param args The @_ array for this call frame
-     */
     public static void pushArgs(RuntimeArray args) {
-        if (!debugMode) {
-            return;
-        }
-        // Make a shallow copy of the args array
+        if (!current().debugMode) return;
         RuntimeArray copy = new RuntimeArray();
         copy.setFromList(args.getList());
-        argsStack.get().push(copy);
+        current().argsStack.push(copy);
     }
 
-    /**
-     * Pop subroutine arguments from the stack (called when exiting a sub in debug mode).
-     */
     public static void popArgs() {
-        if (!debugMode) {
-            return;
-        }
-        Deque<RuntimeArray> stack = argsStack.get();
-        if (!stack.isEmpty()) {
-            stack.pop();
-        }
+        Deque<RuntimeArray> stack = current().argsStack;
+        if (!stack.isEmpty()) stack.pop();
     }
 
-    /**
-     * Get arguments for a specific frame (0 = current, 1 = caller, etc).
-     *
-     * @param frame Frame number (0-based)
-     * @return The args array for that frame, or null if not available
-     */
     public static RuntimeArray getArgsForFrame(int frame) {
-        Deque<RuntimeArray> stack = argsStack.get();
-        if (frame < 0 || frame >= stack.size()) {
-            return null;
-        }
-        // Convert to array for indexed access
-        RuntimeArray[] stackArray = stack.toArray(new RuntimeArray[0]);
-        return stackArray[frame];
+        Deque<RuntimeArray> stack = current().argsStack;
+        if (frame < 0 || frame >= stack.size()) return null;
+        return stack.toArray(new RuntimeArray[0])[frame];
     }
 }

--- a/src/main/java/org/perlonjava/runtime/io/DirectoryIO.java
+++ b/src/main/java/org/perlonjava/runtime/io/DirectoryIO.java
@@ -41,7 +41,7 @@ public class DirectoryIO {
         // Resolve and store absolute path
         Path path = Paths.get(directoryPath);
         if (!path.isAbsolute()) {
-            path = Paths.get(System.getProperty("user.dir"), directoryPath);
+            path = Paths.get(org.perlonjava.runtime.runtimetypes.RuntimeEnvironment.currentDirectory(), directoryPath);
         }
         this.absoluteDirectoryPath = path.toAbsolutePath().normalize();
     }

--- a/src/main/java/org/perlonjava/runtime/io/FileDescriptorTable.java
+++ b/src/main/java/org/perlonjava/runtime/io/FileDescriptorTable.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.perlonjava.runtime.runtimetypes.RuntimeIO;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 
 /**
  * Maps simulated file descriptor numbers to {@link IOHandle} objects.
@@ -51,16 +52,9 @@ import org.perlonjava.runtime.runtimetypes.RuntimeIO;
 public class FileDescriptorTable {
 
     /** Next fd to allocate. Starts at 3 (0=stdin, 1=stdout, 2=stderr are reserved). */
-    private static final AtomicInteger nextFd = new AtomicInteger(3);
-
-    /** Forward map: fd number → IOHandle. Used by select() to find handles from fd bits. */
-    private static final ConcurrentHashMap<Integer, IOHandle> fdToHandle = new ConcurrentHashMap<>();
-
-    /**
-     * Reverse map: IOHandle identity hash → fd number.
-     * Prevents assigning multiple fds to the same IOHandle object (identity, not equality).
-     */
-    private static final ConcurrentHashMap<Integer, Integer> handleToFd = new ConcurrentHashMap<>();
+    private static IORuntimeRegistryState state() {
+        return PerlRuntime.current().ioRegistryState;
+    }
 
     /**
      * Register an IOHandle and return its FD number.
@@ -70,14 +64,15 @@ public class FileDescriptorTable {
      * @return the file descriptor number
      */
     public static int register(IOHandle handle) {
+        IORuntimeRegistryState state = state();
         int identity = System.identityHashCode(handle);
-        Integer existing = handleToFd.get(identity);
+        Integer existing = state.handleToFd.get(identity);
         if (existing != null) {
             return existing;
         }
-        int fd = nextFd.getAndIncrement();
-        fdToHandle.put(fd, handle);
-        handleToFd.put(identity, fd);
+        int fd = state.nextFd.getAndIncrement();
+        state.fdToHandle.put(fd, handle);
+        state.handleToFd.put(identity, fd);
         // Keep RuntimeIO in sync to prevent fd collisions with socket()/socketpair()
         RuntimeIO.advanceFilenoCounterPast(fd);
         return fd;
@@ -92,14 +87,15 @@ public class FileDescriptorTable {
      * @param handle the IOHandle to register
      */
     public static void registerAt(int fd, IOHandle handle) {
+        IORuntimeRegistryState state = state();
         // Remove any previous handle at this fd
-        IOHandle oldHandle = fdToHandle.put(fd, handle);
+        IOHandle oldHandle = state.fdToHandle.put(fd, handle);
         if (oldHandle != null) {
-            handleToFd.remove(System.identityHashCode(oldHandle));
+            state.handleToFd.remove(System.identityHashCode(oldHandle));
         }
-        handleToFd.put(System.identityHashCode(handle), fd);
+        state.handleToFd.put(System.identityHashCode(handle), fd);
         // Ensure nextFd is past this fd
-        nextFd.updateAndGet(current -> Math.max(current, fd + 1));
+        state.nextFd.updateAndGet(current -> Math.max(current, fd + 1));
         RuntimeIO.advanceFilenoCounterPast(fd);
     }
 
@@ -111,7 +107,7 @@ public class FileDescriptorTable {
      * @param fd the fd value to advance past
      */
     public static void advancePast(int fd) {
-        nextFd.updateAndGet(current -> Math.max(current, fd + 1));
+        state().nextFd.updateAndGet(current -> Math.max(current, fd + 1));
     }
 
     /**
@@ -119,7 +115,7 @@ public class FileDescriptorTable {
      * Useful as a fallback when the original fd is unknown.
      */
     public static int nextFdValue() {
-        return nextFd.get();
+        return state().nextFd.get();
     }
 
     /**
@@ -129,7 +125,7 @@ public class FileDescriptorTable {
      * @return the IOHandle, or null if not found
      */
     public static IOHandle getHandle(int fd) {
-        return fdToHandle.get(fd);
+        return state().fdToHandle.get(fd);
     }
 
     /**
@@ -138,9 +134,10 @@ public class FileDescriptorTable {
      * @param fd the file descriptor number to remove
      */
     public static void unregister(int fd) {
-        IOHandle handle = fdToHandle.remove(fd);
+        IORuntimeRegistryState state = state();
+        IOHandle handle = state.fdToHandle.remove(fd);
         if (handle != null) {
-            handleToFd.remove(System.identityHashCode(handle));
+            state.handleToFd.remove(System.identityHashCode(handle));
         }
     }
 

--- a/src/main/java/org/perlonjava/runtime/io/IORuntimeRegistryState.java
+++ b/src/main/java/org/perlonjava/runtime/io/IORuntimeRegistryState.java
@@ -1,0 +1,45 @@
+package org.perlonjava.runtime.io;
+
+import org.perlonjava.runtime.runtimetypes.RuntimeGlob;
+import org.perlonjava.runtime.runtimetypes.RuntimeIO;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Runtime-owned descriptor, process, and abandoned-handle registries. */
+public final class IORuntimeRegistryState {
+    public final Map<Long, Process> childProcesses = new ConcurrentHashMap<>();
+    public final Map<Long, Process> windowsChildProcesses = new ConcurrentHashMap<>();
+    public final AtomicInteger nextFileno = new AtomicInteger(3);
+    public final ConcurrentHashMap<Integer, RuntimeIO> filenoToIO = new ConcurrentHashMap<>();
+    public final ConcurrentHashMap<RuntimeIO, Integer> ioToFileno = new ConcurrentHashMap<>();
+    public final ConcurrentLinkedQueue<Integer> recycledFds = new ConcurrentLinkedQueue<>();
+    public final ReferenceQueue<RuntimeGlob> globGCQueue = new ReferenceQueue<>();
+    public final ConcurrentHashMap<PhantomReference<RuntimeGlob>, RuntimeIO> phantomToIO =
+            new ConcurrentHashMap<>();
+    public final AtomicInteger nextFd = new AtomicInteger(3);
+    public final ConcurrentHashMap<Integer, IOHandle> fdToHandle = new ConcurrentHashMap<>();
+    public final ConcurrentHashMap<Integer, Integer> handleToFd = new ConcurrentHashMap<>();
+    public final Map<Integer, RuntimeIO> operatorFileDescriptors = new ConcurrentHashMap<>();
+
+    public void clear() {
+        childProcesses.clear();
+        windowsChildProcesses.clear();
+        nextFileno.set(3);
+        filenoToIO.clear();
+        ioToFileno.clear();
+        recycledFds.clear();
+        phantomToIO.clear();
+        nextFd.set(3);
+        fdToHandle.clear();
+        handleToFd.clear();
+        operatorFileDescriptors.clear();
+        while (globGCQueue.poll() != null) {
+            // Drain references owned by this closed runtime.
+        }
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/io/PipeInputChannel.java
+++ b/src/main/java/org/perlonjava/runtime/io/PipeInputChannel.java
@@ -94,7 +94,7 @@ public class PipeInputChannel implements IOHandle {
      */
     private void setupProcess(ProcessBuilder processBuilder) throws IOException {
         // Set working directory to current directory
-        String userDir = System.getProperty("user.dir");
+        String userDir = org.perlonjava.runtime.runtimetypes.RuntimeEnvironment.currentDirectory();
         processBuilder.directory(new File(userDir));
 
         // Copy %ENV to the subprocess environment

--- a/src/main/java/org/perlonjava/runtime/io/PipeInputChannel.java
+++ b/src/main/java/org/perlonjava/runtime/io/PipeInputChannel.java
@@ -216,11 +216,15 @@ public class PipeInputChannel implements IOHandle {
      */
     private void startProcess(String command) throws IOException {
         // Determine if we need shell interpretation
-        if (SHELL_METACHARACTERS.matcher(command).find()) {
+        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("windows");
+        if (isWindows || SHELL_METACHARACTERS.matcher(command).find()) {
             // Use shell
             String[] shellCommand;
-            if (System.getProperty("os.name").toLowerCase().contains("windows")) {
-                shellCommand = new String[]{"cmd.exe", "/c", command};
+            if (isWindows) {
+                // String-form pipe commands have shell semantics. This is also
+                // required for cmd built-ins such as `type`, which have no
+                // executable that ProcessBuilder can launch directly.
+                shellCommand = new String[]{"cmd.exe", "/d", "/s", "/c", command};
             } else {
                 shellCommand = new String[]{"/bin/sh", "-c", command};
             }

--- a/src/main/java/org/perlonjava/runtime/io/PipeOutputChannel.java
+++ b/src/main/java/org/perlonjava/runtime/io/PipeOutputChannel.java
@@ -154,7 +154,7 @@ public class PipeOutputChannel implements IOHandle {
      */
     private void setupProcess(ProcessBuilder processBuilder) throws IOException {
         // Set working directory to current directory
-        String userDir = System.getProperty("user.dir");
+        String userDir = org.perlonjava.runtime.runtimetypes.RuntimeEnvironment.currentDirectory();
         processBuilder.directory(new File(userDir));
 
         // Copy %ENV to the subprocess environment

--- a/src/main/java/org/perlonjava/runtime/io/PipeOutputChannel.java
+++ b/src/main/java/org/perlonjava/runtime/io/PipeOutputChannel.java
@@ -124,6 +124,12 @@ public class PipeOutputChannel implements IOHandle {
                 // String-form pipe commands have shell semantics. This is also
                 // required for cmd built-ins such as `type`, which have no
                 // executable that ProcessBuilder can launch directly.
+                // Unlike Unix `cat`, bare `type` does not consume standard
+                // input; `more` is the cmd-provided stdin filter with the
+                // behavior Perl's portable pipe idiom expects here.
+                if (command.trim().equalsIgnoreCase("type")) {
+                    command = "more";
+                }
                 shellCommand = new String[]{"cmd.exe", "/d", "/s", "/c", command};
             } else {
                 shellCommand = new String[]{"/bin/sh", "-c", command};

--- a/src/main/java/org/perlonjava/runtime/io/PipeOutputChannel.java
+++ b/src/main/java/org/perlonjava/runtime/io/PipeOutputChannel.java
@@ -116,11 +116,15 @@ public class PipeOutputChannel implements IOHandle {
      */
     private void startProcess(String command) throws IOException {
         // Determine if we need shell interpretation
-        if (SHELL_METACHARACTERS.matcher(command).find()) {
+        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("windows");
+        if (isWindows || SHELL_METACHARACTERS.matcher(command).find()) {
             // Use shell
             String[] shellCommand;
-            if (System.getProperty("os.name").toLowerCase().contains("windows")) {
-                shellCommand = new String[]{"cmd.exe", "/c", command};
+            if (isWindows) {
+                // String-form pipe commands have shell semantics. This is also
+                // required for cmd built-ins such as `type`, which have no
+                // executable that ProcessBuilder can launch directly.
+                shellCommand = new String[]{"cmd.exe", "/d", "/s", "/c", command};
             } else {
                 shellCommand = new String[]{"/bin/sh", "-c", command};
             }

--- a/src/main/java/org/perlonjava/runtime/nativ/ExtendedNativeUtils.java
+++ b/src/main/java/org/perlonjava/runtime/nativ/ExtendedNativeUtils.java
@@ -13,22 +13,43 @@ import java.util.concurrent.ConcurrentHashMap;
 import static org.perlonjava.runtime.runtimetypes.RuntimeContextType.SCALAR;
 
 public class ExtendedNativeUtils extends NativeUtils {
+    public static final class State {
+        final Map<String, RuntimeArray> userInfoCache = new ConcurrentHashMap<>();
+        final Map<String, RuntimeArray> groupInfoCache = new ConcurrentHashMap<>();
+        final Map<String, RuntimeArray> hostInfoCache = new ConcurrentHashMap<>();
+        Iterator<String> userIterator;
+        Iterator<String> groupIterator;
+        Iterator<String> hostIterator;
+        Iterator<String> netIterator;
+        Iterator<String> protoIterator;
+        Iterator<String> servIterator;
+        final Map<Integer, RuntimeArray> messageQueues = new ConcurrentHashMap<>();
+        final Map<Integer, RuntimeArray> semaphores = new ConcurrentHashMap<>();
+        final Map<Integer, RuntimeArray> sharedMemory = new ConcurrentHashMap<>();
+        int nextIpcId = 1000;
+        public int errno;
 
-    private static final Map<String, RuntimeArray> userInfoCache = new ConcurrentHashMap<>();
-    private static final Map<String, RuntimeArray> groupInfoCache = new ConcurrentHashMap<>();
-    private static final Map<String, RuntimeArray> hostInfoCache = new ConcurrentHashMap<>();
+        public void clear() {
+            userInfoCache.clear();
+            groupInfoCache.clear();
+            hostInfoCache.clear();
+            userIterator = null;
+            groupIterator = null;
+            hostIterator = null;
+            netIterator = null;
+            protoIterator = null;
+            servIterator = null;
+            messageQueues.clear();
+            semaphores.clear();
+            sharedMemory.clear();
+            nextIpcId = 1000;
+            errno = 0;
+        }
+    }
 
-    private static final ThreadLocal<Iterator<String>> userIterator = new ThreadLocal<>();
-    private static final ThreadLocal<Iterator<String>> groupIterator = new ThreadLocal<>();
-    private static final ThreadLocal<Iterator<String>> hostIterator = new ThreadLocal<>();
-    private static final ThreadLocal<Iterator<String>> netIterator = new ThreadLocal<>();
-    private static final ThreadLocal<Iterator<String>> protoIterator = new ThreadLocal<>();
-    private static final ThreadLocal<Iterator<String>> servIterator = new ThreadLocal<>();
-
-    private static final Map<Integer, RuntimeArray> messageQueues = new ConcurrentHashMap<>();
-    private static final Map<Integer, RuntimeArray> semaphores = new ConcurrentHashMap<>();
-    private static final Map<Integer, RuntimeArray> sharedMemory = new ConcurrentHashMap<>();
-    private static int nextIpcId = 1000;
+    private static State state() {
+        return PerlRuntime.current().nativeState;
+    }
 
     // ================== User/Group Information Functions ==================
 
@@ -163,8 +184,8 @@ public class ExtendedNativeUtils extends NativeUtils {
         String groupname = args[0].toString();
 
         String cacheKey = "group:" + groupname;
-        if (groupInfoCache.containsKey(cacheKey)) {
-            return groupInfoCache.get(cacheKey);
+        if (state().groupInfoCache.containsKey(cacheKey)) {
+            return state().groupInfoCache.get(cacheKey);
         }
 
         RuntimeArray result = new RuntimeArray();
@@ -190,7 +211,7 @@ public class ExtendedNativeUtils extends NativeUtils {
                 }
             }
 
-            groupInfoCache.put(cacheKey, result);
+            state().groupInfoCache.put(cacheKey, result);
         } catch (Exception e) {
         }
 
@@ -226,11 +247,11 @@ public class ExtendedNativeUtils extends NativeUtils {
     }
 
     public static RuntimeArray getgrent(int ctx, RuntimeBase... args) {
-        Iterator<String> iterator = groupIterator.get();
+        Iterator<String> iterator = state().groupIterator;
         if (iterator == null) {
             List<String> groups = getSystemGroups();
             iterator = groups.iterator();
-            groupIterator.set(iterator);
+            state().groupIterator = iterator;
         }
 
         if (iterator.hasNext()) {
@@ -247,14 +268,14 @@ public class ExtendedNativeUtils extends NativeUtils {
             } catch (Exception e) {
             }
         }
-        userIterator.remove();
-        userInfoCache.clear();
+        state().userIterator = null;
+        state().userInfoCache.clear();
         return new RuntimeScalar(1);
     }
 
     public static RuntimeScalar setgrent(int ctx, RuntimeBase... args) {
-        groupIterator.remove();
-        groupInfoCache.clear();
+        state().groupIterator = null;
+        state().groupInfoCache.clear();
         return new RuntimeScalar(1);
     }
 
@@ -265,12 +286,12 @@ public class ExtendedNativeUtils extends NativeUtils {
             } catch (Exception e) {
             }
         }
-        userIterator.remove();
+        state().userIterator = null;
         return new RuntimeScalar(1);
     }
 
     public static RuntimeScalar endgrent(int ctx, RuntimeBase... args) {
-        groupIterator.remove();
+        state().groupIterator = null;
         return new RuntimeScalar(1);
     }
 
@@ -281,8 +302,8 @@ public class ExtendedNativeUtils extends NativeUtils {
         String hostname = args[0].toString();
 
         String cacheKey = "host:" + hostname;
-        if (hostInfoCache.containsKey(cacheKey)) {
-            RuntimeArray cached = hostInfoCache.get(cacheKey);
+        if (state().hostInfoCache.containsKey(cacheKey)) {
+            RuntimeArray cached = state().hostInfoCache.get(cacheKey);
             if (ctx == SCALAR && cached.size() >= 5) {
                 return cached.get(4);
             }
@@ -303,7 +324,7 @@ public class ExtendedNativeUtils extends NativeUtils {
             RuntimeScalar packedAddress = new RuntimeScalar(addr.getAddress());
             RuntimeArray.push(result, packedAddress);
 
-            hostInfoCache.put(cacheKey, result);
+            state().hostInfoCache.put(cacheKey, result);
 
             if (ctx == SCALAR) {
                 return packedAddress;
@@ -562,17 +583,17 @@ public class ExtendedNativeUtils extends NativeUtils {
 
         switch (cmd) {
             case 0: // IPC_STAT
-                if (messageQueues.containsKey(msqid)) {
+                if (state().messageQueues.containsKey(msqid)) {
                     return new RuntimeScalar(0);
                 }
                 break;
             case 1: // IPC_SET
-                if (messageQueues.containsKey(msqid)) {
+                if (state().messageQueues.containsKey(msqid)) {
                     return new RuntimeScalar(0);
                 }
                 break;
             case 2: // IPC_RMID
-                if (messageQueues.remove(msqid) != null) {
+                if (state().messageQueues.remove(msqid) != null) {
                     return new RuntimeScalar(0);
                 }
                 break;
@@ -586,9 +607,9 @@ public class ExtendedNativeUtils extends NativeUtils {
         int key = args[0].scalar().getInt();
         int msgflg = args[1].scalar().getInt();
 
-        int msqid = nextIpcId++;
+        int msqid = state().nextIpcId++;
         RuntimeArray msgQueue = new RuntimeArray();
-        messageQueues.put(msqid, msgQueue);
+        state().messageQueues.put(msqid, msgQueue);
 
         return new RuntimeScalar(msqid);
     }
@@ -602,7 +623,7 @@ public class ExtendedNativeUtils extends NativeUtils {
         int msgtyp = args[3].scalar().getInt();
         int msgflg = args[4].scalar().getInt();
 
-        RuntimeArray msgQueue = messageQueues.get(msqid);
+        RuntimeArray msgQueue = state().messageQueues.get(msqid);
         if (msgQueue == null || msgQueue.size() == 0) {
             return new RuntimeScalar(-1);
         }
@@ -620,7 +641,7 @@ public class ExtendedNativeUtils extends NativeUtils {
         RuntimeBase msgp = args[1];
         int msgsz = args[2].scalar().getInt();
 
-        RuntimeArray msgQueue = messageQueues.get(msqid);
+        RuntimeArray msgQueue = state().messageQueues.get(msqid);
         if (msgQueue == null) {
             return new RuntimeScalar(-1);
         }
@@ -636,7 +657,7 @@ public class ExtendedNativeUtils extends NativeUtils {
         int semnum = args[1].scalar().getInt();
         int cmd = args[2].scalar().getInt();
 
-        RuntimeArray semArray = semaphores.get(semid);
+        RuntimeArray semArray = state().semaphores.get(semid);
         if (semArray == null) {
             return new RuntimeScalar(-1);
         }
@@ -654,7 +675,7 @@ public class ExtendedNativeUtils extends NativeUtils {
                 }
                 break;
             case 2: // IPC_RMID
-                if (semaphores.remove(semid) != null) {
+                if (state().semaphores.remove(semid) != null) {
                     return new RuntimeScalar(0);
                 }
                 break;
@@ -669,12 +690,12 @@ public class ExtendedNativeUtils extends NativeUtils {
         int nsems = args[1].scalar().getInt();
         int semflg = args[2].scalar().getInt();
 
-        int semid = nextIpcId++;
+        int semid = state().nextIpcId++;
         RuntimeArray semArray = new RuntimeArray();
         for (int i = 0; i < nsems; i++) {
             RuntimeArray.push(semArray, new RuntimeScalar(0));
         }
-        semaphores.put(semid, semArray);
+        state().semaphores.put(semid, semArray);
 
         return new RuntimeScalar(semid);
     }
@@ -685,7 +706,7 @@ public class ExtendedNativeUtils extends NativeUtils {
         int semid = args[0].scalar().getInt();
         RuntimeBase sops = args[1];
 
-        RuntimeArray semArray = semaphores.get(semid);
+        RuntimeArray semArray = state().semaphores.get(semid);
         if (semArray == null) {
             return new RuntimeScalar(-1);
         }
@@ -700,7 +721,7 @@ public class ExtendedNativeUtils extends NativeUtils {
         int cmd = args[1].scalar().getInt();
         RuntimeBase buf = args[2];
 
-        RuntimeArray shmSeg = sharedMemory.get(shmid);
+        RuntimeArray shmSeg = state().sharedMemory.get(shmid);
 
         switch (cmd) {
             case 0: // IPC_STAT
@@ -714,7 +735,7 @@ public class ExtendedNativeUtils extends NativeUtils {
                 }
                 break;
             case 2: // IPC_RMID
-                if (sharedMemory.remove(shmid) != null) {
+                if (state().sharedMemory.remove(shmid) != null) {
                     return new RuntimeScalar(0);
                 }
                 break;
@@ -729,12 +750,12 @@ public class ExtendedNativeUtils extends NativeUtils {
         int size = args[1].scalar().getInt();
         int shmflg = args[2].scalar().getInt();
 
-        int shmid = nextIpcId++;
+        int shmid = state().nextIpcId++;
         RuntimeArray shmSeg = new RuntimeArray();
         for (int i = 0; i < size; i++) {
             RuntimeArray.push(shmSeg, new RuntimeScalar(0));
         }
-        sharedMemory.put(shmid, shmSeg);
+        state().sharedMemory.put(shmid, shmSeg);
 
         return new RuntimeScalar(shmid);
     }
@@ -747,7 +768,7 @@ public class ExtendedNativeUtils extends NativeUtils {
         int pos = args[2].scalar().getInt();
         int size = args[3].scalar().getInt();
 
-        RuntimeArray shmSeg = sharedMemory.get(shmid);
+        RuntimeArray shmSeg = state().sharedMemory.get(shmid);
         if (shmSeg == null || pos < 0 || pos >= shmSeg.size()) {
             return new RuntimeScalar(-1);
         }
@@ -772,7 +793,7 @@ public class ExtendedNativeUtils extends NativeUtils {
         int pos = args[2].scalar().getInt();
         int size = args[3].scalar().getInt();
 
-        RuntimeArray shmSeg = sharedMemory.get(shmid);
+        RuntimeArray shmSeg = state().sharedMemory.get(shmid);
         if (shmSeg == null || pos < 0) {
             return new RuntimeScalar(-1);
         }
@@ -794,31 +815,31 @@ public class ExtendedNativeUtils extends NativeUtils {
     // ================== Network Enumeration Functions ==================
 
     public static RuntimeScalar endhostent(int ctx, RuntimeBase... args) {
-        hostIterator.remove();
+        state().hostIterator = null;
         return new RuntimeScalar(1);
     }
 
     public static RuntimeScalar endnetent(int ctx, RuntimeBase... args) {
-        netIterator.remove();
+        state().netIterator = null;
         return new RuntimeScalar(1);
     }
 
     public static RuntimeScalar endprotoent(int ctx, RuntimeBase... args) {
-        protoIterator.remove();
+        state().protoIterator = null;
         return new RuntimeScalar(1);
     }
 
     public static RuntimeScalar endservent(int ctx, RuntimeBase... args) {
-        servIterator.remove();
+        state().servIterator = null;
         return new RuntimeScalar(1);
     }
 
     public static RuntimeArray gethostent(int ctx, RuntimeBase... args) {
-        Iterator<String> iterator = hostIterator.get();
+        Iterator<String> iterator = state().hostIterator;
         if (iterator == null) {
             List<String> hosts = getSystemHosts();
             iterator = hosts.iterator();
-            hostIterator.set(iterator);
+            state().hostIterator = iterator;
         }
 
         if (iterator.hasNext()) {
@@ -861,11 +882,11 @@ public class ExtendedNativeUtils extends NativeUtils {
     }
 
     public static RuntimeArray getnetent(int ctx, RuntimeBase... args) {
-        Iterator<String> iterator = netIterator.get();
+        Iterator<String> iterator = state().netIterator;
         if (iterator == null) {
             List<String> networks = Arrays.asList("loopback", "localhost");
             iterator = networks.iterator();
-            netIterator.set(iterator);
+            state().netIterator = iterator;
         }
 
         if (iterator.hasNext()) {
@@ -877,11 +898,11 @@ public class ExtendedNativeUtils extends NativeUtils {
     }
 
     public static RuntimeBase getprotoent(int ctx, RuntimeBase... args) {
-        Iterator<String> iterator = protoIterator.get();
+        Iterator<String> iterator = state().protoIterator;
         if (iterator == null) {
             List<String> protocols = Arrays.asList("tcp", "udp", "icmp", "ip");
             iterator = protocols.iterator();
-            protoIterator.set(iterator);
+            state().protoIterator = iterator;
         }
 
         if (iterator.hasNext()) {
@@ -893,11 +914,11 @@ public class ExtendedNativeUtils extends NativeUtils {
     }
 
     public static RuntimeArray getservent(int ctx, RuntimeBase... args) {
-        Iterator<String> iterator = servIterator.get();
+        Iterator<String> iterator = state().servIterator;
         if (iterator == null) {
             List<String> services = Arrays.asList("http", "https", "ftp", "ssh", "telnet", "smtp", "dns", "pop3", "imap", "snmp");
             iterator = services.iterator();
-            servIterator.set(iterator);
+            state().servIterator = iterator;
         }
 
         if (iterator.hasNext()) {
@@ -909,22 +930,22 @@ public class ExtendedNativeUtils extends NativeUtils {
     }
 
     public static RuntimeScalar sethostent(int ctx, RuntimeBase... args) {
-        hostIterator.remove();
+        state().hostIterator = null;
         return new RuntimeScalar(1);
     }
 
     public static RuntimeScalar setnetent(int ctx, RuntimeBase... args) {
-        netIterator.remove();
+        state().netIterator = null;
         return new RuntimeScalar(1);
     }
 
     public static RuntimeScalar setprotoent(int ctx, RuntimeBase... args) {
-        protoIterator.remove();
+        state().protoIterator = null;
         return new RuntimeScalar(1);
     }
 
     public static RuntimeScalar setservent(int ctx, RuntimeBase... args) {
-        servIterator.remove();
+        state().servIterator = null;
         return new RuntimeScalar(1);
     }
 

--- a/src/main/java/org/perlonjava/runtime/nativ/ffm/FFMPosixLinux.java
+++ b/src/main/java/org/perlonjava/runtime/nativ/ffm/FFMPosixLinux.java
@@ -12,6 +12,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.VarHandle;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 
 /**
  * Linux/macOS implementation of FFM POSIX interface.
@@ -24,9 +25,6 @@ public class FFMPosixLinux implements FFMPosixInterface {
     // Platform detection
     private static final boolean IS_MACOS = System.getProperty("os.name").toLowerCase().contains("mac");
     private static final boolean IS_LINUX = System.getProperty("os.name").toLowerCase().contains("linux");
-    
-    // Thread-local errno storage (used as fallback)
-    private static final ThreadLocal<Integer> threadErrno = ThreadLocal.withInitial(() -> 0);
     
     // Lazy-initialized FFM components
     private static volatile boolean initialized = false;
@@ -1304,12 +1302,12 @@ public class FFMPosixLinux implements FFMPosixInterface {
     
     @Override
     public int errno() {
-        return threadErrno.get();
+        return PerlRuntime.current().nativeState.errno;
     }
     
     @Override
     public void setErrno(int errno) {
-        threadErrno.set(errno);
+        PerlRuntime.current().nativeState.errno = errno;
     }
     
     @Override

--- a/src/main/java/org/perlonjava/runtime/nativ/ffm/FFMPosixWindows.java
+++ b/src/main/java/org/perlonjava/runtime/nativ/ffm/FFMPosixWindows.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.DosFileAttributes;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 
 /**
  * Windows implementation of FFM POSIX interface.
@@ -29,9 +30,6 @@ import java.nio.file.attribute.DosFileAttributes;
  * implementations will be added in Phase 4.</p>
  */
 public class FFMPosixWindows implements FFMPosixInterface {
-    
-    // Thread-local errno storage
-    private static final ThreadLocal<Integer> threadErrno = ThreadLocal.withInitial(() -> 0);
     
     // Default UID/GID values for Windows (simulated)
     private static final int DEFAULT_UID = 1000;
@@ -598,12 +596,12 @@ public class FFMPosixWindows implements FFMPosixInterface {
     
     @Override
     public int errno() {
-        return threadErrno.get();
+        return PerlRuntime.current().nativeState.errno;
     }
     
     @Override
     public void setErrno(int errno) {
-        threadErrno.set(errno);
+        PerlRuntime.current().nativeState.errno = errno;
     }
     
     @Override

--- a/src/main/java/org/perlonjava/runtime/operators/Directory.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Directory.java
@@ -96,7 +96,7 @@ public class Directory {
             try {
                 // Match getcwd(3): collapse . and .., and resolve symlinks like
                 // macOS /var -> /private/var after chdir().
-                System.setProperty("user.dir", absoluteDir.getCanonicalPath());
+                RuntimeEnvironment.setCurrentDirectory(absoluteDir.getCanonicalPath());
             } catch (IOException e) {
                 handleIOException(e, "chdir failed");
                 return scalarFalse;

--- a/src/main/java/org/perlonjava/runtime/operators/FileTestOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/FileTestOperator.java
@@ -42,26 +42,32 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.*;
  * floating-point number.
  */
 public class FileTestOperator {
+    public static final class State {
+        final RuntimeScalar lastFileHandle = new RuntimeScalar();
+        boolean lastStatOk;
+        int lastStatErrno;
+        final RuntimeScalar lastStatArg = new RuntimeScalar();
+        boolean lastStatWasLstat;
+        BasicFileAttributes lastBasicAttr;
+        PosixFileAttributes lastPosixAttr;
+        Stat.NativeStatFields lastNativeStatFields;
+    }
 
-    static RuntimeScalar lastFileHandle = new RuntimeScalar();
-
-    static boolean lastStatOk = false;
-    static int lastStatErrno = 0;
-    static RuntimeScalar lastStatArg = new RuntimeScalar();
-    static boolean lastStatWasLstat = false;
-    static BasicFileAttributes lastBasicAttr;
-    static PosixFileAttributes lastPosixAttr;
+    static State state() {
+        return PerlRuntime.current().fileTestState;
+    }
 
     static void updateLastStat(RuntimeScalar arg, boolean ok, int errno, boolean wasLstat) {
-        lastStatArg.set(arg);
-        lastStatOk = ok;
-        lastStatErrno = errno;
-        lastStatWasLstat = wasLstat;
-        Stat.lastNativeStatFields = null;
+        State state = state();
+        state.lastStatArg.set(arg);
+        state.lastStatOk = ok;
+        state.lastStatErrno = errno;
+        state.lastStatWasLstat = wasLstat;
+        state.lastNativeStatFields = null;
         // Always reset BasicFileAttributes - they should only be set by statForFileTest
         // for real filesystem paths. JAR resources don't have BasicFileAttributes.
-        lastBasicAttr = null;
-        lastPosixAttr = null;
+        state.lastBasicAttr = null;
+        state.lastPosixAttr = null;
     }
 
     static void updateLastStat(RuntimeScalar arg, boolean ok, int errno) {
@@ -130,9 +136,10 @@ public class FileTestOperator {
             getGlobalVariable("main::!").set(0);
             updateLastStat(arg, true, 0, lstat);
             // Set attributes after updateLastStat (which resets them to null)
-            lastBasicAttr = basicAttr;
-            lastPosixAttr = posixAttr;
-            Stat.lastNativeStatFields = Stat.nativeStat(path.toString(), !lstat);
+            State state = state();
+            state.lastBasicAttr = basicAttr;
+            state.lastPosixAttr = posixAttr;
+            state.lastNativeStatFields = Stat.nativeStat(path.toString(), !lstat);
             return true;
         } catch (NoSuchFileException e) {
             getGlobalVariable("main::!").set(2);
@@ -146,40 +153,41 @@ public class FileTestOperator {
     }
 
     private static RuntimeScalar fileTestFromLastStat(String operator) {
-        if (!lastStatOk) {
+        State state = state();
+        if (!state.lastStatOk) {
             if (operator.equals("-T") || operator.equals("-B")) {
-                getGlobalVariable("main::!").set(lastStatErrno != 0 ? lastStatErrno : 2);
+                getGlobalVariable("main::!").set(state.lastStatErrno != 0 ? state.lastStatErrno : 2);
                 return scalarUndef;
             }
             getGlobalVariable("main::!").set(9);
             return scalarUndef;
         }
 
-        if (operator.equals("-l") && !lastStatWasLstat) {
+        if (operator.equals("-l") && !state.lastStatWasLstat) {
             throw new PerlCompilerException("The stat preceding -l _ wasn't an lstat");
         }
 
         // If lastBasicAttr is null (e.g., after testing a JAR path), fall back to re-testing
-        if (lastBasicAttr == null) {
-            return fileTest(operator, lastFileHandle);
+        if (state.lastBasicAttr == null) {
+            return fileTest(operator, state.lastFileHandle);
         }
 
         return switch (operator) {
             case "-e" -> scalarTrue;
-            case "-f" -> getScalarBoolean(lastBasicAttr.isRegularFile());
-            case "-d" -> getScalarBoolean(lastBasicAttr.isDirectory());
+            case "-f" -> getScalarBoolean(state.lastBasicAttr.isRegularFile());
+            case "-d" -> getScalarBoolean(state.lastBasicAttr.isDirectory());
             case "-s" -> {
-                long size = lastBasicAttr.size();
+                long size = state.lastBasicAttr.size();
                 yield size > 0 ? new RuntimeScalar(size) : RuntimeScalarCache.scalarZero;
             }
-            case "-z" -> getScalarBoolean(lastBasicAttr.size() == 0);
-            case "-l" -> getScalarBoolean(lastBasicAttr.isSymbolicLink());
+            case "-z" -> getScalarBoolean(state.lastBasicAttr.size() == 0);
+            case "-l" -> getScalarBoolean(state.lastBasicAttr.isSymbolicLink());
             case "-T", "-B" -> {
                 // Handle -T/-B on _ without re-statting (preserves stat buffer)
                 // We need to resolve the path from the last stat argument and read file content
                 // without calling fileTest() which would overwrite the stat buffer.
                 try {
-                    String filename = lastStatArg.toString();
+                    String filename = state.lastStatArg.toString();
                     Path path = resolvePath(filename);
                     if (path == null || !Files.exists(path)) {
                         getGlobalVariable("main::!").set(2);
@@ -192,7 +200,7 @@ public class FileTestOperator {
                     yield scalarUndef;
                 }
             }
-            default -> fileTest(operator, lastFileHandle);
+            default -> fileTest(operator, state.lastFileHandle);
         };
     }
 
@@ -224,7 +232,7 @@ public class FileTestOperator {
      * @return A RuntimeScalar containing the result of the file test
      */
     public static RuntimeScalar fileTest(String operator, RuntimeScalar fileHandle) {
-        lastFileHandle.set(fileHandle);
+        state().lastFileHandle.set(fileHandle);
 
         // Check if the argument is a file handle (GLOB or GLOBREFERENCE)
         if (fileHandle.type == RuntimeScalarType.GLOB || fileHandle.type == RuntimeScalarType.GLOBREFERENCE) {
@@ -243,8 +251,8 @@ public class FileTestOperator {
             if (fh == null) {
                 // Special case: -T/-B on * _ (or \*_) should preserve last stat errno when the last stat failed,
                 // even if the underscore typeglob doesn't have its IO slot initialized.
-                if ((operator.equals("-T") || operator.equals("-B")) && !lastStatOk && isUnderscoreTypeglob(fileHandle)) {
-                    getGlobalVariable("main::!").set(lastStatErrno != 0 ? lastStatErrno : 2);
+                if ((operator.equals("-T") || operator.equals("-B")) && !state().lastStatOk && isUnderscoreTypeglob(fileHandle)) {
+                    getGlobalVariable("main::!").set(state().lastStatErrno != 0 ? state().lastStatErrno : 2);
                     return scalarUndef;
                 }
                 // Set $! to EBADF (Bad file descriptor) = 9
@@ -254,16 +262,16 @@ public class FileTestOperator {
             }
 
             // Special case: -T/-B on * _ (or \*_) should preserve last stat errno when the last stat failed.
-            if ((operator.equals("-T") || operator.equals("-B")) && !lastStatOk && isUnderscoreTypeglob(fileHandle)) {
-                getGlobalVariable("main::!").set(lastStatErrno != 0 ? lastStatErrno : 2);
+            if ((operator.equals("-T") || operator.equals("-B")) && !state().lastStatOk && isUnderscoreTypeglob(fileHandle)) {
+                getGlobalVariable("main::!").set(state().lastStatErrno != 0 ? state().lastStatErrno : 2);
                 return scalarUndef;
             }
 
             // Check for closed handle or no valid IO handles
             if ((fh.ioHandle == null || fh.ioHandle instanceof ClosedIOHandle) &&
                     fh.directoryIO == null) {
-                if ((operator.equals("-T") || operator.equals("-B")) && !lastStatOk && isUnderscoreTypeglob(fileHandle)) {
-                    getGlobalVariable("main::!").set(lastStatErrno != 0 ? lastStatErrno : 2);
+                if ((operator.equals("-T") || operator.equals("-B")) && !state().lastStatOk && isUnderscoreTypeglob(fileHandle)) {
+                    getGlobalVariable("main::!").set(state().lastStatErrno != 0 ? state().lastStatErrno : 2);
                     return scalarUndef;
                 }
                 // Set $! to EBADF (Bad file descriptor) = 9
@@ -543,10 +551,10 @@ public class FileTestOperator {
                 }
                 case "-s" -> {
                     // Return file size if non-zero, otherwise return false
-                    if (!lastStatOk) {
+                    if (!state().lastStatOk) {
                         yield scalarUndef;
                     }
-                    long size = lastBasicAttr.size();
+                    long size = state().lastBasicAttr.size();
                     yield size > 0 ? new RuntimeScalar(size) : RuntimeScalarCache.scalarZero;
                 }
                 case "-f" -> {
@@ -569,10 +577,10 @@ public class FileTestOperator {
                 }
                 case "-l" -> {
                     // Check if path is a symbolic link
-                    if (!lastStatOk) {
+                    if (!state().lastStatOk) {
                         yield scalarUndef;
                     }
-                    yield getScalarBoolean(lastBasicAttr.isSymbolicLink());
+                    yield getScalarBoolean(state().lastBasicAttr.isSymbolicLink());
                 }
                 case "-o" -> {
                     // Check if file is owned by the effective user id (approximate with current user)
@@ -593,8 +601,8 @@ public class FileTestOperator {
                         yield scalarUndef;
                     }
                     getGlobalVariable("main::!").set(0);
-                    if (Stat.lastNativeStatFields != null) {
-                        yield getScalarBoolean((Stat.lastNativeStatFields.mode() & 0170000) == 0010000);
+                    if (state().lastNativeStatFields != null) {
+                        yield getScalarBoolean((state().lastNativeStatFields.mode() & 0170000) == 0010000);
                     }
                     yield getScalarBoolean(Files.isRegularFile(path) && filename.endsWith(".fifo"));
                 }
@@ -605,8 +613,8 @@ public class FileTestOperator {
                         yield scalarUndef;
                     }
                     getGlobalVariable("main::!").set(0);
-                    if (Stat.lastNativeStatFields != null) {
-                        yield getScalarBoolean((Stat.lastNativeStatFields.mode() & 0170000) == 0140000);
+                    if (state().lastNativeStatFields != null) {
+                        yield getScalarBoolean((state().lastNativeStatFields.mode() & 0170000) == 0140000);
                     }
                     yield getScalarBoolean(Files.isRegularFile(path) && filename.endsWith(".sock"));
                 }
@@ -617,8 +625,8 @@ public class FileTestOperator {
                         yield scalarUndef;
                     }
                     getGlobalVariable("main::!").set(0);
-                    if (Stat.lastNativeStatFields != null) {
-                        yield getScalarBoolean((Stat.lastNativeStatFields.mode() & 0170000) == 0060000);
+                    if (state().lastNativeStatFields != null) {
+                        yield getScalarBoolean((state().lastNativeStatFields.mode() & 0170000) == 0060000);
                     }
                     yield getScalarBoolean(Files.isRegularFile(path) && filename.startsWith("/dev/"));
                 }
@@ -629,8 +637,8 @@ public class FileTestOperator {
                         yield scalarUndef;
                     }
                     getGlobalVariable("main::!").set(0);
-                    if (Stat.lastNativeStatFields != null) {
-                        yield getScalarBoolean((Stat.lastNativeStatFields.mode() & 0170000) == 0020000);
+                    if (state().lastNativeStatFields != null) {
+                        yield getScalarBoolean((state().lastNativeStatFields.mode() & 0170000) == 0020000);
                     }
                     yield getScalarBoolean(Files.isRegularFile(path) && filename.startsWith("/dev/"));
                 }
@@ -641,8 +649,8 @@ public class FileTestOperator {
                         yield scalarUndef;
                     }
                     getGlobalVariable("main::!").set(0);
-                    if (Stat.lastNativeStatFields != null) {
-                        yield getScalarBoolean((Stat.lastNativeStatFields.mode() & 04000) != 0);
+                    if (state().lastNativeStatFields != null) {
+                        yield getScalarBoolean((state().lastNativeStatFields.mode() & 04000) != 0);
                     }
                     yield getScalarBoolean
                             ((Files.getPosixFilePermissions(path).contains(PosixFilePermission.OWNER_EXECUTE)));
@@ -654,8 +662,8 @@ public class FileTestOperator {
                         yield scalarUndef;
                     }
                     getGlobalVariable("main::!").set(0);
-                    if (Stat.lastNativeStatFields != null) {
-                        yield getScalarBoolean((Stat.lastNativeStatFields.mode() & 02000) != 0);
+                    if (state().lastNativeStatFields != null) {
+                        yield getScalarBoolean((state().lastNativeStatFields.mode() & 02000) != 0);
                     }
                     yield getScalarBoolean
                             ((Files.getPosixFilePermissions(path).contains(PosixFilePermission.GROUP_EXECUTE)));
@@ -667,8 +675,8 @@ public class FileTestOperator {
                         yield scalarUndef;
                     }
                     getGlobalVariable("main::!").set(0);
-                    if (Stat.lastNativeStatFields != null) {
-                        yield getScalarBoolean((Stat.lastNativeStatFields.mode() & 01000) != 0);
+                    if (state().lastNativeStatFields != null) {
+                        yield getScalarBoolean((state().lastNativeStatFields.mode() & 01000) != 0);
                     }
                     yield getScalarBoolean
                             ((Files.getPosixFilePermissions(path).contains(PosixFilePermission.OTHERS_EXECUTE)));
@@ -901,8 +909,8 @@ public class FileTestOperator {
                     ((FileTime) Files.getAttribute(path, "lastAccessTime", LinkOption.NOFOLLOW_LINKS)).toMillis();
             case "-C" -> {
                 // Get ctime (inode change time on Unix, creation time fallback)
-                if (Stat.lastNativeStatFields != null) {
-                    yield Stat.lastNativeStatFields.ctime() * 1000L;
+                if (state().lastNativeStatFields != null) {
+                    yield state().lastNativeStatFields.ctime() * 1000L;
                 }
                 yield ((FileTime) Files.getAttribute(path, "creationTime", LinkOption.NOFOLLOW_LINKS)).toMillis();
             }

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -28,17 +28,15 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalVariable;
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.*;
 
 public class IOOperator {
-    // Simple socket option storage: key is "socketHashCode:level:optname", value is the option value
-    private static final Map<String, Integer> globalSocketOptions = new ConcurrentHashMap<>();
-
     // File descriptor to RuntimeIO mapping for duplication support
-    private static final Map<Integer, RuntimeIO> fileDescriptorMap = new ConcurrentHashMap<>();
+    private static Map<Integer, RuntimeIO> fileDescriptorMap() {
+        return PerlRuntime.current().ioRegistryState.operatorFileDescriptors;
+    }
 
     public static RuntimeScalar select(RuntimeList runtimeList, int ctx) {
         if (runtimeList.isEmpty()) {
@@ -2930,7 +2928,7 @@ public class IOOperator {
             return fromRegistry;
         }
 
-        RuntimeIO handle = fileDescriptorMap.get(fd);
+        RuntimeIO handle = fileDescriptorMap().get(fd);
         if (handle != null && handle.ioHandle != null
                 && !(handle.ioHandle instanceof ClosedIOHandle)) {
             return handle;
@@ -3166,7 +3164,7 @@ public class IOOperator {
      */
     public static void registerFileDescriptor(int fd, RuntimeIO handle) {
         if (handle != null) {
-            fileDescriptorMap.put(fd, handle);
+            fileDescriptorMap().put(fd, handle);
         }
     }
 
@@ -3174,7 +3172,7 @@ public class IOOperator {
      * Unregister a file descriptor when the handle is closed.
      */
     public static void unregisterFileDescriptor(int fd) {
-        fileDescriptorMap.remove(fd);
+        fileDescriptorMap().remove(fd);
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
@@ -5,6 +5,7 @@ import org.perlonjava.app.scriptengine.PerlLanguageProvider;
 import org.perlonjava.backend.bytecode.InterpreterState;
 import org.perlonjava.core.Configuration;
 import org.perlonjava.runtime.perlmodule.BHooksEndOfScope;
+import org.perlonjava.runtime.perlmodule.Feature;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import java.io.IOException;
@@ -14,7 +15,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static org.perlonjava.runtime.perlmodule.Feature.featureManager;
 import static org.perlonjava.runtime.runtimetypes.ExceptionFormatter.findInnermostCause;
 import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalHash;
 import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalVariable;
@@ -680,7 +680,7 @@ public class ModuleOperators {
         }
 
         RuntimeList result;
-        FeatureFlags outerFeature = featureManager;
+        FeatureFlags outerFeature = Feature.getFeatureManager();
         String savedPackage = InterpreterState.currentPackage.get().toString();
 
         // Tell the inner compilation to start in the caller's package, rather
@@ -713,14 +713,14 @@ public class ModuleOperators {
                         .saveAndResetFilterState();
 
         try {
-            featureManager = new FeatureFlags();
+            Feature.setFeatureManager(new FeatureFlags());
             
             // Clear the hints hash for a fresh compilation context
             hintHash.elements.clear();
 
             result = PerlLanguageProvider.executePerlCode(parsedArgs, false, ctx);
 
-            boolean moduleTrue = featureManager.isFeatureEnabled("module_true");
+            boolean moduleTrue = Feature.getFeatureManager().isFeatureEnabled("module_true");
             if (moduleTrue) {
                 result = scalarTrue.getList();
             }
@@ -749,7 +749,7 @@ public class ModuleOperators {
             // This must happen BEFORE restoring outer context
             BHooksEndOfScope.endFileLoad(parsedArgs.fileName);
             
-            featureManager = outerFeature;
+            Feature.setFeatureManager(outerFeature);
             InterpreterState.currentPackage.get().set(savedPackage);
             
             // Restore the caller's hints hash

--- a/src/main/java/org/perlonjava/runtime/operators/Random.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Random.java
@@ -2,6 +2,7 @@ package org.perlonjava.runtime.operators;
 
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalarType;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 
 /**
  * The Random class provides methods to generate random numbers and manage random seeds.
@@ -10,9 +11,14 @@ public class Random {
     /**
      * The current seed used for random number generation.
      */
-    public static long currentSeed = System.currentTimeMillis();
+    public static final class State {
+        long currentSeed = System.currentTimeMillis();
+        final java.util.Random random = new java.util.Random(currentSeed);
+    }
 
-    private static final java.util.Random random = new java.util.Random(currentSeed);
+    private static State state() {
+        return PerlRuntime.current().randomState;
+    }
 
     /**
      * Sets a new seed for the random number generator. If a seed is provided via the
@@ -23,14 +29,15 @@ public class Random {
      * @return A {@link RuntimeScalar} containing the old seed value.
      */
     public static RuntimeScalar srand(RuntimeScalar runtimeScalar) {
-        long oldSeed = currentSeed;
+        State state = state();
+        long oldSeed = state.currentSeed;
         if (runtimeScalar.type != RuntimeScalarType.UNDEF) {
-            currentSeed = runtimeScalar.getInt();
+            state.currentSeed = runtimeScalar.getInt();
         } else {
             // Semi-randomly choose a seed if no argument is provided
-            currentSeed = System.nanoTime() ^ System.identityHashCode(Thread.currentThread());
+            state.currentSeed = System.nanoTime() ^ System.identityHashCode(Thread.currentThread());
         }
-        random.setSeed(currentSeed);
+        state.random.setSeed(state.currentSeed);
         return new RuntimeScalar(oldSeed);
     }
 
@@ -41,6 +48,6 @@ public class Random {
      * @return A {@link RuntimeScalar} containing the scaled random number.
      */
     public static RuntimeScalar rand(RuntimeScalar runtimeScalar) {
-        return new RuntimeScalar(random.nextDouble() * runtimeScalar.getDouble());
+        return new RuntimeScalar(state().random.nextDouble() * runtimeScalar.getDouble());
     }
 }

--- a/src/main/java/org/perlonjava/runtime/operators/ReferenceOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ReferenceOperators.java
@@ -179,7 +179,7 @@ public class ReferenceOperators {
                     MortalList.deferDecrement(referent);
                 }
                 // Activate the mortal mechanism
-                MortalList.active = true;
+                MortalList.setActive(true);
             }
             DestroyDispatch.registerIfDestroyable(referent, newBlessId);
         } else {

--- a/src/main/java/org/perlonjava/runtime/operators/ScalarFlipFlopOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ScalarFlipFlopOperator.java
@@ -4,6 +4,8 @@ import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 
 /**
  * Implements a scalar flip-flop operator, similar to Perl's flip-flop operator.
@@ -13,8 +15,15 @@ import java.util.Map;
 public class ScalarFlipFlopOperator {
 
     // Map to store the state (flip-flop) and sequence count for each operator instance
-    public static final Map<Integer, ScalarFlipFlopOperator> flipFlops = new HashMap<>();
-    public static Integer currentId = 0;
+    private static final AtomicInteger NEXT_ID = new AtomicInteger();
+
+    public static int allocateId() {
+        return NEXT_ID.getAndIncrement();
+    }
+
+    public static Map<Integer, ScalarFlipFlopOperator> flipFlops() {
+        return PerlRuntime.current().flipFlopState;
+    }
 
     private final boolean isThreeDot; // true for three dots, false for two dots
     private boolean currentState;
@@ -40,7 +49,7 @@ public class ScalarFlipFlopOperator {
      * @return A RuntimeScalar representing the current sequence count or an empty string.
      */
     public static RuntimeScalar evaluate(int id, RuntimeScalar left, RuntimeScalar right) {
-        ScalarFlipFlopOperator ff = flipFlops.get(id);
+        ScalarFlipFlopOperator ff = flipFlops().get(id);
         boolean leftOperand = left.getBoolean();
         boolean rightOperand = right.getBoolean();
         if (!ff.currentState) {

--- a/src/main/java/org/perlonjava/runtime/operators/ScalarGlobOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ScalarGlobOperator.java
@@ -5,6 +5,7 @@ import org.perlonjava.runtime.runtimetypes.*;
 import java.io.File;
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalVariable;
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarUndef;
@@ -17,12 +18,18 @@ public class ScalarGlobOperator {
     /**
      * Map storing glob operator instances by their unique ID for state management
      */
-    private static final Map<Integer, ScalarGlobOperator> globOperators = new HashMap<>();
+    private static Map<Integer, ScalarGlobOperator> globOperators() {
+        return PerlRuntime.current().scalarGlobState;
+    }
 
     /**
      * Counter for generating unique operator IDs
      */
-    public static Integer currentId = 0;
+    private static final AtomicInteger NEXT_ID = new AtomicInteger();
+
+    public static int allocateId() {
+        return NEXT_ID.getAndIncrement();
+    }
 
     /**
      * Iterator over the current glob results
@@ -83,6 +90,7 @@ public class ScalarGlobOperator {
      * Evaluates glob in scalar context, returning one result per call.
      */
     private static RuntimeBase evaluateInScalarContext(int id, String pattern) {
+        Map<Integer, ScalarGlobOperator> globOperators = globOperators();
         ScalarGlobOperator globOperator = globOperators.get(id);
 
         if (globOperator == null) {
@@ -227,7 +235,7 @@ public class ScalarGlobOperator {
                 startSegment = 1;
             }
         } else {
-            startDir = new File(System.getProperty("user.dir"));
+            startDir = new File(RuntimeEnvironment.currentDirectory());
             prefix = "";
             startSegment = 0;
         }
@@ -380,7 +388,7 @@ public class ScalarGlobOperator {
             filePattern = normalizedPattern.substring(lastSep + 1);
         } else {
             // No directory separator - use current directory
-            baseDir = new File(System.getProperty("user.dir"));
+            baseDir = new File(RuntimeEnvironment.currentDirectory());
         }
 
         return new PathComponents(baseDir, filePattern, hasDirectory, directoryPart);

--- a/src/main/java/org/perlonjava/runtime/operators/SprintfOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/SprintfOperator.java
@@ -21,8 +21,6 @@ public class SprintfOperator {
 
     // Maximum practical limit for width/precision to prevent memory issues
     public static final int MAX_PRACTICAL_FORMAT_SIZE = 8192;
-    private static int charsWritten = 0;
-
     /**
      * Formats the elements according to the specified format string.
      * <p>
@@ -47,7 +45,7 @@ public class SprintfOperator {
 
     private static RuntimeScalar sprintfInternal(RuntimeScalar runtimeScalar, RuntimeList list, boolean bytesMode) {
         RuntimeScalar.checkTaint(runtimeScalar, "sprintf");
-        charsWritten = 0;  // Reset counter
+        int charsWritten = 0;
         // Expand the list to ensure all elements are available
         list = new RuntimeList((RuntimeBase) list);
         String format = runtimeScalar.toString();
@@ -165,7 +163,7 @@ public class SprintfOperator {
                     // %n doesn't produce output, but does consume an argument
                     int targetIndex = spec.parameterIndex != null ? spec.parameterIndex - 1 : argIndex;
                     maxArgIndexUsed = Math.max(maxArgIndexUsed, targetIndex);
-                    handlePercentN(spec, list, argIndex);
+                    handlePercentN(spec, list, argIndex, charsWritten);
 
                     // Update sequential argument index for non-positional width/precision
                     if (spec.parameterIndex == null) {
@@ -276,7 +274,7 @@ public class SprintfOperator {
     }
 
     private static void handlePercentN(FormatSpecifier spec,
-                                       RuntimeList list, int argIndex) {
+                                       RuntimeList list, int argIndex, int charsWritten) {
         int targetIndex = spec.parameterIndex != null ? spec.parameterIndex - 1 : argIndex;
         if (targetIndex >= list.size()) {
             // Missing argument for %n

--- a/src/main/java/org/perlonjava/runtime/operators/Stat.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Stat.java
@@ -23,8 +23,6 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.*;
 
 public class Stat {
 
-    static NativeStatFields lastNativeStatFields;
-
     // FFM POSIX implementation
     private static final FFMPosixInterface posix = FFMPosix.get();
 
@@ -78,15 +76,16 @@ public class Stat {
     }
 
     public static RuntimeList statLastHandle() {
-        if (!lastStatOk) {
+        FileTestOperator.State state = state();
+        if (!state.lastStatOk) {
             getGlobalVariable("main::!").set(9);
             return new RuntimeList();
         }
         RuntimeList res = new RuntimeList();
-        if (lastNativeStatFields != null) {
-            statInternalNative(res, lastNativeStatFields);
+        if (state.lastNativeStatFields != null) {
+            statInternalNative(res, state.lastNativeStatFields);
         } else {
-            statInternal(res, lastBasicAttr, lastPosixAttr);
+            statInternal(res, state.lastBasicAttr, state.lastPosixAttr);
         }
         getGlobalVariable("main::!").set(0);
         return res;
@@ -94,7 +93,7 @@ public class Stat {
 
     public static RuntimeBase statLastHandle(int ctx) {
         if (ctx == RuntimeContextType.SCALAR) {
-            if (!lastStatOk) {
+            if (!state().lastStatOk) {
                 getGlobalVariable("main::!").set(9);
                 return new RuntimeScalar("");
             }
@@ -105,29 +104,30 @@ public class Stat {
     }
 
     public static RuntimeList lstatLastHandle() {
-        if (!lastStatWasLstat) {
+        FileTestOperator.State state = state();
+        if (!state.lastStatWasLstat) {
             throw new PerlCompilerException("The stat preceding lstat() wasn't an lstat");
         }
-        if (!lastStatOk) {
+        if (!state.lastStatOk) {
             getGlobalVariable("main::!").set(9);
             return new RuntimeList();
         }
         RuntimeList res = new RuntimeList();
-        if (lastNativeStatFields != null) {
-            statInternalNative(res, lastNativeStatFields);
+        if (state.lastNativeStatFields != null) {
+            statInternalNative(res, state.lastNativeStatFields);
         } else {
-            statInternal(res, lastBasicAttr, lastPosixAttr);
+            statInternal(res, state.lastBasicAttr, state.lastPosixAttr);
         }
         getGlobalVariable("main::!").set(0);
         return res;
     }
 
     public static RuntimeBase lstatLastHandle(int ctx) {
-        if (!lastStatWasLstat) {
+        if (!state().lastStatWasLstat) {
             throw new PerlCompilerException("The stat preceding lstat() wasn't an lstat");
         }
         if (ctx == RuntimeContextType.SCALAR) {
-            if (!lastStatOk) {
+            if (!state().lastStatOk) {
                 getGlobalVariable("main::!").set(9);
                 return new RuntimeScalar("");
             }
@@ -154,7 +154,7 @@ public class Stat {
     }
 
     public static RuntimeList stat(RuntimeScalar arg) {
-        lastFileHandle.set(arg);
+        state().lastFileHandle.set(arg);
         RuntimeList res = new RuntimeList();
 
         if (arg.type == RuntimeScalarType.GLOB || arg.type == RuntimeScalarType.GLOBREFERENCE) {
@@ -230,9 +230,10 @@ public class Stat {
             getGlobalVariable("main::!").set(0);
             updateLastStat(arg, true, 0, false);
             // Set attributes after updateLastStat (which resets them to null)
-            lastBasicAttr = basicAttr;
-            lastPosixAttr = posixAttr;
-            lastNativeStatFields = nf;
+            FileTestOperator.State state = state();
+            state.lastBasicAttr = basicAttr;
+            state.lastPosixAttr = posixAttr;
+            state.lastNativeStatFields = nf;
         } catch (NoSuchFileException e) {
             getGlobalVariable("main::!").set(2);
             updateLastStat(arg, false, 2, false);
@@ -244,14 +245,14 @@ public class Stat {
     }
 
     public static RuntimeList lstat(RuntimeScalar arg) {
-        lastFileHandle.set(arg);
+        state().lastFileHandle.set(arg);
         RuntimeList res = new RuntimeList();
 
         if (arg.type == RuntimeScalarType.GLOB || arg.type == RuntimeScalarType.GLOBREFERENCE) {
             // Check if this is the special underscore glob (*_ or \*_)
             if (isUnderscoreGlob(arg)) {
                 // lstat on *_ or \*_ after stat should croak
-                if (!lastStatWasLstat) {
+                if (!state().lastStatWasLstat) {
                     throw new PerlCompilerException("The stat preceding lstat() wasn't an lstat");
                 }
                 return lstatLastHandle();
@@ -292,9 +293,10 @@ public class Stat {
             getGlobalVariable("main::!").set(0);
             updateLastStat(arg, true, 0, true);
             // Set attributes after updateLastStat (which resets them to null)
-            lastBasicAttr = basicAttr;
-            lastPosixAttr = posixAttr;
-            lastNativeStatFields = nf;
+            FileTestOperator.State state = state();
+            state.lastBasicAttr = basicAttr;
+            state.lastPosixAttr = posixAttr;
+            state.lastNativeStatFields = nf;
         } catch (NoSuchFileException e) {
             getGlobalVariable("main::!").set(2);
             updateLastStat(arg, false, 2, true);

--- a/src/main/java/org/perlonjava/runtime/operators/SystemOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/SystemOperator.java
@@ -372,7 +372,7 @@ public class SystemOperator {
             return commandArgs;
         }
 
-        String userDir = System.getProperty("user.dir");
+        String userDir = RuntimeEnvironment.currentDirectory();
         String pathSeparator = SystemUtils.osIsWindows() ? ";" : ":";
         for (String dir : path.split(Pattern.quote(pathSeparator), -1)) {
             File pathDir = dir.isEmpty() ? new File(userDir) : new File(dir);
@@ -422,7 +422,7 @@ public class SystemOperator {
 
         File script = new File(command);
         if (!script.isAbsolute()) {
-            script = new File(System.getProperty("user.dir"), command);
+            script = new File(RuntimeEnvironment.currentDirectory(), command);
         }
 
         StringBuilder commandLine = new StringBuilder("call ").append(quoteForCmd(script.getAbsolutePath()));
@@ -449,7 +449,7 @@ public class SystemOperator {
 
         File script = new File(commandArgs.getFirst());
         if (!script.isAbsolute()) {
-            script = new File(System.getProperty("user.dir"), commandArgs.getFirst());
+            script = new File(RuntimeEnvironment.currentDirectory(), commandArgs.getFirst());
         }
         if (!script.isFile()) {
             return commandArgs;
@@ -613,7 +613,7 @@ public class SystemOperator {
             }
 
             ProcessBuilder processBuilder = new ProcessBuilder(shellCommand);
-            String userDir = System.getProperty("user.dir");
+            String userDir = RuntimeEnvironment.currentDirectory();
             processBuilder.directory(new File(userDir));
             
             // Copy %ENV to the subprocess environment
@@ -716,7 +716,7 @@ public class SystemOperator {
             flushAllHandles();
 
             ProcessBuilder processBuilder = new ProcessBuilder(resolveCommandForProcessBuilder(commandArgs));
-            String userDir = System.getProperty("user.dir");
+            String userDir = RuntimeEnvironment.currentDirectory();
             processBuilder.directory(new File(userDir));
             
             // Copy %ENV to the subprocess environment
@@ -768,7 +768,7 @@ public class SystemOperator {
             flushAllHandles();
 
             ProcessBuilder processBuilder = new ProcessBuilder(resolveCommandForProcessBuilder(commandArgs));
-            String userDir = System.getProperty("user.dir");
+            String userDir = RuntimeEnvironment.currentDirectory();
             processBuilder.directory(new File(userDir));
             
             // Copy %ENV to the subprocess environment
@@ -1114,7 +1114,7 @@ public class SystemOperator {
 
             // Run command and capture output
             ProcessBuilder processBuilder = new ProcessBuilder(resolveCommandForProcessBuilder(command));
-            processBuilder.directory(new File(System.getProperty("user.dir")));
+            processBuilder.directory(new File(RuntimeEnvironment.currentDirectory()));
             copyPerlEnvToProcessBuilder(processBuilder);
             processBuilder.redirectErrorStream(false);  // Keep stderr separate
 
@@ -1191,7 +1191,7 @@ public class SystemOperator {
         }
 
         ProcessBuilder processBuilder = new ProcessBuilder(shellCommand);
-        String userDir = System.getProperty("user.dir");
+        String userDir = RuntimeEnvironment.currentDirectory();
         processBuilder.directory(new File(userDir));
         
         // Copy %ENV to the subprocess environment
@@ -1214,7 +1214,7 @@ public class SystemOperator {
      */
     private static int execCommandDirect(List<String> commandArgs) throws IOException, InterruptedException {
         ProcessBuilder processBuilder = new ProcessBuilder(resolveCommandForProcessBuilder(commandArgs));
-        String userDir = System.getProperty("user.dir");
+        String userDir = RuntimeEnvironment.currentDirectory();
         processBuilder.directory(new File(userDir));
         
         // Copy %ENV to the subprocess environment

--- a/src/main/java/org/perlonjava/runtime/operators/SystemOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/SystemOperator.java
@@ -607,7 +607,7 @@ public class SystemOperator {
             String[] shellCommand;
             if (SystemUtils.osIsWindows()) {
                 // Windows
-                shellCommand = new String[]{"cmd.exe", "/c", command};
+                shellCommand = new String[]{"cmd.exe", "/d", "/s", "/c", command};
             } else {
                 // Unix-like (Linux, macOS)
                 shellCommand = new String[]{"/bin/sh", "-c", command};
@@ -1104,7 +1104,7 @@ public class SystemOperator {
                     command = directCommand;
                 } else {
                     if (SystemUtils.osIsWindows()) {
-                        command = Arrays.asList("cmd.exe", "/c", cmdStr);
+                        command = Arrays.asList("cmd.exe", "/d", "/s", "/c", cmdStr);
                     } else {
                         command = Arrays.asList("/bin/sh", "-c", cmdStr);
                     }
@@ -1185,7 +1185,7 @@ public class SystemOperator {
         String[] shellCommand;
         if (SystemUtils.osIsWindows()) {
             // Windows
-            shellCommand = new String[]{"cmd.exe", "/c", command};
+            shellCommand = new String[]{"cmd.exe", "/d", "/s", "/c", command};
         } else {
             // Unix-like (Linux, macOS)
             shellCommand = new String[]{"/bin/sh", "-c", command};

--- a/src/main/java/org/perlonjava/runtime/operators/SystemOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/SystemOperator.java
@@ -301,14 +301,15 @@ public class SystemOperator {
     }
 
     private static void checkPathDirectories(String pathValue) {
-        if (SystemUtils.osIsWindows()) {
-            return;
-        }
-
-        for (String directory : pathValue.split(":", -1)) {
+        boolean windows = SystemUtils.osIsWindows();
+        String separator = windows ? ";" : ":";
+        for (String directory : pathValue.split(Pattern.quote(separator), -1)) {
             try {
                 Path path = Path.of(directory);
-                if (directory.isEmpty() || !path.isAbsolute() || isWorldWritableDirectory(path)) {
+                boolean absolute = path.isAbsolute()
+                        || (windows && (directory.startsWith("/") || directory.startsWith("\\")));
+                if (directory.isEmpty() || !absolute
+                        || (!windows && isWorldWritableDirectory(path))) {
                     throw insecurePathException();
                 }
             } catch (InvalidPathException e) {

--- a/src/main/java/org/perlonjava/runtime/operators/SystemOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/SystemOperator.java
@@ -340,15 +340,61 @@ public class SystemOperator {
             return null;
         }
 
+        if (SystemUtils.osIsWindows()) {
+            return splitWindowsDirectCommandWords(trimmed);
+        }
+
         if (DIRECT_COMMAND_SHELL_METACHARACTERS.matcher(trimmed).find()) {
             return null;
         }
 
-        if (!SystemUtils.osIsWindows() && trimmed.contains("\\")) {
+        if (trimmed.contains("\\")) {
             return null;
         }
 
         return Arrays.asList(trimmed.split("\\s+"));
+    }
+
+    /**
+     * Split a Windows one-string command when it only needs argv quoting, not
+     * cmd.exe expansion. Shell metacharacters inside a quoted argument are
+     * ordinary argument data (notably Perl source passed through {@code -e}).
+     */
+    static List<String> splitWindowsDirectCommandWords(String command) {
+        List<String> words = new ArrayList<>();
+        StringBuilder word = new StringBuilder();
+        boolean quoted = false;
+        boolean started = false;
+
+        for (int i = 0; i < command.length(); i++) {
+            char ch = command.charAt(i);
+            if (ch == '"') {
+                quoted = !quoted;
+                started = true;
+                continue;
+            }
+            if (!quoted && Character.isWhitespace(ch)) {
+                if (started) {
+                    words.add(word.toString());
+                    word.setLength(0);
+                    started = false;
+                }
+                continue;
+            }
+            if (!quoted && "*?[]{}()<>|&;`'$%".indexOf(ch) >= 0) {
+                return null;
+            }
+            word.append(ch);
+            started = true;
+        }
+
+        if (quoted) {
+            return null;
+        }
+        if (started) {
+            words.add(word.toString());
+        }
+        return words.isEmpty() ? null : words;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/operators/Time.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Time.java
@@ -33,10 +33,16 @@ public class Time {
         t.setDaemon(true);  // Daemon thread won't prevent JVM shutdown
         return t;
     });
-    private static ScheduledFuture<?> currentAlarmTask = null;
-    private static long alarmStartTime;
-    private static int alarmDuration;
-    private static Thread alarmTargetThread;
+    public static final class State {
+        ScheduledFuture<?> currentAlarmTask;
+        long alarmStartTime;
+        int alarmDuration;
+        Thread alarmTargetThread;
+    }
+
+    private static State state() {
+        return PerlRuntime.current().timeState;
+    }
 
     /**
      * Returns the current time in seconds since the Unix epoch with second precision.
@@ -344,6 +350,7 @@ public class Time {
      * @return a RuntimeScalar representing the seconds remaining from previous alarm
      */
     public static RuntimeScalar alarm(int ctx, RuntimeBase... args) {
+        State state = state();
         int seconds = 0;
         if (args.length > 0) {
             seconds = args[0].scalar().getInt();
@@ -351,25 +358,25 @@ public class Time {
 
         // Calculate remaining time on previous timer
         int remainingTime = 0;
-        if (currentAlarmTask != null && !currentAlarmTask.isDone()) {
-            long elapsedTime = (System.currentTimeMillis() - alarmStartTime) / 1000;
-            remainingTime = Math.max(0, alarmDuration - (int) elapsedTime);
-            currentAlarmTask.cancel(false);
+        if (state.currentAlarmTask != null && !state.currentAlarmTask.isDone()) {
+            long elapsedTime = (System.currentTimeMillis() - state.alarmStartTime) / 1000;
+            remainingTime = Math.max(0, state.alarmDuration - (int) elapsedTime);
+            state.currentAlarmTask.cancel(false);
         }
 
         if (seconds == 0) {
-            currentAlarmTask = null;
+            state.currentAlarmTask = null;
             return new RuntimeScalar(remainingTime);
         }
 
         // Set up new alarm
-        alarmStartTime = System.currentTimeMillis();
-        alarmDuration = seconds;
-        alarmTargetThread = Thread.currentThread();
+        state.alarmStartTime = System.currentTimeMillis();
+        state.alarmDuration = seconds;
+        state.alarmTargetThread = Thread.currentThread();
         PerlRuntime alarmOwner = PerlRuntime.current();
-        Thread targetThread = alarmTargetThread;
+        Thread targetThread = state.alarmTargetThread;
 
-        currentAlarmTask = alarmScheduler.schedule(
+        state.currentAlarmTask = alarmScheduler.schedule(
                 () -> dispatchAlarm(alarmOwner, targetThread), seconds, TimeUnit.SECONDS);
 
         return new RuntimeScalar(remainingTime);
@@ -402,7 +409,8 @@ public class Time {
      * @return true if alarm is active, false otherwise
      */
     public static boolean hasActiveAlarm() {
-        return currentAlarmTask != null && !currentAlarmTask.isDone();
+        State state = state();
+        return state.currentAlarmTask != null && !state.currentAlarmTask.isDone();
     }
 
     /**
@@ -411,11 +419,20 @@ public class Time {
      * @return seconds remaining, or 0 if no alarm active
      */
     public static int getAlarmRemainingSeconds() {
+        State state = state();
         if (!hasActiveAlarm()) {
             return 0;
         }
-        long elapsedTime = (System.currentTimeMillis() - alarmStartTime) / 1000;
-        return Math.max(0, alarmDuration - (int) elapsedTime);
+        long elapsedTime = (System.currentTimeMillis() - state.alarmStartTime) / 1000;
+        return Math.max(0, state.alarmDuration - (int) elapsedTime);
+    }
+
+    public static void cancelCurrentAlarm() {
+        State state = state();
+        if (state.currentAlarmTask != null) {
+            state.currentAlarmTask.cancel(false);
+            state.currentAlarmTask = null;
+        }
     }
 
     /**
@@ -423,9 +440,11 @@ public class Time {
      * This method is called by the shutdown hook and can also be called manually.
      */
     public static void shutdownAlarmScheduler() {
-        if (currentAlarmTask != null && !currentAlarmTask.isDone()) {
-            currentAlarmTask.cancel(false);
-            currentAlarmTask = null;
+        PerlRuntime runtime = PerlRuntime.currentOrNull();
+        if (runtime != null && runtime.timeState.currentAlarmTask != null
+                && !runtime.timeState.currentAlarmTask.isDone()) {
+            runtime.timeState.currentAlarmTask.cancel(false);
+            runtime.timeState.currentAlarmTask = null;
         }
 
         if (!alarmScheduler.isShutdown()) {

--- a/src/main/java/org/perlonjava/runtime/operators/WaitpidOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/WaitpidOperator.java
@@ -5,6 +5,7 @@ import org.perlonjava.runtime.nativ.ffm.FFMPosix;
 import org.perlonjava.runtime.runtimetypes.RuntimeArray;
 import org.perlonjava.runtime.runtimetypes.RuntimeBase;
 import org.perlonjava.runtime.runtimetypes.RuntimeIO;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
 import java.util.Map;
@@ -20,7 +21,9 @@ public class WaitpidOperator {
     public static final int WUNTRACED = 2;
     public static final int WCONTINUED = 8;
 
-    private static final Map<Long, Process> windowsChildProcesses = new ConcurrentHashMap<>();
+    private static Map<Long, Process> windowsChildProcesses() {
+        return PerlRuntime.current().ioRegistryState.windowsChildProcesses;
+    }
 
     private static final boolean IS_WINDOWS = NativeUtils.IS_WINDOWS;
 
@@ -123,7 +126,7 @@ public class WaitpidOperator {
             return new RuntimeScalar(-1);
         }
 
-        Process childProcess = windowsChildProcesses.get((long) pid);
+        Process childProcess = windowsChildProcesses().get((long) pid);
         if (childProcess != null) {
             if (nonBlocking) {
                 if (childProcess.isAlive()) return new RuntimeScalar(0);
@@ -136,7 +139,7 @@ public class WaitpidOperator {
                 }
             }
             int exitCode = childProcess.exitValue();
-            windowsChildProcesses.remove((long) pid);
+            windowsChildProcesses().remove((long) pid);
             setExitStatus(exitCode << 8);
             return new RuntimeScalar(pid);
         }
@@ -154,7 +157,7 @@ public class WaitpidOperator {
     }
 
     public static void registerChildProcess(long pid, Process process) {
-        windowsChildProcesses.put(pid, process);
+        windowsChildProcesses().put(pid, process);
     }
 
     private static void setExitStatus(int status) {

--- a/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
+++ b/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
@@ -18,13 +18,8 @@ import static org.perlonjava.runtime.runtimetypes.SpecialBlock.runEndBlocks;
  * respectively. These operations can trigger custom signal handlers if defined.
  */
 public class WarnDie {
-    private static final ThreadLocal<java.util.IdentityHashMap<Throwable, Boolean>> unhandledDieHandlerSeen =
-            ThreadLocal.withInitial(java.util.IdentityHashMap::new);
-    private static final ThreadLocal<Boolean> insideUnhandledDieHandler =
-            ThreadLocal.withInitial(() -> Boolean.FALSE);
-
     public static boolean isInsideUnhandledDieHandler() {
-        return insideUnhandledDieHandler.get();
+        return PerlRuntime.current().executionState().insideUnhandledDieHandler;
     }
 
     private record SyntheticDieCallerFrame(String packageName, String filename, int line) {
@@ -136,7 +131,7 @@ public class WarnDie {
             return e;
         }
 
-        var seen = unhandledDieHandlerSeen.get();
+        var seen = PerlRuntime.current().executionState().unhandledDieHandlerSeen;
         if (seen.containsKey(unwrapped)) {
             return e;
         }
@@ -150,8 +145,9 @@ public class WarnDie {
 
         int level = DynamicVariableManager.getLocalLevel();
         DynamicVariableManager.pushLocalVariable(sig);
-        boolean wasInsideUnhandledDieHandler = insideUnhandledDieHandler.get();
-        insideUnhandledDieHandler.set(Boolean.TRUE);
+        ExecutionRuntimeState runtimeState = PerlRuntime.current().executionState();
+        boolean wasInsideUnhandledDieHandler = runtimeState.insideUnhandledDieHandler;
+        runtimeState.insideUnhandledDieHandler = true;
         boolean pushedSyntheticFrame = false;
         try {
             if (syntheticFrame != null) {
@@ -173,7 +169,7 @@ public class WarnDie {
             if (pushedSyntheticFrame) {
                 RuntimeCode.popSyntheticCallerFrame();
             }
-            insideUnhandledDieHandler.set(wasInsideUnhandledDieHandler);
+            runtimeState.insideUnhandledDieHandler = wasInsideUnhandledDieHandler;
             DynamicVariableManager.popToLocalLevel(level);
         }
         return e;

--- a/src/main/java/org/perlonjava/runtime/operators/pack/PointerPackHandler.java
+++ b/src/main/java/org/perlonjava/runtime/operators/pack/PointerPackHandler.java
@@ -1,10 +1,9 @@
 package org.perlonjava.runtime.operators.pack;
 
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Handler for pointer formats 'p' and 'P'.
@@ -17,7 +16,9 @@ public class PointerPackHandler implements PackFormatHandler {
      * Temporary storage for pointer simulation used by 'p' and 'P' formats.
      * Maps hash codes to their corresponding string values for later retrieval by unpack.
      */
-    private static final Map<Integer, String> pointerMap = new HashMap<>();
+    private static java.util.Map<Integer, String> pointerMap() {
+        return PerlRuntime.current().pointerPackState;
+    }
 
     /**
      * The format character ('p' or 'P')
@@ -42,7 +43,7 @@ public class PointerPackHandler implements PackFormatHandler {
      * @return The string associated with the hash code, or null if not found
      */
     public static String getPointerString(int hashCode) {
-        return pointerMap.get(hashCode);
+        return pointerMap().get(hashCode);
     }
 
     @Override
@@ -82,7 +83,7 @@ public class PointerPackHandler implements PackFormatHandler {
                 String str = value.toString();
                 // Use hashCode as a unique identifier, but as a long for 64-bit pointer
                 ptr = Integer.toUnsignedLong(str.hashCode());
-                pointerMap.put((int) ptr, str);  // Still use int key for the map
+                pointerMap().put((int) ptr, str);  // Still use int key for the map
             }
 
             // Write as 8 bytes (64-bit pointer) 

--- a/src/main/java/org/perlonjava/runtime/perlmodule/ArchiveZip.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/ArchiveZip.java
@@ -45,13 +45,13 @@ public class ArchiveZip extends PerlModuleBase {
     private static Path resolvePath(String name) {
         Path p = Paths.get(name);
         if (p.isAbsolute()) return p;
-        return Paths.get(System.getProperty("user.dir")).resolve(p);
+        return Paths.get(RuntimeEnvironment.currentDirectory()).resolve(p);
     }
 
     private static Path resolvePath(String first, String... more) {
         Path p = Paths.get(first, more);
         if (p.isAbsolute()) return p;
-        return Paths.get(System.getProperty("user.dir")).resolve(p);
+        return Paths.get(RuntimeEnvironment.currentDirectory()).resolve(p);
     }
 
     // Constants (matching Archive::Zip)

--- a/src/main/java/org/perlonjava/runtime/perlmodule/BHooksEndOfScope.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/BHooksEndOfScope.java
@@ -1,9 +1,9 @@
 package org.perlonjava.runtime.perlmodule;
 
 import org.perlonjava.runtime.runtimetypes.*;
+import org.perlonjava.runtime.CompilationRuntimeState;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Java XS implementation for B::Hooks::EndOfScope.
@@ -22,23 +22,9 @@ public class BHooksEndOfScope extends PerlModuleBase {
      * Registry of callbacks keyed by the file that registered them.
      * When a file finishes loading, callbacks registered for that file are fired in LIFO order.
      */
-    private static final Map<String, Deque<RuntimeScalar>> fileCallbacks = new ConcurrentHashMap<>();
-    
-    /**
-     * Stack of currently-loading files. Each doFile/require pushes onto this stack,
-     * and pops when done. This allows us to know which file is being loaded when
-     * on_scope_end is called.
-     */
-    private static final ThreadLocal<Deque<String>> loadingFileStack = ThreadLocal.withInitial(ArrayDeque::new);
-
-    /**
-     * Compile-time lexical scopes currently being parsed.  Perl's
-     * B::Hooks::EndOfScope fires at the end of the lexical scope in which
-     * on_scope_end was called, which can be earlier than the end of the file
-     * (for example, a namespace::clean pragma inside an eval block).
-     */
-    private static final ThreadLocal<Deque<Deque<RuntimeScalar>>> compileScopes =
-            ThreadLocal.withInitial(ArrayDeque::new);
+    private static CompilationRuntimeState state() {
+        return PerlRuntime.current().compilationState;
+    }
 
     public BHooksEndOfScope() {
         super("B::Hooks::EndOfScope", false);
@@ -64,7 +50,7 @@ public class BHooksEndOfScope extends PerlModuleBase {
      */
     public static void beginFileLoad(String fileName) {
         if (fileName != null) {
-            loadingFileStack.get().push(fileName);
+            state().loadingFileStack.push(fileName);
         }
     }
     
@@ -78,7 +64,7 @@ public class BHooksEndOfScope extends PerlModuleBase {
             return;
         }
         
-        Deque<String> stack = loadingFileStack.get();
+        Deque<String> stack = state().loadingFileStack;
         if (!stack.isEmpty() && stack.peek().equals(fileName)) {
             stack.pop();
         }
@@ -94,7 +80,7 @@ public class BHooksEndOfScope extends PerlModuleBase {
         // hooks clobber it - otherwise the outer `require` reports a
         // misleading "Can't locate <outer-file>.pm" instead of the real
         // inner cause. (Reproducible with `jcpan -t Text::WordCounter`.)
-        Deque<RuntimeScalar> callbacks = fileCallbacks.remove(fileName);
+        Deque<RuntimeScalar> callbacks = state().endOfScopeFileCallbacks.remove(fileName);
         if (callbacks != null) {
             String savedErr = GlobalVariable.getGlobalVariable("main::@").toString();
             String savedBang = GlobalVariable.getGlobalVariable("main::!").toString();
@@ -121,13 +107,13 @@ public class BHooksEndOfScope extends PerlModuleBase {
      * Get the current file being loaded (top of stack), or null if not in a file load.
      */
     private static String getCurrentLoadingFile() {
-        Deque<String> stack = loadingFileStack.get();
+        Deque<String> stack = state().loadingFileStack;
         return stack.isEmpty() ? null : stack.peek();
     }
 
     /** Enter a parser-visible lexical scope. */
     public static void beginCompileScope() {
-        compileScopes.get().push(new ArrayDeque<>());
+        state().compileScopes.push(new ArrayDeque<>());
     }
 
     /**
@@ -135,7 +121,7 @@ public class BHooksEndOfScope extends PerlModuleBase {
      * in LIFO order, matching the native hook's ordering.
      */
     public static void endCompileScope() {
-        Deque<Deque<RuntimeScalar>> scopes = compileScopes.get();
+        Deque<Deque<RuntimeScalar>> scopes = state().compileScopes;
         if (scopes.isEmpty()) {
             return;
         }
@@ -180,7 +166,7 @@ public class BHooksEndOfScope extends PerlModuleBase {
         
         // Prefer the innermost parser-visible lexical scope.  This is the
         // behavior required by namespace::clean for nested blocks.
-        Deque<Deque<RuntimeScalar>> scopes = compileScopes.get();
+        Deque<Deque<RuntimeScalar>> scopes = state().compileScopes;
         if (!scopes.isEmpty()) {
             scopes.peek().push(codeRef);
             return new RuntimeList();
@@ -191,7 +177,7 @@ public class BHooksEndOfScope extends PerlModuleBase {
         
         if (currentFile != null) {
             // Register callback for end of file load
-            fileCallbacks.computeIfAbsent(currentFile, k -> new ArrayDeque<>()).push(codeRef);
+            state().endOfScopeFileCallbacks.computeIfAbsent(currentFile, k -> new ArrayDeque<>()).push(codeRef);
         } else {
             // Fallback: if not in a file load context (e.g., main script or eval),
             // use defer mechanism for immediate scope exit

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Feature.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Feature.java
@@ -11,7 +11,17 @@ import static org.perlonjava.runtime.runtimetypes.FeatureFlags.getFeatureList;
  */
 public class Feature extends PerlModuleBase {
 
-    public static FeatureFlags featureManager = new FeatureFlags();
+    private static FeatureFlags featureManager() {
+        return PerlRuntime.current().compilationState.featureManager;
+    }
+
+    public static FeatureFlags getFeatureManager() {
+        return featureManager();
+    }
+
+    public static void setFeatureManager(FeatureFlags manager) {
+        PerlRuntime.current().compilationState.featureManager = manager;
+    }
 
     /**
      * Constructor for FeatureFlags.
@@ -48,7 +58,7 @@ public class Feature extends PerlModuleBase {
             System.err.println("Warning: Missing Feature method: " + e.getMessage());
         }
 
-        featureManager = new FeatureFlags();
+        PerlRuntime.current().compilationState.featureManager = new FeatureFlags();
 
         // Populate %feature::feature hash for experimental.pm compatibility
         // This makes the hash accessible from Perl code
@@ -97,7 +107,7 @@ public class Feature extends PerlModuleBase {
 
             // enableFeatureBundle handles both bundles (":5.10") and individual features ("say")
             // It calls enableFeature() which updates both featureManager and symbolTable
-            featureManager.enableFeatureBundle(featureName);
+            featureManager().enableFeatureBundle(featureName);
         }
         return new RuntimeScalar().getList();
     }
@@ -122,7 +132,7 @@ public class Feature extends PerlModuleBase {
 
             // disableFeatureBundle handles both bundles (":5.10") and individual features ("say")
             // It calls disableFeature() which updates both featureManager and symbolTable
-            featureManager.disableFeatureBundle(featureName);
+            featureManager().disableFeatureBundle(featureName);
         }
         return new RuntimeScalar().getList();
     }
@@ -130,7 +140,7 @@ public class Feature extends PerlModuleBase {
     public static RuntimeList useFeaturePragma(RuntimeArray args, int ctx) {
         String featureName = featureNameFromPragma(args);
         if (featureName != null) {
-            featureManager.enableFeatureBundle(featureName);
+            featureManager().enableFeatureBundle(featureName);
         }
         return new RuntimeScalar().getList();
     }
@@ -138,7 +148,7 @@ public class Feature extends PerlModuleBase {
     public static RuntimeList noFeaturePragma(RuntimeArray args, int ctx) {
         String featureName = featureNameFromPragma(args);
         if (featureName != null) {
-            featureManager.disableFeatureBundle(featureName);
+            featureManager().disableFeatureBundle(featureName);
         }
         return new RuntimeScalar().getList();
     }
@@ -167,7 +177,7 @@ public class Feature extends PerlModuleBase {
             throw new IllegalStateException("Bad number of arguments for feature_enabled()");
         }
         String feature = args.get(0).toString();
-        boolean isEnabled = featureManager.isFeatureEnabled(feature);
+        boolean isEnabled = featureManager().isFeatureEnabled(feature);
         return new RuntimeScalar(isEnabled).getList();
     }
 
@@ -181,7 +191,7 @@ public class Feature extends PerlModuleBase {
     public static RuntimeList features_enabled(RuntimeArray args, int ctx) {
         RuntimeList enabledFeatures = new RuntimeList();
         for (String feature : getFeatureList()) {
-            if (featureManager.isFeatureEnabled(feature)) {
+            if (featureManager().isFeatureEnabled(feature)) {
                 enabledFeatures.elements.add(new RuntimeScalar(feature));
             }
         }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
@@ -14,7 +14,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -96,38 +95,18 @@ public class FileSpec extends PerlModuleBase {
             return new RuntimeScalar("").getList();
         }
         
-        String canonPath;
-        if (SystemUtils.osIsWindows()) {
-            String sep = File.separator;
-            String quotedSep = Pattern.quote(sep);
-            String replSep = Matcher.quoteReplacement(sep);
-
-            canonPath = path.replaceAll("[/\\\\]+", replSep);
-            canonPath = canonPath.replaceAll("(?:" + quotedSep + "\\.)+(?:"
-                    + quotedSep + "|$)", replSep);
-
-            if (!canonPath.equals("." + sep) && !canonPath.equals(".")) {
-                while (canonPath.startsWith("." + sep)) {
-                    canonPath = canonPath.substring(1 + sep.length());
-                }
-            }
-
-            if (!canonPath.equals(sep) && canonPath.endsWith(sep)) {
-                canonPath = canonPath.substring(0, canonPath.length() - sep.length());
-            }
-        } else {
-            // Match File::Spec::Unix::canonpath. Backslash is a literal path
-            // character on Unix, not a directory separator.
-            canonPath = path.replaceAll("/{2,}", "/");
-            canonPath = canonPath.replaceAll("(?:/\\.)+(?:/|$)", "/");
-            if (!canonPath.equals("./")) {
-                canonPath = canonPath.replaceFirst("^(?:\\./)+", "");
-            }
-            canonPath = canonPath.replaceFirst("^/(?:\\.\\./)+", "/");
-            canonPath = canonPath.replaceFirst("^/\\.\\.$", "/");
-            if (!canonPath.equals("/") && canonPath.endsWith("/")) {
-                canonPath = canonPath.substring(0, canonPath.length() - 1);
-            }
+        // These Java methods are installed in File::Spec::Unix. Platform
+        // subclasses (including File::Spec::Win32) override them in Perl, so
+        // their behavior must remain Unix-specific even on a Windows host.
+        String canonPath = path.replaceAll("/{2,}", "/");
+        canonPath = canonPath.replaceAll("(?:/\\.)+(?:/|$)", "/");
+        if (!canonPath.equals("./")) {
+            canonPath = canonPath.replaceFirst("^(?:\\./)+", "");
+        }
+        canonPath = canonPath.replaceFirst("^/(?:\\.\\./)+", "/");
+        canonPath = canonPath.replaceFirst("^/\\.\\.$", "/");
+        if (!canonPath.equals("/") && canonPath.endsWith("/")) {
+            canonPath = canonPath.substring(0, canonPath.length() - 1);
         }
         
         // If we reduced to empty string from a non-empty input, return "."
@@ -151,8 +130,7 @@ public class FileSpec extends PerlModuleBase {
         }
 
         StringBuilder result = new StringBuilder();
-        boolean isWindows = SystemUtils.osIsWindows();
-        String separator = File.separator;
+        String separator = "/";
         boolean isFirst = true;
 
         for (int i = 1; i < args.size(); i++) {
@@ -160,7 +138,7 @@ public class FileSpec extends PerlModuleBase {
 
             // Empty first element represents root directory on Unix
             if (part.isEmpty()) {
-                if (isFirst && !isWindows) {
+                if (isFirst) {
                     // First empty element = absolute path (root)
                     result.append(separator);
                 }
@@ -168,11 +146,6 @@ public class FileSpec extends PerlModuleBase {
                 continue;
             }
             isFirst = false;
-
-            // For Windows, normalize slashes to the system separator
-            if (isWindows) {
-                part = part.replace('/', '\\');
-            }
 
             if (result.length() == 0) {
                 // First component
@@ -251,7 +224,7 @@ public class FileSpec extends PerlModuleBase {
         }
         
         // Ensure proper separator between dir and file
-        String separator = File.separator;
+        String separator = "/";
         char lastChar = dir.charAt(dir.length() - 1);
         if (lastChar == '/' || lastChar == '\\') {
             return new RuntimeScalar(dir + filePart).getList();

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FileSpec.java
@@ -6,6 +6,7 @@ import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
 import org.perlonjava.runtime.runtimetypes.RuntimeHash;
 import org.perlonjava.runtime.runtimetypes.RuntimeList;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+import org.perlonjava.runtime.runtimetypes.RuntimeEnvironment;
 import org.perlonjava.runtime.runtimetypes.SystemUtils;
 
 import java.io.File;
@@ -602,14 +603,14 @@ public class FileSpec extends PerlModuleBase {
             throw new IllegalStateException("Bad number of arguments for abs2rel() method");
         }
         String path = args.get(1).toString();
-        String base = args.size() == 3 ? args.get(2).toString() : System.getProperty("user.dir");
+        String base = args.size() == 3 ? args.get(2).toString() : RuntimeEnvironment.currentDirectory();
         
         // Ensure both paths are absolute before relativizing (like Perl does)
         // Note: We use user.dir explicitly because Java's Path.toAbsolutePath() 
         // doesn't respect System.setProperty("user.dir", ...) set by chdir()
         Path pathObj = Paths.get(path);
         Path baseObj = Paths.get(base);
-        String userDir = System.getProperty("user.dir");
+        String userDir = RuntimeEnvironment.currentDirectory();
         
         if (!pathObj.isAbsolute()) {
             pathObj = Paths.get(userDir).resolve(pathObj).normalize();
@@ -639,7 +640,7 @@ public class FileSpec extends PerlModuleBase {
             throw new IllegalStateException("Bad number of arguments for rel2abs() method");
         }
         String path = args.get(1).toString();
-        String base = args.size() == 3 ? args.get(2).toString() : System.getProperty("user.dir");
+        String base = args.size() == 3 ? args.get(2).toString() : RuntimeEnvironment.currentDirectory();
 
         // PerlOnJava: jar: paths are already absolute, return as-is
         if (path.startsWith("jar:")) {
@@ -655,7 +656,7 @@ public class FileSpec extends PerlModuleBase {
         // If base is relative, resolve it against current working directory first
         Path basePath = Paths.get(base);
         if (!basePath.isAbsolute()) {
-            basePath = Paths.get(System.getProperty("user.dir")).resolve(basePath);
+            basePath = Paths.get(RuntimeEnvironment.currentDirectory()).resolve(basePath);
         }
 
         // For relative paths, resolve against the base directory

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FileTemp.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FileTemp.java
@@ -4,6 +4,7 @@ import org.perlonjava.runtime.runtimetypes.RuntimeArray;
 import org.perlonjava.runtime.runtimetypes.RuntimeIO;
 import org.perlonjava.runtime.runtimetypes.RuntimeList;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+import org.perlonjava.runtime.runtimetypes.RuntimeEnvironment;
 import org.perlonjava.runtime.runtimetypes.SystemUtils;
 
 import java.io.IOException;
@@ -208,7 +209,7 @@ public class FileTemp extends PerlModuleBase {
             if (prefix.isEmpty()) {
                 // Template is only trailing X's (e.g. "XXXXXX") with no path: Perl creates
                 // the file in the current working directory, not File::Spec->tmpdir.
-                dir = Paths.get(System.getProperty("user.dir"));
+                dir = Paths.get(RuntimeEnvironment.currentDirectory());
                 namePrefix = "";
             } else if (prefix.endsWith("/") || prefix.endsWith("\\")) {
                 // Prefix is a directory path with trailing separator
@@ -224,7 +225,7 @@ public class FileTemp extends PerlModuleBase {
                 
                 if (dir == null) {
                     // Relative name prefix only (e.g. "fooXXXXXX"): parent is cwd, not tmpdir.
-                    dir = Paths.get(System.getProperty("user.dir"));
+                    dir = Paths.get(RuntimeEnvironment.currentDirectory());
                 }
             }
 
@@ -301,7 +302,7 @@ public class FileTemp extends PerlModuleBase {
             String namePrefix;
             
             if (prefix.isEmpty()) {
-                parentDir = Paths.get(System.getProperty("user.dir"));
+                parentDir = Paths.get(RuntimeEnvironment.currentDirectory());
                 namePrefix = "";
             } else if (prefix.endsWith("/") || prefix.endsWith("\\")) {
                 // Prefix is a directory path with trailing separator
@@ -315,7 +316,7 @@ public class FileTemp extends PerlModuleBase {
                         templatePath.getFileName().toString() : "";
                 
                 if (parentDir == null) {
-                    parentDir = Paths.get(System.getProperty("user.dir"));
+                    parentDir = Paths.get(RuntimeEnvironment.currentDirectory());
                 }
             }
 

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FilterRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FilterRuntimeState.java
@@ -1,0 +1,20 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.runtime.runtimetypes.RuntimeList;
+
+/** Runtime-owned source-filter stack and in-progress input cursor. */
+public final class FilterRuntimeState {
+    RuntimeList filterStack = new RuntimeList();
+    String[] sourceLines;
+    int currentLine;
+    boolean inFilterRead;
+    boolean installedDuringUse;
+
+    void clear() {
+        filterStack = new RuntimeList();
+        sourceLines = null;
+        currentLine = 0;
+        inFilterRead = false;
+        installedDuringUse = false;
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FilterUtilCall.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FilterUtilCall.java
@@ -26,24 +26,16 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarZero;
  */
 public class FilterUtilCall extends PerlModuleBase {
 
-    /**
-     * Thread-local storage for source filter context.
-     * Each thread can have its own stack of active filters.
-     */
-    private static final ThreadLocal<FilterContext> filterContext = ThreadLocal.withInitial(FilterContext::new);
-
-    /**
-     * Thread-local flag to track if a filter was installed during the current use statement.
-     * This is used by the parser to know when to rejoin/re-tokenize remaining source.
-     */
-    private static final ThreadLocal<Boolean> filterInstalledDuringUse = ThreadLocal.withInitial(() -> false);
+    private static FilterRuntimeState state() {
+        return PerlRuntime.current().filterState;
+    }
 
     /**
      * Mark that a filter was installed during the current use statement.
      * Called by real_import() when a filter is added to the stack.
      */
     public static void markFilterInstalled() {
-        filterInstalledDuringUse.set(true);
+        state().installedDuringUse = true;
     }
 
     /**
@@ -53,8 +45,8 @@ public class FilterUtilCall extends PerlModuleBase {
      * @return true if a filter was installed, false otherwise
      */
     public static boolean wasFilterInstalled() {
-        boolean result = filterInstalledDuringUse.get();
-        filterInstalledDuringUse.set(false);  // Reset after checking
+        boolean result = state().installedDuringUse;
+        state().installedDuringUse = false;  // Reset after checking
         return result;
     }
 
@@ -64,7 +56,7 @@ public class FilterUtilCall extends PerlModuleBase {
      * @return true if filters are active, false otherwise
      */
     public static boolean hasActiveFilters() {
-        FilterContext context = filterContext.get();
+        FilterRuntimeState context = state();
         return context.filterStack.size() > 0;
     }
 
@@ -112,7 +104,7 @@ public class FilterUtilCall extends PerlModuleBase {
         RuntimeScalar packageName = args.get(1);
         RuntimeScalar isCodeRef = args.get(2);
 
-        FilterContext context = filterContext.get();
+        FilterRuntimeState context = state();
 
         // Create a filter entry
         RuntimeArray filterEntry = new RuntimeArray();
@@ -143,7 +135,7 @@ public class FilterUtilCall extends PerlModuleBase {
      * @return status code
      */
     public static RuntimeList filter_read(RuntimeArray args, int ctx) {
-        FilterContext context = filterContext.get();
+        FilterRuntimeState context = state();
 
         // Prevent infinite recursion
         if (context.inFilterRead) {
@@ -219,7 +211,7 @@ public class FilterUtilCall extends PerlModuleBase {
      * @return true on success
      */
     public static RuntimeList filter_del(RuntimeArray args, int ctx) {
-        FilterContext context = filterContext.get();
+        FilterRuntimeState context = state();
 
         // Remove the top filter from the stack
         if (context.filterStack.size() > 0) {
@@ -239,7 +231,7 @@ public class FilterUtilCall extends PerlModuleBase {
      * @return The filtered source code
      */
     public static String applyFilters(String sourceCode) {
-        FilterContext context = filterContext.get();
+        FilterRuntimeState context = state();
 
         if (context.filterStack.size() == 0) {
             // No filters active
@@ -468,7 +460,7 @@ public class FilterUtilCall extends PerlModuleBase {
      * Used when starting a new do/eval.
      */
     public static void clearFilters() {
-        FilterContext context = filterContext.get();
+        FilterRuntimeState context = state();
         context.filterStack = new RuntimeList();
         context.sourceLines = null;
         context.currentLine = 0;
@@ -506,13 +498,13 @@ public class FilterUtilCall extends PerlModuleBase {
      * @return a snapshot to pass back to {@link #restoreFilterState(FilterStateSnapshot)}
      */
     public static FilterStateSnapshot saveAndResetFilterState() {
-        FilterContext context = filterContext.get();
+        FilterRuntimeState context = state();
         FilterStateSnapshot snapshot =
-                new FilterStateSnapshot(context.filterStack, filterInstalledDuringUse.get());
+                new FilterStateSnapshot(context.filterStack, context.installedDuringUse);
         context.filterStack = new RuntimeList();
         context.sourceLines = null;
         context.currentLine = 0;
-        filterInstalledDuringUse.set(false);
+        context.installedDuringUse = false;
         return snapshot;
     }
 
@@ -524,25 +516,11 @@ public class FilterUtilCall extends PerlModuleBase {
      */
     public static void restoreFilterState(FilterStateSnapshot snapshot) {
         if (snapshot == null) return;
-        FilterContext context = filterContext.get();
+        FilterRuntimeState context = state();
         context.filterStack = snapshot.filterStack;
         context.sourceLines = null;
         context.currentLine = 0;
-        filterInstalledDuringUse.set(snapshot.installedDuringUse);
+        context.installedDuringUse = snapshot.installedDuringUse;
     }
 
-    /**
-     * Context for managing active source filters.
-     */
-    static class FilterContext {
-        // Stack of active filters (LIFO - last added is first applied)
-        RuntimeList filterStack = new RuntimeList();
-
-        // Current input source being filtered (set during do/eval)
-        String[] sourceLines = null;
-        int currentLine = 0;
-
-        // Whether we're currently inside a filter_read() call
-        boolean inFilterRead = false;
-    }
 }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/IPCOpen3.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/IPCOpen3.java
@@ -176,7 +176,7 @@ public class IPCOpen3 extends PerlModuleBase {
             }
 
             ProcessBuilder processBuilder = new ProcessBuilder(command);
-            String userDir = System.getProperty("user.dir");
+            String userDir = RuntimeEnvironment.currentDirectory();
             processBuilder.directory(new File(userDir));
 
             // Copy %ENV to the subprocess
@@ -536,7 +536,7 @@ public class IPCOpen3 extends PerlModuleBase {
             }
 
             ProcessBuilder processBuilder = new ProcessBuilder(command);
-            String userDir = System.getProperty("user.dir");
+            String userDir = RuntimeEnvironment.currentDirectory();
             processBuilder.directory(new File(userDir));
 
             // Copy %ENV to the subprocess

--- a/src/main/java/org/perlonjava/runtime/perlmodule/IntegerPragma.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/IntegerPragma.java
@@ -13,12 +13,6 @@ import static org.perlonjava.frontend.parser.SpecialBlockParser.getCurrentScope;
 public class IntegerPragma extends PerlModuleBase {
 
     /**
-     * Runtime flag to track if integer mode is enabled.
-     * This is used by math operators to determine whether to use integer arithmetic.
-     */
-    public static boolean useIntegerMode = false;
-
-    /**
      * Constructor for IntegerPragma.
      * Initializes the module with the name "integer".
      */

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Internals.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Internals.java
@@ -800,7 +800,7 @@ public class Internals extends PerlModuleBase {
      * @return RuntimeScalar with the current working directory path
      */
     public static RuntimeList getcwd(RuntimeArray args, int ctx) {
-        return new RuntimeScalar(System.getProperty("user.dir")).getList();
+        return new RuntimeScalar(RuntimeEnvironment.currentDirectory()).getList();
     }
 
     /**
@@ -827,7 +827,7 @@ public class Internals extends PerlModuleBase {
         try {
             java.io.File file = new java.io.File(path);
             if (!file.isAbsolute()) {
-                file = new java.io.File(System.getProperty("user.dir"), path);
+                file = new java.io.File(RuntimeEnvironment.currentDirectory(), path);
             }
             if (!file.exists()) {
                 return new RuntimeScalar().getList();  // return undef

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Lib.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Lib.java
@@ -5,6 +5,7 @@ import org.perlonjava.runtime.runtimetypes.RuntimeArray;
 import org.perlonjava.runtime.runtimetypes.RuntimeList;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalarType;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -15,14 +16,12 @@ import java.util.Set;
  */
 public class Lib extends PerlModuleBase {
 
-    private static RuntimeArray ORIG_INC = null;
-
     /**
      * Resets static state for test isolation.
      * Called from GlobalVariable.resetAllGlobals().
      */
     public static void resetState() {
-        ORIG_INC = null;
+        PerlRuntime.current().libOriginalInc = null;
     }
 
     /**
@@ -89,10 +88,11 @@ public class Lib extends PerlModuleBase {
     }
 
     private static void initOrigInc(RuntimeArray INC) {
-        if (ORIG_INC == null) {
-            ORIG_INC = GlobalVariable.getGlobalArray("lib::ORIG_INC");
+        PerlRuntime runtime = PerlRuntime.current();
+        if (runtime.libOriginalInc == null) {
+            runtime.libOriginalInc = GlobalVariable.getGlobalArray("lib::ORIG_INC");
             for (RuntimeScalar elem : INC.elements) {
-                RuntimeArray.push(ORIG_INC, elem);
+                RuntimeArray.push(runtime.libOriginalInc, elem);
             }
         }
     }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Mro.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Mro.java
@@ -82,7 +82,7 @@ public class Mro extends PerlModuleBase {
     public static RuntimeList useMro(RuntimeArray args, int ctx) {
         if (args.size() == 1) {
             // use mro; - enables next::method globally
-            Feature.featureManager.enableFeatureBundle("perlonjava::internal::next_method");
+            Feature.getFeatureManager().enableFeatureBundle("perlonjava::internal::next_method");
             return new RuntimeList();
         }
 
@@ -98,7 +98,7 @@ public class Mro extends PerlModuleBase {
             } else if (mroType.equals("c3")) {
                 InheritanceResolver.setPackageMRO(callerPackage, MROAlgorithm.C3);
                 // Enable the c3 feature
-                Feature.featureManager.enableFeatureBundle("perlonjava::internal::mro_c3");
+                Feature.getFeatureManager().enableFeatureBundle("perlonjava::internal::mro_c3");
             } else {
                 // Change error message to match Perl's format
                 throw new PerlCompilerException("Invalid mro name: '" + mroType + "'");
@@ -117,7 +117,7 @@ public class Mro extends PerlModuleBase {
      */
     public static RuntimeList noMro(RuntimeArray args, int ctx) {
         // Disable next::method feature
-        Feature.featureManager.disableFeatureBundle("perlonjava::internal::next_method");
+        Feature.getFeatureManager().disableFeatureBundle("perlonjava::internal::next_method");
         return new RuntimeList();
     }
 

--- a/src/main/java/org/perlonjava/runtime/perlmodule/NetSSLeay.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/NetSSLeay.java
@@ -20,6 +20,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
@@ -248,9 +249,9 @@ public class NetSSLeay extends PerlModuleBase {
     // Shared SecureRandom instance for RAND_* functions
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
-    // Thread-local error queue for ERR_put_error / ERR_get_error
-    private static final ThreadLocal<Deque<Long>> ERROR_QUEUE =
-            ThreadLocal.withInitial(ArrayDeque::new);
+    private static Deque<Long> errorQueue() {
+        return PerlRuntime.current().netSslErrorQueue;
+    }
 
     // Counter for generating unique opaque handle IDs
     private static final AtomicLong HANDLE_COUNTER = new AtomicLong(1);
@@ -258,49 +259,105 @@ public class NetSSLeay extends PerlModuleBase {
     // ex_data indices — OpenSSL reserves index 0, and AnyEvent::TLS does
     // `until $REF_IDX;` around get_ex_new_index, so start at 1.
     private static final AtomicLong EX_INDEX_COUNTER = new AtomicLong(1);
+    public static final class State {
+        final Map<Long, Map<Integer, RuntimeScalar>> exData = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, MemoryBIO> bios = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, EvpMdCtx> evpMdContexts = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, HmacCtx> hmacContexts = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, KeyPair> rsaKeys = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, Long> asn1Times = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, SslCtxState> sslContexts = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, SslState> sslStates = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, java.security.Key> evpKeys = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, X509Certificate> x509Certificates = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, X509NameInfo> x509Names = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, X509NameEntry> x509NameEntries = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, String> asn1Objects = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, Asn1StringValue> asn1Strings = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, BigInteger> asn1Integers = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, X509ExtInfo> x509Extensions = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, X509StoreState> x509Stores = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, X509StoreCtxState> x509StoreContexts = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, List<Long>> x509Stacks = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, VerifyParamState> verifyParams = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, List<X509InfoEntry>> x509InfoStacks = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, MutableX509State> mutableX509 = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, MutableX509ReqState> x509Requests = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, BigInteger> bigNumbers = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, String> evpCiphers = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, KeyPair> ecKeys = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, MutableCRLState> crls = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, X509CRL> x509Crls = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<String, Long> crlTimeCache = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<String, Long> providerNames = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, String> providerHandles = new java.util.concurrent.ConcurrentHashMap<>();
+        final Map<Long, String> loadedProviders = Collections.synchronizedMap(new LinkedHashMap<>());
+        long libctxHandle;
+    }
+
+    private static State state() {
+        return PerlRuntime.current().netSslState;
+    }
+
+    private static final class CurrentRuntimeMap<K, V> extends AbstractMap<K, V> {
+        private final Function<State, Map<K, V>> selector;
+
+        CurrentRuntimeMap(Function<State, Map<K, V>> selector) {
+            this.selector = selector;
+        }
+
+        private Map<K, V> delegate() {
+            return selector.apply(state());
+        }
+
+        @Override public V get(Object key) { return delegate().get(key); }
+        @Override public boolean containsKey(Object key) { return delegate().containsKey(key); }
+        @Override public V put(K key, V value) { return delegate().put(key, value); }
+        @Override public V remove(Object key) { return delegate().remove(key); }
+        @Override public void clear() { delegate().clear(); }
+        @Override public int size() { return delegate().size(); }
+        @Override public Set<Entry<K, V>> entrySet() { return delegate().entrySet(); }
+    }
+
     private static final Map<Long, Map<Integer, RuntimeScalar>> EX_DATA =
-            new java.util.concurrent.ConcurrentHashMap<>();
+            new CurrentRuntimeMap<>(s -> s.exData);
 
     // Maps for opaque handles: handle_id → Java object
-    private static final Map<Long, MemoryBIO> BIO_HANDLES = new HashMap<>();
-    private static final Map<Long, EvpMdCtx> EVP_MD_CTX_HANDLES = new HashMap<>();
-    private static final Map<Long, HmacCtx> HMAC_CTX_HANDLES = new HashMap<>();
-    private static final Map<Long, KeyPair> RSA_HANDLES = new HashMap<>();
-    private static final Map<Long, Long> ASN1_TIME_HANDLES = new HashMap<>();  // handle → epoch seconds
-    private static final Map<Long, SslCtxState> CTX_HANDLES = new HashMap<>();
-    private static final Map<Long, SslState> SSL_HANDLES = new HashMap<>();
-    private static final Map<Long, java.security.Key> EVP_PKEY_HANDLES = new HashMap<>();
+    private static final Map<Long, MemoryBIO> BIO_HANDLES = new CurrentRuntimeMap<>(s -> s.bios);
+    private static final Map<Long, EvpMdCtx> EVP_MD_CTX_HANDLES = new CurrentRuntimeMap<>(s -> s.evpMdContexts);
+    private static final Map<Long, HmacCtx> HMAC_CTX_HANDLES = new CurrentRuntimeMap<>(s -> s.hmacContexts);
+    private static final Map<Long, KeyPair> RSA_HANDLES = new CurrentRuntimeMap<>(s -> s.rsaKeys);
+    private static final Map<Long, Long> ASN1_TIME_HANDLES = new CurrentRuntimeMap<>(s -> s.asn1Times);
+    private static final Map<Long, SslCtxState> CTX_HANDLES = new CurrentRuntimeMap<>(s -> s.sslContexts);
+    private static final Map<Long, SslState> SSL_HANDLES = new CurrentRuntimeMap<>(s -> s.sslStates);
+    private static final Map<Long, java.security.Key> EVP_PKEY_HANDLES = new CurrentRuntimeMap<>(s -> s.evpKeys);
 
     // X509 handle maps
-    private static final Map<Long, X509Certificate> X509_HANDLES = new HashMap<>();
-    private static final Map<Long, X509NameInfo> X509_NAME_HANDLES = new HashMap<>();
-    private static final Map<Long, X509NameEntry> X509_NAME_ENTRY_HANDLES = new HashMap<>();
-    private static final Map<Long, String> ASN1_OBJECT_HANDLES = new HashMap<>(); // handle → OID string
-    private static final Map<Long, Asn1StringValue> ASN1_STRING_HANDLES = new HashMap<>();
-    private static final Map<Long, BigInteger> ASN1_INTEGER_HANDLES = new HashMap<>();
-    private static final Map<Long, X509ExtInfo> X509_EXT_HANDLES = new HashMap<>();
-    private static final Map<Long, X509StoreState> X509_STORE_HANDLES = new HashMap<>();
-    private static final Map<Long, X509StoreCtxState> X509_STORE_CTX_HANDLES = new HashMap<>();
-    private static final Map<Long, List<Long>> SK_X509_HANDLES = new HashMap<>();
-    private static final Map<Long, VerifyParamState> VERIFY_PARAM_HANDLES = new HashMap<>();
-    private static final Map<Long, List<X509InfoEntry>> X509_INFO_SK_HANDLES = new HashMap<>();
-    private static final Map<Long, MutableX509State> MUTABLE_X509_HANDLES = new HashMap<>();
-    private static final Map<Long, MutableX509ReqState> X509_REQ_HANDLES = new HashMap<>();
-    private static final Map<Long, BigInteger> BIGNUM_HANDLES = new HashMap<>();
-    private static final Map<Long, String> EVP_CIPHER_HANDLES = new HashMap<>(); // handle → cipher name
-    private static final Map<Long, KeyPair> EC_KEY_HANDLES = new HashMap<>(); // EC key pairs
-    private static final Map<Long, MutableCRLState> CRL_HANDLES = new HashMap<>();
-    private static final Map<Long, X509CRL> X509_CRL_HANDLES = new HashMap<>(); // read-only parsed CRLs
-    private static final Map<String, Long> CRL_TIME_CACHE = new HashMap<>(); // cache for read-only CRL time handles
+    private static final Map<Long, X509Certificate> X509_HANDLES = new CurrentRuntimeMap<>(s -> s.x509Certificates);
+    private static final Map<Long, X509NameInfo> X509_NAME_HANDLES = new CurrentRuntimeMap<>(s -> s.x509Names);
+    private static final Map<Long, X509NameEntry> X509_NAME_ENTRY_HANDLES = new CurrentRuntimeMap<>(s -> s.x509NameEntries);
+    private static final Map<Long, String> ASN1_OBJECT_HANDLES = new CurrentRuntimeMap<>(s -> s.asn1Objects);
+    private static final Map<Long, Asn1StringValue> ASN1_STRING_HANDLES = new CurrentRuntimeMap<>(s -> s.asn1Strings);
+    private static final Map<Long, BigInteger> ASN1_INTEGER_HANDLES = new CurrentRuntimeMap<>(s -> s.asn1Integers);
+    private static final Map<Long, X509ExtInfo> X509_EXT_HANDLES = new CurrentRuntimeMap<>(s -> s.x509Extensions);
+    private static final Map<Long, X509StoreState> X509_STORE_HANDLES = new CurrentRuntimeMap<>(s -> s.x509Stores);
+    private static final Map<Long, X509StoreCtxState> X509_STORE_CTX_HANDLES = new CurrentRuntimeMap<>(s -> s.x509StoreContexts);
+    private static final Map<Long, List<Long>> SK_X509_HANDLES = new CurrentRuntimeMap<>(s -> s.x509Stacks);
+    private static final Map<Long, VerifyParamState> VERIFY_PARAM_HANDLES = new CurrentRuntimeMap<>(s -> s.verifyParams);
+    private static final Map<Long, List<X509InfoEntry>> X509_INFO_SK_HANDLES = new CurrentRuntimeMap<>(s -> s.x509InfoStacks);
+    private static final Map<Long, MutableX509State> MUTABLE_X509_HANDLES = new CurrentRuntimeMap<>(s -> s.mutableX509);
+    private static final Map<Long, MutableX509ReqState> X509_REQ_HANDLES = new CurrentRuntimeMap<>(s -> s.x509Requests);
+    private static final Map<Long, BigInteger> BIGNUM_HANDLES = new CurrentRuntimeMap<>(s -> s.bigNumbers);
+    private static final Map<Long, String> EVP_CIPHER_HANDLES = new CurrentRuntimeMap<>(s -> s.evpCiphers);
+    private static final Map<Long, KeyPair> EC_KEY_HANDLES = new CurrentRuntimeMap<>(s -> s.ecKeys);
+    private static final Map<Long, MutableCRLState> CRL_HANDLES = new CurrentRuntimeMap<>(s -> s.crls);
+    private static final Map<Long, X509CRL> X509_CRL_HANDLES = new CurrentRuntimeMap<>(s -> s.x509Crls);
+    private static final Map<String, Long> CRL_TIME_CACHE = new CurrentRuntimeMap<>(s -> s.crlTimeCache);
 
     // OSSL_PROVIDER simulation
-    private static final Map<String, Long> PROVIDER_NAME_TO_HANDLE = new HashMap<>();
-    private static final Map<Long, String> PROVIDER_HANDLE_TO_NAME = new HashMap<>();
-    private static long LIBCTX_HANDLE = 0; // lazily assigned
-    // Track whether fallback providers (default) should auto-load
-    private static boolean retainFallbacks = true;
-    // Track explicitly loaded providers for do_all iteration
-    private static final LinkedHashMap<Long, String> LOADED_PROVIDERS = new LinkedHashMap<>();
+    private static final Map<String, Long> PROVIDER_NAME_TO_HANDLE = new CurrentRuntimeMap<>(s -> s.providerNames);
+    private static final Map<Long, String> PROVIDER_HANDLE_TO_NAME = new CurrentRuntimeMap<>(s -> s.providerHandles);
+    private static final Map<Long, String> LOADED_PROVIDERS = new CurrentRuntimeMap<>(s -> s.loadedProviders);
 
     /**
      * Resets all mutable static state so that tests running in the same JVM
@@ -308,7 +365,7 @@ public class NetSSLeay extends PerlModuleBase {
      * Called from GlobalVariable.resetAllGlobals().
      */
     public static void resetState() {
-        HANDLE_COUNTER.set(1);
+        EX_DATA.clear();
         BIO_HANDLES.clear();
         EVP_MD_CTX_HANDLES.clear();
         HMAC_CTX_HANDLES.clear();
@@ -339,10 +396,9 @@ public class NetSSLeay extends PerlModuleBase {
         CRL_TIME_CACHE.clear();
         PROVIDER_NAME_TO_HANDLE.clear();
         PROVIDER_HANDLE_TO_NAME.clear();
-        LIBCTX_HANDLE = 0;
-        retainFallbacks = true;
+        state().libctxHandle = 0;
         LOADED_PROVIDERS.clear();
-        ERROR_QUEUE.remove();
+        errorQueue().clear();
     }
 
     // SSL method type sentinels
@@ -3231,12 +3287,12 @@ public class NetSSLeay extends PerlModuleBase {
     // ---- Error functions (thread-local error queue) ----
 
     public static RuntimeList ERR_clear_error(RuntimeArray args, int ctx) {
-        ERROR_QUEUE.get().clear();
+        errorQueue().clear();
         return new RuntimeScalar(0).getList();
     }
 
     public static RuntimeList ERR_get_error(RuntimeArray args, int ctx) {
-        Deque<Long> queue = ERROR_QUEUE.get();
+        Deque<Long> queue = errorQueue();
         if (queue.isEmpty()) {
             return new RuntimeScalar(0).getList();
         }
@@ -3244,7 +3300,7 @@ public class NetSSLeay extends PerlModuleBase {
     }
 
     public static RuntimeList ERR_peek_error(RuntimeArray args, int ctx) {
-        Deque<Long> queue = ERROR_QUEUE.get();
+        Deque<Long> queue = errorQueue();
         if (queue.isEmpty()) {
             return new RuntimeScalar(0).getList();
         }
@@ -3272,7 +3328,7 @@ public class NetSSLeay extends PerlModuleBase {
         int reason = args.size() > 2 ? (int) args.get(2).getLong() : 0;
         // OpenSSL 3.0.0 packing: lib << 23 | reason
         long errorCode = ((long) lib << 23) | (reason & 0x7FFFFF);
-        ERROR_QUEUE.get().addLast(errorCode);
+        errorQueue().addLast(errorCode);
         return new RuntimeScalar(0).getList();
     }
 
@@ -3307,7 +3363,7 @@ public class NetSSLeay extends PerlModuleBase {
         if (cb == null || cb.type != RuntimeScalarType.CODE) {
             return new RuntimeScalar(0).getList();
         }
-        Deque<Long> queue = ERROR_QUEUE.get();
+        Deque<Long> queue = errorQueue();
         while (!queue.isEmpty()) {
             long code = queue.pollFirst();
             int lib = (int) ((code >> 23) & 0x1FF);
@@ -3362,7 +3418,7 @@ public class NetSSLeay extends PerlModuleBase {
 
     public static RuntimeList print_errs(RuntimeArray args, int ctx) {
         String prefix = args.size() > 0 ? args.get(0).toString() : "";
-        Deque<Long> queue = ERROR_QUEUE.get();
+        Deque<Long> queue = errorQueue();
         if (queue.isEmpty()) {
             return new RuntimeScalar("").getList();
         }
@@ -7594,10 +7650,11 @@ public class NetSSLeay extends PerlModuleBase {
 
     // OSSL_LIB_CTX_get0_global_default() - return a dummy libctx handle
     public static RuntimeList OSSL_LIB_CTX_get0_global_default(RuntimeArray args, int ctx) {
-        if (LIBCTX_HANDLE == 0) {
-            LIBCTX_HANDLE = HANDLE_COUNTER.getAndIncrement();
+        State state = state();
+        if (state.libctxHandle == 0) {
+            state.libctxHandle = HANDLE_COUNTER.getAndIncrement();
         }
-        return new RuntimeScalar(LIBCTX_HANDLE).getList();
+        return new RuntimeScalar(state.libctxHandle).getList();
     }
 
     // ---- Phase 2b: Mutable X509 creation and signing ----

--- a/src/main/java/org/perlonjava/runtime/perlmodule/POSIX.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/POSIX.java
@@ -503,7 +503,7 @@ public class POSIX extends PerlModuleBase {
     }
 
     public static RuntimeList getcwd(RuntimeArray args, int ctx) {
-        return new RuntimeScalar(System.getProperty("user.dir")).getList();
+        return new RuntimeScalar(RuntimeEnvironment.currentDirectory()).getList();
     }
 
     public static RuntimeList strerror(RuntimeArray args, int ctx) {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Storable.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Storable.java
@@ -59,14 +59,12 @@ public class Storable extends PerlModuleBase {
     // Tracks whether the last freeze/store operation used network byte order.
     // Set true by nfreeze()/nstore(); set false by freeze()/store().
     // Exposed via Storable::last_op_in_netorder().
-    private static volatile boolean lastOpInNetorder = false;
-
     /**
      * Returns 1 if the last freeze/store operation used network byte order
      * (i.e. was nfreeze or nstore), 0 otherwise.
      */
     public static RuntimeList last_op_in_netorder(RuntimeArray args, int ctx) {
-        return new RuntimeScalar(lastOpInNetorder ? 1 : 0).getList();
+        return new RuntimeScalar(PerlRuntime.current().storableLastOpInNetorder ? 1 : 0).getList();
     }
 
     /**
@@ -81,7 +79,7 @@ public class Storable extends PerlModuleBase {
     }
 
     private static RuntimeList freezeImpl(RuntimeArray args, boolean netorder) {
-        lastOpInNetorder = netorder;
+        PerlRuntime.current().storableLastOpInNetorder = netorder;
         if (args.isEmpty()) {
             return WarnDie.die(new RuntimeScalar("freeze: not enough arguments"), new RuntimeScalar("\n")).getList();
         }
@@ -162,7 +160,7 @@ public class Storable extends PerlModuleBase {
     }
 
     private static RuntimeList storeImpl(RuntimeArray args, boolean netorder) {
-        lastOpInNetorder = netorder;
+        PerlRuntime.current().storableLastOpInNetorder = netorder;
         if (args.size() < 2) {
             return WarnDie.die(new RuntimeScalar("store: not enough arguments"), new RuntimeScalar("\n")).getList();
         }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/SysSyslog.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/SysSyslog.java
@@ -205,13 +205,13 @@ public class SysSyslog extends PerlModuleBase {
         return new RuntimeScalar(logUpto(priority)).getList();
     }
 
-    public static RuntimeList openlog_xs(RuntimeArray args, int ctx) {
+    public static synchronized RuntimeList openlog_xs(RuntimeArray args, int ctx) {
         ident = args.size() > 0 ? args.get(0).toString() : "";
         logOptions = args.size() > 1 ? args.get(1).getInt() : 0;
         return new RuntimeList();
     }
 
-    public static RuntimeList syslog_xs(RuntimeArray args, int ctx) {
+    public static synchronized RuntimeList syslog_xs(RuntimeArray args, int ctx) {
         if ((logOptions & LOG_PERROR) != 0) {
             String message = args.size() > 1 ? args.get(1).toString() : "";
             String prefix = ident == null || ident.isEmpty() ? "syslog" : ident;
@@ -226,7 +226,7 @@ public class SysSyslog extends PerlModuleBase {
         return new RuntimeList();
     }
 
-    public static RuntimeList setlogmask_xs(RuntimeArray args, int ctx) {
+    public static synchronized RuntimeList setlogmask_xs(RuntimeArray args, int ctx) {
         int oldMask = currentMask;
         if (args.size() > 0) {
             currentMask = args.get(0).getInt();
@@ -234,7 +234,7 @@ public class SysSyslog extends PerlModuleBase {
         return new RuntimeScalar(oldMask).getList();
     }
 
-    public static RuntimeList closelog_xs(RuntimeArray args, int ctx) {
+    public static synchronized RuntimeList closelog_xs(RuntimeArray args, int ctx) {
         ident = "";
         logOptions = 0;
         return new RuntimeList();

--- a/src/main/java/org/perlonjava/runtime/perlmodule/XMLParserExpat.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/XMLParserExpat.java
@@ -1062,7 +1062,7 @@ public class XMLParserExpat extends PerlModuleBase {
         }
         // Set systemId to the current working directory so SAX resolves relative URIs correctly.
         // This also allows unresolveSysId to strip this prefix and recover relative paths.
-        String cwd = System.getProperty("user.dir");
+        String cwd = RuntimeEnvironment.currentDirectory();
         String baseUri = new java.io.File(cwd, "dummy").toURI().toString();
         baseUri = baseUri.substring(0, baseUri.lastIndexOf('/') + 1);
         inputSource.setSystemId(baseUri);

--- a/src/main/java/org/perlonjava/runtime/perlmodule/XMLParserExpat.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/XMLParserExpat.java
@@ -2174,6 +2174,7 @@ public class XMLParserExpat extends PerlModuleBase {
             state.rawSystemIds = new HashMap<>();
         }
         state.rawSystemIds.put(rawSystemId, rawSystemId);
+        rememberWindowsRawSystemIdAliases(rawSystemId, state);
         try {
             java.net.URI rawUri = new java.net.URI(rawSystemId);
             if (rawUri.isAbsolute()) {
@@ -2184,6 +2185,29 @@ public class XMLParserExpat extends PerlModuleBase {
                 state.rawSystemIds.put(new java.net.URI(state.parseBaseUri).resolve(rawUri).toString(), rawSystemId);
             }
         } catch (Exception ignored) {
+        }
+    }
+
+    /**
+     * Xerces normalizes lexical Windows paths before reporting them to SAX.
+     * Keep aliases for those normalized spellings so Expat callbacks still see
+     * the exact SYSTEM identifier that appeared in the document.
+     */
+    private static void rememberWindowsRawSystemIdAliases(String rawSystemId, ParserState state) {
+        String normalized = rawSystemId.replace('\\', '/');
+        if (normalized.length() >= 10
+                && normalized.regionMatches(true, 0, "file://", 0, 7)
+                && Character.isLetter(normalized.charAt(7))
+                && normalized.charAt(8) == ':'
+                && normalized.charAt(9) == '/') {
+            state.rawSystemIds.put(normalized, rawSystemId);
+            state.rawSystemIds.put(normalized.substring(0, 8) + normalized.substring(9), rawSystemId);
+        } else if (normalized.length() >= 3
+                && Character.isLetter(normalized.charAt(0))
+                && normalized.charAt(1) == ':'
+                && normalized.charAt(2) == '/') {
+            state.rawSystemIds.put("file:/" + normalized, rawSystemId);
+            state.rawSystemIds.put("file:///" + normalized, rawSystemId);
         }
     }
 

--- a/src/main/java/org/perlonjava/runtime/perlmodule/XSLoader.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/XSLoader.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
 import java.util.Set;
 
 import static org.perlonjava.runtime.runtimetypes.RuntimeContextType.SCALAR;
@@ -17,8 +16,6 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarTrue;
 public class XSLoader extends PerlModuleBase {
 
     /** Guard against recursive loadJarShimOverrides calls (e.g. Clone.pm evals XSLoader::load). */
-    private static final Set<String> shimLoadingInProgress = new HashSet<>();
-
     /**
      * Non-functional base classes that should be ignored when checking @ISA
      * for pure-Perl fallback parents. These classes provide infrastructure
@@ -337,7 +334,7 @@ public class XSLoader extends PerlModuleBase {
     private static boolean loadJarShimOverrides(String moduleName) {
         // Guard against recursion: the shim code may call XSLoader::load() again
         // for the same module (e.g. Clone.pm's eval { XSLoader::load('Clone') })
-        if (!shimLoadingInProgress.add(moduleName)) {
+        if (!PerlRuntime.current().xsShimLoadingInProgress.add(moduleName)) {
             return false; // Already loading this module's shim — break the cycle
         }
         try {
@@ -366,7 +363,7 @@ public class XSLoader extends PerlModuleBase {
             // Silently ignore - the module works via inheritance anyway
             return false;
         } finally {
-            shimLoadingInProgress.remove(moduleName);
+            PerlRuntime.current().xsShimLoadingInProgress.remove(moduleName);
         }
     }
 }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/YAMLPP.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/YAMLPP.java
@@ -28,7 +28,7 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.*;
  */
 public class YAMLPP extends PerlModuleBase {
 
-    static RuntimeScalar perlClassName = new RuntimeScalar("YAML::PP");
+    static final RuntimeScalar perlClassName = new RuntimeScalarReadOnly("YAML::PP");
 
     /**
      * Constructor for YAMLPP module.

--- a/src/main/java/org/perlonjava/runtime/perlmodule/storable/StorableWriter.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/storable/StorableWriter.java
@@ -445,7 +445,7 @@ public final class StorableWriter {
                     && org.perlonjava.runtime.runtimetypes.OverloadContext
                             .prepare(blessId) != null;
             boolean isWeak =
-                    org.perlonjava.runtime.runtimetypes.WeakRefRegistry.weakRefsExist
+                    org.perlonjava.runtime.runtimetypes.WeakRefRegistry.weakRefsExist()
                             && org.perlonjava.runtime.runtimetypes.WeakRefRegistry.isweak(value);
             int opcode;
             if (isWeak) {

--- a/src/main/java/org/perlonjava/runtime/regex/UnicodeResolver.java
+++ b/src/main/java/org/perlonjava/runtime/regex/UnicodeResolver.java
@@ -5,7 +5,6 @@ import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.text.UnicodeSet;
 import org.perlonjava.runtime.runtimetypes.*;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -17,7 +16,9 @@ public class UnicodeResolver {
      * Key: fully qualified sub name (e.g., "main::IsMyUpper")
      * Value: the parsed character class pattern from parseUserDefinedProperty
      */
-    private static final Map<String, String> userPropertyCache = new HashMap<>();
+    private static Map<String, String> userPropertyCache() {
+        return PerlRuntime.current().regexState().userUnicodePropertyCache;
+    }
 
     /**
      * Retrieves the Unicode code point for a given character name.
@@ -450,8 +451,8 @@ public class UnicodeResolver {
         }
 
         // Check cache first — Perl only calls user-defined property subs once
-        if (userPropertyCache.containsKey(subName)) {
-            return userPropertyCache.get(subName);
+        if (userPropertyCache().containsKey(subName)) {
+            return userPropertyCache().get(subName);
         }
 
         // Look up the subroutine without autovivifying an empty CODE slot.
@@ -467,7 +468,7 @@ public class UnicodeResolver {
 
             if (result.elements.isEmpty()) {
                 String parsed = "";
-                userPropertyCache.put(subName, parsed);
+                userPropertyCache().put(subName, parsed);
                 return parsed;
             }
 
@@ -475,7 +476,7 @@ public class UnicodeResolver {
 
             // Parse and cache the property definition
             String parsed = parseUserDefinedProperty(definition, newRecursionSet, subName);
-            userPropertyCache.put(subName, parsed);
+            userPropertyCache().put(subName, parsed);
             return parsed;
 
         } catch (PerlCompilerException e) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/CloneablePerlSubroutine.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/CloneablePerlSubroutine.java
@@ -1,0 +1,10 @@
+package org.perlonjava.runtime.runtimetypes;
+
+/** Explicit capture metadata implemented by generated JVM closures. */
+public interface CloneablePerlSubroutine extends PerlSubroutine {
+    RuntimeBase[] capturedValues();
+
+    CloneablePerlSubroutine cloneWithCaptures(RuntimeBase[] captures);
+
+    void setSelfReference(RuntimeScalar selfReference);
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/DestroyDispatch.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/DestroyDispatch.java
@@ -21,39 +21,24 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class DestroyDispatch {
 
-    // BitSet indexed by |blessId| — set if the class defines DESTROY (or AUTOLOAD)
-    private static final BitSet destroyClasses = new BitSet();
-
-    // Cache of resolved DESTROY methods per blessId (avoids hierarchy traversal on every call)
-    private static final ConcurrentHashMap<Integer, RuntimeScalar> destroyMethodCache =
-            new ConcurrentHashMap<>();
-
-    // Cursor objects whose classes define DESTROY. Weak-ref sweeps already
-    // clean unreachable weak referents; this registry covers DBIC-style
-    // storage cursors that are not themselves weakened, but whose finish()
-    // side-effect must happen deterministically.
-    private static final Set<RuntimeBase> destroyableObjects =
-            Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
-
-    // DESTROY rescue detection: when DESTROY stores $self in a hash element,
-    // the object should survive (like Perl 5's Schema::DESTROY self-save pattern).
-    // These fields track the current DESTROY target so RuntimeHash.put can detect
-    // when the referent is being "rescued" by storing it elsewhere.
-    static volatile RuntimeBase currentDestroyTarget = null;
-    static volatile boolean destroyTargetRescued = false;
-
-    // Phase D: sweep-pending flag. Set by RuntimeScalar.set() when it
-    // releases a blessed-with-DESTROY ref whose refCount stays > 0
-    // (cyclic) *while inside* a DESTROY body. Drained by doCallDestroy's
-    // outermost finally: if set, fire the reachability walker once to
-    // catch any newly-orphaned subgraphs that would otherwise keep weak
-    // refs defined past their owners' lives. Amortizes what would
-    // otherwise be a sweep on every set() — only the outermost DESTROY
-    // pays the cost.
-    static boolean sweepPendingAfterOuterDestroy = false;
+    private static LifecycleRuntimeState state() {
+        return PerlRuntime.current().lifecycleState;
+    }
 
     public static boolean isInsideDestroy() {
-        return currentDestroyTarget != null;
+        return state().currentDestroyTarget != null;
+    }
+
+    static RuntimeBase currentDestroyTarget() {
+        return state().currentDestroyTarget;
+    }
+
+    static void markDestroyTargetRescued() {
+        state().destroyTargetRescued = true;
+    }
+
+    static void requestSweepAfterOuterDestroy() {
+        state().sweepPendingAfterOuterDestroy = true;
     }
 
     public static void registerIfDestroyable(RuntimeBase referent, int blessId) {
@@ -62,26 +47,27 @@ public class DestroyDispatch {
         if (className != null
                 && className.endsWith("::Cursor")
                 && classHasDestroy(blessId, className)) {
-            destroyableObjects.add(referent);
+            state().destroyableObjects.add(referent);
         } else {
-            destroyableObjects.remove(referent);
+            state().destroyableObjects.remove(referent);
         }
     }
 
     public static void unregisterDestroyable(RuntimeBase referent) {
         if (referent != null) {
-            destroyableObjects.remove(referent);
+            state().destroyableObjects.remove(referent);
         }
     }
 
     public static ArrayList<RuntimeBase> snapshotDestroyableObjects() {
-        synchronized (destroyableObjects) {
-            return new ArrayList<>(destroyableObjects);
+        Set<RuntimeBase> objects = state().destroyableObjects;
+        synchronized (objects) {
+            return new ArrayList<>(objects);
         }
     }
 
     public static boolean hasDestroyableObjects() {
-        return !destroyableObjects.isEmpty();
+        return !state().destroyableObjects.isEmpty();
     }
 
     // Rescued objects whose weak refs need deferred clearing.
@@ -91,9 +77,6 @@ public class DestroyDispatch {
     // and clear their weak refs (with a deep sweep into nested blessed objects)
     // just before END blocks run, when all test code has finished and the
     // back-references are no longer needed.
-    private static final java.util.List<RuntimeBase> rescuedObjects =
-            java.util.Collections.synchronizedList(new java.util.ArrayList<>());
-
     /**
      * Phase 4 (refcount_alignment_plan.md): Snapshot the rescued-objects
      * list for use by {@link ReachabilityWalker}. Rescued objects (the
@@ -101,20 +84,22 @@ public class DestroyDispatch {
      * graph even though they've "already fired" DESTROY.
      */
     public static java.util.List<RuntimeBase> snapshotRescuedForWalk() {
-        synchronized (rescuedObjects) {
-            return new java.util.ArrayList<>(rescuedObjects);
+        java.util.List<RuntimeBase> objects = state().rescuedObjects;
+        synchronized (objects) {
+            return new java.util.ArrayList<>(objects);
         }
     }
 
     public static boolean isRescued(RuntimeBase referent) {
         if (referent == null) return false;
-        synchronized (rescuedObjects) {
-            return rescuedObjects.contains(referent);
+        java.util.List<RuntimeBase> objects = state().rescuedObjects;
+        synchronized (objects) {
+            return objects.contains(referent);
         }
     }
 
     public static boolean hasRescuedObjects() {
-        return !rescuedObjects.isEmpty();
+        return !state().rescuedObjects.isEmpty();
     }
 
     /**
@@ -144,12 +129,10 @@ public class DestroyDispatch {
      * get the gate; they were already broken on master and need a
      * separate fix path.
      */
-    private static final java.util.BitSet walkerGateClasses = new java.util.BitSet();
-    private static final java.util.BitSet walkerGateChecked = new java.util.BitSet();
-
     public static boolean classNeedsWalkerGate(int blessId) {
+        LifecycleRuntimeState state = state();
         int idx = Math.abs(blessId);
-        if (walkerGateChecked.get(idx)) return walkerGateClasses.get(idx);
+        if (state.walkerGateChecked.get(idx)) return state.walkerGateClasses.get(idx);
         String cn = NameNormalizer.getBlessStr(blessId);
         boolean needs = cn != null && (
                 cn.startsWith("Class::MOP")
@@ -158,21 +141,22 @@ public class DestroyDispatch {
              || cn.startsWith("Moo::")
              || cn.equals("Moo")
         );
-        walkerGateChecked.set(idx);
-        if (needs) walkerGateClasses.set(idx);
+        state.walkerGateChecked.set(idx);
+        if (needs) state.walkerGateClasses.set(idx);
         return needs;
     }
 
     public static boolean classHasDestroy(int blessId, String className) {
+        LifecycleRuntimeState state = state();
         int idx = Math.abs(blessId);
-        if (destroyClasses.get(idx)) return true;
+        if (state.destroyClasses.get(idx)) return true;
         // First time for this class — check hierarchy.
         // findMethodInHierarchy already falls through to AUTOLOAD if no explicit DESTROY exists.
         RuntimeScalar m = InheritanceResolver.findMethodInHierarchy("DESTROY", className, null, 0);
         if (m != null) {
-            destroyClasses.set(idx);
+            state.destroyClasses.set(idx);
             // Activate the mortal mechanism now that we know DESTROY classes exist
-            MortalList.active = true;
+            MortalList.setActive(true);
             return true;
         }
         return false;
@@ -183,8 +167,8 @@ public class DestroyDispatch {
      * Clears both the destroyClasses BitSet and the DESTROY method cache.
      */
     public static void invalidateCache() {
-        destroyClasses.clear();
-        destroyMethodCache.clear();
+        state().destroyClasses.clear();
+        state().destroyMethodCache.clear();
     }
 
     /**
@@ -242,7 +226,7 @@ public class DestroyDispatch {
             // refs and internal fields must remain intact because the phantom chain
             // (or other code) may still access the object through its weak refs.
             // Proper cleanup happens at END time via clearRescuedWeakRefs.
-            if (rescuedObjects.contains(referent)) {
+            if (state().rescuedObjects.contains(referent)) {
                 return;
             }
             WeakRefRegistry.clearWeakRefsTo(referent);
@@ -300,13 +284,14 @@ public class DestroyDispatch {
      * Perform the actual DESTROY method call.
      */
     private static void doCallDestroy(RuntimeBase referent, String className) {
+        LifecycleRuntimeState state = state();
         // Use cached method if available
-        RuntimeScalar destroyMethod = destroyMethodCache.get(referent.blessId);
+        RuntimeScalar destroyMethod = state.destroyMethodCache.get(referent.blessId);
         if (destroyMethod == null) {
             destroyMethod = InheritanceResolver.findMethodInHierarchy(
                     "DESTROY", className, null, 0);
             if (destroyMethod != null) {
-                destroyMethodCache.put(referent.blessId, destroyMethod);
+                state.destroyMethodCache.put(referent.blessId, destroyMethod);
             }
         }
 
@@ -354,10 +339,10 @@ public class DestroyDispatch {
         // Schema::DESTROY reattaching to a ResultSource), RuntimeHash.put
         // will detect the referent and set destroyTargetRescued = true.
         // After DESTROY, if rescued, skip cascade to keep internals alive.
-        RuntimeBase savedTarget = currentDestroyTarget;
-        boolean savedRescued = destroyTargetRescued;
-        currentDestroyTarget = referent;
-        destroyTargetRescued = false;
+        RuntimeBase savedTarget = state.currentDestroyTarget;
+        boolean savedRescued = state.destroyTargetRescued;
+        state.currentDestroyTarget = referent;
+        state.destroyTargetRescued = false;
 
         // Phase 3 (refcount_alignment_plan.md): Transition from MIN_VALUE
         // back to 0 so increments/decrements inside DESTROY work normally.
@@ -440,7 +425,7 @@ public class DestroyDispatch {
             // self-save). Mark needsReDestroy and let the next decrement-to-0
             // re-invoke DESTROY. Don't clear weak refs or cascade — the object
             // is still alive.
-            if (referent.refCount > 0 && !destroyTargetRescued) {
+            if (referent.refCount > 0 && !state.destroyTargetRescued) {
                 referent.needsReDestroy = true;
                 return;
             }
@@ -455,7 +440,7 @@ public class DestroyDispatch {
             //   $source->{schema} = $self
             // This triggers rescue detection because the old value ($source->{schema},
             // a weak ref to Schema) is being replaced by a strong ref to Schema.
-            if (destroyTargetRescued) {
+            if (state.destroyTargetRescued) {
                 // Object was rescued by DESTROY (e.g., Schema::DESTROY self-save).
                 //
                 // refCount has been set to 1 by setLargeRefCounted during rescue
@@ -480,7 +465,7 @@ public class DestroyDispatch {
                 //
                 // Track rescued objects so clearRescuedWeakRefs can clean up
                 // at END time.
-                rescuedObjects.add(referent);
+                state.rescuedObjects.add(referent);
                 MortalList.invalidateExternalRootSnapshot();
                 return;
             }
@@ -516,8 +501,8 @@ public class DestroyDispatch {
                     new RuntimeScalar(""));
         } finally {
             // Restore the DESTROY target and rescue flag for nested DESTROY calls
-            currentDestroyTarget = savedTarget;
-            destroyTargetRescued = savedRescued;
+            state.currentDestroyTarget = savedTarget;
+            state.destroyTargetRescued = savedRescued;
             // Phase 3: Exit DESTROY state. If refCount is still 0 and we're
             // not taking the resurrection path, set MIN_VALUE so future
             // callDestroy enters the normal cleanup path.
@@ -535,9 +520,9 @@ public class DestroyDispatch {
             // the sweep cost to at most one per top-level DESTROY instead
             // of per-set(). Gated by ModuleInitGuard to avoid tripping
             // during require/use load.
-            if (savedTarget == null && sweepPendingAfterOuterDestroy
+            if (savedTarget == null && state.sweepPendingAfterOuterDestroy
                     && !ModuleInitGuard.inModuleInit()) {
-                sweepPendingAfterOuterDestroy = false;
+                state.sweepPendingAfterOuterDestroy = false;
                 ReachabilityWalker.sweepWeakRefs(false, false);
             }
         }
@@ -561,6 +546,7 @@ public class DestroyDispatch {
      * into elements. This ensures DBIC's leak tracer sees the weak refs as undef.
      */
     public static void processRescuedObjects() {
+        java.util.List<RuntimeBase> rescuedObjects = state().rescuedObjects;
         if (rescuedObjects.isEmpty()) return;
         // Snapshot and clear to avoid ConcurrentModificationException
         java.util.List<RuntimeBase> snapshot;
@@ -606,6 +592,7 @@ public class DestroyDispatch {
      *    and clear their weak refs too
      */
     public static void clearRescuedWeakRefs() {
+        java.util.List<RuntimeBase> rescuedObjects = state().rescuedObjects;
         if (rescuedObjects.isEmpty()) return;
         java.util.List<RuntimeBase> snapshot;
         synchronized (rescuedObjects) {
@@ -629,6 +616,7 @@ public class DestroyDispatch {
      */
     public static boolean clearRescuedWeakRefsTo(RuntimeBase rescued) {
         if (rescued == null) return false;
+        java.util.List<RuntimeBase> rescuedObjects = state().rescuedObjects;
         boolean removed;
         synchronized (rescuedObjects) {
             removed = rescuedObjects.remove(rescued);
@@ -652,6 +640,7 @@ public class DestroyDispatch {
      */
     public static boolean clearRescuedWeakRefsToSelfOnly(RuntimeBase rescued) {
         if (rescued == null) return false;
+        java.util.List<RuntimeBase> rescuedObjects = state().rescuedObjects;
         boolean present;
         synchronized (rescuedObjects) {
             present = rescuedObjects.contains(rescued);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/DiamondIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/DiamondIO.java
@@ -19,38 +19,40 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarUndef
  * editing with backup creation, akin to Perl's -i switch.
  */
 public class DiamondIO {
+    public static final class State {
+        RuntimeIO currentReader;
+        RuntimeIO currentWriter;
+        boolean eofReached;
+        boolean readingStarted;
+        boolean argvWasInitiallyEmpty;
+        int accumulatedLineNumber;
+        String inPlaceExtension;
+        boolean inPlaceEdit;
+        Path tempFilePath;
 
-    // Static variable to hold the current file reader
-    static RuntimeIO currentReader;
+        void clear() {
+            currentReader = null;
+            currentWriter = null;
+            eofReached = false;
+            readingStarted = false;
+            argvWasInitiallyEmpty = false;
+            accumulatedLineNumber = 0;
+            inPlaceExtension = null;
+            inPlaceEdit = false;
+            tempFilePath = null;
+        }
+    }
 
-    // Static variable to hold the current file writer (for in-place editing)
-    static RuntimeIO currentWriter;
-
-    // Flag to indicate if the end of all files has been reached
-    static boolean eofReached = false;
-
-    // Flag to indicate if the reading process has started
-    static boolean readingStarted = false;
-
-    // Flag to track if @ARGV was initially empty (determines STDIN fallback behavior)
-    static boolean argvWasInitiallyEmpty = false;
-
-    // Accumulated line number across ARGV files (Perl's $. continues across <> files)
-    static int accumulatedLineNumber = 0;
-
-    // Static field to store the in-place extension for the -i switch
-    static String inPlaceExtension = null;
-    static boolean inPlaceEdit = false;
-
-    // Path to the temporary file to be deleted on exit
-    static Path tempFilePath = null;
+    private static State state() {
+        return PerlRuntime.current().diamondIOState;
+    }
 
     public static void initialize(CompilerOptions compilerOptions) {
         // Reset all static variables to ensure clean state between compiler runs
         reset();
 
-        inPlaceExtension = compilerOptions.inPlaceExtension;
-        inPlaceEdit = compilerOptions.inPlaceEdit;
+        state().inPlaceExtension = compilerOptions.inPlaceExtension;
+        state().inPlaceEdit = compilerOptions.inPlaceEdit;
     }
 
     /**
@@ -58,15 +60,7 @@ public class DiamondIO {
      * This ensures clean state between compiler runs and prevents state leakage.
      */
     public static void reset() {
-        currentReader = null;
-        currentWriter = null;
-        eofReached = false;
-        readingStarted = false;
-        argvWasInitiallyEmpty = false;
-        accumulatedLineNumber = 0;
-        inPlaceExtension = null;
-        inPlaceEdit = false;
-        tempFilePath = null;
+        state().clear();
     }
 
     /**
@@ -80,6 +74,7 @@ public class DiamondIO {
      * undefined scalar if EOF is reached for all files.
      */
     public static RuntimeBase readline(RuntimeScalar arg, int ctx) {
+        State state = state();
         if (ctx == RuntimeContextType.LIST) {
             // Handle LIST context
             RuntimeList lines = new RuntimeList();
@@ -91,19 +86,19 @@ public class DiamondIO {
         } else {
             // Handle SCALAR context
             // Initialize the reading process if it hasn't started yet
-            if (!readingStarted) {
-                readingStarted = true;
+            if (!state.readingStarted) {
+                state.readingStarted = true;
                 // Check if @ARGV was initially empty to determine STDIN fallback behavior
-                argvWasInitiallyEmpty = getGlobalArray("main::ARGV").isEmpty();
+                state.argvWasInitiallyEmpty = getGlobalArray("main::ARGV").isEmpty();
 
                 RuntimeIO argv = getGlobalIO("main::ARGV").getRuntimeIO();
                 // Only use ARGV filehandle directly if @ARGV is empty (handles aliased filehandles like *ARGV = *DATA)
                 if (argv != null && !(argv.ioHandle instanceof ClosedIOHandle) && getGlobalArray("main::ARGV").isEmpty()) {
-                    currentReader = argv;
-                } else if (argvWasInitiallyEmpty) {
+                    state.currentReader = argv;
+                } else if (state.argvWasInitiallyEmpty) {
                     RuntimeIO stdin = getGlobalIO("main::STDIN").getRuntimeIO();
                     if (stdin == null || stdin.ioHandle instanceof ClosedIOHandle) {
-                        eofReached = true;
+                        state.eofReached = true;
                         return scalarUndef;
                     }
                     // Only use STDIN if @ARGV was initially empty, not if it became empty after processing files
@@ -113,25 +108,25 @@ public class DiamondIO {
 
             while (true) {
                 // If there's no current reader, try to open the next file
-                if (currentReader == null) {
+                if (state.currentReader == null) {
                     if (!openNextFile()) {
-                        eofReached = true;
+                        state.eofReached = true;
                         return scalarUndef;
                     }
                     // Carry over accumulated line number (Perl's $. continues across <> files)
-                    currentReader.currentLineNumber = accumulatedLineNumber;
+                    state.currentReader.currentLineNumber = state.accumulatedLineNumber;
                 }
 
                 // Attempt to read a line from the current file
-                RuntimeScalar line = Readline.readline(currentReader);
+                RuntimeScalar line = Readline.readline(state.currentReader);
                 if (line.type != RuntimeScalarType.UNDEF) {
-                    accumulatedLineNumber = currentReader.currentLineNumber;
+                    state.accumulatedLineNumber = state.currentReader.currentLineNumber;
                     return line;
                 }
 
                 // EOF for current file — save accumulated line count before discarding reader
-                accumulatedLineNumber = currentReader.currentLineNumber;
-                currentReader = null;
+                state.accumulatedLineNumber = state.currentReader.currentLineNumber;
+                state.currentReader = null;
             }
         }
     }
@@ -145,14 +140,15 @@ public class DiamondIO {
      * @return true if a new file was successfully opened, false if no more files are available.
      */
     private static boolean openNextFile() {
+        State state = state();
         // Close the current reader and writer if they exist
-        if (currentReader != null) {
-            currentReader.close();
-            currentReader = null;
+        if (state.currentReader != null) {
+            state.currentReader.close();
+            state.currentReader = null;
         }
-        if (currentWriter != null) {
-            currentWriter.close();
-            currentWriter = null;
+        if (state.currentWriter != null) {
+            state.currentWriter.close();
+            state.currentWriter = null;
         }
 
         // Get the next file name from the global ARGV array
@@ -167,8 +163,8 @@ public class DiamondIO {
         String backupFileName = null;
 
         // Check if in-place editing is enabled (either via -i switch or $^I variable)
-        boolean isInPlaceEnabled = inPlaceEdit;
-        String extension = inPlaceExtension;
+        boolean isInPlaceEnabled = state.inPlaceEdit;
+        String extension = state.inPlaceExtension;
 
         // Also check $^I variable for runtime in-place editing
         if (!isInPlaceEnabled) {
@@ -190,13 +186,13 @@ public class DiamondIO {
             if (extension == null || extension.isEmpty()) {
                 // Create a temporary file for the original file
                 try {
-                    tempFilePath = Files.createTempFile("temp_", null);
-                    backupFileName = tempFilePath.toString();
+                    state.tempFilePath = Files.createTempFile("temp_", null);
+                    backupFileName = state.tempFilePath.toString();
 
-                    Files.move(originalPath, tempFilePath, StandardCopyOption.REPLACE_EXISTING);
+                    Files.move(originalPath, state.tempFilePath, StandardCopyOption.REPLACE_EXISTING);
 
                     // Schedule the file for deletion on JVM exit
-                    tempFilePath.toFile().deleteOnExit();
+                    state.tempFilePath.toFile().deleteOnExit();
 
                 } catch (IOException e) {
                     System.err.println("Error: Unable to create temporary file for " + originalFileName + ": " + e);
@@ -239,20 +235,20 @@ public class DiamondIO {
 
             // Open the original file for writing (this is the ARGVOUT equivalent)
             // Use the resolved path to ensure we write to the correct location
-            currentWriter = RuntimeIO.open(originalPath.toString(), ">");
-            getGlobalIO("main::ARGVOUT").set(currentWriter);
-            RuntimeIO.setLastAccessedHandle(currentWriter);
+            state.currentWriter = RuntimeIO.open(originalPath.toString(), ">");
+            getGlobalIO("main::ARGVOUT").set(state.currentWriter);
+            RuntimeIO.setLastAccessedHandle(state.currentWriter);
 
             // CRITICAL: Update selectedHandle so print statements without explicit filehandle
             // write to the original file during in-place editing
-            RuntimeIO.setSelectedHandle(currentWriter);
+            RuntimeIO.setSelectedHandle(state.currentWriter);
         }
 
         // Open the renamed file for reading
-        String readerPath = tempFilePath != null ? tempFilePath.toString() : (backupFileName != null ? backupFileName : originalFileName);
-        currentReader = RuntimeIO.open(readerPath);
-        getGlobalIO("main::ARGV").set(currentReader);
+        String readerPath = state.tempFilePath != null ? state.tempFilePath.toString() : (backupFileName != null ? backupFileName : originalFileName);
+        state.currentReader = RuntimeIO.open(readerPath);
+        getGlobalIO("main::ARGV").set(state.currentReader);
 
-        return currentReader != null;
+        return state.currentReader != null;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ExecutionRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ExecutionRuntimeState.java
@@ -52,6 +52,15 @@ public final class ExecutionRuntimeState {
     public final Deque<Integer> callContextStack = new ArrayDeque<>();
     public int evalDepth;
     public int tailCallTrampolineDepth;
+    public final ArrayDeque<Runnable> futureResumeQueue = new ArrayDeque<>();
+    public boolean futureResumeDraining;
+    public int overloadStringifyDepth;
+    public boolean taintMode;
+    public boolean joinTaint;
+    public int moduleInitDepth;
+    public final IdentityHashMap<Throwable, Boolean> unhandledDieHandlerSeen =
+            new IdentityHashMap<>();
+    public boolean insideUnhandledDieHandler;
     ControlFlowMarker controlFlowMarker;
 
     final ArrayList<Object> myVarCleanupStack = new ArrayList<>();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
@@ -18,11 +18,6 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeIO.initStdHandles;
  */
 public class GlobalContext {
 
-    private static final ThreadLocal<Boolean> threadTaintMode =
-            ThreadLocal.withInitial(() -> Boolean.FALSE);
-    private static final ThreadLocal<Boolean> threadJoinTaint =
-            ThreadLocal.withInitial(() -> Boolean.FALSE);
-
     // Special variables internal names
     public static final String GLOBAL_PHASE = encodeSpecialVar("GLOBAL_PHASE"); // $^GLOBAL_PHASE
     public static final String OPEN = encodeSpecialVar("OPEN"); // $^OPEN
@@ -30,22 +25,23 @@ public class GlobalContext {
 
     /** Keep command-line taint mode isolated between concurrently executing scripts. */
     public static void setThreadTaintMode(boolean enabled) {
-        threadTaintMode.set(enabled);
+        PerlRuntime.current().executionState().taintMode = enabled;
     }
 
     public static boolean isTaintModeActive() {
-        return threadTaintMode.get();
+        return PerlRuntime.current().executionState().taintMode;
     }
 
     /** Record the taint state left by join(), used by Perl's legacy taint probe. */
     public static void setThreadJoinTaint(boolean tainted) {
-        threadJoinTaint.set(tainted);
+        PerlRuntime.current().executionState().joinTaint = tainted;
     }
 
     /** Return and clear the taint state left by the immediately preceding join(). */
     public static boolean consumeThreadJoinTaint() {
-        boolean tainted = threadJoinTaint.get();
-        threadJoinTaint.set(false);
+        ExecutionRuntimeState state = PerlRuntime.current().executionState();
+        boolean tainted = state.joinTaint;
+        state.joinTaint = false;
         return tainted;
     }
 
@@ -130,7 +126,7 @@ public class GlobalContext {
             ors.set(compilerOptions.outputRecordSeparator);    // initialize $\
             GlobalVariable.globalVariables.put("main::\\", ors);
         }
-        GlobalVariable.getGlobalVariable("main::$").set(ProcessHandle.current().pid()); // initialize `$$` to process id
+        GlobalVariable.getGlobalVariable("main::$").set(RuntimeEnvironment.pid()); // initialize `$$` to runtime process id
         GlobalVariable.getGlobalVariable("main::?");
         // Only set $0 if it hasn't been set yet - prevents overwriting during re-entrant calls
         // (e.g., when require() is called during module initialization)

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeState.java
@@ -268,4 +268,47 @@ public final class GlobalRuntimeState {
         packageVersions.clear();
         generatedClassLoader = new CustomClassLoader(GlobalVariable.class.getClassLoader());
     }
+
+    /** Copy package-owned interpreter state through one ithread graph cloner. */
+    void snapshotInto(GlobalRuntimeState target, RuntimeGraphCloner cloner) {
+        cloneMap(scalarValues, target.scalarValues, cloner, RuntimeScalar.class);
+        cloneMap(arrayValues, target.arrayValues, cloner, RuntimeArray.class);
+        cloneMap(hashValues, target.hashValues, cloner, RuntimeHash.class);
+        cloneMap(foreachScalarAliases, target.foreachScalarAliases, cloner, RuntimeScalar.class);
+        cloneMap(codeRefs, target.codeRefs, cloner, RuntimeScalar.class);
+        cloneMap(pseudoConstants, target.pseudoConstants, cloner, RuntimeScalar.class);
+        cloneMap(pinnedCodeRefs, target.pinnedCodeRefs, cloner, RuntimeScalar.class);
+        for (Map.Entry<Integer, RuntimeScalar> entry : compiledCodeRefs.entrySet()) {
+            target.compiledCodeRefs.put(entry.getKey(),
+                    (RuntimeScalar) cloner.cloneValue(entry.getValue()));
+        }
+
+        target.importedSubs.putAll(importedSubs);
+        target.operatorOverrideGlobs.putAll(operatorOverrideGlobs);
+        target.deletedCodeRefPins.addAll(deletedCodeRefPins);
+        target.localizedCodeRefDepth.putAll(localizedCodeRefDepth);
+        target.stashAliases.putAll(stashAliases);
+        target.resolvedStashAliases.putAll(resolvedStashAliases);
+        target.globAliases.putAll(globAliases);
+        target.packageExistsCache.putAll(packageExistsCache);
+        target.declaredGlobalVariables.addAll(declaredGlobalVariables);
+        target.declaredGlobalArrays.addAll(declaredGlobalArrays);
+        target.declaredGlobalHashes.addAll(declaredGlobalHashes);
+        target.classNames.addAll(classNames);
+        classFields.forEach((name, fields) -> target.classFields.put(name, new HashSet<>(fields)));
+        target.classParents.putAll(classParents);
+        target.packageVersions.putAll(packageVersions);
+        target.nextCompiledCodeRefId = nextCompiledCodeRefId;
+        target.stashEnumerationVersion = stashEnumerationVersion;
+        target.coreGlobalsInitialized = coreGlobalsInitialized;
+        // Class loaders, caches, named IO and formats are child-owned/fresh.
+    }
+
+    private static <T extends RuntimeBase> void cloneMap(
+            Map<String, T> source, Map<String, T> target,
+            RuntimeGraphCloner cloner, Class<T> type) {
+        for (Map.Entry<String, T> entry : source.entrySet()) {
+            target.put(entry.getKey(), type.cast(cloner.cloneValue(entry.getValue())));
+        }
+    }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/LifecycleRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/LifecycleRuntimeState.java
@@ -1,0 +1,95 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.WeakHashMap;
+
+/** Runtime-owned mortal, weak-reference, DESTROY, and reachability sweep state. */
+final class LifecycleRuntimeState {
+    final AtomicBoolean boundaryWorkRegistered = new AtomicBoolean();
+    boolean mortalActive = true;
+    final ArrayList<RuntimeBase> pending = new ArrayList<>();
+    final ArrayList<TiedVariableBase> pendingTiedReleases = new ArrayList<>();
+    final ArrayList<RuntimeScalar> deferredCaptures = new ArrayList<>();
+    final IdentityHashMap<RuntimeScalar, Integer> deferredCapturesSet = new IdentityHashMap<>();
+    boolean deferredCapturesMayBeReady;
+    final ArrayDeque<RuntimeBase> temporaryRoots = new ArrayDeque<>();
+    final IdentityHashMap<RuntimeBase, Integer> suspendedRoots = new IdentityHashMap<>();
+    final ArrayList<Integer> marks = new ArrayList<>();
+    final ArrayList<Integer> tiedReleaseMarks = new ArrayList<>();
+    boolean flushing;
+    long lastAutoSweepNanos;
+    boolean inAutoSweep;
+    boolean immediateWeakSweepRequested;
+    final Set<RuntimeBase> targetedWeakSweepReferents =
+            Collections.newSetFromMap(new IdentityHashMap<>());
+    Set<RuntimeBase> flushReachableCache;
+    ReachabilityWalker.ExternalRootSnapshot externalRootSnapshot;
+    ReachabilityWalker.LiveRootSnapshot liveRootSnapshot;
+
+    final Set<RuntimeScalar> weakScalars = Collections.newSetFromMap(new IdentityHashMap<>());
+    final IdentityHashMap<RuntimeBase, Set<RuntimeScalar>> referentToWeakRefs = new IdentityHashMap<>();
+    volatile boolean weakRefsExist;
+
+    final BitSet destroyClasses = new BitSet();
+    final ConcurrentHashMap<Integer, RuntimeScalar> destroyMethodCache = new ConcurrentHashMap<>();
+    final Set<RuntimeBase> destroyableObjects =
+            Collections.synchronizedSet(Collections.newSetFromMap(new IdentityHashMap<>()));
+    RuntimeBase currentDestroyTarget;
+    boolean destroyTargetRescued;
+    boolean sweepPendingAfterOuterDestroy;
+    final List<RuntimeBase> rescuedObjects = Collections.synchronizedList(new ArrayList<>());
+    final BitSet walkerGateClasses = new BitSet();
+    final BitSet walkerGateChecked = new BitSet();
+    boolean blessedObjectExists;
+    final Map<RuntimeBase, LinkedHashMap<Integer, String>> traceOwners =
+            Collections.synchronizedMap(new IdentityHashMap<>());
+    final Map<RuntimeScalar, Boolean> scalarRegistry = new WeakHashMap<>();
+    final Map<RuntimeScalar, Throwable> scalarRegisterStacks = new WeakHashMap<>();
+
+    void clear() {
+        mortalActive = true;
+        pending.clear();
+        pendingTiedReleases.clear();
+        deferredCaptures.clear();
+        deferredCapturesSet.clear();
+        deferredCapturesMayBeReady = false;
+        temporaryRoots.clear();
+        suspendedRoots.clear();
+        marks.clear();
+        tiedReleaseMarks.clear();
+        flushing = false;
+        lastAutoSweepNanos = 0;
+        inAutoSweep = false;
+        immediateWeakSweepRequested = false;
+        targetedWeakSweepReferents.clear();
+        flushReachableCache = null;
+        externalRootSnapshot = null;
+        liveRootSnapshot = null;
+        weakScalars.clear();
+        referentToWeakRefs.clear();
+        weakRefsExist = false;
+        destroyClasses.clear();
+        destroyMethodCache.clear();
+        destroyableObjects.clear();
+        currentDestroyTarget = null;
+        destroyTargetRescued = false;
+        sweepPendingAfterOuterDestroy = false;
+        rescuedObjects.clear();
+        walkerGateClasses.clear();
+        walkerGateChecked.clear();
+        blessedObjectExists = false;
+        traceOwners.clear();
+        scalarRegistry.clear();
+        scalarRegisterStacks.clear();
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ModuleInitGuard.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ModuleInitGuard.java
@@ -21,28 +21,24 @@ package org.perlonjava.runtime.runtimetypes;
  */
 public class ModuleInitGuard {
 
-    // Use int[1] to avoid autoboxing on every enter/exit.
-    private static final ThreadLocal<int[]> depth =
-            ThreadLocal.withInitial(() -> new int[]{0});
-
     /** Enter module-initialization state (increments depth). */
     public static void enter() {
-        depth.get()[0]++;
+        PerlRuntime.current().executionState().moduleInitDepth++;
     }
 
     /** Exit module-initialization state (decrements depth). */
     public static void exit() {
-        int[] d = depth.get();
-        if (d[0] > 0) d[0]--;
+        ExecutionRuntimeState state = PerlRuntime.current().executionState();
+        if (state.moduleInitDepth > 0) state.moduleInitDepth--;
     }
 
     /** True if currently inside require/use/BEGIN/eval-STRING execution. */
     public static boolean inModuleInit() {
-        return depth.get()[0] > 0;
+        return PerlRuntime.current().executionState().moduleInitDepth > 0;
     }
 
     /** Diagnostic: current depth. */
     public static int currentDepth() {
-        return depth.get()[0];
+        return PerlRuntime.current().executionState().moduleInitDepth;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Lightweight mortal-like defer-decrement mechanism.
@@ -17,6 +18,7 @@ import java.util.Set;
  * trigger DESTROY at statement end, not immediately during delete.
  */
 public class MortalList {
+    private static final AtomicInteger runtimesWithBoundaryWork = new AtomicInteger();
 
     // Always-on: refCount tracking for birth-tracked objects (anonymous hashes,
     // arrays, closures with captures) requires balanced increment/decrement.
@@ -24,51 +26,59 @@ public class MortalList {
     // so the decrement side (deferDecrementIfTracked, flush, etc.) must also
     // be active from the start.  The per-method `!active` guards are retained
     // as a trivially-predicted branch; the JIT will elide them.
-    public static boolean active = true;
+    private static LifecycleRuntimeState state() {
+        return PerlRuntime.current().lifecycleState;
+    }
 
-    // List of RuntimeBase references awaiting decrement.
-    // Populated by delete() when removing tracked elements.
-    // Drained at statement boundaries (FREETMPS equivalent).
-    private static final ArrayList<RuntimeBase> pending = new ArrayList<>();
+    private static void markBoundaryWork(LifecycleRuntimeState state) {
+        synchronized (state) {
+            if (state.boundaryWorkRegistered.compareAndSet(false, true)) {
+                runtimesWithBoundaryWork.incrementAndGet();
+            }
+        }
+    }
 
-    // Tied scalar wrappers whose handler release must happen at the next
-    // statement boundary. Used when a :lvalue sub returns a tied lexical: the
-    // callee's scope exits before the caller performs STORE.
-    private static final ArrayList<TiedVariableBase> pendingTiedReleases = new ArrayList<>();
+    private static void refreshBoundaryWork(LifecycleRuntimeState state) {
+        synchronized (state) {
+            boolean needed = !state.pending.isEmpty()
+                    || !state.pendingTiedReleases.isEmpty()
+                    || state.deferredCapturesMayBeReady
+                    || state.immediateWeakSweepRequested
+                    || !state.targetedWeakSweepReferents.isEmpty()
+                    || state.weakRefsExist;
+            if (!needed && state.boundaryWorkRegistered.compareAndSet(true, false)) {
+                runtimesWithBoundaryWork.decrementAndGet();
+            }
+        }
+    }
 
-    // Scalars whose scope has exited while captureCount > 0.
-    // These variables hold blessed references that could not be decremented
-    // at scope exit because closures still reference the RuntimeScalar.
-    // Processed by flushDeferredCaptures() after the main script returns,
-    // before END blocks run.
-    private static final ArrayList<RuntimeScalar> deferredCaptures = new ArrayList<>();
+    static void noteBoundaryWork() {
+        markBoundaryWork(state());
+    }
 
-    // Phase I: parallel identity set for O(1) membership check.
-    // Used by ReachabilityWalker to skip scalars that are waiting in
-    // deferredCaptures for final cleanup — they are effectively dead
-    // from Perl's view, only held Java-alive by this static list.
-    private static final java.util.IdentityHashMap<RuntimeScalar, Integer> deferredCapturesSet = new java.util.IdentityHashMap<>();
-    private static boolean deferredCapturesMayBeReady = false;
+    static void clearCurrentRuntimeState() {
+        LifecycleRuntimeState state = state();
+        state.clear();
+        refreshBoundaryWork(state);
+    }
 
-    private static final ThreadLocal<ArrayDeque<RuntimeBase>> temporaryRoots =
-            ThreadLocal.withInitial(ArrayDeque::new);
+    public static boolean isActive() {
+        return state().mortalActive;
+    }
 
-    // Heap-resident interpreter frames are Perl-visible owners while an async
-    // sub is suspended.  They are not ordinary lexical roots (and therefore
-    // are invisible to MyVarCleanupStack), but a weak-reference sweep must not
-    // collect the Future or other value that the frame is actively awaiting.
-    private static final IdentityHashMap<RuntimeBase, Integer> suspendedRoots =
-            new IdentityHashMap<>();
+    public static void setActive(boolean active) {
+        state().mortalActive = active;
+    }
 
     public static void pushTemporaryRoot(RuntimeBase root) {
         if (root != null) {
-            temporaryRoots.get().push(root);
+            state().temporaryRoots.push(root);
         }
     }
 
     public static void popTemporaryRoot(RuntimeBase root) {
         if (root != null) {
-            ArrayDeque<RuntimeBase> roots = temporaryRoots.get();
+            ArrayDeque<RuntimeBase> roots = state().temporaryRoots;
             if (!roots.isEmpty() && roots.peek() == root) {
                 roots.pop();
             } else {
@@ -78,36 +88,37 @@ public class MortalList {
     }
 
     public static java.util.List<RuntimeBase> snapshotTemporaryRoots() {
-        return new java.util.ArrayList<>(temporaryRoots.get());
+        return new java.util.ArrayList<>(state().temporaryRoots);
     }
 
     public static boolean hasTemporaryRoots() {
-        return !temporaryRoots.get().isEmpty();
+        return !state().temporaryRoots.isEmpty();
     }
 
     public static void retainSuspendedRoot(RuntimeBase root) {
         if (root != null) {
-            suspendedRoots.merge(root, 1, Integer::sum);
+            state().suspendedRoots.merge(root, 1, Integer::sum);
             invalidateAllRootSnapshots();
         }
     }
 
     public static void releaseSuspendedRoot(RuntimeBase root) {
         if (root == null) return;
-        Integer count = suspendedRoots.get(root);
+        LifecycleRuntimeState state = state();
+        Integer count = state.suspendedRoots.get(root);
         if (count == null) return;
-        if (count <= 1) suspendedRoots.remove(root);
-        else suspendedRoots.put(root, count - 1);
+        if (count <= 1) state.suspendedRoots.remove(root);
+        else state.suspendedRoots.put(root, count - 1);
         invalidateAllRootSnapshots();
     }
 
     public static java.util.List<RuntimeBase> snapshotSuspendedRoots() {
-        return new java.util.ArrayList<>(suspendedRoots.keySet());
+        return new java.util.ArrayList<>(state().suspendedRoots.keySet());
     }
 
     public static void clearSuspendedRoots() {
-        suspendedRoots.clear();
-        temporaryRoots.remove();
+        state().suspendedRoots.clear();
+        state().temporaryRoots.clear();
         invalidateAllRootSnapshots();
     }
 
@@ -118,7 +129,7 @@ public class MortalList {
      */
     public static boolean isDeferredCapture(RuntimeScalar scalar) {
         if (scalar == null) return false;
-        return deferredCapturesSet.containsKey(scalar);
+        return state().deferredCapturesSet.containsKey(scalar);
     }
 
     /**
@@ -130,12 +141,16 @@ public class MortalList {
         if (base.refCountTrace) {
             base.traceRefCount(0, "MortalList.deferDecrement (queued)");
         }
-        pending.add(base);
+        LifecycleRuntimeState state = state();
+        markBoundaryWork(state);
+        state.pending.add(base);
     }
 
     public static void deferTiedObjectRelease(TiedVariableBase tiedVariable) {
-        if (!active || tiedVariable == null) return;
-        pendingTiedReleases.add(tiedVariable);
+        LifecycleRuntimeState state = state();
+        if (!state.mortalActive || tiedVariable == null) return;
+        markBoundaryWork(state);
+        state.pendingTiedReleases.add(tiedVariable);
     }
 
     /**
@@ -148,16 +163,20 @@ public class MortalList {
      * the main script returns, before END blocks run.
      */
     public static void addDeferredCapture(RuntimeScalar scalar) {
-        deferredCaptures.add(scalar);
-        deferredCapturesSet.merge(scalar, 1, Integer::sum);
+        LifecycleRuntimeState state = state();
+        markBoundaryWork(state);
+        state.deferredCaptures.add(scalar);
+        state.deferredCapturesSet.merge(scalar, 1, Integer::sum);
         if (scalar.captureCount == 0 && scalar.scopeExited) {
-            deferredCapturesMayBeReady = true;
+            state.deferredCapturesMayBeReady = true;
         }
     }
 
     static void noteDeferredCaptureMayBeReady() {
-        if (!deferredCaptures.isEmpty()) {
-            deferredCapturesMayBeReady = true;
+        LifecycleRuntimeState state = state();
+        if (!state.deferredCaptures.isEmpty()) {
+            markBoundaryWork(state);
+            state.deferredCapturesMayBeReady = true;
         }
     }
 
@@ -177,16 +196,16 @@ public class MortalList {
      * leaving others for later processing (either a subsequent block exit
      * or flushDeferredCaptures at script end).
      */
-    private static void processReadyDeferredCaptures() {
-        if (deferredCaptures.isEmpty()) return;
-        if (!deferredCapturesMayBeReady) return;
-        deferredCapturesMayBeReady = false;
+    private static void processReadyDeferredCaptures(LifecycleRuntimeState state) {
+        if (state.deferredCaptures.isEmpty()) return;
+        if (!state.deferredCapturesMayBeReady) return;
+        state.deferredCapturesMayBeReady = false;
         boolean found = false;
-        for (int i = deferredCaptures.size() - 1; i >= 0; i--) {
-            RuntimeScalar scalar = deferredCaptures.get(i);
+        for (int i = state.deferredCaptures.size() - 1; i >= 0; i--) {
+            RuntimeScalar scalar = state.deferredCaptures.get(i);
             if (scalar.captureCount == 0 && scalar.scopeExited) {
                 deferDecrementIfTracked(scalar);
-                deferredCaptures.remove(i);
+                state.deferredCaptures.remove(i);
                 removeFromDeferredSet(scalar);
                 found = true;
             }
@@ -197,10 +216,11 @@ public class MortalList {
     }
 
     private static void removeFromDeferredSet(RuntimeScalar scalar) {
-        Integer c = deferredCapturesSet.get(scalar);
+        LifecycleRuntimeState state = state();
+        Integer c = state.deferredCapturesSet.get(scalar);
         if (c == null) return;
-        if (c <= 1) deferredCapturesSet.remove(scalar);
-        else deferredCapturesSet.put(scalar, c - 1);
+        if (c <= 1) state.deferredCapturesSet.remove(scalar);
+        else state.deferredCapturesSet.put(scalar, c - 1);
     }
 
     /**
@@ -220,13 +240,14 @@ public class MortalList {
      * refCount should reflect that the declaring scope is gone.
      */
     public static void flushDeferredCaptures() {
-        if (deferredCaptures.isEmpty()) return;
-        for (RuntimeScalar scalar : deferredCaptures) {
+        LifecycleRuntimeState state = state();
+        if (state.deferredCaptures.isEmpty()) return;
+        for (RuntimeScalar scalar : state.deferredCaptures) {
             deferDecrementIfTracked(scalar);
         }
-        deferredCaptures.clear();
-        deferredCapturesSet.clear();
-        deferredCapturesMayBeReady = false;
+        state.deferredCaptures.clear();
+        state.deferredCapturesSet.clear();
+        state.deferredCapturesMayBeReady = false;
         flush();
 
         // After flushing deferred captures, clear weak refs for objects that
@@ -256,7 +277,7 @@ public class MortalList {
      * spurious decrements from copies that never incremented.
      */
     public static void deferDecrementIfTracked(RuntimeScalar scalar) {
-        if (!active || scalar == null) return;
+        if (!isActive() || scalar == null) return;
         if (!scalar.refCountOwned) return;
         if ((scalar.type & RuntimeScalarType.REFERENCE_BIT) != 0
                 && scalar.value instanceof RuntimeBase base) {
@@ -267,7 +288,9 @@ public class MortalList {
                     base.releaseOwner(scalar, "deferDecrementIfTracked");
                 }
                 base.releaseActiveOwner(scalar);
-                pending.add(base);
+                LifecycleRuntimeState state = state();
+                markBoundaryWork(state);
+                state.pending.add(base);
             } else if (base.refCount == 0
                     && base.clearedOwnedAggregateElement
                     && WeakRefRegistry.hasWeakRefsTo(base)) {
@@ -303,7 +326,7 @@ public class MortalList {
      * DESTROY fires at lexical scope exit.
      */
     public static void releaseCapturedDecrement(RuntimeScalar scalar) {
-        if (!active || scalar == null) return;
+        if (!isActive() || scalar == null) return;
         if (!scalar.refCountOwned) return;
         if ((scalar.type & RuntimeScalarType.REFERENCE_BIT) != 0
                 && scalar.value instanceof RuntimeBase base
@@ -329,7 +352,7 @@ public class MortalList {
      * {@link RuntimeScalar#scopeExitCleanup}.
      */
     public static void deferDecrementIfNotCaptured(RuntimeScalar scalar) {
-        if (!active || scalar == null) return;
+        if (!isActive() || scalar == null) return;
         if (scalar.captureCount > 0) {
             // Delegate to scopeExitCleanup which handles:
             // - Self-referential cycle detection (eval STRING closures)
@@ -348,7 +371,7 @@ public class MortalList {
      * Never-stored blessed objects (refCount == 0) are bumped to ensure DESTROY fires.
      */
     public static void deferDestroyForContainerClear(Iterable<RuntimeScalar> elements) {
-        if (!active) return;
+        if (!isActive()) return;
         for (RuntimeScalar scalar : elements) {
             // Use the recursive path so a discarded wrapper/container also
             // releases references stored in its fields.  Test::Deep's
@@ -388,7 +411,7 @@ public class MortalList {
      * arrays/hashes). Called at scope exit for {@code my %hash} variables.
      */
     public static void scopeExitCleanupHash(RuntimeHash hash) {
-        if (!active || hash == null) return;
+        if (!isActive() || hash == null) return;
         // Clear localBindingExists: the named variable's scope is ending.
         // This allows subsequent refCount==0 events (from setLargeRefCounted
         // or flush) to correctly trigger callDestroy, since the local
@@ -403,7 +426,7 @@ public class MortalList {
         // weak refs anywhere in the JVM. If weak refs exist (even to unblessed
         // data), we must still cascade decrements so their weak-ref entries
         // can be cleared when the referent's refCount reaches 0.
-        if (!RuntimeBase.blessedObjectExists && !WeakRefRegistry.weakRefsExist) return;
+        if (!RuntimeBase.blessedObjectExists() && !WeakRefRegistry.weakRefsExist()) return;
         // If the hash has outstanding references (e.g., from \%hash stored elsewhere),
         // do NOT clean up elements — the hash is still alive and its elements are
         // accessible through the reference. Cleanup will happen when the last
@@ -460,7 +483,7 @@ public class MortalList {
      * arrays/hashes). Called at scope exit for {@code my @array} variables.
      */
     public static void scopeExitCleanupArray(RuntimeArray arr) {
-        if (!active || arr == null) return;
+        if (!isActive() || arr == null) return;
         // Clear localBindingExists: the named variable's scope is ending.
         // This allows subsequent refCount==0 events (from setLargeRefCounted
         // or flush) to correctly trigger callDestroy, since the local
@@ -472,7 +495,7 @@ public class MortalList {
         }
         // Skip container walks only when there are NO blessed objects AND NO
         // weak refs anywhere in the JVM (see scopeExitCleanupHash for details).
-        if (!RuntimeBase.blessedObjectExists && !WeakRefRegistry.weakRefsExist) return;
+        if (!RuntimeBase.blessedObjectExists() && !WeakRefRegistry.weakRefsExist()) return;
         // If the array has outstanding references (e.g., from \@array stored elsewhere),
         // do NOT clean up elements — the array is still alive and its elements are
         // accessible through the reference. Cleanup will happen when the last
@@ -530,7 +553,7 @@ public class MortalList {
     }
 
     public static void releaseTailCallArgs(RuntimeArray args) {
-        if (args == null || !active || !args.elementsOwned) return;
+        if (args == null || !isActive() || !args.elementsOwned) return;
         if (args.elementsAliased) {
             if (args.ownedAliasElements == null || args.ownedAliasElements.isEmpty()) return;
             RuntimeScalar[] owned = args.ownedAliasElements.toArray(new RuntimeScalar[0]);
@@ -548,7 +571,7 @@ public class MortalList {
 
     public static void releaseTailCallCodeRef(RuntimeScalar codeRef) {
         if (codeRef == null
-                || !active
+                || !isActive()
                 || !codeRef.refCountOwned
                 || codeRef.type != RuntimeScalarType.CODE
                 || !(codeRef.value instanceof RuntimeCode code)
@@ -682,13 +705,17 @@ public class MortalList {
                     // activeOwners is diagnostic and can retain a stale
                     // call-frame alias until the enclosing sub returns.
                     releasingLastOwner = base.refCount == 1;
-                    pending.add(base);
+                    LifecycleRuntimeState state = state();
+                    markBoundaryWork(state);
+                    state.pending.add(base);
                 } else if (base.refCount == 0) {
                     if (base.refCountTrace) {
                         base.traceRefCount(+1, "MortalList.deferDecrementRecursive (blessed never-stored bump+queue)");
                     }
                     base.refCount = 1;
-                    pending.add(base);
+                    LifecycleRuntimeState state = state();
+                    markBoundaryWork(state);
+                    state.pending.add(base);
                     // A zero-count blessed container returned from a helper
                     // has no counted owner to release, but its fields still
                     // disappear when this temporary dies.
@@ -721,8 +748,10 @@ public class MortalList {
                         base.traceRefCount(0, "MortalList.deferDecrementRecursive (unblessed container, queued)");
                     }
                     base.releaseActiveOwner(s);
-                    pending.add(base);
-                    if (!WeakRefRegistry.weakRefsExist && base.refCount > 1) {
+                    LifecycleRuntimeState state = state();
+                    markBoundaryWork(state);
+                    state.pending.add(base);
+                    if (!WeakRefRegistry.weakRefsExist() && base.refCount > 1) {
                         continue;
                     }
                     if (!hasCleanupTargets
@@ -733,7 +762,7 @@ public class MortalList {
                         continue;
                     }
                 } else if (base.refCount > 0
-                        && !WeakRefRegistry.weakRefsExist) {
+                        && !WeakRefRegistry.weakRefsExist()) {
                     // A non-owning copy of a still-counted unblessed container
                     // must not release that container's children. With no weak
                     // refs anywhere, there is no weak-ref cleanup that requires
@@ -802,7 +831,7 @@ public class MortalList {
     }
 
     private static boolean containerHasWeakElementRefs(RuntimeBase base) {
-        if (!WeakRefRegistry.weakRefsExist) return false;
+        if (!WeakRefRegistry.weakRefsExist()) return false;
         if (base instanceof RuntimeArray arr) {
             for (RuntimeScalar elem : arr.elements) {
                 if (elem != null && WeakRefRegistry.hasWeakRefsTo(elem)) {
@@ -826,7 +855,7 @@ public class MortalList {
      * Only processes elements with refCount==0 (never-stored objects).
      */
     public static void mortalizeForVoidDiscard(RuntimeList result) {
-        if (!active || result == null) return;
+        if (!isActive() || result == null) return;
         for (RuntimeBase elem : result.elements) {
             if (elem instanceof RuntimeScalar scalar
                     && (scalar.type & RuntimeScalarType.REFERENCE_BIT) != 0
@@ -846,7 +875,9 @@ public class MortalList {
                         base.releaseOwner(scalar, "mortalizeForVoidDiscard container");
                     }
                     base.releaseActiveOwner(scalar);
-                    pending.add(base);
+                    LifecycleRuntimeState state = state();
+                    markBoundaryWork(state);
+                    state.pending.add(base);
                 } else if (base.refCount == 0
                         && (base.blessId != 0
                         || base instanceof RuntimeHash
@@ -856,7 +887,9 @@ public class MortalList {
                         base.traceRefCount(+1, "MortalList.mortalizeForVoidDiscard (refCount=1 bump+queue)");
                     }
                     base.refCount = 1;
-                    pending.add(base);
+                    LifecycleRuntimeState state = state();
+                    markBoundaryWork(state);
+                    state.pending.add(base);
                 }
             }
         }
@@ -865,18 +898,16 @@ public class MortalList {
     // Mark stack for scoped flushing (analogous to Perl 5's SAVETMPS).
     // Each mark records the pending list size at scope entry, so that
     // popAndFlush() only processes entries added within that scope.
-    private static final ArrayList<Integer> marks = new ArrayList<>();
-    private static final ArrayList<Integer> tiedReleaseMarks = new ArrayList<>();
-
     private static void processDeferredEntriesFrom(int pendingStartIdx, int tiedReleaseStartIdx) {
+        LifecycleRuntimeState state = state();
         int pendingIdx = pendingStartIdx;
         int tiedReleaseIdx = tiedReleaseStartIdx;
-        while (pendingIdx < pending.size() || tiedReleaseIdx < pendingTiedReleases.size()) {
-            while (tiedReleaseIdx < pendingTiedReleases.size()) {
-                pendingTiedReleases.get(tiedReleaseIdx++).releaseTiedObject();
+        while (pendingIdx < state.pending.size() || tiedReleaseIdx < state.pendingTiedReleases.size()) {
+            while (tiedReleaseIdx < state.pendingTiedReleases.size()) {
+                state.pendingTiedReleases.get(tiedReleaseIdx++).releaseTiedObject();
             }
-            while (pendingIdx < pending.size()) {
-                processDeferredBase(pending.get(pendingIdx++), false);
+            while (pendingIdx < state.pending.size()) {
+                processDeferredBase(state.pending.get(pendingIdx++), false);
             }
         }
     }
@@ -899,8 +930,6 @@ public class MortalList {
      * list assignment materialization. This prevents premature destruction of
      * return values while the caller is still capturing them into variables.
      */
-    private static boolean flushing = false;
-
     /**
      * Suppress or unsuppress flushing. Used by setFromList to prevent pending
      * decrements from earlier scopes (e.g., clone's $self) being processed
@@ -911,8 +940,9 @@ public class MortalList {
      * @return the previous value of the flushing flag (for nesting).
      */
     public static boolean suppressFlush(boolean suppress) {
-        boolean prev = flushing;
-        flushing = suppress;
+        LifecycleRuntimeState state = state();
+        boolean prev = state.flushing;
+        state.flushing = suppress;
         return prev;
     }
 
@@ -922,7 +952,6 @@ public class MortalList {
     // inside require/use/do/BEGIN/eval-STRING code paths — those
     // often rely on weak-refed intermediate state that the sweep
     // would prematurely clear.
-    private static long lastAutoSweepNanos = 0;
     // Tuned for DBIC-scale tests: 5s throttle. Shorter intervals
     // (100ms, 500ms) fire too frequently — 52leaks.t creates thousands
     // of weaken'd refs and each sweep's System.gc() + weak-ref cascade
@@ -946,24 +975,23 @@ public class MortalList {
     // very slow, only for diagnostics.
     private static final boolean FORCE_SWEEP_EVERY_FLUSH =
             System.getenv("JPERL_FORCE_SWEEP_EVERY_FLUSH") != null;
-    private static boolean inAutoSweep = false;
-    private static boolean immediateWeakSweepRequested = false;
 
     // Objects explicitly released by undef while JVM statement temporaries may
     // still make them appear reachable. Recheck only these referents at the
     // next Perl statement boundary; a full nested-call sweep can invalidate
     // unrelated weak callback graphs whose caller-owned return values have not
     // reached a walker-visible lexical yet.
-    private static final Set<RuntimeBase> targetedWeakSweepReferents =
-            Collections.newSetFromMap(new IdentityHashMap<>());
-
     public static void requestImmediateWeakSweep() {
-        immediateWeakSweepRequested = true;
+        LifecycleRuntimeState state = state();
+        markBoundaryWork(state);
+        state.immediateWeakSweepRequested = true;
     }
 
     public static void requestTargetedWeakSweep(RuntimeBase referent) {
         if (referent != null) {
-            targetedWeakSweepReferents.add(referent);
+            LifecycleRuntimeState state = state();
+            markBoundaryWork(state);
+            state.targetedWeakSweepReferents.add(referent);
         }
     }
 
@@ -1012,7 +1040,7 @@ public class MortalList {
     }
 
     static void finalizeClearedAggregateOwnerAfterScopeExit(RuntimeBase base) {
-        if (!active
+        if (!isActive()
                 || base == null
                 || base.refCount != 0
                 || !base.clearedOwnedAggregateElement
@@ -1031,36 +1059,34 @@ public class MortalList {
     // blessed objects are stored-in-package-global AND have weak refs
     // (Schema/ResultSource back-refs) — every flush would re-walk the
     // full global graph for each one. Computed lazily on first need.
-    private static Set<RuntimeBase> flushReachableCache = null;
-    private static ReachabilityWalker.ExternalRootSnapshot externalRootSnapshot = null;
-    private static ReachabilityWalker.LiveRootSnapshot liveRootSnapshot = null;
-
     private static boolean isReachableCached(RuntimeBase base) {
-        if (flushReachableCache == null) {
+        LifecycleRuntimeState state = state();
+        if (state.flushReachableCache == null) {
             ReachabilityWalker w = new ReachabilityWalker();
-            flushReachableCache = w.walk();
+            state.flushReachableCache = w.walk();
         }
-        return flushReachableCache.contains(base);
+        return state.flushReachableCache.contains(base);
     }
 
     private static boolean isReachableFromExternalRootCached(RuntimeBase base) {
         if (ReachabilityWalker.isReachableFromTemporaryRoots(base)) {
             return true;
         }
-        if (externalRootSnapshot == null) {
-            externalRootSnapshot = new ReachabilityWalker.ExternalRootSnapshot();
+        LifecycleRuntimeState state = state();
+        if (state.externalRootSnapshot == null) {
+            state.externalRootSnapshot = new ReachabilityWalker.ExternalRootSnapshot();
         }
-        if (externalRootSnapshot.isReachableFromNonLexicalRoot(base)) {
+        if (state.externalRootSnapshot.isReachableFromNonLexicalRoot(base)) {
             return true;
         }
-        if (liveRootSnapshot == null) {
-            liveRootSnapshot = new ReachabilityWalker.LiveRootSnapshot();
+        if (state.liveRootSnapshot == null) {
+            state.liveRootSnapshot = new ReachabilityWalker.LiveRootSnapshot();
         }
-        return liveRootSnapshot.isReachable(base);
+        return state.liveRootSnapshot.isReachable(base);
     }
 
     static void invalidateExternalRootSnapshot() {
-        externalRootSnapshot = null;
+        state().externalRootSnapshot = null;
     }
 
     static void invalidateAllRootSnapshots() {
@@ -1069,11 +1095,11 @@ public class MortalList {
     }
 
     static void invalidateLiveRootSnapshot() {
-        liveRootSnapshot = null;
+        state().liveRootSnapshot = null;
     }
 
     private static void invalidateDrainReachabilityCaches() {
-        flushReachableCache = null;
+        state().flushReachableCache = null;
         invalidateLiveRootSnapshot();
     }
 
@@ -1081,10 +1107,11 @@ public class MortalList {
         if (ReachabilityWalker.isReachableFromTemporaryRoots(base)) {
             return true;
         }
-        if (externalRootSnapshot == null) {
-            externalRootSnapshot = new ReachabilityWalker.ExternalRootSnapshot();
+        LifecycleRuntimeState state = state();
+        if (state.externalRootSnapshot == null) {
+            state.externalRootSnapshot = new ReachabilityWalker.ExternalRootSnapshot();
         }
-        return externalRootSnapshot.isReachableFromNonLexicalRoot(base);
+        return state.externalRootSnapshot.isReachableFromNonLexicalRoot(base);
     }
 
     private static void processDeferredBase(RuntimeBase base, boolean clearWeakRefsForLocalBinding) {
@@ -1201,37 +1228,44 @@ public class MortalList {
     }
 
     public static void flush() {
-        if (!active) return;
-        if (flushing) return;
-        if (pending.isEmpty() && pendingTiedReleases.isEmpty()) {
-            processReadyDeferredCaptures();
-            maybeAutoSweepAfterFlush();
+        LifecycleRuntimeState state = state();
+        if (!state.mortalActive) return;
+        if (state.flushing) return;
+        if (state.pending.isEmpty() && state.pendingTiedReleases.isEmpty()) {
+            processReadyDeferredCaptures(state);
+            maybeAutoSweep(state);
+            refreshBoundaryWork(state);
             return;
         }
         invalidateDrainReachabilityCaches();
-        flushing = true;
+        state.flushing = true;
         try {
             processDeferredEntriesFrom(0, 0);
-            pending.clear();
-            pendingTiedReleases.clear();
-            marks.clear(); // All entries drained; marks are meaningless now
-            tiedReleaseMarks.clear();
+            state.pending.clear();
+            state.pendingTiedReleases.clear();
+            state.marks.clear(); // All entries drained; marks are meaningless now
+            state.tiedReleaseMarks.clear();
         } finally {
-            flushing = false;
+            state.flushing = false;
             invalidateDrainReachabilityCaches();
         }
-        processReadyDeferredCaptures();
-        maybeAutoSweepAfterFlush();
+        processReadyDeferredCaptures(state);
+        maybeAutoSweep(state);
+        refreshBoundaryWork(state);
     }
 
     private static void maybeAutoSweep() {
+        maybeAutoSweep(state());
+    }
+
+    private static void maybeAutoSweep(LifecycleRuntimeState state) {
         if (AUTO_GC_DISABLED) return;
-        if (inAutoSweep) return;
-        boolean immediateSweep = immediateWeakSweepRequested;
+        if (state.inAutoSweep) return;
+        boolean immediateSweep = state.immediateWeakSweepRequested;
         // FORCE_SWEEP_EVERY_FLUSH bypasses the weakRefsExist gate AND the
         // 5-s throttle so reproducers can deterministically trigger the
         // walker at every statement boundary.
-        if (!FORCE_SWEEP_EVERY_FLUSH && !WeakRefRegistry.weakRefsExist && !immediateSweep) return;
+        if (!FORCE_SWEEP_EVERY_FLUSH && !state.weakRefsExist && !immediateSweep) return;
         // Phase B2a: skip while require/use/BEGIN/eval-STRING is running.
         // Those paths depend on weak-refed intermediate state staying
         // defined until the init completes.
@@ -1240,17 +1274,17 @@ public class MortalList {
         // temporaries and closure metadata through JVM locals that are not
         // complete Perl-visible walker roots yet.
         if (RuntimeCode.argsStackDepth() > 1) return;
-        if (hasTemporaryRoots()) return;
+        if (!state.temporaryRoots.isEmpty()) return;
         if (!FORCE_SWEEP_EVERY_FLUSH && !immediateSweep) {
             long now = System.nanoTime();
-            if (now - lastAutoSweepNanos < AUTO_SWEEP_MIN_INTERVAL_NS) return;
-            lastAutoSweepNanos = now;
+            if (now - state.lastAutoSweepNanos < AUTO_SWEEP_MIN_INTERVAL_NS) return;
+            state.lastAutoSweepNanos = now;
         }
-        inAutoSweep = true;
+        state.inAutoSweep = true;
         try {
             if (immediateSweep) {
-                immediateWeakSweepRequested = false;
-                lastAutoSweepNanos = System.nanoTime();
+                state.immediateWeakSweepRequested = false;
+                state.lastAutoSweepNanos = System.nanoTime();
             }
             // Quiet auto-sweeps run from normal statement-boundary checks.
             // Do not force HotSpot GC here: current live-lexical tracking is
@@ -1262,35 +1296,32 @@ public class MortalList {
                 System.err.println("DBG auto-sweep cleared=" + cleared);
             }
         } finally {
-            inAutoSweep = false;
+            state.inAutoSweep = false;
         }
     }
 
-    private static void maybeAutoSweepAfterFlush() {
-        maybeAutoSweep();
-    }
-
-    private static void maybeAutoSweepIfRequested() {
-        if (immediateWeakSweepRequested) {
-            maybeAutoSweep();
+    private static void maybeAutoSweepIfRequested(LifecycleRuntimeState state) {
+        if (state.immediateWeakSweepRequested) {
+            maybeAutoSweep(state);
         }
     }
 
-    private static void maybeAutoSweepAtStatementBoundary(boolean topLevel) {
+    private static void maybeAutoSweepAtStatementBoundary(
+            LifecycleRuntimeState state, boolean topLevel) {
         // RuntimeScalar.setLargeRefCounted() flushes while protecting the old
         // and new values as temporary roots.  That is an assignment-internal
         // flush, not a safe Perl statement boundary.  Defer targeted sweeps
         // until the emitted boundary flush after those roots are removed;
         // otherwise every assignment of a DESTROY-able object performs a full
         // root walk when any weak reference exists anywhere in the program.
-        if (!targetedWeakSweepReferents.isEmpty() && !hasTemporaryRoots()) {
+        if (!state.targetedWeakSweepReferents.isEmpty() && state.temporaryRoots.isEmpty()) {
             Set<RuntimeBase> targets = Collections.newSetFromMap(new IdentityHashMap<>());
-            targets.addAll(targetedWeakSweepReferents);
-            targetedWeakSweepReferents.clear();
+            targets.addAll(state.targetedWeakSweepReferents);
+            state.targetedWeakSweepReferents.clear();
             ReachabilityWalker.sweepReleasedWeakReferents(targets);
         }
         if (topLevel) {
-            maybeAutoSweep();
+            maybeAutoSweep(state);
         }
     }
 
@@ -1302,7 +1333,7 @@ public class MortalList {
      * waiting for the outer {@link #flush} to run.
      */
     public static int pendingSize() {
-        return pending.size();
+        return state().pending.size();
     }
 
     /**
@@ -1316,15 +1347,16 @@ public class MortalList {
      * @param startIdx the {@link #pendingSize} captured before apply()
      */
     public static void drainPendingSince(int startIdx) {
-        if (!active) return;
+        if (!isActive()) return;
         if (startIdx < 0) startIdx = 0;
-        if (startIdx >= pending.size()) return;
+        LifecycleRuntimeState state = state();
+        if (startIdx >= state.pending.size()) return;
         invalidateDrainReachabilityCaches();
         // Loop because DESTROY may add further entries
         int i = startIdx;
         try {
-            while (i < pending.size()) {
-                processDeferredBase(pending.get(i), true);
+            while (i < state.pending.size()) {
+                processDeferredBase(state.pending.get(i), true);
                 i++;
             }
         } finally {
@@ -1332,8 +1364,8 @@ public class MortalList {
         }
         // Truncate the pending list back to startIdx to mark these entries
         // as processed. Outer flush won't re-process them.
-        while (pending.size() > startIdx) {
-            pending.remove(pending.size() - 1);
+        while (state.pending.size() > startIdx) {
+            state.pending.remove(state.pending.size() - 1);
         }
     }
 
@@ -1349,9 +1381,10 @@ public class MortalList {
      * Analogous to Perl 5's SAVETMPS.
      */
     public static void pushMark() {
-        if (!active) return;
-        marks.add(pending.size());
-        tiedReleaseMarks.add(pendingTiedReleases.size());
+        if (!isActive()) return;
+        LifecycleRuntimeState state = state();
+        state.marks.add(state.pending.size());
+        state.tiedReleaseMarks.add(state.pendingTiedReleases.size());
     }
 
     /**
@@ -1362,10 +1395,11 @@ public class MortalList {
      * next statement boundary.
      */
     public static void popMark() {
-        if (!active || marks.isEmpty()) return;
-        marks.removeLast();
-        if (!tiedReleaseMarks.isEmpty()) {
-            tiedReleaseMarks.removeLast();
+        if (!isActive() || state().marks.isEmpty()) return;
+        LifecycleRuntimeState state = state();
+        state.marks.removeLast();
+        if (!state.tiedReleaseMarks.isEmpty()) {
+            state.tiedReleaseMarks.removeLast();
         }
     }
 
@@ -1381,38 +1415,43 @@ public class MortalList {
      * If no mark exists (top-level code), behaves like {@link #flush()}.
      */
     public static void flushAboveMark() {
-        if (!active) return;
-        if (flushing) return;
-        boolean topLevel = marks.isEmpty();
-        if (pending.isEmpty() && pendingTiedReleases.isEmpty()) {
-            processReadyDeferredCaptures();
-            maybeAutoSweepAtStatementBoundary(topLevel);
+        if (runtimesWithBoundaryWork.get() == 0) return;
+        LifecycleRuntimeState state = state();
+        if (!state.mortalActive) return;
+        if (state.flushing) return;
+        boolean topLevel = state.marks.isEmpty();
+        if (state.pending.isEmpty() && state.pendingTiedReleases.isEmpty()) {
+            processReadyDeferredCaptures(state);
+            maybeAutoSweepAtStatementBoundary(state, topLevel);
+            refreshBoundaryWork(state);
             return;
         }
-        int mark = marks.isEmpty() ? 0 : marks.getLast();
-        int tiedMark = tiedReleaseMarks.isEmpty() ? 0 : tiedReleaseMarks.getLast();
-        if (pending.size() <= mark && pendingTiedReleases.size() <= tiedMark) {
-            processReadyDeferredCaptures();
-            maybeAutoSweepAtStatementBoundary(topLevel);
+        int mark = state.marks.isEmpty() ? 0 : state.marks.getLast();
+        int tiedMark = state.tiedReleaseMarks.isEmpty() ? 0 : state.tiedReleaseMarks.getLast();
+        if (state.pending.size() <= mark && state.pendingTiedReleases.size() <= tiedMark) {
+            processReadyDeferredCaptures(state);
+            maybeAutoSweepAtStatementBoundary(state, topLevel);
+            refreshBoundaryWork(state);
             return;
         }
         invalidateDrainReachabilityCaches();
-        flushing = true;
+        state.flushing = true;
         try {
             processDeferredEntriesFrom(mark, tiedMark);
             // Remove only entries above the mark
-            while (pending.size() > mark) {
-                pending.removeLast();
+            while (state.pending.size() > mark) {
+                state.pending.removeLast();
             }
-            while (pendingTiedReleases.size() > tiedMark) {
-                pendingTiedReleases.removeLast();
+            while (state.pendingTiedReleases.size() > tiedMark) {
+                state.pendingTiedReleases.removeLast();
             }
         } finally {
-            flushing = false;
+            state.flushing = false;
             invalidateDrainReachabilityCaches();
         }
-        processReadyDeferredCaptures();
-        maybeAutoSweepAtStatementBoundary(topLevel);
+        processReadyDeferredCaptures(state);
+        maybeAutoSweepAtStatementBoundary(state, topLevel);
+        refreshBoundaryWork(state);
     }
 
     /**
@@ -1422,31 +1461,32 @@ public class MortalList {
      * Analogous to Perl 5's FREETMPS after LEAVE.
      */
     public static void popAndFlush() {
-        if (!active || marks.isEmpty()) return;
-        int mark = marks.removeLast();
-        int tiedMark = tiedReleaseMarks.isEmpty() ? 0 : tiedReleaseMarks.removeLast();
-        if (pending.size() <= mark && pendingTiedReleases.size() <= tiedMark) {
+        LifecycleRuntimeState state = state();
+        if (!state.mortalActive || state.marks.isEmpty()) return;
+        int mark = state.marks.removeLast();
+        int tiedMark = state.tiedReleaseMarks.isEmpty() ? 0 : state.tiedReleaseMarks.removeLast();
+        if (state.pending.size() <= mark && state.pendingTiedReleases.size() <= tiedMark) {
             // Even if no mortal entries to process, check deferred captures
             // that may have become ready (captureCount reached 0) during
             // scope cleanup.
-            processReadyDeferredCaptures();
-            maybeAutoSweepIfRequested();
+            processReadyDeferredCaptures(state);
+            maybeAutoSweepIfRequested(state);
             return;
         }
         invalidateDrainReachabilityCaches();
         // Process entries from mark onwards (DESTROY may add new entries)
         processDeferredEntriesFrom(mark, tiedMark);
         // Remove only the entries we processed (keep entries before mark)
-        while (pending.size() > mark) {
-            pending.removeLast();
+        while (state.pending.size() > mark) {
+            state.pending.removeLast();
         }
-        while (pendingTiedReleases.size() > tiedMark) {
-            pendingTiedReleases.removeLast();
+        while (state.pendingTiedReleases.size() > tiedMark) {
+            state.pendingTiedReleases.removeLast();
         }
         invalidateDrainReachabilityCaches();
         // After processing mortals (which may have triggered releaseCaptures
         // via callDestroy), check if any deferred captures are now ready.
-        processReadyDeferredCaptures();
-        maybeAutoSweepIfRequested();
+        processReadyDeferredCaptures(state);
+        maybeAutoSweepIfRequested(state);
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/MyVarCleanupStack.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/MyVarCleanupStack.java
@@ -110,7 +110,7 @@ public class MyVarCleanupStack {
         // weaken trigger a one-time backfill via
         // {@link #snapshotStackToLiveCounts()} from WeakRefRegistry,
         // which seeds liveCounts with all already-registered my-vars.
-        if (var != null && WeakRefRegistry.weakRefsExist) {
+        if (var != null && WeakRefRegistry.weakRefsExist()) {
             liveCounts().merge(var, 1, Integer::sum);
             MortalList.invalidateLiveRootSnapshot();
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/NameNormalizer.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/NameNormalizer.java
@@ -2,9 +2,9 @@ package org.perlonjava.runtime.runtimetypes;
 
 import org.perlonjava.runtime.mro.InheritanceResolver;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The NameNormalizer class provides utility methods for normalizing Perl variable names
@@ -14,21 +14,26 @@ import java.util.Set;
 public class NameNormalizer {
     // Cache to store previously normalized variables for faster lookup
     // Using composite key avoids ~12ns string concatenation per lookup
-    private static final Map<CacheKey, String> nameCache = new HashMap<>();
-    private static final Map<String, Integer> blessIdCache = new HashMap<>();
-    // Changed to HashMap to support non-contiguous IDs (positive: normal, negative: overloaded)
-    private static final Map<Integer, String> blessStrCache = new HashMap<>();
+    private static final Map<CacheKey, String> nameCache = new ConcurrentHashMap<>();
     private static final Set<String> SPECIAL_VARIABLES = Set.of(
             "ARGV", "ARGVOUT", "ENV", "INC", "SIG", "STDOUT", "STDERR", "STDIN"
     );
     // Cache to store blessed class lookups
     // Positive blessIds (1, 2, 3, ...): normal classes without overloads
     // Negative blessIds (-1, -2, -3, ...): classes with overloads (enables fast rejection in OverloadContext.prepare)
-    private static int currentBlessId = 0;
-    private static int currentOverloadedBlessId = -1;
+    public static final class State {
+        final Map<String, Integer> blessIdCache = new java.util.HashMap<>();
+        final Map<Integer, String> blessStrCache = new java.util.HashMap<>();
+        int currentBlessId;
+        int currentOverloadedBlessId = -1;
 
-    static {
-        blessStrCache.put(0, "");  // Reserve 0 for unblessed
+        public State() {
+            blessStrCache.put(0, "");
+        }
+    }
+
+    private static State state() {
+        return PerlRuntime.current().nameNormalizerState;
     }
 
     /**
@@ -40,7 +45,8 @@ public class NameNormalizer {
      * @return The unique ID associated with the class name.
      */
     public static int getBlessId(String str) {
-        Integer id = blessIdCache.get(str);
+        State state = state();
+        Integer id = state.blessIdCache.get(str);
         if (id != null) {
             // If this className was previously anonymized (e.g. by `undef
             // %Pkg::`), the cached id maps to "__ANON__". A NEW `bless` into
@@ -51,7 +57,7 @@ public class NameNormalizer {
             // This is what enables `clean_inc` style patterns (Class::Trait
             // tests, etc.) to wipe and reload a package without leaving new
             // objects stuck reporting "__ANON__".
-            String blessStr = blessStrCache.get(id);
+            String blessStr = state.blessStrCache.get(id);
             if ("__ANON__".equals(blessStr) && !"__ANON__".equals(str)) {
                 id = null;  // fall through to fresh allocation below
             }
@@ -61,21 +67,21 @@ public class NameNormalizer {
             boolean hasOverload = hasOverloadMarker(str);
 
             if (hasOverload) {
-                id = currentOverloadedBlessId;
-                currentOverloadedBlessId--;  // Next overloaded class gets -2, -3, etc.
+                id = state.currentOverloadedBlessId;
+                state.currentOverloadedBlessId--;  // Next overloaded class gets -2, -3, etc.
             } else {
-                currentBlessId++;  // Next normal class gets 2, 3, etc.
-                id = currentBlessId;
+                state.currentBlessId++;  // Next normal class gets 2, 3, etc.
+                id = state.currentBlessId;
             }
 
-            blessIdCache.put(str, id);
-            blessStrCache.put(id, str);
+            state.blessIdCache.put(str, id);
+            state.blessStrCache.put(id, str);
         }
         return id;
     }
 
     public static void invalidateBlessIdCache() {
-        blessIdCache.clear();
+        state().blessIdCache.clear();
     }
 
     /**
@@ -87,12 +93,13 @@ public class NameNormalizer {
     public static int getEffectiveBlessId(int id) {
         if (id == 0) return id;
 
-        String className = blessStrCache.get(id);
+        State state = state();
+        String className = state.blessStrCache.get(id);
         if (className == null || "__ANON__".equals(className)) {
             return id;
         }
 
-        Integer cached = blessIdCache.get(className);
+        Integer cached = state.blessIdCache.get(className);
         if (cached != null && cached < 0) {
             return cached;
         }
@@ -135,13 +142,14 @@ public class NameNormalizer {
      * @return The class name associated with the ID.
      */
     public static String getBlessStr(int id) {
-        return blessStrCache.get(id);
+        return state().blessStrCache.get(id);
     }
 
     public static void anonymizeBlessId(String className) {
-        Integer id = blessIdCache.get(className);
+        State state = state();
+        Integer id = state.blessIdCache.get(className);
         boolean foundExistingId = false;
-        for (Map.Entry<Integer, String> entry : blessStrCache.entrySet()) {
+        for (Map.Entry<Integer, String> entry : state.blessStrCache.entrySet()) {
             if (className.equals(entry.getValue())) {
                 if (id == null) {
                     id = entry.getKey();
@@ -155,9 +163,9 @@ public class NameNormalizer {
             // (until a NEW `bless` rebinds the cache via the
             // anonymized-cache-entry detection in getBlessId above).
             id = getBlessId(className);
-            blessStrCache.put(id, "__ANON__");
+            state.blessStrCache.put(id, "__ANON__");
         }
-        blessIdCache.put(className, id);
+        state.blessIdCache.put(className, id);
         // Note: we deliberately keep the className→id mapping in
         // blessIdCache so that *glob{PACKAGE} on a glob in this stash
         // (and ref() of objects already blessed into this id) continue
@@ -169,7 +177,7 @@ public class NameNormalizer {
     }
 
     public static String getBlessStrForClassName(String className) {
-        Integer id = blessIdCache.get(className);
+        Integer id = state().blessIdCache.get(className);
         if (id == null) {
             return className;
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/Overload.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/Overload.java
@@ -43,9 +43,6 @@ public class Overload {
      * overloaded objects inside overload methods (e.g., an overload that
      * stringifies a DIFFERENT overloaded object).
      */
-    private static final ThreadLocal<Integer> stringifyDepth =
-            ThreadLocal.withInitial(() -> 0);
-
     /** Maximum {@code stringify} recursion before we give up and return default. */
     private static final int STRINGIFY_MAX_DEPTH = 10;
 
@@ -62,7 +59,8 @@ public class Overload {
      */
     public static RuntimeScalar stringify(RuntimeScalar runtimeScalar) {
         // Recursion guard — see STRINGIFY_MAX_DEPTH javadoc.
-        int depth = stringifyDepth.get();
+        ExecutionRuntimeState state = PerlRuntime.current().executionState();
+        int depth = state.overloadStringifyDepth;
         if (depth >= STRINGIFY_MAX_DEPTH) {
             // Skip overload dispatch and return the raw reference form directly.
             if (runtimeScalar.type == RuntimeScalarType.REFERENCE) {
@@ -74,7 +72,7 @@ public class Overload {
             return new RuntimeScalar("");
         }
 
-        stringifyDepth.set(depth + 1);
+        state.overloadStringifyDepth = depth + 1;
         try {
             // Prepare overload context and check if object is eligible for overloading
             int blessId = RuntimeScalarType.blessedId(runtimeScalar);
@@ -101,7 +99,7 @@ public class Overload {
             }
             return new RuntimeScalar(((RuntimeBase) runtimeScalar.value).toStringRef());
         } finally {
-            stringifyDepth.set(depth);
+            state.overloadStringifyDepth = depth;
         }
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -1,8 +1,22 @@
 package org.perlonjava.runtime.runtimetypes;
 
+import org.perlonjava.backend.jvm.ByteCodeSourceMapper;
+import org.perlonjava.frontend.parser.DataSection;
+import org.perlonjava.runtime.CompilationRuntimeState;
+import org.perlonjava.runtime.ForkOpenState;
+import org.perlonjava.runtime.debugger.DebugRuntimeState;
 import org.perlonjava.runtime.io.IOHandle;
+import org.perlonjava.runtime.io.IORuntimeRegistryState;
 import org.perlonjava.runtime.io.StandardIO;
 import org.perlonjava.runtime.mro.MroRuntimeState;
+import org.perlonjava.runtime.operators.Time;
+import org.perlonjava.runtime.operators.Random;
+import org.perlonjava.runtime.operators.ScalarFlipFlopOperator;
+import org.perlonjava.runtime.operators.ScalarGlobOperator;
+import org.perlonjava.runtime.operators.FileTestOperator;
+import org.perlonjava.runtime.perlmodule.FilterRuntimeState;
+import org.perlonjava.runtime.perlmodule.NetSSLeay;
+import org.perlonjava.runtime.nativ.ExtendedNativeUtils;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -10,6 +24,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.Callable;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Identity and scoped thread binding for one Perl interpreter instance.
@@ -19,14 +37,40 @@ import java.util.Set;
  * they do not inherit into child or executor threads, whose tasks must capture
  * and bind the intended runtime themselves.</p>
  */
-public final class PerlRuntime {
+public final class PerlRuntime implements AutoCloseable {
     private static final ThreadLocal<BindingFrame> CURRENT = new ThreadLocal<>();
+    public final long pid = ProcessHandle.current().pid();
+    String currentDirectory = System.getProperty("user.dir");
+    private final ReentrantLock executionLock = new ReentrantLock();
+    private volatile boolean initialized;
+    private volatile boolean closed;
 
     public final ExecutionRuntimeState executionState = new ExecutionRuntimeState();
     public final RuntimeRegexState regexState = new RuntimeRegexState();
     public final MroRuntimeState mroState = new MroRuntimeState();
     public final GlobalRuntimeState globalState = new GlobalRuntimeState();
     public final RuntimeCodeRuntimeState runtimeCodeState = new RuntimeCodeRuntimeState();
+    public final CompilationRuntimeState compilationState = new CompilationRuntimeState();
+    public final ByteCodeSourceMapper.State sourceMapperState = new ByteCodeSourceMapper.State();
+    public final FilterRuntimeState filterState = new FilterRuntimeState();
+    public final Time.State timeState = new Time.State();
+    public final PerlSignalQueue.State signalState = new PerlSignalQueue.State();
+    public final Random.State randomState = new Random.State();
+    public final DataSection.State dataSectionState = new DataSection.State();
+    public final Map<Integer, ScalarFlipFlopOperator> flipFlopState = new HashMap<>();
+    public final Map<Integer, ScalarGlobOperator> scalarGlobState = new HashMap<>();
+    public final Map<Integer, String> pointerPackState = new HashMap<>();
+    public final IORuntimeRegistryState ioRegistryState = new IORuntimeRegistryState();
+    public final FileTestOperator.State fileTestState = new FileTestOperator.State();
+    public final DebugRuntimeState debugState = new DebugRuntimeState();
+    public final DiamondIO.State diamondIOState = new DiamondIO.State();
+    public final ExtendedNativeUtils.State nativeState = new ExtendedNativeUtils.State();
+    public final Deque<Long> netSslErrorQueue = new ArrayDeque<>();
+    public final NetSSLeay.State netSslState = new NetSSLeay.State();
+    public ForkOpenState.PendingForkOpen pendingForkOpen;
+    public RuntimeArray libOriginalInc;
+    public boolean storableLastOpInNetorder;
+    public final Set<String> xsShimLoadingInProgress = new HashSet<>();
 
     RuntimeIO ioStdout;
     RuntimeIO ioStderr;
@@ -51,6 +95,9 @@ public final class PerlRuntime {
     };
     private final Map<String, RuntimeGlob> standardIOGlobs = new HashMap<>();
     private final Set<String> hiddenStandardIOGlobs = new HashSet<>();
+    final Map<String, Boolean> stateVariableInitialized = new HashMap<>();
+    final LifecycleRuntimeState lifecycleState = new LifecycleRuntimeState();
+    final NameNormalizer.State nameNormalizerState = new NameNormalizer.State();
 
     public PerlRuntime() {
         ioStdout = new RuntimeIO(new StandardIO(System.out, true));
@@ -89,6 +136,9 @@ public final class PerlRuntime {
 
     /** Bind this runtime until the returned scope is closed. */
     public Binding bind() {
+        if (closed) {
+            throw new IllegalStateException("PerlRuntime is closed");
+        }
         BindingFrame frame = new BindingFrame(this, CURRENT.get());
         CURRENT.set(frame);
         return new Binding(frame, Thread.currentThread());
@@ -127,6 +177,84 @@ public final class PerlRuntime {
 
     public RuntimeCodeRuntimeState runtimeCodeState() {
         return runtimeCodeState;
+    }
+
+    /** Initialize this independent interpreter's globals and runtime services. */
+    public PerlRuntime initialize() {
+        executionLock.lock();
+        try {
+            if (closed) throw new IllegalStateException("PerlRuntime is closed");
+            if (initialized) return this;
+            try (Binding ignored = bind()) {
+                org.perlonjava.app.scriptengine.PerlLanguageProvider.resetAll();
+            }
+            initialized = true;
+            return this;
+        } finally {
+            executionLock.unlock();
+        }
+    }
+
+    /** Execute one operation while enforcing exclusive runtime ownership. */
+    public <T> T execute(Callable<T> operation) throws Exception {
+        Objects.requireNonNull(operation, "operation");
+        executionLock.lock();
+        try {
+            if (!initialized) initialize();
+            try (Binding ignored = bind()) {
+                return operation.call();
+            }
+        } finally {
+            executionLock.unlock();
+        }
+    }
+
+    /** Execute a void operation while enforcing exclusive runtime ownership. */
+    public void execute(Runnable operation) {
+        Objects.requireNonNull(operation, "operation");
+        try {
+            execute(() -> {
+                operation.run();
+                return null;
+            });
+        } catch (RuntimeException | Error error) {
+            throw error;
+        } catch (Exception impossible) {
+            throw new IllegalStateException("Runnable execution failed", impossible);
+        }
+    }
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
+
+    /** Release runtime-owned I/O, alarms, signals, and lifecycle registries. */
+    @Override
+    public void close() {
+        executionLock.lock();
+        try {
+            if (closed) return;
+            try (Binding ignored = bind()) {
+                Time.cancelCurrentAlarm();
+                PerlSignalQueue.clearSignals();
+                RuntimeIO.closeAllHandles();
+                NetSSLeay.resetState();
+                MortalList.clearCurrentRuntimeState();
+                stateVariableInitialized.clear();
+                ioRegistryState.clear();
+                nativeState.clear();
+                flipFlopState.clear();
+                scalarGlobState.clear();
+                pointerPackState.clear();
+            }
+            closed = true;
+        } finally {
+            executionLock.unlock();
+        }
     }
 
     RuntimeGlob standardIOGlob(String name) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -28,6 +28,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.concurrent.Callable;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.TreeSet;
 
 /**
  * Identity and scoped thread binding for one Perl interpreter instance.
@@ -200,7 +201,16 @@ public final class PerlRuntime implements AutoCloseable {
         Objects.requireNonNull(operation, "operation");
         executionLock.lock();
         try {
-            if (!initialized) initialize();
+            if (!initialized) {
+                // Public provider/JSR entry points may have initialized this
+                // runtime before it was adopted by the managed lifecycle API.
+                // Never reset that live package graph just to mark ownership.
+                if (globalState.coreGlobalsInitialized()) {
+                    initialized = true;
+                } else {
+                    initialize();
+                }
+            }
             try (Binding ignored = bind()) {
                 return operation.call();
             }
@@ -230,6 +240,83 @@ public final class PerlRuntime implements AutoCloseable {
 
     public boolean isClosed() {
         return closed;
+    }
+
+    /**
+     * Clone this interpreter's package graph for a new ithread. Execution,
+     * lifecycle, alarm, signal, native and I/O state starts fresh in the child.
+     */
+    public PerlRuntime snapshotClone() {
+        executionLock.lock();
+        try {
+            if (closed) throw new IllegalStateException("PerlRuntime is closed");
+            if (!initialized) {
+                if (globalState.coreGlobalsInitialized()) {
+                    initialized = true;
+                } else {
+                    initialize();
+                }
+            }
+
+            Set<String> skipped;
+            try (Binding ignored = bind()) {
+                materializeCloneHookDefinitions();
+                skipped = preflightCloneSkip();
+            }
+
+            PerlRuntime child = new PerlRuntime();
+            RuntimeGraphCloner cloner = new RuntimeGraphCloner(this, child, skipped);
+            try (Binding ignored = bind()) {
+                globalState.snapshotInto(child.globalState, cloner);
+            }
+            child.currentDirectory = currentDirectory;
+            child.initialized = true;
+            try (Binding ignored = child.bind()) {
+                child.runCloneHooks();
+            }
+            return child;
+        } finally {
+            executionLock.unlock();
+        }
+    }
+
+    private Set<String> preflightCloneSkip() {
+        Set<String> skipped = new HashSet<>();
+        for (String fqn : new TreeSet<>(globalState.codeRefs().keySet())) {
+            if (!fqn.endsWith("::CLONE_SKIP")) continue;
+            RuntimeScalar hook = globalState.codeRefs().get(fqn);
+            if (hook == null || !(hook.value instanceof RuntimeCode code) || !code.defined()) continue;
+            String packageName = fqn.substring(0, fqn.length() - "::CLONE_SKIP".length());
+            RuntimeArray args = new RuntimeArray(new RuntimeScalar(packageName));
+            if (RuntimeCode.apply(hook, args, RuntimeContextType.SCALAR).scalar().getBoolean()) {
+                skipped.add(packageName);
+            }
+        }
+        return skipped;
+    }
+
+    private void materializeCloneHookDefinitions() {
+        for (Map.Entry<String, RuntimeScalar> entry
+                : new java.util.ArrayList<>(globalState.codeRefs().entrySet())) {
+            String fqn = entry.getKey();
+            if (!fqn.endsWith("::CLONE") && !fqn.endsWith("::CLONE_SKIP")) continue;
+            RuntimeScalar hook = entry.getValue();
+            if (hook != null && hook.value instanceof RuntimeCode code
+                    && code.compilerSupplier != null) {
+                code.compilerSupplier.get();
+            }
+        }
+    }
+
+    private void runCloneHooks() {
+        for (String fqn : new TreeSet<>(globalState.codeRefs().keySet())) {
+            if (!fqn.endsWith("::CLONE") || fqn.endsWith("::CLONE_SKIP")) continue;
+            RuntimeScalar hook = globalState.codeRefs().get(fqn);
+            if (hook == null || !(hook.value instanceof RuntimeCode code) || !code.defined()) continue;
+            String packageName = fqn.substring(0, fqn.length() - "::CLONE".length());
+            RuntimeCode.apply(hook, new RuntimeArray(new RuntimeScalar(packageName)),
+                    RuntimeContextType.VOID);
+        }
     }
 
     /** Release runtime-owned I/O, alarms, signals, and lifecycle registries. */

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlSignalQueue.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlSignalQueue.java
@@ -9,11 +9,14 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * rather than the timer thread context.
  */
 public class PerlSignalQueue {
-    private static final Queue<SignalEvent> signalQueue = new ConcurrentLinkedQueue<>();
+    public static final class State {
+        final Queue<SignalEvent> signalQueue = new ConcurrentLinkedQueue<>();
+        volatile boolean hasPendingSignal;
+    }
 
-    // Volatile flag for ultra-fast signal checking in hot paths
-    // Reading a volatile boolean is ~2 CPU cycles, much faster than queue.isEmpty()
-    private static volatile boolean hasPendingSignal = false;
+    private static State state() {
+        return PerlRuntime.current().signalState;
+    }
 
     /**
      * Enqueue a signal for processing in the main thread.
@@ -22,8 +25,9 @@ public class PerlSignalQueue {
      * @param handler The signal handler to execute
      */
     public static void enqueue(String signal, RuntimeScalar handler) {
-        signalQueue.offer(new SignalEvent(signal, handler));
-        hasPendingSignal = true;  // Set flag for fast checking
+        State state = state();
+        state.signalQueue.offer(new SignalEvent(signal, handler));
+        state.hasPendingSignal = true;  // Set flag for fast checking
     }
 
     /**
@@ -32,7 +36,7 @@ public class PerlSignalQueue {
      * Signal handlers may throw PerlCompilerException which will propagate.
      */
     public static void checkPendingSignals() {
-        if (!hasPendingSignal) {
+        if (!state().hasPendingSignal) {
             return;  // Fast path: no signals pending
         }
         // Slow path: process signals (rare)
@@ -52,15 +56,16 @@ public class PerlSignalQueue {
      * Internal implementation of signal processing.
      */
     private static void processSignalsImpl() {
+        State state = state();
         Thread.interrupted();
         SignalEvent event;
-        while ((event = signalQueue.poll()) != null) {
-            hasPendingSignal = !signalQueue.isEmpty();
+        while ((event = state.signalQueue.poll()) != null) {
+            state.hasPendingSignal = !state.signalQueue.isEmpty();
             RuntimeArray args = new RuntimeArray();
             args.push(new RuntimeScalar(event.signal));
             RuntimeCode.apply(event.handler, args, RuntimeContextType.VOID);
         }
-        hasPendingSignal = false;
+        state.hasPendingSignal = false;
     }
 
     /**
@@ -69,14 +74,16 @@ public class PerlSignalQueue {
      * @return true if signals are pending
      */
     public static boolean hasPendingSignals() {
-        return !signalQueue.isEmpty();
+        return !state().signalQueue.isEmpty();
     }
 
     /**
      * Clear all pending signals (used for cleanup).
      */
     public static void clearSignals() {
-        signalQueue.clear();
+        State state = state();
+        state.signalQueue.clear();
+        state.hasPendingSignal = false;
     }
 
     static class SignalEvent {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ReachabilityWalker.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ReachabilityWalker.java
@@ -1398,7 +1398,7 @@ public class ReachabilityWalker {
      * @return number of weak-ref entries cleared
      */
     public static int sweepWeakRefs(boolean quiet, boolean forceJvmGc) {
-        if (!WeakRefRegistry.weakRefsExist) return 0;
+        if (!WeakRefRegistry.weakRefsExist()) return 0;
         if (forceJvmGc) {
             ScalarRefRegistry.forceGcAndSnapshot();
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeBase.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeBase.java
@@ -332,7 +332,13 @@ public abstract class RuntimeBase implements DynamicState, Iterable<RuntimeScala
      * walks when no blessed objects have ever been created in this JVM instance.
      * Once set to true, it stays true forever (conservative but safe).
      */
-    public static volatile boolean blessedObjectExists = false;
+    public static boolean blessedObjectExists() {
+        return PerlRuntime.current().lifecycleState.blessedObjectExists;
+    }
+
+    static void noteBlessedObject() {
+        PerlRuntime.current().lifecycleState.blessedObjectExists = true;
+    }
 
     /**
      * Adds this entity to the specified RuntimeList.
@@ -416,7 +422,7 @@ public abstract class RuntimeBase implements DynamicState, Iterable<RuntimeScala
 
     public void setBlessId(int blessId) {
         this.blessId = blessId;
-        if (blessId != 0) blessedObjectExists = true;
+        if (blessId != 0) noteBlessedObject();
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeBaseProxy.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeBaseProxy.java
@@ -381,6 +381,6 @@ public abstract class RuntimeBaseProxy extends RuntimeScalar {
         // Don't vivify when blessing - we're not modifying the underlying value,
         // just setting the blessId on the lvalue itself
         this.blessId = blessId;
-        if (blessId != 0) blessedObjectExists = true;
+        if (blessId != 0) noteBlessedObject();
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -3796,7 +3796,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 // test 18).
                 if (calledFromDB) {
                     RuntimeArray dbArgs = GlobalVariable.getGlobalArray("DB::args");
-                    if (DebugState.debugMode) {
+                    if (DebugState.isDebugMode()) {
                         RuntimeArray frameArgs = DebugState.getArgsForFrame(frame);
                         if (frameArgs != null) {
                             dbArgs.setFromListAliased(frameArgs.getList());
@@ -4355,16 +4355,18 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             int effectiveContext = effectiveCallContext(code, callContext);
             // Look up warning bits for the code's class and push to context stack
             // This enables FATAL warnings to work even at top-level (no caller frame)
-            String warningBits = getWarningBitsForCode(code);
+            org.perlonjava.runtime.CompilationRuntimeState compilationState =
+                    PerlRuntime.current().compilationState;
+            String warningBits = getWarningBitsForCode(code, compilationState);
             if (warningBits != null) {
-                WarningBitsRegistry.pushCurrent(warningBits);
+                WarningBitsRegistry.pushCurrent(warningBits, compilationState);
             }
             // Save caller's call-site warning bits so caller()[9] can retrieve them
-            WarningBitsRegistry.pushCallerBits();
+            WarningBitsRegistry.pushCallerBits(compilationState);
             // Save caller's $^H so caller()[8] can retrieve them
-            WarningBitsRegistry.pushCallerHints();
+            WarningBitsRegistry.pushCallerHints(compilationState);
             // Save caller's call-site hint hash so caller()[10] can retrieve them
-            HintHashRegistry.pushCallerHintHash();
+            HintHashRegistry.pushCallerHintHash(compilationState);
             int cleanupMark = MyVarCleanupStack.pushMark();
             // Establish a function-scoped mortal boundary so that
             // statement-boundary flushAboveMark() inside this function
@@ -4444,11 +4446,11 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 // After unwindTo, entries are already removed; popMark is a no-op.
                 // On normal return, popMark discards registrations without cleanup.
                 MyVarCleanupStack.popMark(cleanupMark);
-                HintHashRegistry.popCallerHintHash();
-                WarningBitsRegistry.popCallerHints();
-                WarningBitsRegistry.popCallerBits();
+                HintHashRegistry.popCallerHintHash(compilationState);
+                WarningBitsRegistry.popCallerHints(compilationState);
+                WarningBitsRegistry.popCallerBits(compilationState);
                 if (warningBits != null) {
-                    WarningBitsRegistry.popCurrent();
+                    WarningBitsRegistry.popCurrent(compilationState);
                 }
                 // eval BLOCK is compiled as an immediately-invoked anonymous sub
                 // (sub { ... }->()) that captures outer lexicals, incrementing their
@@ -4584,6 +4586,12 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
      * @return The warning bits string, or null if not available
      */
     public static String getWarningBitsForCode(RuntimeCode code) {
+        return getWarningBitsForCode(code, PerlRuntime.current().compilationState);
+    }
+
+    private static String getWarningBitsForCode(
+            RuntimeCode code,
+            org.perlonjava.runtime.CompilationRuntimeState compilationState) {
         // For InterpretedCode, use the stored field directly
         if (code instanceof org.perlonjava.backend.bytecode.InterpretedCode interpCode) {
             return interpCode.warningBitsString;
@@ -4597,7 +4605,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 // The type contains the declaring class as the first parameter type for instance methods
                 // For our generated apply methods, we use the class that was loaded
                 String className = code.methodHandle.type().parameterType(0).getName();
-                return WarningBitsRegistry.get(className);
+                return compilationState.warningBitsByClass.get(className);
             } catch (Exception e) {
                 // If we can't get the class name, fall back to null
                 return null;
@@ -4687,23 +4695,25 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 requireLvalueCallable(code, callContext, subroutineName);
                 int effectiveContext = effectiveCallContext(code, callContext);
                 // Look up warning bits for the code's class and push to context stack
-                String warningBits = getWarningBitsForCode(code);
+                org.perlonjava.runtime.CompilationRuntimeState compilationState =
+                        PerlRuntime.current().compilationState;
+                String warningBits = getWarningBitsForCode(code, compilationState);
                 if (warningBits != null) {
-                    WarningBitsRegistry.pushCurrent(warningBits);
+                    WarningBitsRegistry.pushCurrent(warningBits, compilationState);
                 }
                 // Interpreter statement boundaries expose their lexical warning
                 // bits through runtimeWarningBits. A call into JVM-compiled Perl
                 // must replace that value with the callee's definition-time bits
                 // (or null when it has none), otherwise caller warnings leak into
                 // helpers such as test.pl::skip despite `local $^W = 0`.
-                String savedRuntimeWarningBits = WarningBitsRegistry.getRuntimeWarningBits();
-                WarningBitsRegistry.setRuntimeWarningBits(warningBits);
+                String savedRuntimeWarningBits = compilationState.runtimeWarningBits;
+                compilationState.runtimeWarningBits = warningBits;
                 // Save caller's call-site warning bits so caller()[9] can retrieve them
-                WarningBitsRegistry.pushCallerBits();
+                WarningBitsRegistry.pushCallerBits(compilationState);
                 // Save caller's $^H so caller()[8] can retrieve them
-                WarningBitsRegistry.pushCallerHints();
+                WarningBitsRegistry.pushCallerHints(compilationState);
                 // Save caller's call-site hint hash so caller()[10] can retrieve them
-                HintHashRegistry.pushCallerHintHash();
+                HintHashRegistry.pushCallerHintHash(compilationState);
                 int cleanupMark = MyVarCleanupStack.pushMark();
                 MortalList.pushMark();
                 try {
@@ -4738,12 +4748,12 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     }
                     MortalList.popMark();
                     MyVarCleanupStack.popMark(cleanupMark);
-                    HintHashRegistry.popCallerHintHash();
-                    WarningBitsRegistry.popCallerHints();
-                    WarningBitsRegistry.popCallerBits();
-                    WarningBitsRegistry.setRuntimeWarningBits(savedRuntimeWarningBits);
+                    HintHashRegistry.popCallerHintHash(compilationState);
+                    WarningBitsRegistry.popCallerHints(compilationState);
+                    WarningBitsRegistry.popCallerBits(compilationState);
+                    compilationState.runtimeWarningBits = savedRuntimeWarningBits;
                     if (warningBits != null) {
-                        WarningBitsRegistry.popCurrent();
+                        WarningBitsRegistry.popCurrent(compilationState);
                     }
                 }
             }
@@ -4952,16 +4962,18 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 requireLvalueCallable(code, callContext, subroutineName);
                 int effectiveContext = effectiveCallContext(code, callContext);
                 // Look up warning bits for the code's class and push to context stack
-                String warningBits = getWarningBitsForCode(code);
+                org.perlonjava.runtime.CompilationRuntimeState compilationState =
+                        PerlRuntime.current().compilationState;
+                String warningBits = getWarningBitsForCode(code, compilationState);
                 if (warningBits != null) {
-                    WarningBitsRegistry.pushCurrent(warningBits);
+                    WarningBitsRegistry.pushCurrent(warningBits, compilationState);
                 }
                 // Save caller's call-site warning bits so caller()[9] can retrieve them
-                WarningBitsRegistry.pushCallerBits();
+                WarningBitsRegistry.pushCallerBits(compilationState);
                 // Save caller's $^H so caller()[8] can retrieve them
-                WarningBitsRegistry.pushCallerHints();
+                WarningBitsRegistry.pushCallerHints(compilationState);
                 // Save caller's call-site hint hash so caller()[10] can retrieve them
-                HintHashRegistry.pushCallerHintHash();
+                HintHashRegistry.pushCallerHintHash(compilationState);
                 int cleanupMark = MyVarCleanupStack.pushMark();
                 MortalList.pushMark();
                 try {
@@ -4996,11 +5008,11 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     }
                     MortalList.popMark();
                     MyVarCleanupStack.popMark(cleanupMark);
-                    HintHashRegistry.popCallerHintHash();
-                    WarningBitsRegistry.popCallerHints();
-                    WarningBitsRegistry.popCallerBits();
+                    HintHashRegistry.popCallerHintHash(compilationState);
+                    WarningBitsRegistry.popCallerHints(compilationState);
+                    WarningBitsRegistry.popCallerBits(compilationState);
                     if (warningBits != null) {
-                        WarningBitsRegistry.popCurrent();
+                        WarningBitsRegistry.popCurrent(compilationState);
                     }
                 }
             }
@@ -5418,7 +5430,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             int effectiveContext = effectiveCallContext(this, callContext);
 
             // Debug mode: push args and track subroutine entry
-            if (DebugState.debugMode) {
+            if (DebugState.isDebugMode()) {
                 String debugSubName = (this.subName != null)
                         ? NameNormalizer.normalizeVariableName(this.subName, this.packageName != null ? this.packageName : "main")
                         : "";
@@ -5470,7 +5482,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 exitCall();
                 popActiveCode(this);
                 popArgs(); // also pops hasArgsStack — see popArgs() implementation
-                if (DebugState.debugMode) {
+                if (DebugState.isDebugMode()) {
                     DebugHooks.exitSubroutine();
                     DebugState.popArgs();
                 }
@@ -5553,7 +5565,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             int effectiveContext = effectiveCallContext(this, callContext);
 
             // Debug mode: push args and track subroutine entry
-            if (DebugState.debugMode) {
+            if (DebugState.isDebugMode()) {
                 String debugSubName;
                 if (this.subName != null) {
                     debugSubName = NameNormalizer.normalizeVariableName(this.subName, this.packageName != null ? this.packageName : "main");
@@ -5609,7 +5621,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 exitCall();
                 popActiveCode(this);
                 popArgs(); // also pops hasArgsStack — see popArgs() implementation
-                if (DebugState.debugMode) {
+                if (DebugState.isDebugMode()) {
                     DebugHooks.exitSubroutine();
                     DebugState.popArgs();
                 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeEnvironment.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeEnvironment.java
@@ -1,0 +1,27 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/** Runtime-owned process-like environment that Perl may change independently. */
+public final class RuntimeEnvironment {
+    private RuntimeEnvironment() {
+    }
+
+    public static String currentDirectory() {
+        return PerlRuntime.current().currentDirectory;
+    }
+
+    public static void setCurrentDirectory(String directory) {
+        PerlRuntime.current().currentDirectory = Paths.get(directory).toAbsolutePath().normalize().toString();
+    }
+
+    public static Path resolve(String path) {
+        Path candidate = Paths.get(path);
+        return candidate.isAbsolute() ? candidate : Paths.get(currentDirectory()).resolve(candidate);
+    }
+
+    public static long pid() {
+        return PerlRuntime.current().pid;
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
@@ -1,9 +1,11 @@
 package org.perlonjava.runtime.runtimetypes;
 
+import org.perlonjava.backend.bytecode.InterpretedCode;
 import org.perlonjava.runtime.regex.RuntimeRegex;
 
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -81,8 +83,143 @@ public class RuntimeGraphCloner {
         throw new IllegalArgumentException("Unsupported Perl graph node: " + value.getClass().getName());
     }
 
-    protected RuntimeBase cloneCode(RuntimeCode code) {
-        throw new IllegalStateException("CODE cloning requires Phase 15 capture metadata");
+    protected RuntimeBase cloneCode(RuntimeCode source) {
+        Object existing = clones.get(source);
+        if (existing != null) return (RuntimeCode) existing;
+
+        RuntimeCode target;
+        if (source instanceof InterpretedCode interpreted) {
+            target = cloneInterpretedCode(interpreted);
+        } else {
+            target = new RuntimeCode((PerlSubroutine) null, source.prototype);
+            clones.put(source, target);
+            if (source.subroutine instanceof CloneablePerlSubroutine cloneable) {
+                RuntimeBase[] captures = cloneable.capturedValues();
+                RuntimeBase[] clonedCaptures = new RuntimeBase[captures.length];
+                for (int i = 0; i < captures.length; i++) {
+                    clonedCaptures[i] = cloneValue(captures[i]);
+                }
+                CloneablePerlSubroutine clonedSubroutine = cloneable.cloneWithCaptures(clonedCaptures);
+                target.subroutine = clonedSubroutine;
+                target.codeObject = clonedSubroutine;
+            } else {
+                // Java/native PerlSubroutine implementations carry no Perl pad.
+                target.subroutine = source.subroutine;
+                target.codeObject = source.codeObject;
+                target.methodHandle = source.methodHandle;
+            }
+        }
+        copyCodeMetadata(source, target);
+        return target;
+    }
+
+    private InterpretedCode cloneInterpretedCode(InterpretedCode source) {
+        // Register a temporary RuntimeCode first so recursive captured CODE
+        // edges resolve. The finished interpreted object replaces it before
+        // any public clone boundary returns.
+        RuntimeCode placeholder = new RuntimeCode((PerlSubroutine) null, source.prototype);
+        clones.put(source, placeholder);
+
+        RuntimeBase[] captures = cloneRuntimeBases(source.capturedVars);
+        Object[] constants = source.constants.clone();
+        for (int i = 0; i < constants.length; i++) {
+            if (constants[i] instanceof RuntimeBase base) constants[i] = cloneValue(base);
+        }
+        InterpretedCode target;
+        try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
+            target = new InterpretedCode(
+                    source.bytecode, constants, source.stringPool, source.maxRegisters, captures,
+                    source.sourceName, source.sourceLine, source.pcToTokenIndex,
+                    source.variableRegistry, source.errorUtil, source.strictOptions,
+                    source.featureFlags, source.warningFlags, source.compilePackage,
+                    source.evalSiteRegistries, source.evalSitePragmaFlags,
+                    source.warningBitsString);
+        }
+        clones.put(source, target);
+        target.ourVariableRegistry = source.ourVariableRegistry;
+        target.usesLocalization = source.usesLocalization;
+        target.futureAsyncAwaitSub = source.futureAsyncAwaitSub;
+        target.futureAsyncAwaitFutureClass = source.futureAsyncAwaitFutureClass;
+        target.signatureMinArgs = source.signatureMinArgs;
+        target.signatureMaxArgs = source.signatureMaxArgs;
+        target.signatureSubName = source.signatureSubName;
+        target.gotoLabelPcs = source.gotoLabelPcs;
+        copyCodeMetadata(source, target);
+        return target;
+    }
+
+    private RuntimeBase[] cloneRuntimeBases(RuntimeBase[] values) {
+        if (values == null) return null;
+        RuntimeBase[] result = new RuntimeBase[values.length];
+        for (int i = 0; i < values.length; i++) result[i] = cloneValue(values[i]);
+        return result;
+    }
+
+    private void copyCodeMetadata(RuntimeCode source, RuntimeCode target) {
+        target.prototype = source.prototype;
+        target.attributes = source.attributes == null ? null : new ArrayList<>(source.attributes);
+        target.packageName = source.packageName;
+        target.subName = source.subName;
+        target.sourcePackage = source.sourcePackage;
+        target.autoloadVariableName = source.autoloadVariableName;
+        target.isStatic = source.isStatic;
+        target.isBuiltin = source.isBuiltin;
+        target.isDeclared = source.isDeclared;
+        target.isSymbolicReference = source.isSymbolicReference;
+        target.isClosurePrototype = source.isClosurePrototype;
+        target.isMapGrepBlock = source.isMapGrepBlock;
+        target.isEvalBlock = source.isEvalBlock;
+        target.isTryExpressionWrapper = source.isTryExpressionWrapper;
+        target.cvStartFile = source.cvStartFile;
+        target.cvStartLine = source.cvStartLine;
+        target.deparseSourceText = source.deparseSourceText;
+        target.deparseFlags = source.deparseFlags;
+        target.deparseSourceOffset = source.deparseSourceOffset;
+        target.deparseSourceEnd = source.deparseSourceEnd;
+        target.lexicalVariableNames = source.lexicalVariableNames == null
+                ? null : new java.util.LinkedHashSet<>(source.lexicalVariableNames);
+        target.stateVariableInitialized = new java.util.HashMap<>(source.stateVariableInitialized);
+        target.stateVariable = cloneScalarMap(source.stateVariable);
+        target.stateArray = cloneArrayMap(source.stateArray);
+        target.stateHash = cloneHashMap(source.stateHash);
+        target.constantValue = source.constantValue;
+
+        if (source.closedOverVariables != null) {
+            target.closedOverVariables = new LinkedHashMap<>();
+            for (Map.Entry<String, RuntimeBase> entry : source.closedOverVariables.entrySet()) {
+                target.closedOverVariables.put(entry.getKey(), cloneValue(entry.getValue()));
+            }
+            target.capturedScalars = target.closedOverVariables.values().stream()
+                    .filter(RuntimeScalar.class::isInstance).map(RuntimeScalar.class::cast)
+                    .toArray(RuntimeScalar[]::new);
+            target.capturedAggregates = target.closedOverVariables.values().stream()
+                    .filter(value -> value instanceof RuntimeArray || value instanceof RuntimeHash)
+                    .toArray(RuntimeBase[]::new);
+        }
+    }
+
+    private Map<String, RuntimeScalar> cloneScalarMap(Map<String, RuntimeScalar> source) {
+        Map<String, RuntimeScalar> result = new java.util.HashMap<>();
+        for (Map.Entry<String, RuntimeScalar> entry : source.entrySet()) {
+            result.put(entry.getKey(), (RuntimeScalar) cloneValue(entry.getValue()));
+        }
+        return result;
+    }
+
+    private Map<String, RuntimeArray> cloneArrayMap(Map<String, RuntimeArray> source) {
+        Map<String, RuntimeArray> result = new java.util.HashMap<>();
+        for (Map.Entry<String, RuntimeArray> entry : source.entrySet()) {
+            result.put(entry.getKey(), (RuntimeArray) cloneValue(entry.getValue()));
+        }
+        return result;
+    }
+
+    private Map<String, RuntimeHash> cloneHashMap(Map<String, RuntimeHash> source) {
+        Map<String, RuntimeHash> result = new java.util.HashMap<>();
+        for (Map.Entry<String, RuntimeHash> entry : source.entrySet()) {
+            result.put(entry.getKey(), (RuntimeHash) cloneValue(entry.getValue()));
+        }
+        return result;
     }
 
     private RuntimeScalar cloneScalar(RuntimeScalar source) {
@@ -120,6 +257,14 @@ public class RuntimeGraphCloner {
         }
 
         if (isWeak(source)) weakReferences.add(target);
+        if (target.value instanceof RuntimeCode code
+                && code.subroutine instanceof CloneablePerlSubroutine cloneable
+                && code.__SUB__ == null) {
+            code.__SUB__ = target;
+            cloneable.setSelfReference(target);
+        } else if (target.value instanceof InterpretedCode interpreted && interpreted.__SUB__ == null) {
+            interpreted.__SUB__ = target;
+        }
         return target;
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
@@ -1,0 +1,258 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.perlonjava.runtime.regex.RuntimeRegex;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.CODE;
+import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.GLOB;
+import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.TIED_SCALAR;
+import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.UNDEF;
+
+/**
+ * Clones one Perl value graph between runtimes while preserving SV identity,
+ * aliases, cycles, blessings and weak edges.
+ *
+ * <p>This is deliberately separate from Storable: ithread cloning does not run
+ * serialization hooks and uses one identity map across all runtime roots.</p>
+ */
+public class RuntimeGraphCloner {
+    private final PerlRuntime sourceRuntime;
+    private final PerlRuntime targetRuntime;
+    private final IdentityHashMap<Object, Object> clones = new IdentityHashMap<>();
+    private final List<RuntimeScalar> weakReferences = new ArrayList<>();
+    private int publicDepth;
+
+    public RuntimeGraphCloner(PerlRuntime sourceRuntime, PerlRuntime targetRuntime) {
+        this.sourceRuntime = java.util.Objects.requireNonNull(sourceRuntime, "sourceRuntime");
+        this.targetRuntime = java.util.Objects.requireNonNull(targetRuntime, "targetRuntime");
+    }
+
+    public PerlRuntime sourceRuntime() {
+        return sourceRuntime;
+    }
+
+    public PerlRuntime targetRuntime() {
+        return targetRuntime;
+    }
+
+    /** Clone a root, completing deferred weak-edge installation at the boundary. */
+    @SuppressWarnings("unchecked")
+    public <T extends RuntimeBase> T cloneGraph(T value) {
+        publicDepth++;
+        try {
+            return (T) cloneValue(value);
+        } finally {
+            if (--publicDepth == 0) finishWeakReferences();
+        }
+    }
+
+    /** Clone several roots through the same identity map. */
+    public List<RuntimeBase> cloneRoots(List<? extends RuntimeBase> roots) {
+        publicDepth++;
+        try {
+            List<RuntimeBase> result = new ArrayList<>(roots.size());
+            for (RuntimeBase root : roots) result.add(cloneValue(root));
+            return result;
+        } finally {
+            if (--publicDepth == 0) finishWeakReferences();
+        }
+    }
+
+    /** Package/runtime snapshot entry point that retains the shared graph map. */
+    RuntimeBase cloneValue(RuntimeBase value) {
+        if (value == null) return null;
+        Object existing = clones.get(value);
+        if (existing != null) return (RuntimeBase) existing;
+
+        if (value instanceof RuntimeScalarReadOnly) {
+            // Constants are immutable and may safely retain process identity.
+            clones.put(value, value);
+            return value;
+        }
+        if (value instanceof RuntimeStash stash) return cloneStash(stash);
+        if (value instanceof RuntimeGlob glob) return cloneGlob(glob);
+        if (value instanceof RuntimeScalar scalar) return cloneScalar(scalar);
+        if (value instanceof RuntimeArray array) return cloneArray(array);
+        if (value instanceof RuntimeHash hash) return cloneHash(hash);
+        throw new IllegalArgumentException("Unsupported Perl graph node: " + value.getClass().getName());
+    }
+
+    protected RuntimeBase cloneCode(RuntimeCode code) {
+        throw new IllegalStateException("CODE cloning requires Phase 15 capture metadata");
+    }
+
+    private RuntimeScalar cloneScalar(RuntimeScalar source) {
+        if (source instanceof TieScalar tied) {
+            RuntimeScalar placeholder = new RuntimeScalar();
+            clones.put(source, placeholder);
+            TieScalar result = new TieScalar(tied.getTiedPackage(),
+                    (RuntimeScalar) cloneValue(tied.getPreviousValue()),
+                    (RuntimeScalar) cloneValue(tied.getSelf()));
+            clones.put(source, result);
+            copyBase(source, result);
+            return result;
+        }
+
+        RuntimeScalar target = new RuntimeScalar();
+        clones.put(source, target);
+        copyBase(source, target);
+        copyScalarMetadata(source, target);
+
+        if (source.type == CODE && source.value instanceof RuntimeCode code) {
+            target.value = cloneCode(code);
+        } else if (source.value instanceof RuntimeRegex regex) {
+            target.value = regex.cloneTracked();
+        } else if (source.value instanceof RuntimeIO) {
+            // Java channels/descriptors have no portable ithread duplication
+            // semantics. Non-standard resource scalars become undef.
+            target.type = UNDEF;
+            target.value = null;
+        } else if (source.value instanceof RuntimeBase base) {
+            target.value = cloneValue(base);
+        } else if (source.value instanceof byte[] bytes) {
+            target.value = bytes.clone();
+        } else {
+            target.value = source.value;
+        }
+
+        if (isWeak(source)) weakReferences.add(target);
+        return target;
+    }
+
+    private RuntimeArray cloneArray(RuntimeArray source) {
+        RuntimeArray target = new RuntimeArray(source.elements.size());
+        clones.put(source, target);
+        copyBase(source, target);
+        target.type = source.type;
+        target.strictAutovivify = source.strictAutovivify;
+        target.scalarContextSize = source.scalarContextSize;
+        target.elementsOwned = source.elementsOwned;
+        target.elementsAliased = source.elementsAliased;
+
+        if (source.type == RuntimeArray.TIED_ARRAY && source.elements instanceof TieArray tie) {
+            target.elements = new TieArray(tie.getTiedPackage(),
+                    (RuntimeArray) cloneValue(tie.getPreviousValue()),
+                    (RuntimeScalar) cloneValue(tie.getSelf()), target);
+        } else {
+            try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
+                for (RuntimeScalar element : source.elements) {
+                    target.addClonedElement((RuntimeScalar) cloneValue(element));
+                }
+            }
+        }
+        return target;
+    }
+
+    private RuntimeHash cloneHash(RuntimeHash source) {
+        RuntimeHash target = new RuntimeHash();
+        clones.put(source, target);
+        copyBase(source, target);
+        target.type = source.type;
+        target.taintEnvironmentAliasDescription = source.taintEnvironmentAliasDescription;
+        target.isGlobalPackageHash = source.isGlobalPackageHash;
+        target.isEnvironmentHash = source.isEnvironmentHash;
+
+        if (source.type == RuntimeHash.TIED_HASH && source.elements instanceof TieHash tie) {
+            target.elements = new TieHash(tie.getTiedPackage(),
+                    (RuntimeHash) cloneValue(tie.getPreviousValue()),
+                    (RuntimeScalar) cloneValue(tie.getSelf()));
+        } else {
+            try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
+                for (Map.Entry<String, RuntimeScalar> entry : source.elements.entrySet()) {
+                    target.putClonedElement(entry.getKey(),
+                            (RuntimeScalar) cloneValue(entry.getValue()));
+                }
+            }
+        }
+        return target;
+    }
+
+    private RuntimeStash cloneStash(RuntimeStash source) {
+        RuntimeStash target;
+        try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
+            target = new RuntimeStash(source.namespace);
+        }
+        clones.put(source, target);
+        copyBase(source, target);
+        target.type = source.type;
+        for (Map.Entry<String, RuntimeScalar> entry : source.elements.entrySet()) {
+            RuntimeScalar cloned = (RuntimeScalar) cloneValue(entry.getValue());
+            try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
+                target.elements.put(entry.getKey(), cloned);
+            }
+        }
+        return target;
+    }
+
+    private RuntimeGlob cloneGlob(RuntimeGlob source) {
+        RuntimeGlob target = new RuntimeGlob(source.globName);
+        clones.put(source, target);
+        copyBase(source, target);
+        target.type = source.type;
+        target.value = target;
+        target.nameOverride = source.nameOverride;
+        target.scalarSlot = (RuntimeScalar) cloneValue(source.scalarSlot);
+        target.arraySlot = (RuntimeArray) cloneValue(source.arraySlot);
+        target.hashSlot = (RuntimeHash) cloneValue(source.hashSlot);
+        if (source.codeSlot != null) {
+            target.codeSlot = (RuntimeScalar) cloneValue(source.codeSlot);
+        }
+        // Filehandles are runtime resources. Standard handles are installed by
+        // PerlRuntime; detached/non-standard handles become an empty IO slot.
+        target.IO = new RuntimeScalar();
+        return target;
+    }
+
+    private void copyScalarMetadata(RuntimeScalar source, RuntimeScalar target) {
+        target.type = source.type;
+        target.numericLiteralText = source.numericLiteralText;
+        target.firstClassRegexScalar = source.firstClassRegexScalar;
+        target.formatPictureTainted = source.formatPictureTainted;
+        target.numericContextSeen = source.numericContextSeen;
+        target.utf8UncheckedOctets = source.utf8UncheckedOctets;
+        target.tainted = source.tainted;
+        target.globalCodeRefFqn = source.globalCodeRefFqn;
+        target.ioOwner = false;
+    }
+
+    private void copyBase(RuntimeBase source, RuntimeBase target) {
+        target.blessId = cloneBlessId(source.blessId);
+        target.localBindingExists = source.localBindingExists;
+        target.storedInPackageGlobal = source.storedInPackageGlobal;
+        target.isPackageGlobalRoot = source.isPackageGlobalRoot;
+        // Refcount/lifecycle queues are reconstructed in the child runtime.
+        target.refCount = source.refCount >= 0 ? 0 : -1;
+    }
+
+    private int cloneBlessId(int sourceBlessId) {
+        if (sourceBlessId == 0) return 0;
+        String className;
+        try (PerlRuntime.Binding ignored = sourceRuntime.bind()) {
+            className = NameNormalizer.getBlessStr(sourceBlessId);
+        }
+        if (className == null || className.isEmpty()) return 0;
+        try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
+            return NameNormalizer.getBlessId(className);
+        }
+    }
+
+    private boolean isWeak(RuntimeScalar scalar) {
+        try (PerlRuntime.Binding ignored = sourceRuntime.bind()) {
+            return WeakRefRegistry.isweak(scalar);
+        }
+    }
+
+    private void finishWeakReferences() {
+        if (weakReferences.isEmpty()) return;
+        try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
+            for (RuntimeScalar weakReference : weakReferences) {
+                WeakRefRegistry.weaken(weakReference);
+            }
+        }
+        weakReferences.clear();
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
@@ -8,6 +8,7 @@ import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.CODE;
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.GLOB;
@@ -26,11 +27,18 @@ public class RuntimeGraphCloner {
     private final PerlRuntime targetRuntime;
     private final IdentityHashMap<Object, Object> clones = new IdentityHashMap<>();
     private final List<RuntimeScalar> weakReferences = new ArrayList<>();
+    private final Set<String> skippedClasses;
     private int publicDepth;
 
     public RuntimeGraphCloner(PerlRuntime sourceRuntime, PerlRuntime targetRuntime) {
+        this(sourceRuntime, targetRuntime, Set.of());
+    }
+
+    public RuntimeGraphCloner(
+            PerlRuntime sourceRuntime, PerlRuntime targetRuntime, Set<String> skippedClasses) {
         this.sourceRuntime = java.util.Objects.requireNonNull(sourceRuntime, "sourceRuntime");
         this.targetRuntime = java.util.Objects.requireNonNull(targetRuntime, "targetRuntime");
+        this.skippedClasses = Set.copyOf(skippedClasses);
     }
 
     public PerlRuntime sourceRuntime() {
@@ -167,6 +175,8 @@ public class RuntimeGraphCloner {
         target.isDeclared = source.isDeclared;
         target.isSymbolicReference = source.isSymbolicReference;
         target.isClosurePrototype = source.isClosurePrototype;
+        target.definitionPending = source.definitionPending;
+        target.compilerSupplier = source.compilerSupplier;
         target.isMapGrepBlock = source.isMapGrepBlock;
         target.isEvalBlock = source.isEvalBlock;
         target.isTryExpressionWrapper = source.isTryExpressionWrapper;
@@ -249,7 +259,12 @@ public class RuntimeGraphCloner {
             target.type = UNDEF;
             target.value = null;
         } else if (source.value instanceof RuntimeBase base) {
-            target.value = cloneValue(base);
+            if (shouldSkip(base)) {
+                target.type = UNDEF;
+                target.value = null;
+            } else {
+                target.value = cloneValue(base);
+            }
         } else if (source.value instanceof byte[] bytes) {
             target.value = bytes.clone();
         } else {
@@ -382,6 +397,13 @@ public class RuntimeGraphCloner {
         if (className == null || className.isEmpty()) return 0;
         try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
             return NameNormalizer.getBlessId(className);
+        }
+    }
+
+    private boolean shouldSkip(RuntimeBase base) {
+        if (base.blessId == 0 || skippedClasses.isEmpty()) return false;
+        try (PerlRuntime.Binding ignored = sourceRuntime.bind()) {
+            return skippedClasses.contains(NameNormalizer.getBlessStr(base.blessId));
         }
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
@@ -886,6 +886,15 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
         return result;
     }
 
+    /** Install an already-cloned scalar slot without Perl assignment/FETCH semantics. */
+    public void putClonedElement(String key, RuntimeScalar value) {
+        elements.put(key, value);
+        if (value != null) {
+            value.markContainerOwner(this);
+            RuntimeScalar.incrementRefCountForContainerStore(value);
+        }
+    }
+
     @Override
     public RuntimeScalar createReferenceWithTrackedElements() {
         // Birth-track anonymous hashes: set refCount=0 so setLarge() can

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
@@ -96,8 +96,7 @@ public class RuntimeIO extends RuntimeScalar {
      */
     static final int MAX_OPEN_HANDLES = 100;
 
-    /** Child processes remain process-global until the later registry migration. */
-    private static final Map<Long, Process> childProcesses = new java.util.concurrent.ConcurrentHashMap<>();
+    private static IORuntimeRegistryState registry() { return PerlRuntime.current().ioRegistryState; }
 
     public static RuntimeIO getStdout() { return PerlRuntime.current().ioStdout; }
     public static void setStdout(RuntimeIO io) { PerlRuntime.current().replaceStandardHandle("main::STDOUT", io); }
@@ -133,12 +132,6 @@ public class RuntimeIO extends RuntimeScalar {
      * (see RuntimeScalar.setLarge), so fds are never prematurely freed while
      * other variables still reference the handle.
      */
-    private static final AtomicInteger nextFileno = new AtomicInteger(3);
-    private static final ConcurrentHashMap<Integer, RuntimeIO> filenoToIO = new ConcurrentHashMap<>();
-    private static final ConcurrentHashMap<RuntimeIO, Integer> ioToFileno = new ConcurrentHashMap<>();
-    /** Pool of released fd numbers available for reuse. Perl reuses fds (lowest available),
-     *  so we must do the same to pass tests like io/perlio_leaks.t that verify fd recycling. */
-    private static final ConcurrentLinkedQueue<Integer> recycledFds = new ConcurrentLinkedQueue<>();
 
     /**
      * GC-based fd recycling for anonymous lexical filehandles.
@@ -158,8 +151,6 @@ public class RuntimeIO extends RuntimeScalar {
      * If no recycled fds are available, {@code System.gc()} is called as a hint
      * to encourage the JVM to enqueue phantom references sooner.
      */
-    private static final ReferenceQueue<RuntimeGlob> globGCQueue = new ReferenceQueue<>();
-    private static final ConcurrentHashMap<PhantomReference<RuntimeGlob>, RuntimeIO> phantomToIO = new ConcurrentHashMap<>();
 
     /**
      * Registers an anonymous RuntimeGlob for GC-based fd recycling.
@@ -171,8 +162,9 @@ public class RuntimeIO extends RuntimeScalar {
      * @param io   the RuntimeIO whose fd should be freed when the glob is collected
      */
     public static void registerGlobForFdRecycling(RuntimeGlob glob, RuntimeIO io) {
-        PhantomReference<RuntimeGlob> phantom = new PhantomReference<>(glob, globGCQueue);
-        phantomToIO.put(phantom, io);
+        IORuntimeRegistryState registry = registry();
+        PhantomReference<RuntimeGlob> phantom = new PhantomReference<>(glob, registry.globGCQueue);
+        registry.phantomToIO.put(phantom, io);
     }
 
     /**
@@ -181,8 +173,9 @@ public class RuntimeIO extends RuntimeScalar {
      */
     public static void processAbandonedGlobs() {
         Reference<? extends RuntimeGlob> ref;
-        while ((ref = globGCQueue.poll()) != null) {
-            RuntimeIO io = phantomToIO.remove(ref);
+        IORuntimeRegistryState registry = registry();
+        while ((ref = registry.globGCQueue.poll()) != null) {
+            RuntimeIO io = registry.phantomToIO.remove(ref);
             if (io != null && !(io.ioHandle instanceof ClosedIOHandle)) {
                 io.close();
             }
@@ -203,7 +196,8 @@ public class RuntimeIO extends RuntimeScalar {
      * @return the assigned fileno (always >= 3)
      */
     public int assignFileno() {
-        Integer existing = ioToFileno.get(this);
+        IORuntimeRegistryState registry = registry();
+        Integer existing = registry.ioToFileno.get(this);
         if (existing != null) {
             return existing;
         }
@@ -212,32 +206,32 @@ public class RuntimeIO extends RuntimeScalar {
         // Try to reuse the lowest freed fd
         int fd = tryRecycleLowestFd();
         if (fd >= 0) {
-            filenoToIO.put(fd, this);
-            ioToFileno.put(this, fd);
+            registry.filenoToIO.put(fd, this);
+            registry.ioToFileno.put(this, fd);
             FileDescriptorTable.advancePast(fd);
             return fd;
         }
         // No recycled fds — if there are tracked anonymous globs that might
         // be collectible, hint the GC and retry a few times with short sleeps
         // to give the ReferenceHandler thread time to process the queue.
-        if (!phantomToIO.isEmpty()) {
+        if (!registry.phantomToIO.isEmpty()) {
             for (int attempt = 0; attempt < 5; attempt++) {
                 System.gc();
                 try { Thread.sleep(1); } catch (InterruptedException e) { break; }
                 processAbandonedGlobs();
                 fd = tryRecycleLowestFd();
                 if (fd >= 0) {
-                    filenoToIO.put(fd, this);
-                    ioToFileno.put(this, fd);
+                    registry.filenoToIO.put(fd, this);
+                    registry.ioToFileno.put(this, fd);
                     FileDescriptorTable.advancePast(fd);
                     return fd;
                 }
             }
         }
         // Allocate a fresh fd
-        fd = nextFileno.getAndIncrement();
-        filenoToIO.put(fd, this);
-        ioToFileno.put(this, fd);
+        fd = registry.nextFileno.getAndIncrement();
+        registry.filenoToIO.put(fd, this);
+        registry.ioToFileno.put(this, fd);
         FileDescriptorTable.advancePast(fd);
         return fd;
     }
@@ -247,13 +241,14 @@ public class RuntimeIO extends RuntimeScalar {
      * Returns -1 if none available.
      */
     private static int tryRecycleLowestFd() {
+        IORuntimeRegistryState registry = registry();
         SortedSet<Integer> candidates = new TreeSet<>();
         Integer recycled;
-        while ((recycled = recycledFds.poll()) != null) {
+        while ((recycled = registry.recycledFds.poll()) != null) {
             // Aliased/borrowed handles can keep a descriptor live after another
             // wrapper releases it. Discard stale recycle entries rather than
             // letting a new socket overwrite the current fd owner.
-            if (recycled >= 3 && !filenoToIO.containsKey(recycled)) {
+            if (recycled >= 3 && !registry.filenoToIO.containsKey(recycled)) {
                 candidates.add(recycled);
             }
         }
@@ -263,7 +258,7 @@ public class RuntimeIO extends RuntimeScalar {
         int fd = candidates.first();
         // Put back the rest
         for (int candidate : candidates.tailSet(fd + 1)) {
-            recycledFds.add(candidate);
+            registry.recycledFds.add(candidate);
         }
         return fd;
     }
@@ -272,7 +267,7 @@ public class RuntimeIO extends RuntimeScalar {
      * Gets the assigned fileno for this RuntimeIO, or -1 if not assigned.
      */
     public int getAssignedFileno() {
-        Integer fd = ioToFileno.get(this);
+        Integer fd = registry().ioToFileno.get(this);
         return fd != null ? fd : -1;
     }
 
@@ -280,7 +275,7 @@ public class RuntimeIO extends RuntimeScalar {
      * Looks up a RuntimeIO by its assigned fileno.
      */
     public static RuntimeIO getByFileno(int fd) {
-        return filenoToIO.get(fd);
+        return registry().filenoToIO.get(fd);
     }
 
     /**
@@ -291,15 +286,16 @@ public class RuntimeIO extends RuntimeScalar {
      * @param fd the file descriptor number to register at
      */
     public void registerExternalFd(int fd) {
-        Integer oldFd = ioToFileno.remove(this);
+        IORuntimeRegistryState registry = registry();
+        Integer oldFd = registry.ioToFileno.remove(this);
         if (oldFd != null && oldFd != fd) {
-            filenoToIO.remove(oldFd);
+            registry.filenoToIO.remove(oldFd);
         }
-        filenoToIO.put(fd, this);
-        ioToFileno.put(this, fd);
-        recycledFds.removeIf(candidate -> candidate == fd);
+        registry.filenoToIO.put(fd, this);
+        registry.ioToFileno.put(this, fd);
+        registry.recycledFds.removeIf(candidate -> candidate == fd);
         // Advance nextFileno past this fd to avoid collisions
-        nextFileno.updateAndGet(current -> Math.max(current, fd + 1));
+        registry.nextFileno.updateAndGet(current -> Math.max(current, fd + 1));
     }
 
     /**
@@ -307,17 +303,18 @@ public class RuntimeIO extends RuntimeScalar {
      * the fd to the recycle pool for reuse by future {@link #assignFileno()} calls.
      */
     public void unregisterFileno() {
-        Integer fd = ioToFileno.remove(this);
+        IORuntimeRegistryState registry = registry();
+        Integer fd = registry.ioToFileno.remove(this);
         if (fd != null) {
             // Only the RuntimeIO that still owns the fd mapping may release it.
             // Borrowed aliases intentionally share a descriptor; closing an
             // older alias must not unregister or recycle the newer live owner.
-            boolean released = filenoToIO.remove(fd, this);
+            boolean released = registry.filenoToIO.remove(fd, this);
             // Return fd to the recycle pool so it can be reused (POSIX: lowest available).
             // Descriptors 0, 1, and 2 are reserved for stdin/stdout/stderr and must
             // never be assigned to lazily-numbered regular filehandles.
             if (released && fd >= 3) {
-                recycledFds.add(fd);
+                registry.recycledFds.add(fd);
             }
         }
     }
@@ -330,7 +327,7 @@ public class RuntimeIO extends RuntimeScalar {
      * @param fd the fd value to advance past
      */
     public static void advanceFilenoCounterPast(int fd) {
-        nextFileno.updateAndGet(current -> Math.max(current, fd + 1));
+        registry().nextFileno.updateAndGet(current -> Math.max(current, fd + 1));
     }
 
     static {
@@ -408,10 +405,11 @@ public class RuntimeIO extends RuntimeScalar {
             return;
         }
 
-        Integer fd = ioToFileno.remove(other);
+        IORuntimeRegistryState registry = registry();
+        Integer fd = registry.ioToFileno.remove(other);
         if (fd != null) {
-            ioToFileno.put(this, fd);
-            filenoToIO.put(fd, this);
+            registry.ioToFileno.put(this, fd);
+            registry.filenoToIO.put(fd, this);
         }
 
         this.currentLineNumber = other.currentLineNumber;
@@ -440,15 +438,15 @@ public class RuntimeIO extends RuntimeScalar {
     }
 
     public static void registerChildProcess(Process p) {
-        if (p != null) childProcesses.put(p.pid(), p);
+        if (p != null) registry().childProcesses.put(p.pid(), p);
     }
 
     public static Process getChildProcess(long pid) {
-        return childProcesses.get(pid);
+        return registry().childProcesses.get(pid);
     }
 
     public static Process removeChildProcess(long pid) {
-        return childProcesses.remove(pid);
+        return registry().childProcesses.remove(pid);
     }
 
     /**
@@ -993,7 +991,7 @@ public class RuntimeIO extends RuntimeScalar {
         }
 
         // For relative paths, resolve against current directory
-        return Paths.get(System.getProperty("user.dir")).resolve(sanitized).toAbsolutePath();
+        return Paths.get(RuntimeEnvironment.currentDirectory()).resolve(sanitized).toAbsolutePath();
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeRegexState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeRegexState.java
@@ -39,6 +39,7 @@ public final class RuntimeRegexState {
 
     /** Per-runtime callsite state for {@code /o} and {@code m?PAT?}. */
     public final Map<Integer, RuntimeScalar> optimizedRegexCache = new LinkedHashMap<>();
+    public final Map<String, String> userUnicodePropertyCache = new LinkedHashMap<>();
 
     /**
      * Per-runtime compiled templates. Some templates support deferred runtime

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -1664,7 +1664,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 && !thisWasWeak
                 && value.type == UNDEF
                 && oldBase.blessId != 0
-                && WeakRefRegistry.weakRefsExist
+                && WeakRefRegistry.weakRefsExist()
                 && blessedClassHasDestroy(oldBase);
         if (oldBase != null && this.captureRefCountOwned > 0) {
             releaseAllClosureCaptureReferents(oldBase);
@@ -1716,8 +1716,8 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         // But avoids false positives from:
         //   my $self = shift  (new local variable, oldBase is null)
         if (thisWasWeak
-                && DestroyDispatch.currentDestroyTarget != null
-                && oldBase == DestroyDispatch.currentDestroyTarget
+                && DestroyDispatch.currentDestroyTarget() != null
+                && oldBase == DestroyDispatch.currentDestroyTarget()
                 // Package weak maps (PPI's global parent indexes are the
                 // common case) may briefly replace/reuse an entry while its
                 // target is being destroyed.  That is handled by the normal
@@ -1728,8 +1728,8 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 && !(containerOwner instanceof RuntimeHash owner
                     && owner.isPackageRootedHash())
                 && this.value instanceof RuntimeBase base
-                && base == DestroyDispatch.currentDestroyTarget) {
-            DestroyDispatch.destroyTargetRescued = true;
+                && base == DestroyDispatch.currentDestroyTarget()) {
+            DestroyDispatch.markDestroyTargetRescued();
             // Transition from destroyed (MIN_VALUE) to tracked so that when the
             // rescuing reference is eventually released (e.g., source goes out of
             // scope at the end of DESTROY), cascading cleanup brings the refCount
@@ -1815,7 +1815,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             } else if (oldBase.refCount > 0 && value.type == UNDEF
                     && oldBase.blessId != 0
                     && DestroyDispatch.isInsideDestroy()
-                    && WeakRefRegistry.weakRefsExist) {
+                    && WeakRefRegistry.weakRefsExist()) {
                 // Phase D: inside a DESTROY body, an explicit undef
                 // assignment released our strong ref to another
                 // blessed-with-DESTROY object but selective refCount
@@ -1826,7 +1826,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 // and one BitSet lookup.
                 String cn = NameNormalizer.getBlessStr(oldBase.blessId);
                 if (cn != null && DestroyDispatch.classHasDestroy(oldBase.blessId, cn)) {
-                    DestroyDispatch.sweepPendingAfterOuterDestroy = true;
+                    DestroyDispatch.requestSweepAfterOuterDestroy();
                 }
             }
         }
@@ -3090,7 +3090,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             this.formatPictureTainted = false;
             // Invalidate the method resolution cache
             InheritanceResolver.invalidateCache();
-            if (releasedCode && WeakRefRegistry.weakRefsExist && !ModuleInitGuard.inModuleInit()) {
+            if (releasedCode && WeakRefRegistry.weakRefsExist() && !ModuleInitGuard.inModuleInit()) {
                 ReachabilityWalker.sweepWeakRefs(true);
             }
             return this;
@@ -3146,7 +3146,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                         // to the rescued object (e.g. HandleError closure's weak
                         // $schema) must be cleared so callbacks that fire AFTER
                         // this point can detect "schema is gone".
-                        if (oldBase.blessId != 0 && WeakRefRegistry.weakRefsExist) {
+                        if (oldBase.blessId != 0 && WeakRefRegistry.weakRefsExist()) {
                             String cn = NameNormalizer.getBlessStr(oldBase.blessId);
                             if (cn != null && DestroyDispatch.classHasDestroy(oldBase.blessId, cn)) {
                                 undefOnBlessedWithDestroy = true;
@@ -3154,7 +3154,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                         }
                     }
                 } else if (oldBase.blessId != 0 && oldBase.refCount > 0
-                        && WeakRefRegistry.weakRefsExist) {
+                        && WeakRefRegistry.weakRefsExist()) {
                     // Phase D: selective refCount suggests this object still has
                     // strong references, but those may all be internal cycles
                     // (e.g. DBIC's Schema <-> source_registrations). Defer to the
@@ -3166,7 +3166,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                         undefOnBlessedWithDestroy = true;
                     }
                 }
-            } else if (oldBase.blessId != 0 && WeakRefRegistry.weakRefsExist) {
+            } else if (oldBase.blessId != 0 && WeakRefRegistry.weakRefsExist()) {
                 // Phase D: no owned-count decrement (refCountOwned was false, or
                 // refCount was already 0 from prior selective drift). The
                 // object is blessed — if its class has DESTROY, let the walker

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarRefRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarRefRegistry.java
@@ -27,16 +27,14 @@ public class ScalarRefRegistry {
     // WeakHashMap uses identity-based hashing when keys don't override
     // hashCode/equals — RuntimeScalar uses Object's defaults, so this
     // is effectively IdentityHashMap-with-weak-keys.
-    private static final Map<RuntimeScalar, Boolean> scalarRegistry =
-            new WeakHashMap<>();
-
     // Phase E: optional per-scalar registerRef call-site stacks.
     // Populated only when JPERL_REGISTER_STACKS=1 is set. Uses a
     // WeakHashMap with the same scalar as key, so entries are pruned
     // automatically when the scalar is JVM-GC'd. Lookup via
     // stackFor() is O(1).
-    private static final Map<RuntimeScalar, Throwable> registerStacks =
-            new WeakHashMap<>();
+    private static LifecycleRuntimeState state() {
+        return PerlRuntime.current().lifecycleState;
+    }
 
     // Phase B1 performance toggle: when set, skip all registry
     // maintenance. Useful for benchmarks; does NOT affect correctness
@@ -77,14 +75,14 @@ public class ScalarRefRegistry {
      */
     public static void registerRef(RuntimeScalar scalar) {
         if (OPT_OUT || scalar == null) return;
-        if (!WeakRefRegistry.weakRefsExist && !UNGATED) return;
-        scalarRegistry.put(scalar, Boolean.TRUE);
+        if (!WeakRefRegistry.weakRefsExist() && !UNGATED) return;
+        state().scalarRegistry.put(scalar, Boolean.TRUE);
         if (RECORD_STACKS) {
-            registerStacks.put(scalar, new Throwable("registerRef"));
+            state().scalarRegisterStacks.put(scalar, new Throwable("registerRef"));
         }
         if (DEBUG) {
             System.err.println("DBG registerRef scalar=" + System.identityHashCode(scalar)
-                    + " type=" + scalar.type + " size=" + scalarRegistry.size());
+                    + " type=" + scalar.type + " size=" + state().scalarRegistry.size());
         }
     }
 
@@ -97,7 +95,7 @@ public class ScalarRefRegistry {
      */
     public static Throwable stackFor(RuntimeScalar sc) {
         if (!RECORD_STACKS || sc == null) return null;
-        return registerStacks.get(sc);
+        return state().scalarRegisterStacks.get(sc);
     }
 
     /**
@@ -106,7 +104,7 @@ public class ScalarRefRegistry {
      * unreachable entries first (e.g., freshly-exited lexical scopes).
      */
     public static java.util.List<RuntimeScalar> snapshot() {
-        return new java.util.ArrayList<>(scalarRegistry.keySet());
+        return new java.util.ArrayList<>(state().scalarRegistry.keySet());
     }
 
     /**
@@ -144,12 +142,12 @@ public class ScalarRefRegistry {
      * hold? (Subject to JVM GC between calls.)
      */
     public static int approximateSize() {
-        return scalarRegistry.size();
+        return state().scalarRegistry.size();
     }
 
     /** Drop weak-key bookkeeping belonging to the previous top-level script. */
     public static void resetState() {
-        scalarRegistry.clear();
-        registerStacks.clear();
+        state().scalarRegistry.clear();
+        state().scalarRegisterStacks.clear();
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/StateVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/StateVariable.java
@@ -1,6 +1,5 @@
 package org.perlonjava.runtime.runtimetypes;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarFalse;
@@ -12,7 +11,9 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarTrue;
  */
 public class StateVariable {
     // A map to track whether a state variable has been initialized.
-    static Map<String, Boolean> stateVariableInitialized = new HashMap<>();
+    private static Map<String, Boolean> stateVariableInitialized() {
+        return PerlRuntime.current().stateVariableInitialized;
+    }
 
     /**
      * Checks if a state variable has been initialized.
@@ -26,7 +27,7 @@ public class StateVariable {
         String beginVar = PersistentVariable.beginVariable(id, var.substring(1));
         if (!codeRef.getDefinedBoolean()) {
             // For top-level code without __SUB__, check global initialization.
-            Boolean initialized = stateVariableInitialized.get(beginVar);
+            Boolean initialized = stateVariableInitialized().get(beginVar);
             if (initialized == null || !initialized) {
                 return scalarFalse;
             }
@@ -52,7 +53,7 @@ public class StateVariable {
     public static void markInitializedStateVariable(RuntimeScalar codeRef, String var, int id) {
         String beginVar = PersistentVariable.beginVariable(id, var.substring(1));
         if (!codeRef.getDefinedBoolean()) {
-            stateVariableInitialized.put(beginVar, true);
+            stateVariableInitialized().put(beginVar, true);
         } else {
             RuntimeCode code = (RuntimeCode) codeRef.value;
             code.stateVariableInitialized.put(beginVar, true);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/WarningFlags.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/WarningFlags.java
@@ -1,11 +1,10 @@
 package org.perlonjava.runtime.runtimetypes;
 
 import org.perlonjava.frontend.semantic.ScopedSymbolTable;
+import org.perlonjava.runtime.CompilationRuntimeState;
 
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.perlonjava.frontend.parser.SpecialBlockParser.getCurrentScope;
 
@@ -23,24 +22,9 @@ public class WarningFlags {
     // A hierarchy of warning categories
     private static final Map<String, String[]> warningHierarchy = new HashMap<>();
     
-    // Custom warning categories registered via warnings::register
-    private static final Set<String> customCategories = new HashSet<>();
-    
-    // Global flag to track if "use warnings" has been called (for runtime checks)
-    private static boolean globalWarningsEnabled = false;
-
-    // Command-line override from -W/-X. 1 forces warnings on, -1 forces them off.
-    private static int commandLineWarningOverride = 0;
-    
-    // Scope ID counter for generating unique scope IDs
-    private static final AtomicInteger scopeIdCounter = new AtomicInteger(0);
-    
-    // Map from scope ID to set of disabled warning categories
-    // This is populated at compile time and read at runtime
-    private static final Map<Integer, Set<String>> scopeDisabledWarnings = new HashMap<>();
-    
-    // The scope ID from the last noWarnings() call (read by StatementParser)
-    private static int lastScopeId = 0;
+    private static CompilationRuntimeState state() {
+        return PerlRuntime.current().compilationState;
+    }
 
     static {
         // Initialize the hierarchy of warning categories
@@ -93,14 +77,6 @@ public class WarningFlags {
     /**
      * User-defined category offsets (dynamically assigned starting at 128).
      */
-    private static final ConcurrentHashMap<String, Integer> userCategoryOffsets = 
-        new ConcurrentHashMap<>();
-    
-    /**
-     * Next available offset for user-defined categories.
-     */
-    private static final AtomicInteger nextUserOffset = new AtomicInteger(128);
-    
     /**
      * Size of warning bits string in bytes (Perl 5's WARNsize).
      */
@@ -263,7 +239,7 @@ public class WarningFlags {
             return offset;
         }
         // Check user-defined categories
-        offset = userCategoryOffsets.get(category);
+        offset = state().userWarningCategoryOffsets.get(category);
         return offset != null ? offset : -1;
     }
     
@@ -281,8 +257,9 @@ public class WarningFlags {
             return existing;
         }
         // Check or assign user category offset
-        return userCategoryOffsets.computeIfAbsent(category, 
-            k -> nextUserOffset.getAndIncrement());
+        CompilationRuntimeState state = state();
+        return state.userWarningCategoryOffsets.computeIfAbsent(category,
+            k -> state.nextUserWarningOffset.getAndIncrement());
     }
     
     /**
@@ -298,8 +275,8 @@ public class WarningFlags {
                                               Map<String, Integer> categoryToInternalBit) {
         // Calculate required size
         int maxOffset = WARN_SIZE * 4; // Default Perl 5 size in categories
-        for (String category : userCategoryOffsets.keySet()) {
-            int offset = userCategoryOffsets.get(category);
+        for (String category : state().userWarningCategoryOffsets.keySet()) {
+            int offset = state().userWarningCategoryOffsets.get(category);
             if (offset >= maxOffset) {
                 maxOffset = offset + 1;
             }
@@ -358,16 +335,16 @@ public class WarningFlags {
      * {@code ${^WARNING_BITS}} string.
      *
      * <p>Do not use {@link #warningManager}{@code .isWarningEnabled()} for compile-time
-     * diagnostics: when {@link #globalWarningsEnabled} is true (after a bare {@code use warnings}
+     * diagnostics: when global warnings are enabled (after a bare {@code use warnings}
      * anywhere in the process), that helper incorrectly treats almost every category as on unless
      * explicitly disabled, which breaks modules that set warning state only via
      * {@code ${^WARNING_BITS}} (e.g. AnyEvent's generated {@code AnyEvent::common_sense}).
      */
     public static boolean ckWarnForScope(ScopedSymbolTable scope, String category) {
-        if (commandLineWarningOverride < 0) {
+        if (state().commandLineWarningOverride < 0) {
             return false;
         }
-        if (commandLineWarningOverride > 0) {
+        if (state().commandLineWarningOverride > 0) {
             return true;
         }
         if (scope != null && scope.isWarningCategoryDisabled(category)) {
@@ -398,8 +375,8 @@ public class WarningFlags {
         int offset = getPerl5Offset(category);
         if (offset < 0) {
             // Unknown category - check if it might be a registered user category
-            offset = userCategoryOffsets.get(category) != null ? 
-                     userCategoryOffsets.get(category) : -1;
+            offset = state().userWarningCategoryOffsets.get(category) != null ?
+                     state().userWarningCategoryOffsets.get(category) : -1;
             if (offset < 0) {
                 return false;
             }
@@ -422,7 +399,7 @@ public class WarningFlags {
         // because they were registered (via warnings::register) after the scope's
         // "use warnings" was compiled. In Perl 5, "use warnings" (which enables "all")
         // implicitly enables all custom categories registered later.
-        if (customCategories.contains(category)) {
+        if (state().customWarningCategories.contains(category)) {
             int allOffset = PERL5_OFFSETS.get("all");
             int allBitPos = allOffset * 2;
             int allByteIndex = allBitPos / 8;
@@ -449,8 +426,8 @@ public class WarningFlags {
         
         int offset = getPerl5Offset(category);
         if (offset < 0) {
-            offset = userCategoryOffsets.get(category) != null ? 
-                     userCategoryOffsets.get(category) : -1;
+            offset = state().userWarningCategoryOffsets.get(category) != null ?
+                     state().userWarningCategoryOffsets.get(category) : -1;
             if (offset < 0) {
                 return false;
             }
@@ -466,7 +443,7 @@ public class WarningFlags {
         }
         
         // For custom categories, fall back to checking if "all" is fatal
-        if (customCategories.contains(category)) {
+        if (state().customWarningCategories.contains(category)) {
             int allOffset = PERL5_OFFSETS.get("all");
             int allBitPos = allOffset * 2 + 1; // Fatal bit for "all"
             int allByteIndex = allBitPos / 8;
@@ -541,7 +518,7 @@ public class WarningFlags {
             warningSet.addAll(Arrays.asList(entry.getValue()));
         }
         // Include custom categories registered via warnings::register
-        warningSet.addAll(customCategories);
+        warningSet.addAll(state().customWarningCategories);
         // Sort to ensure stable bit positions across runs and when new categories are added
         List<String> sorted = new ArrayList<>(warningSet);
         Collections.sort(sorted);
@@ -565,7 +542,7 @@ public class WarningFlags {
      * @param category The name of the custom warning category to register.
      */
     public static void registerCategory(String category) {
-        customCategories.add(category);
+        state().customWarningCategories.add(category);
         // Add it to the hierarchy with no subcategories
         if (!warningHierarchy.containsKey(category)) {
             warningHierarchy.put(category, new String[]{});
@@ -605,7 +582,7 @@ public class WarningFlags {
      * @return True if it's a registered custom category.
      */
     public static boolean isCustomCategory(String category) {
-        return customCategories.contains(category);
+        return state().customWarningCategories.contains(category);
     }
     
     /**
@@ -615,15 +592,16 @@ public class WarningFlags {
      * @return True if "use warnings" has been called.
      */
     public static boolean isGlobalWarningsEnabled() {
-        return globalWarningsEnabled;
+        return state().globalWarningsEnabled;
     }
 
     /** Clear warning state that belongs to one top-level compilation. */
     public static void resetRuntimeState() {
-        globalWarningsEnabled = false;
-        scopeDisabledWarnings.clear();
-        scopeIdCounter.set(0);
-        lastScopeId = 0;
+        CompilationRuntimeState state = state();
+        state.globalWarningsEnabled = false;
+        state.scopeDisabledWarnings.clear();
+        state.warningScopeIdCounter.set(0);
+        state.lastWarningScopeId = 0;
     }
     
     // ==================== Scope-based Warning Suppression ====================
@@ -641,17 +619,17 @@ public class WarningFlags {
      * @return The unique scope ID for this block.
      */
     public static int registerScopeWarnings(Set<String> categories) {
-        int scopeId = scopeIdCounter.incrementAndGet();
+        int scopeId = state().warningScopeIdCounter.incrementAndGet();
         
         // Callers pass the current disabled bitset from ScopedSymbolTable, where
         // parent categories have already been propagated to subcategories and
         // later use-warnings pragmas have cleared re-enabled categories.
         Set<String> expanded = new HashSet<>(categories);
 
-        scopeDisabledWarnings.put(scopeId, expanded);
+        state().scopeDisabledWarnings.put(scopeId, expanded);
         
         // Set lastScopeId for StatementParser to read
-        lastScopeId = scopeId;
+        state().lastWarningScopeId = scopeId;
         
         return scopeId;
     }
@@ -676,7 +654,7 @@ public class WarningFlags {
      * @return True if the category is disabled in this scope.
      */
     public static boolean isWarningDisabledInScope(int scopeId, String category) {
-        Set<String> disabled = scopeDisabledWarnings.get(scopeId);
+        Set<String> disabled = state().scopeDisabledWarnings.get(scopeId);
         if (disabled != null) {
             return disabled.contains(category);
         }
@@ -692,10 +670,10 @@ public class WarningFlags {
      * @return True if the category is suppressed in the current runtime scope.
      */
     public static boolean isWarningSuppressedAtRuntime(String category) {
-        if (commandLineWarningOverride > 0) {
+        if (state().commandLineWarningOverride > 0) {
             return false;
         }
-        if (commandLineWarningOverride < 0) {
+        if (state().commandLineWarningOverride < 0) {
             return true;
         }
         RuntimeScalar scopeVar = GlobalVariable.getGlobalVariable(GlobalContext.WARNING_SCOPE);
@@ -704,15 +682,15 @@ public class WarningFlags {
     }
 
     public static void setCommandLineWarningOverride(int override) {
-        commandLineWarningOverride = override;
+        state().commandLineWarningOverride = override;
     }
 
     public static boolean areWarningsForcedOn() {
-        return commandLineWarningOverride > 0;
+        return state().commandLineWarningOverride > 0;
     }
 
     public static boolean areWarningsForcedOff() {
-        return commandLineWarningOverride < 0;
+        return state().commandLineWarningOverride < 0;
     }
     
     /**
@@ -737,19 +715,19 @@ public class WarningFlags {
      * @return The last scope ID, or 0 if no scope was registered.
      */
     public static int getLastScopeId() {
-        return lastScopeId;
+        return state().lastWarningScopeId;
     }
     
     /**
      * Clears the last scope ID (called after StatementParser reads it).
      */
     public static void clearLastScopeId() {
-        lastScopeId = 0;
+        state().lastWarningScopeId = 0;
     }
 
     public void initializeEnabledWarnings() {
         // Set global flag for runtime checks
-        globalWarningsEnabled = true;
+        state().globalWarningsEnabled = true;
         
         // Enable all warnings by enabling the "all" category
         enableWarning("all");
@@ -788,7 +766,7 @@ public class WarningFlags {
         enableWarning("substr");
         
         // Enable all custom categories that have been registered
-        for (String customCategory : customCategories) {
+        for (String customCategory : state().customWarningCategories) {
             enableWarning(customCategory);
         }
     }
@@ -840,10 +818,10 @@ public class WarningFlags {
      * @return True if the category is enabled, false otherwise.
      */
     public boolean isWarningEnabled(String category) {
-        if (commandLineWarningOverride < 0) {
+        if (state().commandLineWarningOverride < 0) {
             return false;
         }
-        if (commandLineWarningOverride > 0) {
+        if (state().commandLineWarningOverride > 0) {
             return true;
         }
         ScopedSymbolTable scope = getCurrentScope();
@@ -852,7 +830,7 @@ public class WarningFlags {
         }
         // Fall back to global flag for runtime checks
         // If warnings are globally enabled and this isn't a disabled category, return true
-        if (globalWarningsEnabled) {
+        if (state().globalWarningsEnabled) {
             // Check if this specific category was explicitly disabled
             if (scope != null && scope.isWarningCategoryDisabled(category)) {
                 return false;
@@ -871,10 +849,10 @@ public class WarningFlags {
      * @return True if the category was explicitly disabled, false otherwise.
      */
     public boolean isWarningDisabled(String category) {
-        if (commandLineWarningOverride < 0) {
+        if (state().commandLineWarningOverride < 0) {
             return true;
         }
-        if (commandLineWarningOverride > 0) {
+        if (state().commandLineWarningOverride > 0) {
             return false;
         }
         return getCurrentScope().isWarningCategoryDisabled(category);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/WeakRefRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/WeakRefRegistry.java
@@ -13,13 +13,9 @@ import java.util.Set;
  */
 public class WeakRefRegistry {
 
-    // Forward map: is this RuntimeScalar a weak ref?
-    private static final Set<RuntimeScalar> weakScalars =
-            Collections.newSetFromMap(new IdentityHashMap<>());
-
-    // Reverse map: referent → set of weak RuntimeScalars pointing to it.
-    private static final IdentityHashMap<RuntimeBase, Set<RuntimeScalar>> referentToWeakRefs =
-            new IdentityHashMap<>();
+    private static LifecycleRuntimeState state() {
+        return PerlRuntime.current().lifecycleState;
+    }
 
     /**
      * Fast-path flag: has {@code weaken()} ever been called in this JVM?
@@ -31,7 +27,9 @@ public class WeakRefRegistry {
      * unblessed containers may have weak refs that need clearing on scope
      * exit, so those sites must walk elements when weak refs exist.
      */
-    public static volatile boolean weakRefsExist = false;
+    public static boolean weakRefsExist() {
+        return state().weakRefsExist;
+    }
 
     /**
      * Special refCount value for objects that have weak refs but whose strong
@@ -56,8 +54,8 @@ public class WeakRefRegistry {
 
     /** Drop references belonging to the previous top-level script. */
     public static void resetState() {
-        weakScalars.clear();
-        referentToWeakRefs.clear();
+        state().weakScalars.clear();
+        state().referentToWeakRefs.clear();
         // Keep weakRefsExist conservative. Once enabled, the associated
         // lexical/root bookkeeping must remain enabled for this JVM.
     }
@@ -80,7 +78,8 @@ public class WeakRefRegistry {
             throw new PerlCompilerException("Can't weaken a nonreference");
         }
         if (!(ref.value instanceof RuntimeBase base)) return;
-        if (weakScalars.contains(ref)) return;  // already weak
+        LifecycleRuntimeState state = state();
+        if (state.weakScalars.contains(ref)) return;  // already weak
 
         // If referent was already destroyed, immediately undef the weak ref.
         // CODE refs are an exception: Sub::Quote compiles named, no-install
@@ -100,8 +99,8 @@ public class WeakRefRegistry {
             }
         }
 
-        weakScalars.add(ref);
-        referentToWeakRefs
+        state.weakScalars.add(ref);
+        state.referentToWeakRefs
                 .computeIfAbsent(base, k -> Collections.newSetFromMap(new IdentityHashMap<>()))
                 .add(ref);
         base.activateOwnerTracking();
@@ -120,8 +119,9 @@ public class WeakRefRegistry {
         // merge cost on weakRefsExist; without backfill, my-vars
         // declared before the first weaken would never appear in
         // liveCounts and the walker would miss them.
-        if (!weakRefsExist) {
-            weakRefsExist = true;
+        if (!state.weakRefsExist) {
+            MortalList.noteBoundaryWork();
+            state.weakRefsExist = true;
             MyVarCleanupStack.snapshotStackToLiveCounts();
         }
 
@@ -230,7 +230,7 @@ public class WeakRefRegistry {
                 && !ModuleInitGuard.inModuleInit();
         if (base instanceof RuntimeCode code
                 && code.refCount >= 0
-                && weakRefsExist
+                && state.weakRefsExist
                 && (shouldCheckLiveCodeRef
                 || (code.hadStashRef
                 && code.stashRefCount <= 0
@@ -259,19 +259,20 @@ public class WeakRefRegistry {
      * Check if a RuntimeScalar is a weak reference.
      */
     public static boolean isweak(RuntimeScalar ref) {
-        return weakScalars.contains(ref);
+        return state().weakScalars.contains(ref);
     }
 
     /**
      * Make a weak reference strong again.
      */
     public static void unweaken(RuntimeScalar ref) {
-        if (!weakScalars.remove(ref)) return;
+        LifecycleRuntimeState state = state();
+        if (!state.weakScalars.remove(ref)) return;
         if (ref.value instanceof RuntimeBase base) {
-            Set<RuntimeScalar> weakRefs = referentToWeakRefs.get(base);
+            Set<RuntimeScalar> weakRefs = state.referentToWeakRefs.get(base);
             if (weakRefs != null) {
                 weakRefs.remove(ref);
-                if (weakRefs.isEmpty()) referentToWeakRefs.remove(base);
+                if (weakRefs.isEmpty()) state.referentToWeakRefs.remove(base);
             }
             if (base.refCount >= 0) {
                 base.refCount++;  // restore strong count
@@ -287,17 +288,18 @@ public class WeakRefRegistry {
      * skip refCount decrement for the old referent).
      */
     public static boolean removeWeakRef(RuntimeScalar ref, RuntimeBase oldReferent) {
-        if (!weakScalars.remove(ref)) return false;
+        LifecycleRuntimeState state = state();
+        if (!state.weakScalars.remove(ref)) return false;
         if (System.getenv("PJ_WEAKCLEAR_TRACE") != null) {
             System.err.println("[WEAKREMOVE] ref=" + System.identityHashCode(ref)
                 + " oldReferent=" + System.identityHashCode(oldReferent)
                 + " (" + (oldReferent == null ? "null" : oldReferent.getClass().getSimpleName()) + ")");
             new Throwable().printStackTrace(System.err);
         }
-        Set<RuntimeScalar> weakRefs = referentToWeakRefs.get(oldReferent);
+        Set<RuntimeScalar> weakRefs = state.referentToWeakRefs.get(oldReferent);
         if (weakRefs != null) {
             weakRefs.remove(ref);
-            if (weakRefs.isEmpty()) referentToWeakRefs.remove(oldReferent);
+            if (weakRefs.isEmpty()) state.referentToWeakRefs.remove(oldReferent);
         }
         return true;
     }
@@ -306,7 +308,7 @@ public class WeakRefRegistry {
      * Check if any weak references point to a given referent.
      */
     public static boolean hasWeakRefsTo(RuntimeBase referent) {
-        Set<RuntimeScalar> weakRefs = referentToWeakRefs.get(referent);
+        Set<RuntimeScalar> weakRefs = state().referentToWeakRefs.get(referent);
         return weakRefs != null && !weakRefs.isEmpty();
     }
 
@@ -322,7 +324,8 @@ public class WeakRefRegistry {
         // leaving those weak scalars defined keeps the whole quoted/deferred
         // metadata graph Java-reachable and leaks until global destruction.
         if (referent instanceof RuntimeCode code && shouldKeepCodeWeakRefs(code)) return;
-        Set<RuntimeScalar> weakRefs = referentToWeakRefs.remove(referent);
+        LifecycleRuntimeState state = state();
+        Set<RuntimeScalar> weakRefs = state.referentToWeakRefs.remove(referent);
         if (weakRefs == null) return;
         if (System.getenv("PJ_WEAKCLEAR_TRACE") != null) {
             System.err.println("[WEAKCLEAR] referent=" + System.identityHashCode(referent)
@@ -333,7 +336,7 @@ public class WeakRefRegistry {
         for (RuntimeScalar weak : weakRefs) {
             weak.type = RuntimeScalarType.UNDEF;
             weak.value = null;
-            weakScalars.remove(weak);
+            state.weakScalars.remove(weak);
         }
     }
 
@@ -373,14 +376,14 @@ public class WeakRefRegistry {
      * clearing during the walk).
      */
     public static java.util.List<RuntimeBase> snapshotWeakRefReferents() {
-        return new java.util.ArrayList<>(referentToWeakRefs.keySet());
+        return new java.util.ArrayList<>(state().referentToWeakRefs.keySet());
     }
 
     public static void clearAllBlessedWeakRefs() {
         // Snapshot the keys to avoid ConcurrentModificationException,
         // since clearWeakRefsTo modifies referentToWeakRefs.
         java.util.List<RuntimeBase> referents =
-                new java.util.ArrayList<>(referentToWeakRefs.keySet());
+                new java.util.ArrayList<>(state().referentToWeakRefs.keySet());
         for (RuntimeBase referent : referents) {
             if (referent instanceof RuntimeCode) continue;
             // Phase H3: skip unblessed containers (ARRAY/HASH) at pre-END

--- a/src/test/java/org/perlonjava/runtime/CompilationRuntimeIsolationTest.java
+++ b/src/test/java/org/perlonjava/runtime/CompilationRuntimeIsolationTest.java
@@ -1,0 +1,112 @@
+package org.perlonjava.runtime;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+import org.perlonjava.runtime.perlmodule.FilterUtilCall;
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
+import org.perlonjava.runtime.runtimetypes.WarningFlags;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class CompilationRuntimeIsolationTest {
+
+    @Test
+    void warningHintAndFilterStateFollowNestedBindings() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            WarningBitsRegistry.register("same-class", "first-bits");
+            WarningBitsRegistry.setCallSiteHints(17);
+            first.compilationState.hintSnapshots.put(7, Map.of("marker", "first"));
+            first.compilationState.callSiteHintHashId = 7;
+            WarningFlags.registerCategory("Phase10::first");
+            WarningFlags.registerScopeWarnings(Set.of("uninitialized"));
+            FilterUtilCall.markFilterInstalled();
+
+            try (PerlRuntime.Binding nested = second.bind()) {
+                assertNull(WarningBitsRegistry.get("same-class"));
+                assertEquals(0, WarningBitsRegistry.getCallSiteHints());
+                assertNull(HintHashRegistry.getCurrentCallSiteHintHash());
+                assertFalse(WarningFlags.isCustomCategory("Phase10::first"));
+                assertFalse(FilterUtilCall.wasFilterInstalled());
+
+                WarningBitsRegistry.register("same-class", "second-bits");
+                WarningBitsRegistry.setCallSiteHints(23);
+                second.compilationState.hintSnapshots.put(7, Map.of("marker", "second"));
+                second.compilationState.callSiteHintHashId = 7;
+            }
+
+            assertEquals("first-bits", WarningBitsRegistry.get("same-class"));
+            assertEquals(17, WarningBitsRegistry.getCallSiteHints());
+            assertEquals("first", HintHashRegistry.getCurrentCallSiteHintHash().get("marker"));
+            assertTrue(WarningFlags.isCustomCategory("Phase10::first"));
+            assertTrue(FilterUtilCall.wasFilterInstalled());
+        }
+
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertEquals("second-bits", WarningBitsRegistry.get("same-class"));
+            assertEquals(23, WarningBitsRegistry.getCallSiteHints());
+            assertEquals("second", HintHashRegistry.getCurrentCallSiteHintHash().get("marker"));
+        }
+    }
+
+    @Test
+    void concurrentErrorLocationsUseTheOwningSourceMap() throws Exception {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        FutureTask<String> firstTask = failureTask(first, "phase10-first.pl", 71,
+                "first failure", ready, start);
+        FutureTask<String> secondTask = failureTask(second, "phase10-second.pl", 93,
+                "second failure", ready, start);
+        Thread firstThread = Thread.ofPlatform().name("phase10-source-first").start(firstTask);
+        Thread secondThread = Thread.ofPlatform().name("phase10-source-second").start(secondTask);
+
+        try {
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+        } finally {
+            start.countDown();
+            firstThread.join(TimeUnit.SECONDS.toMillis(30));
+            secondThread.join(TimeUnit.SECONDS.toMillis(30));
+        }
+        assertFalse(firstThread.isAlive());
+        assertFalse(secondThread.isAlive());
+        assertAll(
+                () -> assertTrue(firstTask.get(1, TimeUnit.SECONDS).contains("first failure")),
+                () -> assertTrue(firstTask.get(1, TimeUnit.SECONDS).contains("phase10-first.pl")),
+                () -> assertTrue(secondTask.get(1, TimeUnit.SECONDS).contains("second failure")),
+                () -> assertTrue(secondTask.get(1, TimeUnit.SECONDS).contains("phase10-second.pl")));
+    }
+
+    private static FutureTask<String> failureTask(
+            PerlRuntime runtime, String file, int line, String message,
+            CountDownLatch ready, CountDownLatch start) {
+        return new FutureTask<>(() -> {
+            ready.countDown();
+            assertTrue(start.await(10, TimeUnit.SECONDS));
+            CompilerOptions options = new CompilerOptions();
+            options.fileName = "<phase10-source-map>";
+            options.code = "#line " + line + " \"" + file + "\"\ndie '" + message + "';";
+            try (PerlRuntime.Binding ignored = runtime.bind()) {
+                try {
+                    PerlLanguageProvider.executePerlCode(options, false);
+                    fail("die should throw");
+                    return "";
+                } catch (Exception error) {
+                    return error.getMessage();
+                }
+            }
+        });
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/operators/SystemOperatorWindowsCommandTest.java
+++ b/src/test/java/org/perlonjava/runtime/operators/SystemOperatorWindowsCommandTest.java
@@ -1,0 +1,32 @@
+package org.perlonjava.runtime.operators;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@Tag("unit")
+class SystemOperatorWindowsCommandTest {
+
+    @Test
+    void quotedPerlProgramIsSplitWithoutInvokingCmd() {
+        String command = "\"C:\\work tree\\jperl.bat\" -e "
+                + "\"binmode STDOUT; print STDOUT pack q(H*), q(82a0ff)\"";
+
+        assertEquals(List.of(
+                "C:\\work tree\\jperl.bat",
+                "-e",
+                "binmode STDOUT; print STDOUT pack q(H*), q(82a0ff)"),
+                SystemOperator.splitWindowsDirectCommandWords(command));
+    }
+
+    @Test
+    void unquotedShellSyntaxStillRequiresCmd() {
+        assertNull(SystemOperator.splitWindowsDirectCommandWords("echo value | findstr value"));
+        assertNull(SystemOperator.splitWindowsDirectCommandWords("echo %PATH%"));
+        assertNull(SystemOperator.splitWindowsDirectCommandWords("\"unterminated"));
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/operators/TimeAlarmRuntimeBindingTest.java
+++ b/src/test/java/org/perlonjava/runtime/operators/TimeAlarmRuntimeBindingTest.java
@@ -25,7 +25,9 @@ class TimeAlarmRuntimeBindingTest {
             GlobalVariable.getGlobalHash("main::SIG").put("ALRM", handler);
         }
 
-        PerlSignalQueue.clearSignals();
+        try (PerlRuntime.Binding ignored = owner.bind()) {
+            PerlSignalQueue.clearSignals();
+        }
         Thread target = new Thread(() -> { });
         FutureTask<PerlRuntime> callback = new FutureTask<>(() -> {
             Time.dispatchAlarm(owner, target);
@@ -37,10 +39,14 @@ class TimeAlarmRuntimeBindingTest {
             assertNull(callback.get(10, TimeUnit.SECONDS));
             worker.join(TimeUnit.SECONDS.toMillis(10));
             assertFalse(worker.isAlive());
-            assertTrue(PerlSignalQueue.hasPendingSignals());
+            try (PerlRuntime.Binding ignored = owner.bind()) {
+                assertTrue(PerlSignalQueue.hasPendingSignals());
+            }
             assertTrue(target.isInterrupted());
         } finally {
-            PerlSignalQueue.clearSignals();
+            try (PerlRuntime.Binding ignored = owner.bind()) {
+                PerlSignalQueue.clearSignals();
+            }
         }
     }
 }

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/MiscRuntimeIsolationTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/MiscRuntimeIsolationTest.java
@@ -1,0 +1,76 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.runtime.operators.Random;
+import org.perlonjava.runtime.perlmodule.NetSSLeay;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class MiscRuntimeIsolationTest {
+
+    @Test
+    void randomSignalsStateVariablesEnvironmentAndRegistriesAreIndependent() {
+        PerlRuntime first = new PerlRuntime();
+        PerlRuntime second = new PerlRuntime();
+        double firstRandom;
+        double firstSecondRandom;
+        long firstLibContext;
+        RuntimeScalar topLevel = new RuntimeScalar();
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            Random.srand(new RuntimeScalar(12345));
+            firstRandom = Random.rand(new RuntimeScalar(1)).getDouble();
+            firstSecondRandom = Random.rand(new RuntimeScalar(1)).getDouble();
+            PerlSignalQueue.enqueue("USR1", new RuntimeScalar("first-handler"));
+            StateVariable.markInitializedStateVariable(topLevel, "$phase11", 17);
+            RuntimeEnvironment.setCurrentDirectory("/tmp/phase11-first");
+            first.ioRegistryState.nextFileno.set(41);
+            first.lifecycleState.weakRefsExist = true;
+            first.diamondIOState.accumulatedLineNumber = 12;
+            assertEquals(1, NameNormalizer.getBlessId("First::Class"));
+            firstLibContext = NetSSLeay.OSSL_LIB_CTX_get0_global_default(
+                    new RuntimeArray(), RuntimeContextType.SCALAR).scalar().getLong();
+        }
+
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertFalse(PerlSignalQueue.hasPendingSignals());
+            assertFalse(StateVariable.isInitializedStateVariable(topLevel, "$phase11", 17)
+                    .getBoolean());
+            assertNotEquals("/tmp/phase11-first", RuntimeEnvironment.currentDirectory());
+            assertEquals(3, second.ioRegistryState.nextFileno.get());
+            assertFalse(second.lifecycleState.weakRefsExist);
+            assertEquals(0, second.diamondIOState.accumulatedLineNumber);
+            assertEquals(1, NameNormalizer.getBlessId("Second::Class"));
+            assertEquals("Second::Class", NameNormalizer.getBlessStr(1));
+            assertNotEquals(firstLibContext,
+                    NetSSLeay.OSSL_LIB_CTX_get0_global_default(
+                            new RuntimeArray(), RuntimeContextType.SCALAR).scalar().getLong());
+
+            Random.srand(new RuntimeScalar(12345));
+            assertEquals(firstRandom, Random.rand(new RuntimeScalar(1)).getDouble());
+            assertEquals(firstSecondRandom, Random.rand(new RuntimeScalar(1)).getDouble());
+            RuntimeEnvironment.setCurrentDirectory("/tmp/phase11-second");
+        }
+
+        try (PerlRuntime.Binding ignored = first.bind()) {
+            assertTrue(PerlSignalQueue.hasPendingSignals());
+            assertTrue(StateVariable.isInitializedStateVariable(topLevel, "$phase11", 17)
+                    .getBoolean());
+            assertEquals("/tmp/phase11-first", RuntimeEnvironment.currentDirectory());
+            assertEquals(41, first.ioRegistryState.nextFileno.get());
+            assertTrue(first.lifecycleState.weakRefsExist);
+            assertEquals(12, first.diamondIOState.accumulatedLineNumber);
+            assertEquals("First::Class", NameNormalizer.getBlessStr(1));
+            assertEquals(firstLibContext,
+                    NetSSLeay.OSSL_LIB_CTX_get0_global_default(
+                            new RuntimeArray(), RuntimeContextType.SCALAR).scalar().getLong());
+            PerlSignalQueue.clearSignals();
+        }
+
+        try (PerlRuntime.Binding ignored = second.bind()) {
+            assertEquals("/tmp/phase11-second", RuntimeEnvironment.currentDirectory());
+        }
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/MiscRuntimeIsolationTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/MiscRuntimeIsolationTest.java
@@ -2,8 +2,11 @@ package org.perlonjava.runtime.runtimetypes;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.perlonjava.runtime.operators.Random;
 import org.perlonjava.runtime.perlmodule.NetSSLeay;
+
+import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -11,9 +14,11 @@ import static org.junit.jupiter.api.Assertions.*;
 class MiscRuntimeIsolationTest {
 
     @Test
-    void randomSignalsStateVariablesEnvironmentAndRegistriesAreIndependent() {
+    void randomSignalsStateVariablesEnvironmentAndRegistriesAreIndependent(@TempDir Path tempDir) {
         PerlRuntime first = new PerlRuntime();
         PerlRuntime second = new PerlRuntime();
+        String firstDirectory = tempDir.resolve("phase11-first").toString();
+        String secondDirectory = tempDir.resolve("phase11-second").toString();
         double firstRandom;
         double firstSecondRandom;
         long firstLibContext;
@@ -25,7 +30,7 @@ class MiscRuntimeIsolationTest {
             firstSecondRandom = Random.rand(new RuntimeScalar(1)).getDouble();
             PerlSignalQueue.enqueue("USR1", new RuntimeScalar("first-handler"));
             StateVariable.markInitializedStateVariable(topLevel, "$phase11", 17);
-            RuntimeEnvironment.setCurrentDirectory("/tmp/phase11-first");
+            RuntimeEnvironment.setCurrentDirectory(firstDirectory);
             first.ioRegistryState.nextFileno.set(41);
             first.lifecycleState.weakRefsExist = true;
             first.diamondIOState.accumulatedLineNumber = 12;
@@ -38,7 +43,7 @@ class MiscRuntimeIsolationTest {
             assertFalse(PerlSignalQueue.hasPendingSignals());
             assertFalse(StateVariable.isInitializedStateVariable(topLevel, "$phase11", 17)
                     .getBoolean());
-            assertNotEquals("/tmp/phase11-first", RuntimeEnvironment.currentDirectory());
+            assertNotEquals(firstDirectory, RuntimeEnvironment.currentDirectory());
             assertEquals(3, second.ioRegistryState.nextFileno.get());
             assertFalse(second.lifecycleState.weakRefsExist);
             assertEquals(0, second.diamondIOState.accumulatedLineNumber);
@@ -51,14 +56,14 @@ class MiscRuntimeIsolationTest {
             Random.srand(new RuntimeScalar(12345));
             assertEquals(firstRandom, Random.rand(new RuntimeScalar(1)).getDouble());
             assertEquals(firstSecondRandom, Random.rand(new RuntimeScalar(1)).getDouble());
-            RuntimeEnvironment.setCurrentDirectory("/tmp/phase11-second");
+            RuntimeEnvironment.setCurrentDirectory(secondDirectory);
         }
 
         try (PerlRuntime.Binding ignored = first.bind()) {
             assertTrue(PerlSignalQueue.hasPendingSignals());
             assertTrue(StateVariable.isInitializedStateVariable(topLevel, "$phase11", 17)
                     .getBoolean());
-            assertEquals("/tmp/phase11-first", RuntimeEnvironment.currentDirectory());
+            assertEquals(firstDirectory, RuntimeEnvironment.currentDirectory());
             assertEquals(41, first.ioRegistryState.nextFileno.get());
             assertTrue(first.lifecycleState.weakRefsExist);
             assertEquals(12, first.diamondIOState.accumulatedLineNumber);
@@ -70,7 +75,7 @@ class MiscRuntimeIsolationTest {
         }
 
         try (PerlRuntime.Binding ignored = second.bind()) {
-            assertEquals("/tmp/phase11-second", RuntimeEnvironment.currentDirectory());
+            assertEquals(secondDirectory, RuntimeEnvironment.currentDirectory());
         }
     }
 }

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeLifecycleTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeLifecycleTest.java
@@ -1,0 +1,123 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class PerlRuntimeLifecycleTest {
+
+    @Test
+    void initializeExecuteAndCloseHaveExplicitLifecycle() throws Exception {
+        PerlRuntime runtime = new PerlRuntime();
+        assertFalse(runtime.isInitialized());
+        assertFalse(runtime.isClosed());
+        assertSame(runtime, runtime.initialize());
+        assertTrue(runtime.isInitialized());
+        assertNull(PerlRuntime.currentOrNull());
+
+        PerlRuntime sentinel = new PerlRuntime();
+        try (PerlRuntime.Binding ignored = sentinel.bind()) {
+            assertSame(runtime, runtime.execute(PerlRuntime::current));
+            assertSame(sentinel, PerlRuntime.current());
+        }
+
+        runtime.close();
+        runtime.close();
+        assertTrue(runtime.isClosed());
+        assertThrows(IllegalStateException.class, runtime::bind);
+        assertThrows(IllegalStateException.class, runtime::initialize);
+        assertThrows(IllegalStateException.class, () -> runtime.execute(() -> 1));
+    }
+
+    @Test
+    void executeSerializesOwnershipOfOneRuntime() throws Exception {
+        PerlRuntime runtime = new PerlRuntime().initialize();
+        CountDownLatch firstEntered = new CountDownLatch(1);
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        CountDownLatch secondAttempted = new CountDownLatch(1);
+        CountDownLatch secondEntered = new CountDownLatch(1);
+        FutureTask<Void> firstTask = new FutureTask<>(() -> runtime.execute(() -> {
+            firstEntered.countDown();
+            assertTrue(releaseFirst.await(10, TimeUnit.SECONDS));
+            return null;
+        }));
+        FutureTask<Void> secondTask = new FutureTask<>(() -> {
+            secondAttempted.countDown();
+            return runtime.execute(() -> {
+                secondEntered.countDown();
+                return null;
+            });
+        });
+        Thread first = Thread.ofPlatform().name("managed-runtime-first").start(firstTask);
+        Thread second = null;
+        try {
+            assertTrue(firstEntered.await(10, TimeUnit.SECONDS));
+            second = Thread.ofPlatform().name("managed-runtime-second").start(secondTask);
+            assertTrue(secondAttempted.await(10, TimeUnit.SECONDS));
+            assertFalse(secondEntered.await(250, TimeUnit.MILLISECONDS));
+        } finally {
+            releaseFirst.countDown();
+            first.join(TimeUnit.SECONDS.toMillis(10));
+            if (second != null) second.join(TimeUnit.SECONDS.toMillis(10));
+            runtime.close();
+        }
+        assertFalse(first.isAlive());
+        assertNotNull(second);
+        assertFalse(second.isAlive());
+        firstTask.get(1, TimeUnit.SECONDS);
+        secondTask.get(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void independentManagedRuntimesExecuteConflictingProgramsConcurrently() throws Exception {
+        PerlRuntime first = new PerlRuntime().initialize();
+        PerlRuntime second = new PerlRuntime().initialize();
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        FutureTask<String> firstTask = programTask(first, "first", false, ready, start);
+        FutureTask<String> secondTask = programTask(second, "second", true, ready, start);
+        Thread firstThread = Thread.ofPlatform().name("managed-program-first").start(firstTask);
+        Thread secondThread = Thread.ofPlatform().name("managed-program-second").start(secondTask);
+
+        try {
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+        } finally {
+            start.countDown();
+            firstThread.join(TimeUnit.SECONDS.toMillis(30));
+            secondThread.join(TimeUnit.SECONDS.toMillis(30));
+            first.close();
+            second.close();
+        }
+        assertFalse(firstThread.isAlive());
+        assertFalse(secondThread.isAlive());
+        assertEquals("first:first", firstTask.get(1, TimeUnit.SECONDS));
+        assertEquals("second:second", secondTask.get(1, TimeUnit.SECONDS));
+    }
+
+    private static FutureTask<String> programTask(
+            PerlRuntime runtime, String marker, boolean interpreter,
+            CountDownLatch ready, CountDownLatch start) {
+        return new FutureTask<>(() -> {
+            ready.countDown();
+            assertTrue(start.await(10, TimeUnit.SECONDS));
+            return runtime.execute(() -> {
+                CompilerOptions options = new CompilerOptions();
+                options.fileName = "<managed-runtime-" + marker + ">";
+                options.useInterpreter = interpreter;
+                options.code = "$Phase12::value='" + marker + "'; "
+                        + "sub Phase12::value { $Phase12::value } "
+                        + "$Phase12::value . ':' . Phase12::value()";
+                return PerlLanguageProvider.executePerlCode(options, false)
+                        .scalar().toString();
+            });
+        });
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeSnapshotTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeSnapshotTest.java
@@ -1,0 +1,51 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unit")
+class PerlRuntimeSnapshotTest {
+
+    @Test
+    void snapshotClonesGlobalsRunsHooksAndStartsWithFreshExecutionState() throws Exception {
+        for (boolean interpreter : new boolean[]{false, true}) {
+            PerlRuntime parent = new PerlRuntime();
+            run(parent, interpreter, ""
+                    + "package Hook; our $cloned = 0; sub CLONE { ++$cloned } "
+                    + "package Skip; sub CLONE_SKIP { 1 } "
+                    + "package main; our $graph = { value => 40 }; "
+                    + "our $alias = $graph; our $skipped = bless({}, 'Skip'); 1");
+
+            PerlRuntime child = parent.snapshotClone();
+
+            assertTrue(child.isInitialized());
+            assertNotSame(parent.globalState(), child.globalState());
+            assertEquals("0:40:Skip", run(parent, interpreter,
+                    "join q(:), $Hook::cloned, $graph->{value}, ref($skipped)"));
+            assertEquals("1:41:41:", run(child, interpreter,
+                    "$graph->{value}++; join q(:), $Hook::cloned, "
+                            + "$graph->{value}, $alias->{value}, ref($skipped)"));
+            assertEquals("0:40:40", run(parent, interpreter,
+                    "join q(:), $Hook::cloned, $graph->{value}, $alias->{value}"));
+            assertEquals(0, child.executionState().argsStack.size());
+            assertEquals(0, child.executionState().callerStack.size());
+        }
+    }
+
+    private static String run(PerlRuntime runtime, boolean interpreter, String source)
+            throws Exception {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            CompilerOptions options = new CompilerOptions();
+            options.fileName = "<runtime-snapshot>";
+            options.useInterpreter = interpreter;
+            options.code = source;
+            return PerlLanguageProvider.executePerlCode(options, false).scalar().toString();
+        }
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/RuntimeCodeGraphClonerTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/RuntimeCodeGraphClonerTest.java
@@ -1,0 +1,50 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+@Tag("unit")
+class RuntimeCodeGraphClonerTest {
+
+    @Test
+    void jvmAndInterpreterClosuresCloneCapturedScalarArrayAndHash() throws Exception {
+        for (boolean interpreter : new boolean[]{false, true}) {
+            PerlRuntime sourceRuntime = new PerlRuntime();
+            PerlRuntime targetRuntime = new PerlRuntime();
+            RuntimeScalar sourceCodeRef = compileClosure(sourceRuntime, interpreter);
+            RuntimeScalar clonedCodeRef = (RuntimeScalar) new RuntimeGraphCloner(
+                    sourceRuntime, targetRuntime).cloneGraph(sourceCodeRef);
+
+            assertNotSame(sourceCodeRef, clonedCodeRef);
+            assertNotSame(sourceCodeRef.value, clonedCodeRef.value);
+            assertEquals("41:2:2", invoke(sourceRuntime, sourceCodeRef));
+            assertEquals("41:2:2", invoke(targetRuntime, clonedCodeRef));
+            assertEquals("42:3:3", invoke(sourceRuntime, sourceCodeRef));
+            assertEquals("42:3:3", invoke(targetRuntime, clonedCodeRef));
+        }
+    }
+
+    private static RuntimeScalar compileClosure(PerlRuntime runtime, boolean interpreter)
+            throws Exception {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            CompilerOptions options = new CompilerOptions();
+            options.fileName = "<runtime-code-graph-cloner>";
+            options.useInterpreter = interpreter;
+            options.code = "my $x = 40; my @a = (1); my %h = (one => 1); "
+                    + "sub { ++$x; push @a, $x; $h{$x} = 1; join q(:), $x, scalar @a, scalar keys %h }";
+            return PerlLanguageProvider.executePerlCode(options, false).scalar();
+        }
+    }
+
+    private static String invoke(PerlRuntime runtime, RuntimeScalar codeRef) throws Exception {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            return RuntimeCode.apply(codeRef, new RuntimeArray(), RuntimeContextType.SCALAR)
+                    .scalar().toString();
+        }
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphClonerTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphClonerTest.java
@@ -1,0 +1,91 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unit")
+class RuntimeGraphClonerTest {
+
+    @Test
+    void preservesCyclesAliasesBlessingsWeaknessAndSourceGraph() {
+        PerlRuntime sourceRuntime = new PerlRuntime();
+        PerlRuntime targetRuntime = new PerlRuntime();
+        RuntimeArray sourceArray = new RuntimeArray();
+        RuntimeScalar first = sourceArray.createAnonymousReference();
+        RuntimeScalar alias = new RuntimeScalar();
+        alias.type = first.type;
+        alias.value = first.value;
+        sourceArray.elements.add(first);
+        sourceArray.elements.add(alias);
+
+        try (PerlRuntime.Binding ignored = sourceRuntime.bind()) {
+            sourceArray.blessId = NameNormalizer.getBlessId("Graph::Node");
+            WeakRefRegistry.weaken(alias);
+        }
+
+        RuntimeArray cloned = (RuntimeArray) new RuntimeGraphCloner(sourceRuntime, targetRuntime)
+                .cloneGraph(sourceArray);
+
+        assertNotSame(sourceArray, cloned);
+        assertSame(cloned, cloned.elements.get(0).value);
+        assertSame(cloned, cloned.elements.get(1).value);
+        assertNotSame(first, cloned.elements.get(0));
+        try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
+            assertEquals("Graph::Node", NameNormalizer.getBlessStr(cloned.blessId));
+            assertFalse(WeakRefRegistry.isweak(cloned.elements.get(0)));
+            assertTrue(WeakRefRegistry.isweak(cloned.elements.get(1)));
+        }
+
+        assertSame(sourceArray, first.value);
+        assertSame(sourceArray, alias.value);
+        try (PerlRuntime.Binding ignored = sourceRuntime.bind()) {
+            assertTrue(WeakRefRegistry.isweak(alias));
+        }
+    }
+
+    @Test
+    void sharesImmutableConstantsAndDropsNonPortableIoResources() {
+        PerlRuntime sourceRuntime = new PerlRuntime();
+        PerlRuntime targetRuntime = new PerlRuntime();
+        RuntimeScalarReadOnly constant = new RuntimeScalarReadOnly("constant");
+        RuntimeScalar resource = new RuntimeScalar(new RuntimeIO());
+
+        RuntimeGraphCloner cloner = new RuntimeGraphCloner(sourceRuntime, targetRuntime);
+        List<RuntimeBase> cloned = cloner.cloneRoots(List.of(constant, resource));
+
+        assertSame(constant, cloned.get(0));
+        RuntimeScalar clonedResource = (RuntimeScalar) cloned.get(1);
+        assertEquals(RuntimeScalarType.UNDEF, clonedResource.type);
+        assertNull(clonedResource.value);
+        assertTrue(resource.defined().getBoolean());
+    }
+
+    @Test
+    void preservesAliasingAcrossSeparateRoots() {
+        PerlRuntime sourceRuntime = new PerlRuntime();
+        PerlRuntime targetRuntime = new PerlRuntime();
+        RuntimeHash referent = new RuntimeHash();
+        referent.elements.put("value", new RuntimeScalar(42));
+        RuntimeScalar one = referent.createAnonymousReference();
+        RuntimeScalar two = new RuntimeScalar();
+        two.type = one.type;
+        two.value = referent;
+
+        List<RuntimeBase> cloned = new RuntimeGraphCloner(sourceRuntime, targetRuntime)
+                .cloneRoots(List.of(one, two));
+
+        assertSame(((RuntimeScalar) cloned.get(0)).value,
+                ((RuntimeScalar) cloned.get(1)).value);
+        assertNotSame(referent, ((RuntimeScalar) cloned.get(0)).value);
+        assertEquals(42, ((RuntimeHash) ((RuntimeScalar) cloned.get(0)).value)
+                .elements.get("value").getInt());
+    }
+}


### PR DESCRIPTION
## Summary

- complete Perl threads plan phases 10–12 by isolating remaining mutable runtime state and exposing lifecycle-managed independent runtimes
- complete phase 13 with all six measured hot paths inside the 5% regression budget
- complete phase 14 with an identity-preserving non-code value graph cloner for aliases, cycles, blessings, weak refs, readonly values, ties, and explicit resource policy
- complete phase 15 with explicit generated JVM capture metadata and interpreter closure cloning through the same identity map
- complete phase 16 with runtime package snapshots, parent-side `CLONE_SKIP`, child-side `CLONE`, and fresh child execution/resource state
- repair the Windows CI regressions exposed by runtime isolation, including File::Spec::Unix host independence and quoted qx command handling
- keep `Config` thread flags disabled; this PR does not expose the Perl `threads` API

## Validation

- `make` — pass after each significant phase; final gate pass
- Windows and Ubuntu CI — pass for the prerequisite runtime-state/Windows-fix head before phases 13–16
- focused graph tests — aliases, cycles, blessings, weak refs, readonly values, source immutability, and resource policy pass in all shards
- focused closure tests — independent scalar/array/hash captures pass on JVM and interpreter backends
- focused snapshot tests — global aliases, `CLONE_SKIP`, `CLONE`, parent immutability, and fresh execution stacks pass on JVM and interpreter backends
- prior comprehensive compatibility gate: Perl core 83.1%, bundled modules 81.0%, Scalar::Util 1.70 on both backends

## Performance

Three fresh-JVM runs per tree, comparing median rates against the exact merged base:

| Benchmark | Base | Current | Delta |
|---|---:|---:|---:|
| global | 35671 | 37030 | +3.8% |
| lexical | 118820 | 127349 | +7.2% |
| method | 94.40 | 91.45 | -3.1% |
| closure | 32.37 | 34.68 | +7.1% |
| regex | 22048.45 | 21657.60 | -1.8% |
| eval-string | 14910.07 | 15070.22 | +1.1% |

## Design notes

- one identity map spans all cloned roots; Storable hooks and reflective field ordering are not used
- generated JVM closures expose constructor-ordered captures through `CloneablePerlSubroutine`
- nonportable Java I/O resources conservatively become undef in cloned value graphs; child standard I/O remains fresh
- child execution, lifecycle, signal/alarm, native, classloader, cache, and I/O state is not copied
- completed phase history remains in commit and PR messages rather than a growing section in `dev/design/concurrency.md`
