### PR TITLE
Fix CPAN compiler and tooling dependencies

### DIFF
--- a/dev/design/jcpan-lace-jsonrpc-mab2-programinfo.md
+++ b/dev/design/jcpan-lace-jsonrpc-mab2-programinfo.md
@@ -1,0 +1,92 @@
+# CPAN compiler and tooling compatibility batch
+
+## Goal
+
+Fix reusable compiler, runtime, and CPAN-tooling defects exposed by
+`Template::Lace`, `Sledge::Plugin::JSONRPC`, `Catmandu::Exporter::MAB2`, and
+their dependency graphs. Avoid distribution preferences where a general fix
+is possible. A target that also fails with the same installed distribution on
+system Perl is outside this batch.
+
+## Implementation
+
+- Compiler and parser fixes preserve package barewords on the right side of
+  `isa`, extended named characters inside regexes, exception objects in
+  `try`/`catch`, and `return` control flow through a catch block.
+- JVM temporary ownership now keeps array/hash references returned from
+  conditional method expressions alive. `Storable::dclone` preserves weak
+  references without leaving cloned containers owned by temporary roots.
+- `POSIX` exports its standard math functions by default, matching system
+  Perl and allowing `UUID::Tiny` to use `floor`.
+- The CPAN version probe only arms an alarm for filesystem modules; bundled
+  modules loaded from the application JAR no longer trigger an unnecessary
+  probe timeout.
+- A bundled `YAML::Syck` compatibility layer delegates YAML work to the
+  existing `YAML::PP`/SnakeYAML implementation and JSON work to `JSON::PP`.
+- `XML::LibXML::Reader` uses the existing JDK DOM implementation for file,
+  string, and filehandle construction, element traversal, and node copying.
+  The shared XML input adapter accepts UTF-8, UTF-16, and UTF-32 BOM byte
+  strings as well as an already-decoded Unicode BOM.
+- `Data::Util` replaces the native scalar-inspection entry points with Java
+  runtime-type checks. In particular, inspecting a missing aliased array slot
+  does not vivify it, matching the XS implementation used by system Perl.
+  The distribution's upstream `Data::Util::PurePerl` supplies the rest of the
+  public API.
+
+No distribution preferences were added. Existing Java facilities are reused:
+the JDK XML stack and the already bundled SnakeYAML implementation provide the
+required functionality, following the same approach used by existing
+BouncyCastle-backed module ports.
+
+## Verification
+
+- New behavioral tests are validated with system Perl before running on both
+  PerlOnJava backends.
+- Direct Catmandu regressions cover its regex, exception handling, XML/SRU,
+  and `Data::Util` binder paths.
+- The requested module suites and the complete PerlOnJava build are rerun
+  after the final implementation changes.
+- `Log::ProgramInfo` is excluded because its installed suite has the same
+  uname/log-key failures under system Perl.
+
+## Progress Tracking
+
+### Current Status: Completed (2026-08-11)
+
+### Completed Phases
+
+- [x] Phase 1: Reproduce and classify failures (2026-08-11)
+  - Compared requested failures and focused dependency tests with system Perl.
+  - Classified `Log::ProgramInfo` as a matching system-Perl failure.
+- [x] Phase 2: Compiler and runtime repairs (2026-08-11)
+  - Fixed parser, regex, exception, ownership, and cloning behavior.
+  - Files: compiler/parser/runtime Java sources and focused unit tests.
+- [x] Phase 3: Reusable module and tooling support (2026-08-11)
+  - Added `Data::Util`, `YAML::Syck`, XML reader support, POSIX exports, and
+    the safe CPAN version-probe behavior.
+  - Files: `src/main/perl/lib`, Java module bridges, and module tests.
+- [x] Phase 4: Validation (2026-08-11)
+  - `Template::Lace`: 2 files, 142 tests passed.
+  - `Sledge::Plugin::JSONRPC`: 4 files passed (two optional POD suites skipped).
+  - `Catmandu::Exporter::MAB2`: 10 files, 92 tests passed.
+  - Full build: 360 unit scripts passed with two expected skips.
+  - Focused bundled `Data::Util` module test passed.
+  - The complete 384-file bundled-module run has three pre-existing
+    `Math::BigInt` subclass failures; the exact test fails identically in an
+    isolated `master` worktree.
+  - `Log::ProgramInfo`: excluded after its sole test file failed identically
+    under system Perl on the uname-derived nested log key.
+
+### Next Steps
+
+1. No remaining work for this compatibility batch.
+
+### Open Questions
+
+- None.
+
+## Related documentation and skills
+
+- [Module porting guide](../../docs/guides/module-porting.md)
+- [Patch and CPAN preferences layout](patch-and-cpan-prefs-layout.md)
+- Skills: `debug-perlonjava`, `port-cpan-module`

--- a/dev/design/jcpan-lace-jsonrpc-mab2-programinfo.md
+++ b/dev/design/jcpan-lace-jsonrpc-mab2-programinfo.md
@@ -71,11 +71,21 @@ BouncyCastle-backed module ports.
   - `Catmandu::Exporter::MAB2`: 10 files, 92 tests passed.
   - Full build: 360 unit scripts passed with two expected skips.
   - Focused bundled `Data::Util` module test passed.
-  - The complete 384-file bundled-module run has three pre-existing
+  - The initial complete 384-file bundled-module run had three pre-existing
     `Math::BigInt` subclass failures; the exact test fails identically in an
     isolated `master` worktree.
   - `Log::ProgramInfo`: excluded after its sole test file failed identically
     under system Perl on the uname-derived nested log key.
+- [x] Phase 5: Math::BigInt bundled-test follow-up (2026-08-11)
+  - Made overloaded-mutator copy-on-write conditional on aggregate sharing,
+    matching Perl's optimization that skips the copy constructor for an
+    unshared object.
+  - Preserved the existing copy-constructor behavior for aliased objects and
+    conservatively retained it for reference kinds without reliable ownership
+    counts.
+  - `sub_mbf.t`, `sub_mbi.t`, `sub_mbr.t`, and `sub_mif.t` all pass.
+  - The complete bundled-module rerun passes all 384 files with no skips or
+    failures.
 
 ### Next Steps
 

--- a/dev/design/jcpan-lace-jsonrpc-mab2-programinfo.md
+++ b/dev/design/jcpan-lace-jsonrpc-mab2-programinfo.md
@@ -86,6 +86,14 @@ BouncyCastle-backed module ports.
   - `sub_mbf.t`, `sub_mbi.t`, `sub_mbr.t`, and `sub_mif.t` all pass.
   - The complete bundled-module rerun passes all 384 files with no skips or
     failures.
+- [x] Phase 6: Regex regression follow-up (2026-08-12)
+  - Rebased onto the latest `master` and reproduced all five reported regex
+    count regressions after a clean full build.
+  - Fixed named Unicode escapes inside character classes so preprocessing
+    emits one Java `\x{...}` escape instead of a doubled escape whose syntax
+    characters became unintended class members.
+  - Added system-Perl-validated coverage for named punctuation, whitespace,
+    and joiner characters in character classes.
 
 ### Next Steps
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -4,6 +4,12 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 
 ## Work in progress
 
+- CPAN/compiler tooling: unblock `Template::Lace`, `Sledge::Plugin::JSONRPC`,
+  and `Catmandu::Exporter::MAB2` without distribution preferences. Add
+  Java-backed `Data::Util` scalar inspection, a `YAML::Syck` compatibility
+  layer, XML reader/BOM support, POSIX math defaults, and fixes for try/catch
+  control flow, exception values, named-character regexes, bareword `isa`,
+  cloned weak references, and temporary reference ownership.
 - CPAN: add Java-backed `Tie::Array::Packed`, BouncyCastle-backed
   `Crypt::Blowfish`, and ProcessHandle-backed `Proc::ProcessTable` XS
   replacements. Fix MakeMaker test-helper staging, H/h pack semantics, and raw

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -10,6 +10,9 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
   layer, XML reader/BOM support, POSIX math defaults, and fixes for try/catch
   control flow, exception values, named-character regexes, bareword `isa`,
   cloned weak references, and temporary reference ownership.
+- Bugfix: overloaded mutators skip copy constructors for unshared hash/array
+  objects, preserving subclass-only fields in `Math::BigInt`, `Math::BigFloat`,
+  and `Math::BigRat` subclasses.
 - CPAN: add Java-backed `Tie::Array::Packed`, BouncyCastle-backed
   `Crypt::Blowfish`, and ProcessHandle-backed `Proc::ProcessTable` XS
   replacements. Fix MakeMaker test-helper staging, H/h pack semantics, and raw

--- a/docs/reference/bundled-modules.md
+++ b/docs/reference/bundled-modules.md
@@ -25,6 +25,8 @@ Recent CPAN compatibility additions include:
 | `Tie::Array::Packed` | Perl + Java XS bridge | Packed scalar storage for the upstream tied-array API and pack formats |
 | `Digest::JHash` | Java XS bridge | Jenkins 32-bit hash used by CHI and TimeZone::TimeZoneDB |
 | `B::Flags` | Pure Perl over portable `B` objects | Named OP/SV flags without access to Perl C structures |
+| `Data::Util` | Java XS bridge plus upstream pure-Perl fallback | Scalar classification preserves XS non-vivifying behavior; the remaining API uses `Data::Util::PurePerl` |
+| `YAML::Syck` | Pure Perl over bundled `YAML::PP` | Compatibility loader/dumper for distributions that use the legacy Syck API |
 
 ---
 

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -770,6 +770,9 @@ The `:encoding()` layer supports all encodings provided by Java's `Charset.forNa
   storage, mutation, splicing, rotation, and binary search.
 - 🟡 **B::Flags**: portable OP/SV flag names over the bundled partial `B`
   model; host-Perl allocation flags are intentionally unavailable.
+- ✅  **Data::Util**: Java-backed `is_value` and `is_string` preserve the
+  native module's non-vivifying scalar inspection; the rest of the upstream
+  API is supplied by its pure-Perl fallback.
 - ✅  **Scalar::Type** module backed by PerlOnJava scalar metadata (replaces native XS).
 - 🟡 **PadWalker**: `peek_sub`, `closed_over`, and `set_closed_over` use
   runtime-maintained lexical metadata on both backends; caller-pad APIs are
@@ -786,6 +789,7 @@ The `:encoding()` layer supports all encodings provided by Java's `Charset.forNa
 - ✅  **XML::Parser** module backed by JDK SAX (replaces native libexpat XS).
 - ✅  **YAML::PP** module.
 - ✅  **YAML** module.
+- ✅  **YAML::Syck** compatibility module backed by bundled `YAML::PP`.
 - ✅  **IO::Socket::SSL** module backed by Java `javax.net.ssl` SSLEngine.
 - ✅  **Net::SSLeay** module backed by Java security APIs (2327 CPAN tests pass).
 - ✅  **Plack::Handler::Netty** PSGI web server with HTTP/HTTPS, streaming, 32k+ req/sec. See [Web Server Guide](../../examples/http_server_plack/README.md).

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
@@ -705,7 +705,14 @@ public class CompileBinaryOperator {
         } else {
             rightCtx = outerCtx;
         }
-        bytecodeCompiler.compileNode(node.right, -1, rightCtx);
+        Node rightNode = node.right;
+        if (node.operator.equals("isa") && rightNode instanceof IdentifierNode identifier) {
+            // The RHS package name of the feature 'isa' operator is a
+            // class-name bareword even under strict subs. Match the JVM
+            // backend by compiling it as a string constant.
+            rightNode = new StringNode(identifier.name, identifier.getIndex());
+        }
+        bytecodeCompiler.compileNode(rightNode, -1, rightCtx);
         int rs2 = bytecodeCompiler.lastResultReg;
 
         // Emit opcode based on operator (delegated to helper method)

--- a/src/main/java/org/perlonjava/backend/jvm/EmitControlFlow.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitControlFlow.java
@@ -23,6 +23,21 @@ public class EmitControlFlow {
     // Set to true to enable debug output for control flow operations
     private static final boolean DEBUG_CONTROL_FLOW = false;
 
+    private static boolean containsAggregateReferenceReturn(Node node) {
+        if (node instanceof ListNode list) {
+            if (list.elements.size() != 1) return false;
+            return containsAggregateReferenceReturn(list.elements.getFirst());
+        }
+        if (node instanceof TernaryOperatorNode ternary) {
+            return containsAggregateReferenceReturn(ternary.trueExpr)
+                    || containsAggregateReferenceReturn(ternary.falseExpr);
+        }
+        return node instanceof OperatorNode refOp
+                && refOp.operator.equals("\\")
+                && refOp.operand instanceof OperatorNode aggregateOp
+                && (aggregateOp.operator.equals("@") || aggregateOp.operator.equals("%"));
+    }
+
     private static void emitSubroutineExitCleanup(EmitterContext ctx) {
         java.util.List<Integer> scalarIndices =
                 EmitStatement.withoutCaptured(ctx, ctx.symbolTable.getMyScalarIndicesInScope(0));
@@ -281,6 +296,7 @@ public class EmitControlFlow {
         if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("visit(return) will visit " + node.operand + " in context " + emitterVisitor.ctx.with(RuntimeContextType.RUNTIME).contextType);
 
         boolean hasOperand = !(node.operand == null || (node.operand instanceof ListNode list && list.elements.isEmpty()));
+        boolean protectsLexicalAggregate = containsAggregateReferenceReturn(node.operand);
 
         if (!hasOperand) {
             ctx.mv.visitTypeInsn(Opcodes.NEW, "org/perlonjava/runtime/runtimetypes/RuntimeList");
@@ -348,6 +364,21 @@ public class EmitControlFlow {
             }
         }
 
+        // Materialize direct references to lexical aggregates before cleanup.
+        // The short-lived root installed below protects `return \@nodes` and
+        // `return \%items` without extending lifetimes for ordinary object
+        // returns, whose DESTROY timing must remain unchanged.
+        if (protectsLexicalAggregate) {
+            ctx.mv.visitVarInsn(Opcodes.ILOAD, 2);
+            ctx.mv.visitInsn(ctx.javaClassInfo.isLvalueSubroutine
+                    ? Opcodes.ICONST_0 : Opcodes.ICONST_1);
+            ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                    "org/perlonjava/runtime/runtimetypes/RuntimeCode",
+                    "returnList",
+                    "(Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;IZ)Lorg/perlonjava/runtime/runtimetypes/RuntimeList;",
+                    false);
+        }
+
         // Defer refCount decrements for blessed my-scalars in scope.
         // Explicit 'return' jumps to returnLabel, bypassing per-scope
         // emitScopeExitNullStores. Without this, local variables holding blessed
@@ -359,6 +390,14 @@ public class EmitControlFlow {
         if (!scalarIndices.isEmpty() || !hashIndices.isEmpty() || !arrayIndices.isEmpty()) {
             JavaClassInfo.SpillRef spillRef = ctx.javaClassInfo.acquireSpillRefOrAllocate(ctx.symbolTable);
             ctx.javaClassInfo.storeSpillRef(ctx.mv, spillRef);
+            if (protectsLexicalAggregate) {
+                ctx.javaClassInfo.loadSpillRef(ctx.mv, spillRef);
+                ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                        "org/perlonjava/runtime/runtimetypes/MortalList",
+                        "pushTemporaryRoot",
+                        "(Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)V",
+                        false);
+            }
             for (int idx : scalarIndices) {
                 ctx.mv.visitVarInsn(Opcodes.ALOAD, idx);
                 ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
@@ -383,6 +422,14 @@ public class EmitControlFlow {
                         "org/perlonjava/runtime/runtimetypes/MortalList",
                         "scopeExitCleanupArray",
                         "(Lorg/perlonjava/runtime/runtimetypes/RuntimeArray;)V",
+                        false);
+            }
+            if (protectsLexicalAggregate) {
+                ctx.javaClassInfo.loadSpillRef(ctx.mv, spillRef);
+                ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                        "org/perlonjava/runtime/runtimetypes/MortalList",
+                        "popTemporaryRoot",
+                        "(Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)V",
                         false);
             }
             ctx.javaClassInfo.loadSpillRef(ctx.mv, spillRef);

--- a/src/main/java/org/perlonjava/backend/jvm/EmitStatement.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitStatement.java
@@ -875,11 +875,11 @@ public class EmitStatement {
         mv.visitLabel(catchBlock);
 
         // --------- Store the exception in the catch parameter ---------
-        // Convert the exception to a string
+        // Preserve a reference passed to die; non-Perl exceptions become strings.
         mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                 "org/perlonjava/runtime/runtimetypes/ErrorMessageUtil",
-                "stringifyException",
-                "(Ljava/lang/Throwable;)Ljava/lang/String;", false);
+                "exceptionValue",
+                "(Ljava/lang/Throwable;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;", false);
         // Transform catch parameter to 'my'
         OperatorNode catchParameter = new OperatorNode("my", node.catchParameter, node.tokenIndex);
         // Create the lexical variable for the catch parameter, push it to the stack
@@ -889,7 +889,7 @@ public class EmitStatement {
                 Opcodes.INVOKEVIRTUAL,
                 "org/perlonjava/runtime/runtimetypes/RuntimeScalar",
                 "set",
-                "(Ljava/lang/String;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;",
+                "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;",
                 false);
         mv.visitInsn(Opcodes.POP);
         // --------- end of store the catch parameter ---------

--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -434,9 +434,12 @@ public class StatementParser {
 
             TryNode tryNode = new TryNode(
                     tryBlock, catchParameter, catchBlock, finallyBlock, index);
-            // Async bodies must keep try inline so an await suspends the owning
-            // async frame rather than an ordinary internal wrapper subroutine.
-            if (parser.parsingFutureAsyncAwaitSub) {
+            // A return inside core try/catch returns from the containing
+            // subroutine. Keep try/catch without finally inline; lowering it
+            // through an anonymous wrapper traps that return in the wrapper
+            // and lets execution incorrectly continue after the try statement.
+            // Async bodies also stay inline so await suspends the owning frame.
+            if (finallyBlock == null || parser.parsingFutureAsyncAwaitSub) {
                 return tryNode;
             }
 

--- a/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
@@ -1444,6 +1444,14 @@ public abstract class StringSegmentParser {
         if ("}".equals(chr)) {
             TokenUtils.consumeChar(parser); // consume '}'
             var name = nameBuilder.toString();
+            if (isRegex) {
+                // Keep named-character escapes intact until regex preprocessing.
+                // Resolving \N{NUMBER SIGN} to '#' here is observably wrong under
+                // /x: the resolved character is then mistaken for a comment and
+                // any following capture groups disappear from the pattern.
+                appendToCurrentSegment("\\N{" + name + "}");
+                return;
+            }
             try {
                 // Use centralized Unicode name resolution from UnicodeResolver
                 // This handles U+XXXX format, official Unicode names, and Perl charnames aliases

--- a/src/main/java/org/perlonjava/runtime/perlmodule/DataUtil.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/DataUtil.java
@@ -1,0 +1,56 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.runtime.runtimetypes.RuntimeArray;
+import org.perlonjava.runtime.runtimetypes.RuntimeList;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalarType;
+
+/**
+ * XS-compatible primitive scalar classification for Data::Util.
+ *
+ * <p>The distribution's pure-Perl fallback checks {@code ref(\$_[0])} to
+ * distinguish globs.  When the argument aliases a missing array element, that
+ * reference intentionally vivifies the slot in standard Perl.  The XS backend
+ * inspects the SV flags without vivification; these methods provide the same
+ * behavior for PerlOnJava.</p>
+ */
+public final class DataUtil extends PerlModuleBase {
+    public static final String XS_VERSION = "0.67";
+
+    private DataUtil() {
+        super("Data::Util", false);
+    }
+
+    public static void initialize() {
+        DataUtil module = new DataUtil();
+        try {
+            module.registerMethod("is_value", null);
+            module.registerMethod("is_string", null);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Install the distribution's reusable pure-Perl implementation for
+        // the remaining API, then let the shim restore these XS-like methods.
+        XSLoader.loadJarShimOverrides("Data::Util");
+    }
+
+    public static RuntimeList is_value(RuntimeArray args, int ctx) {
+        RuntimeScalar value = args.get(0);
+        boolean result = value != null
+                && value.type != RuntimeScalarType.UNDEF
+                && value.type != RuntimeScalarType.GLOB
+                && !RuntimeScalarType.isReference(value);
+        return new RuntimeScalar(result).getList();
+    }
+
+    public static RuntimeList is_string(RuntimeArray args, int ctx) {
+        RuntimeScalar value = args.get(0);
+        boolean result = value != null && switch (value.type) {
+            case RuntimeScalarType.STRING, RuntimeScalarType.BYTE_STRING,
+                    RuntimeScalarType.VSTRING -> !value.toString().isEmpty();
+            default -> false;
+        };
+        return new RuntimeScalar(result).getList();
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Storable.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Storable.java
@@ -256,8 +256,21 @@ public class Storable extends PerlModuleBase {
 
         try {
             RuntimeScalar data = args.get(0);
-            IdentityHashMap<Object, RuntimeScalar> cloned = new IdentityHashMap<>();
-            RuntimeScalar result = deepClone(data, cloned);
+            CloneContext cloneContext = new CloneContext();
+            RuntimeScalar result = deepClone(data, cloneContext);
+            // The returned scalar is a live strong owner while dclone is
+            // finishing, just as a Perl temporary SV is. Acquire that owner
+            // before restoring weak child-to-root edges; otherwise a graph
+            // whose root is referenced only weakly from within itself reaches
+            // refCount zero before the caller can receive it.
+            RuntimeScalar.incrementRefCountForContainerStore(result);
+            // Restore weak edges only after every strong container edge has
+            // acquired ownership. Weakening during recursion can take a
+            // newly-created referent to refCount zero when the weak edge
+            // precedes its strong edge in traversal order.
+            for (RuntimeScalar weakRef : cloneContext.pendingWeakRefs) {
+                WeakRefRegistry.weaken(weakRef);
+            }
             return result.getList();
         } catch (Exception e) {
             return WarnDie.die(new RuntimeScalar("dclone failed: " + e.getMessage()), new RuntimeScalar("\n")).getList();
@@ -351,12 +364,20 @@ public class Storable extends PerlModuleBase {
      * Recursively deep-clones a RuntimeScalar, handling circular references and
      * STORABLE_freeze/STORABLE_thaw hooks on blessed objects.
      */
-    private static RuntimeScalar deepClone(RuntimeScalar scalar, IdentityHashMap<Object, RuntimeScalar> cloned) {
+    private static final class CloneContext {
+        private final IdentityHashMap<Object, RuntimeScalar> cloned = new IdentityHashMap<>();
+        private final java.util.ArrayList<RuntimeScalar> pendingWeakRefs = new java.util.ArrayList<>();
+    }
+
+    private static RuntimeScalar deepClone(RuntimeScalar scalar, CloneContext context) {
         if (scalar == null) return new RuntimeScalar();
+        boolean sourceWasWeak = WeakRefRegistry.isweak(scalar);
 
         // Check for already-cloned references (circular reference handling)
-        if (scalar.value != null && cloned.containsKey(scalar.value)) {
-            return new RuntimeScalar(cloned.get(scalar.value));
+        if (scalar.value != null && context.cloned.containsKey(scalar.value)) {
+            RuntimeScalar copy = new RuntimeScalar(context.cloned.get(scalar.value));
+            if (sourceWasWeak) context.pendingWeakRefs.add(copy);
+            return copy;
         }
 
         // Check for blessed objects with STORABLE_freeze hook
@@ -398,7 +419,7 @@ public class Storable extends PerlModuleBase {
                         newObj = new RuntimeHash().createAnonymousReference();
                     }
                     ReferenceOperators.bless(newObj, new RuntimeScalar(className));
-                    cloned.put(scalar.value, newObj);
+                    context.cloned.put(scalar.value, newObj);
 
                     // Call STORABLE_thaw($new_obj, $cloning=1, $serialized, @extra_refs)
                     RuntimeScalar thawMethod = InheritanceResolver.findMethodInHierarchy(
@@ -412,7 +433,7 @@ public class Storable extends PerlModuleBase {
                         // Remaining elements are extra refs — deep-clone them
                         // so the thawed object gets independent copies
                         for (int i = 1; i < freezeArray.size(); i++) {
-                            RuntimeArray.push(thawArgs, deepClone(freezeArray.get(i), cloned));
+                            RuntimeArray.push(thawArgs, deepClone(freezeArray.get(i), context));
                         }
                         RuntimeCode.apply(thawMethod, thawArgs, RuntimeContextType.VOID);
                         // Phase G: release arg-push refCount bumps (see
@@ -427,7 +448,7 @@ public class Storable extends PerlModuleBase {
         }
 
         // Regular deep copy based on type
-        return switch (scalar.type) {
+        RuntimeScalar result = switch (scalar.type) {
             case RuntimeScalarType.HASHREFERENCE -> {
                 RuntimeHash origHash = (RuntimeHash) scalar.value;
                 RuntimeHash newHash = new RuntimeHash();
@@ -436,7 +457,7 @@ public class Storable extends PerlModuleBase {
                 // would set localBindingExists=true and suppress DESTROY/weak-ref
                 // clearing (DBIC t/52leaks.t test 18).
                 RuntimeScalar newRef = newHash.createAnonymousReference();
-                cloned.put(scalar.value, newRef);
+                context.cloned.put(scalar.value, newRef);
 
                 // Preserve blessing
                 if (blessId != 0) {
@@ -447,7 +468,7 @@ public class Storable extends PerlModuleBase {
                 // Check for tied hash — preserve tie magic
                 if (origHash.type == RuntimeHash.TIED_HASH && origHash.elements instanceof TieHash tieHash) {
                     // Deep-clone the tie handler object
-                    RuntimeScalar clonedSelf = deepClone(tieHash.getSelf(), cloned);
+                    RuntimeScalar clonedSelf = deepClone(tieHash.getSelf(), context);
                     // Deep-clone the underlying data via FETCH iteration
                     RuntimeHash previousValue = new RuntimeHash();
                     // Create new TieHash with cloned handler
@@ -459,13 +480,13 @@ public class Storable extends PerlModuleBase {
                     RuntimeScalar firstKey = TieHash.tiedFirstKey(origHash);
                     while (firstKey.type != RuntimeScalarType.UNDEF) {
                         RuntimeScalar val = TieHash.tiedFetch(origHash, firstKey);
-                        previousValue.put(firstKey.toString(), deepClone(val, cloned));
+                        previousValue.putClonedElement(firstKey.toString(), deepClone(val, context));
                         firstKey = TieHash.tiedNextKey(origHash, firstKey);
                     }
                 } else {
                     // Regular (untied) hash: deep-clone each value
                     origHash.elements.forEach((key, value) ->
-                            newHash.put(key, deepClone(value, cloned)));
+                            newHash.putClonedElement(key, deepClone(value, context)));
                 }
                 yield newRef;
             }
@@ -474,7 +495,7 @@ public class Storable extends PerlModuleBase {
                 RuntimeArray newArray = new RuntimeArray();
                 // Anonymous ref — see note on HASHREFERENCE case above.
                 RuntimeScalar newRef = newArray.createAnonymousReference();
-                cloned.put(scalar.value, newRef);
+                context.cloned.put(scalar.value, newRef);
 
                 // Preserve blessing
                 if (blessId != 0) {
@@ -485,7 +506,7 @@ public class Storable extends PerlModuleBase {
                 // Check for tied array — preserve tie magic
                 if (origArray.type == RuntimeArray.TIED_ARRAY && origArray.elements instanceof TieArray tieArray) {
                     // Deep-clone the tie handler object
-                    RuntimeScalar clonedSelf = deepClone(tieArray.getSelf(), cloned);
+                    RuntimeScalar clonedSelf = deepClone(tieArray.getSelf(), context);
                     // Create new TieArray with cloned handler
                     RuntimeArray previousValue = new RuntimeArray();
                     newArray.type = RuntimeArray.TIED_ARRAY;
@@ -496,12 +517,12 @@ public class Storable extends PerlModuleBase {
                     int size = TieArray.tiedFetchSize(origArray).getInt();
                     for (int i = 0; i < size; i++) {
                         RuntimeScalar val = TieArray.tiedFetch(origArray, new RuntimeScalar(i));
-                        previousValue.add(deepClone(val, cloned));
+                        previousValue.add(deepClone(val, context));
                     }
                 } else {
                     // Regular (untied) array: deep-clone each element
                     for (RuntimeScalar element : origArray.elements) {
-                        newArray.addClonedElement(deepClone(element, cloned));
+                        newArray.addClonedElement(deepClone(element, context));
                     }
                 }
                 yield newRef;
@@ -511,8 +532,8 @@ public class Storable extends PerlModuleBase {
                 RuntimeScalar origValue = (RuntimeScalar) scalar.value;
                 RuntimeScalar newValue = new RuntimeScalar();
                 RuntimeScalar newRef = newValue.createReference();
-                cloned.put(scalar.value, newRef);
-                RuntimeScalar clonedValue = deepClone(origValue, cloned);
+                context.cloned.put(scalar.value, newRef);
+                RuntimeScalar clonedValue = deepClone(origValue, context);
                 copyScalarPayload(newValue, clonedValue);
 
                 // Preserve blessing
@@ -526,11 +547,11 @@ public class Storable extends PerlModuleBase {
                 // CODE refs are shared, not cloned
                 yield scalar;
             }
-            case RuntimeScalarType.READONLY_SCALAR -> deepClone((RuntimeScalar) scalar.value, cloned);
+            case RuntimeScalarType.READONLY_SCALAR -> deepClone((RuntimeScalar) scalar.value, context);
             case RuntimeScalarType.TIED_SCALAR -> {
                 // Tied scalar: deep-clone the handler and re-tie
                 if (scalar.value instanceof TieScalar tieScalar) {
-                    RuntimeScalar clonedSelf = deepClone(tieScalar.getSelf(), cloned);
+                    RuntimeScalar clonedSelf = deepClone(tieScalar.getSelf(), context);
                     // Fetch the current value through the tie to initialize the previous value
                     RuntimeScalar prevValue = new RuntimeScalar();
                     prevValue.set(tieScalar.tiedFetch());
@@ -553,6 +574,11 @@ public class Storable extends PerlModuleBase {
                 yield copy;
             }
         };
+        // Native Storable promotes a weak reference to strong when it is the
+        // first edge that introduces a referent into the cloned graph. Only
+        // weak aliases to an already-cloned referent remain weak (handled at
+        // the early return above).
+        return result;
     }
 
     private static void copyScalarPayload(RuntimeScalar target, RuntimeScalar source) {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/XMLLibXML.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/XMLLibXML.java
@@ -39,6 +39,7 @@ public class XMLLibXML extends PerlModuleBase {
     private static final String NODE_KEY = "_node";
     private static final String OPTS_KEY = "_parser_opts";
     private static final String XPC_KEY  = "_xpc_state";
+    private static final String READER_KEY = "_reader_state";
 
     /** Pseudo-namespace for functions registered without namespace ("{}name"). */
     private static final String NONS_NS     = "http://perlonjava.org/xpc-nons";
@@ -71,6 +72,30 @@ public class XMLLibXML extends PerlModuleBase {
         RuntimeScalar                     varLookupData     = null;  // data passed to var-lookup func
         int contextPosition = -1;
         int contextSize     = -1;
+    }
+
+    /** DOM-backed state for XML::LibXML::Reader's forward element cursor. */
+    static class ReaderState {
+        final Document document;
+        final List<Element> elements = new ArrayList<>();
+        int position = -1;
+
+        ReaderState(Document document) {
+            this.document = document;
+            collectElements(document);
+        }
+
+        private void collectElements(Node node) {
+            if (node instanceof Element element) elements.add(element);
+            NodeList children = node.getChildNodes();
+            for (int i = 0; i < children.getLength(); i++) {
+                collectElements(children.item(i));
+            }
+        }
+
+        Element current() {
+            return position >= 0 && position < elements.size() ? elements.get(position) : null;
+        }
     }
 
     static class SimpleNamespaceContext implements NamespaceContext {
@@ -142,6 +167,24 @@ public class XMLLibXML extends PerlModuleBase {
             module.registerMethod("_parse_sax_xml_chunk", "nopMethod",     null);
             module.registerMethod("lib_init_callbacks",   "nopMethod", null);
             module.registerMethod("lib_cleanup_callbacks","nopMethod", null);
+
+            // XML::LibXML::Reader is an optional part of the XS distribution.
+            // Provide its core constructors/cursor operations over the same JDK
+            // DOM representation as the rest of this module.
+            String readerPkg = "XML::LibXML::Reader";
+            String[][] readerMethods = {
+                {"_newForFile",   "readerNewForFile"},
+                {"_newForString", "readerNewForString"},
+                {"_newForIO",     "readerNewForIO"},
+                {"nextElement",   "readerNextElement"},
+                {"copyCurrentNode","readerCopyCurrentNode"},
+                {"name",          "readerName"},
+                {"_close",        "readerClose"},
+                {"_DESTROY",      "readerDestroy"},
+            };
+            for (String[] m : readerMethods) {
+                module.registerMethodInPackage(readerPkg, m[0], m[1]);
+            }
 
             // InputCallback methods (nop stubs — no native callback support)
             for (String m : new String[]{"lib_init_callbacks","lib_cleanup_callbacks"}) {
@@ -424,6 +467,22 @@ public class XMLLibXML extends PerlModuleBase {
         String perlClass = nodeTypeToPerlClass(node);
         RuntimeScalar ref = hash.createReferenceWithTrackedElements();
         return ReferenceOperators.bless(ref, new RuntimeScalar(perlClass));
+    }
+
+    private static RuntimeScalar wrapReader(Document document) {
+        RuntimeHash hash = new RuntimeHash();
+        hash.put(READER_KEY, new RuntimeScalar(new ReaderState(document)));
+        RuntimeScalar ref = hash.createReferenceWithTrackedElements();
+        return ReferenceOperators.bless(ref, new RuntimeScalar("XML::LibXML::Reader"));
+    }
+
+    private static ReaderState getReader(RuntimeScalar self) {
+        RuntimeScalar state = self.hashDerefRaw().get(READER_KEY);
+        if (state != null && state.type == RuntimeScalarType.JAVAOBJECT
+                && state.value instanceof ReaderState reader) {
+            return reader;
+        }
+        throw new RuntimeException("Not a valid XML::LibXML::Reader object");
     }
 
     static Node getNode(RuntimeScalar self) {
@@ -934,13 +993,7 @@ public class XMLLibXML extends PerlModuleBase {
             Document doc;
             // Detect binary XML (UTF-16/UTF-32 BOM) and parse as byte stream
             // so the parser can auto-detect the encoding from the BOM/declaration
-            byte[] xmlBytes = xmlStr.getBytes(StandardCharsets.ISO_8859_1);
-            if (hasBinaryXmlBom(xmlBytes)) {
-                InputSource is = new InputSource(new ByteArrayInputStream(xmlBytes));
-                doc = db.parse(is);
-            } else {
-                doc = db.parse(new InputSource(new StringReader(xmlStr)));
-            }
+            doc = db.parse(xmlInputSource(xmlStr));
             if (!opts.keepBlanks) stripBlankTextNodes(doc);
             // Store detected encoding in user data for getEncoding() calls
             String declEnc = doc.getXmlEncoding();
@@ -961,6 +1014,10 @@ public class XMLLibXML extends PerlModuleBase {
 
     private static boolean hasBinaryXmlBom(byte[] b) {
         if (b.length < 2) return false;
+        // UTF-8 BOM: parse byte strings as bytes so the XML parser consumes
+        // the marker instead of seeing the Latin-1 mojibake characters ï»¿.
+        if (b.length >= 3 && (b[0] & 0xFF) == 0xEF
+                && (b[1] & 0xFF) == 0xBB && (b[2] & 0xFF) == 0xBF) return true;
         // UTF-16 BE BOM: FE FF
         if ((b[0] & 0xFF) == 0xFE && (b[1] & 0xFF) == 0xFF) return true;
         // UTF-16 LE BOM: FF FE
@@ -974,6 +1031,19 @@ public class XMLLibXML extends PerlModuleBase {
         // UTF-32 LE without BOM: '<' = 0x3C 0x00 0x00 0x00
         if (b.length >= 4 && b[0] == 0x3C && b[1] == 0x00 && b[2] == 0x00 && b[3] == 0x00) return true;
         return false;
+    }
+
+    private static InputSource xmlInputSource(String xml) {
+        // A Perl byte string may already have been decoded by the scalar bridge,
+        // turning EF BB BF into the Unicode BOM character.  A BOM is encoding
+        // metadata, not XML content, so consume that representation explicitly.
+        if (!xml.isEmpty() && xml.charAt(0) == '\uFEFF') {
+            return new InputSource(new StringReader(xml.substring(1)));
+        }
+        byte[] bytes = xml.getBytes(StandardCharsets.ISO_8859_1);
+        return hasBinaryXmlBom(bytes)
+                ? new InputSource(new ByteArrayInputStream(bytes))
+                : new InputSource(new StringReader(xml));
     }
 
     /**
@@ -1074,6 +1144,100 @@ public class XMLLibXML extends PerlModuleBase {
             return WarnDie.die(new RuntimeScalar("XML::LibXML::parse_fh: " + e.getMessage() + "\n"),
                 new RuntimeScalar("\n")).getList();
         }
+    }
+
+    // ================================================================
+    // XML::LibXML::Reader core methods
+    // ================================================================
+
+    private static Document parseReaderDocument(InputSource source) throws Exception {
+        return newBuilder(new ParserOptions()).parse(source);
+    }
+
+    public static RuntimeList readerNewForFile(RuntimeArray args, int ctx) {
+        String filename = args.get(1).toString();
+        try {
+            File file = new File(filename);
+            Document document = parseReaderDocument(new InputSource(file.toURI().toString()));
+            document.setDocumentURI(file.toURI().toString());
+            return wrapReader(document).getList();
+        } catch (Exception e) {
+            return WarnDie.die(new RuntimeScalar("XML::LibXML::Reader: " + e.getMessage() + "\n"),
+                new RuntimeScalar("\n")).getList();
+        }
+    }
+
+    public static RuntimeList readerNewForString(RuntimeArray args, int ctx) {
+        String xml = args.get(1).toString();
+        String uri = args.size() > 2 && args.get(2).type != RuntimeScalarType.UNDEF
+            ? args.get(2).toString() : null;
+        try {
+            InputSource source = xmlInputSource(xml);
+            source.setSystemId(uri);
+            return wrapReader(parseReaderDocument(source)).getList();
+        } catch (Exception e) {
+            return WarnDie.die(new RuntimeScalar("XML::LibXML::Reader: " + e.getMessage() + "\n"),
+                new RuntimeScalar("\n")).getList();
+        }
+    }
+
+    public static RuntimeList readerNewForIO(RuntimeArray args, int ctx) {
+        RuntimeScalar fh = args.get(1);
+        StringBuilder xml = new StringBuilder();
+        try {
+            RuntimeBase content = org.perlonjava.runtime.operators.Readline.readline(
+                fh, RuntimeContextType.LIST);
+            if (content instanceof RuntimeList list) {
+                for (RuntimeBase element : list.elements) xml.append(element.toString());
+            } else if (content instanceof RuntimeScalar scalar
+                    && scalar.type != RuntimeScalarType.UNDEF) {
+                xml.append(scalar.toString());
+            }
+            InputSource source = xmlInputSource(xml.toString());
+            if (args.size() > 2 && args.get(2).type != RuntimeScalarType.UNDEF) {
+                source.setSystemId(args.get(2).toString());
+            }
+            return wrapReader(parseReaderDocument(source)).getList();
+        } catch (Exception e) {
+            return WarnDie.die(new RuntimeScalar("XML::LibXML::Reader: " + e.getMessage() + "\n"),
+                new RuntimeScalar("\n")).getList();
+        }
+    }
+
+    public static RuntimeList readerNextElement(RuntimeArray args, int ctx) {
+        ReaderState reader = getReader(args.get(0));
+        String wanted = args.size() > 1 && args.get(1).type != RuntimeScalarType.UNDEF
+            ? args.get(1).toString() : null;
+        while (++reader.position < reader.elements.size()) {
+            Element element = reader.elements.get(reader.position);
+            String localName = element.getLocalName();
+            if (wanted == null || wanted.equals(element.getNodeName())
+                    || wanted.equals(localName)) {
+                return scalarTrue.getList();
+            }
+        }
+        return scalarFalse.getList();
+    }
+
+    public static RuntimeList readerCopyCurrentNode(RuntimeArray args, int ctx) {
+        Element current = getReader(args.get(0)).current();
+        if (current == null) return scalarUndef.getList();
+        boolean deep = args.size() < 2 || args.get(1).getBoolean();
+        return wrapNode(current.cloneNode(deep)).getList();
+    }
+
+    public static RuntimeList readerName(RuntimeArray args, int ctx) {
+        Element current = getReader(args.get(0)).current();
+        return current == null ? scalarUndef.getList()
+            : new RuntimeScalar(current.getNodeName()).getList();
+    }
+
+    public static RuntimeList readerClose(RuntimeArray args, int ctx) {
+        return scalarFalse.getList(); // libxml2's _close returns 0 on success
+    }
+
+    public static RuntimeList readerDestroy(RuntimeArray args, int ctx) {
+        return scalarUndef.getList();
     }
 
     public static RuntimeList _parse_html_string(RuntimeArray args, int ctx) {
@@ -4729,4 +4893,3 @@ public class XMLLibXML extends PerlModuleBase {
         return scalarUndef.getList();
     }
 }
-

--- a/src/main/java/org/perlonjava/runtime/perlmodule/XSLoader.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/XSLoader.java
@@ -334,7 +334,7 @@ public class XSLoader extends PerlModuleBase {
      * @param moduleName The fully qualified Perl module name (e.g., "Template::Stash::XS")
      * @return true if a jar shim was found and successfully eval'd, false otherwise.
      */
-    private static boolean loadJarShimOverrides(String moduleName) {
+    static boolean loadJarShimOverrides(String moduleName) {
         // Guard against recursion: the shim code may call XSLoader::load() again
         // for the same module (e.g. Clone.pm's eval { XSLoader::load('Clone') })
         if (!shimLoadingInProgress.add(moduleName)) {

--- a/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessorHelper.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessorHelper.java
@@ -796,10 +796,13 @@ public class RegexPreprocessorHelper {
                                     // Can't use quantifiers inside character class
                                     RegexPreprocessor.regexError(s, offset - 2, "Quantifier \\N{" + content + "} not allowed inside character class");
                                 } else {
-                                    // Keep the resolved character escaped so class
-                                    // punctuation cannot change the class syntax.
+                                    // The class scanner has already copied the
+                                    // leading backslash. Append only the escape
+                                    // body so the result is \x{...}, not
+                                    // \\x{...} (a class containing literal
+                                    // backslash/x/braces characters).
                                     int codePoint = UnicodeResolver.getCodePointFromName(content);
-                                    sb.append("\\x{").append(Integer.toHexString(codePoint)).append('}');
+                                    sb.append("x{").append(Integer.toHexString(codePoint)).append('}');
                                     offset = endBrace;
                                 }
                             } else {

--- a/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessorHelper.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessorHelper.java
@@ -304,11 +304,13 @@ public class RegexPreprocessorHelper {
                         sb.append("[^\\n]{").append(cleanQuantifier).append("}");
                         return endBrace;
                     } else {
-                        // It's a Unicode name; emit literal Unicode character(s)
+                        // Emit an escaped code point rather than the literal
+                        // character. A literal '#' or whitespace would regain
+                        // regex syntax under /x after named-character resolution.
                         int codePoint = UnicodeResolver.getCodePointFromName(content);
                         // Remove the previously appended backslash
                         sb.setLength(sb.length() - 1);
-                        sb.append(Character.toChars(codePoint));
+                        sb.append("\\x{").append(Integer.toHexString(codePoint)).append('}');
                         return endBrace;
                     }
                 } else {
@@ -794,9 +796,10 @@ public class RegexPreprocessorHelper {
                                     // Can't use quantifiers inside character class
                                     RegexPreprocessor.regexError(s, offset - 2, "Quantifier \\N{" + content + "} not allowed inside character class");
                                 } else {
-                                    // It's a Unicode name; emit literal Unicode character(s)
+                                    // Keep the resolved character escaped so class
+                                    // punctuation cannot change the class syntax.
                                     int codePoint = UnicodeResolver.getCodePointFromName(content);
-                                    sb.append(Character.toChars(codePoint));
+                                    sb.append("\\x{").append(Integer.toHexString(codePoint)).append('}');
                                     offset = endBrace;
                                 }
                             } else {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ErrorMessageUtil.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ErrorMessageUtil.java
@@ -88,6 +88,30 @@ public class ErrorMessageUtil {
     }
 
     /**
+     * Convert a Java throwable to the value exposed by Perl's catch parameter.
+     * A reference passed to {@code die} must remain the same blessed Perl value;
+     * stringifying it breaks exception-class checks such as {@code $e->isa(...)}.
+     */
+    public static RuntimeScalar exceptionValue(Throwable t) {
+        Throwable current = t;
+        while (current != null) {
+            if (current instanceof PerlDieException pde && pde.getPayload() != null) {
+                RuntimeScalar first = pde.getPayload().getFirst();
+                if (first != null) {
+                    return first;
+                }
+                break;
+            }
+            Throwable cause = current.getCause();
+            if (cause == null || cause == current) {
+                break;
+            }
+            current = cause;
+        }
+        return new RuntimeScalar(stringifyException(t));
+    }
+
+    /**
      * Regex matching a leading Java exception class name followed by ": ", e.g.
      * "java.lang.NullPointerException: foo" or "org.perlonjava.runtime.RuntimeException: bar".
      * Matches fully-qualified class names composed of dot-separated identifier segments,

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
@@ -85,6 +85,22 @@ public class MortalList {
         return !temporaryRoots.get().isEmpty();
     }
 
+    private static boolean temporaryRootDirectlyReferences(RuntimeBase target) {
+        for (RuntimeBase root : temporaryRoots.get()) {
+            if (root == target) return true;
+            if (root instanceof RuntimeList list) {
+                for (RuntimeBase value : list.elements) {
+                    if (value instanceof RuntimeScalar scalar
+                            && !WeakRefRegistry.isweak(scalar)
+                            && scalar.value == target) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
     public static void retainSuspendedRoot(RuntimeBase root) {
         if (root != null) {
             suspendedRoots.merge(root, 1, Integer::sum);
@@ -408,7 +424,7 @@ public class MortalList {
         // do NOT clean up elements — the hash is still alive and its elements are
         // accessible through the reference. Cleanup will happen when the last
         // reference is released (in DestroyDispatch.callDestroy).
-        if (hash.refCount > 0) return;
+        if (hash.refCount > 0 || temporaryRootDirectlyReferences(hash)) return;
         if (hash.type == RuntimeHash.TIED_HASH && hash.elements instanceof TieHash tieHash) {
             tieHash.releaseTiedObject();
         }
@@ -477,7 +493,7 @@ public class MortalList {
         // do NOT clean up elements — the array is still alive and its elements are
         // accessible through the reference. Cleanup will happen when the last
         // reference is released (in DestroyDispatch.callDestroy).
-        if (arr.refCount > 0) return;
+        if (arr.refCount > 0 || temporaryRootDirectlyReferences(arr)) return;
         if (arr.type == RuntimeArray.TIED_ARRAY && arr.elements instanceof TieArray tieArray) {
             tieArray.releaseTiedObject();
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/OverloadContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/OverloadContext.java
@@ -178,6 +178,17 @@ public class OverloadContext {
      * referring to the original object.
      */
     private void copyForMutator(RuntimeScalar lvalue) {
+        // Perl skips the copy constructor when the aggregate has no other
+        // reference. An anonymous hash/array referent has at most one counted
+        // owner when unshared and gains another count when aliased. Avoiding an
+        // unnecessary copy matters for subclasses whose explicit constructor
+        // copies only the parent fields (Math::BigInt::Subclass's _custom is a
+        // concrete example). Keep the established conservative behavior for
+        // other reference kinds, whose alias counts are not tracked reliably.
+        if ((lvalue.value instanceof RuntimeHash || lvalue.value instanceof RuntimeArray)
+                && ((RuntimeBase) lvalue.value).refCount <= 1) {
+            return;
+        }
         RuntimeScalar copy = tryOverload("(=", new RuntimeArray(
                 lvalue, scalarUndef, new RuntimeScalar("")));
         if (copy != null) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
@@ -510,6 +510,20 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
     }
 
     /**
+     * Store a scalar produced by a deep-clone operation and acquire the
+     * destination hash slot's reference-count ownership. Unlike normal put(),
+     * this retains tied-scalar magic and does not apply Perl assignment/FETCH
+     * semantics to the already-cloned value.
+     */
+    public void putClonedElement(String key, RuntimeScalar value) {
+        elements.put(key, value == null ? new RuntimeScalar() : value);
+        if (value != null) {
+            value.markContainerOwner(this);
+            RuntimeScalar.incrementRefCountForContainerStore(value);
+        }
+    }
+
+    /**
      * Callback owners commonly release their captures with
      * {@code $self->{callbacks} = []}. Preserve that element's scalar slot so
      * the displaced aggregate is released through RuntimeScalar.set(), without

--- a/src/main/perl/lib/CPAN/Module.pm
+++ b/src/main/perl/lib/CPAN/Module.pm
@@ -697,7 +697,13 @@ sub available_version {
 #-> sub CPAN::Module::parse_version ;
 sub parse_version {
     my($self,$parsefile) = @_;
-    if (ALARM_IMPLEMENTED) {
+    # MM_Unix::parse_version only scans bundled jar resources line by line; it
+    # cannot execute module code or block on filesystem I/O.  A wall-clock
+    # alarm here merely turns temporary CPU starvation into a false "module
+    # not installed" result, which can send CPAN into recursive core-module
+    # dependency resolution.  Keep the safety timeout for ordinary files.
+    my $use_alarm = ALARM_IMPLEMENTED && $parsefile !~ /^jar:/;
+    if ($use_alarm) {
         my $timeout = (exists($CPAN::Config{'version_timeout'}))
                             ? $CPAN::Config{'version_timeout'}
                             : 15;
@@ -710,7 +716,7 @@ sub parse_version {
     if ($@) {
         $CPAN::Frontend->mywarn("Error while parsing version number in file '$parsefile'\n");
     }
-    alarm(0) if ALARM_IMPLEMENTED;
+    alarm(0) if $use_alarm;
     my $leastsanity = eval { defined $have && length $have; };
     $have = "undef" unless $leastsanity;
     $have =~ s/^ //; # since the %vd hack these two lines here are needed

--- a/src/main/perl/lib/Data/Util.pm
+++ b/src/main/perl/lib/Data/Util.pm
@@ -1,0 +1,76 @@
+package Data::Util;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.67';
+
+require Exporter;
+our @ISA = qw(Exporter);
+our @EXPORT_OK = qw(
+    is_scalar_ref is_array_ref is_hash_ref is_code_ref is_glob_ref is_rx is_regex_ref
+    is_instance is_invocant
+    is_value is_string is_number is_integer
+    scalar_ref array_ref hash_ref code_ref glob_ref rx regex_ref
+    instance invocant
+    anon_scalar neat
+    get_stash
+    install_subroutine uninstall_subroutine get_code_info get_code_ref
+    curry modify_subroutine subroutine_modifier
+    mkopt mkopt_hash
+);
+our %EXPORT_TAGS = (
+    all => \@EXPORT_OK,
+    check => [qw(
+        is_scalar_ref is_array_ref is_hash_ref is_code_ref is_glob_ref is_rx
+        is_instance is_invocant is_value is_string is_number is_integer is_regex_ref
+    )],
+    validate => [qw(
+        scalar_ref array_ref hash_ref code_ref glob_ref rx instance invocant regex_ref
+    )],
+);
+
+# XSLoader registers the Java implementations before evaluating this shim.
+# Retain them while installing the distribution's pure-Perl implementation
+# for the rest of Data::Util's API.
+unless (defined &is_value && defined &is_string) {
+    require XSLoader;
+    XSLoader::load(__PACKAGE__, $VERSION);
+}
+
+my $java_is_value  = \&is_value;
+my $java_is_string = \&is_string;
+
+require 'Data/Util/PurePerl.pm';
+
+{
+    no warnings 'redefine';
+    *is_value  = $java_is_value;
+    *is_string = $java_is_string;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Data::Util - PerlOnJava XS compatibility shim
+
+=head1 DESCRIPTION
+
+This shim combines PerlOnJava implementations of Data::Util's primitive SV
+classification with the upstream distribution's pure-Perl implementation.
+
+=head1 AUTHOR
+
+Goro Fuji (gfx) E<lt>gfuji(at)cpan.orgE<gt>.
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (c) 2008-2010, Goro Fuji. All rights reserved.
+
+This module is free software; you can redistribute it and/or modify it under
+the same terms as Perl itself.
+
+=cut

--- a/src/main/perl/lib/Data/Util/PurePerl.pm
+++ b/src/main/perl/lib/Data/Util/PurePerl.pm
@@ -1,0 +1,593 @@
+package Data::Util::PurePerl;
+
+die qq{Don't use Data::Util::PurePerl directly, use Data::Util instead.\n} # ' for poor editors
+	if caller() ne 'Data::Util';
+
+package
+	Data::Util;
+
+use strict;
+use warnings;
+
+#use warnings::unused;
+
+use Scalar::Util ();
+use overload ();
+
+sub _croak{
+	require Data::Util::Error;
+	goto &Data::Util::Error::croak;
+}
+sub _fail{
+	my($name, $value) = @_;
+	_croak(sprintf 'Validation failed: you must supply %s, not %s', $name, neat($value));
+}
+
+sub _overloaded{
+	return Scalar::Util::blessed($_[0])
+		&& overload::Method($_[0], $_[1]);
+}
+
+sub is_scalar_ref{
+	return ref($_[0]) eq 'SCALAR' || ref($_[0]) eq 'REF' || _overloaded($_[0], '${}');
+}
+sub is_array_ref{
+	return ref($_[0]) eq 'ARRAY' || _overloaded($_[0], '@{}');
+}
+sub is_hash_ref{
+	return ref($_[0]) eq 'HASH' || _overloaded($_[0], '%{}');
+}
+sub is_code_ref{
+	return ref($_[0]) eq 'CODE' || _overloaded($_[0], '&{}');
+}
+sub is_glob_ref{
+	return ref($_[0]) eq 'GLOB' || _overloaded($_[0], '*{}');
+}
+sub is_regex_ref{
+	return ref($_[0]) eq 'Regexp';
+}
+sub is_rx{
+	return ref($_[0]) eq 'Regexp';
+}
+
+sub is_instance{
+	my($obj, $class) = @_;
+	_fail('a class name', $class)
+		unless is_string($class);
+
+	return Scalar::Util::blessed($obj) && $obj->isa($class);
+}
+sub is_invocant{
+	my($x) = @_;
+	if(ref $x){
+		return !!Scalar::Util::blessed($x);
+	}
+	else{
+		return !!get_stash($x);
+	}
+}
+
+
+sub scalar_ref{
+	return ref($_[0]) eq 'SCALAR' || ref($_[0]) eq 'REF' || _overloaded($_[0], '${}')
+		? $_[0] : _fail('a SCALAR reference', $_[0]);
+
+}
+sub array_ref{
+	return ref($_[0]) eq 'ARRAY' || _overloaded($_[0], '@{}')
+		? $_[0] : _fail('an ARRAY reference', $_[0]);
+}
+sub hash_ref{
+	return ref($_[0]) eq 'HASH' || _overloaded($_[0], '%{}')
+		? $_[0] : _fail('a HASH reference', $_[0]);
+}
+sub code_ref{
+	return ref($_[0]) eq 'CODE' || _overloaded($_[0], '&{}')
+		? $_[0] : _fail('a CODE reference', $_[0]);
+}
+sub glob_ref{
+	return ref($_[0]) eq 'GLOB' || _overloaded($_[0], '*{}')
+		? $_[0] : _fail('a GLOB reference', $_[0]);
+}
+sub regex_ref{
+	return ref($_[0]) eq 'Regexp'
+		? $_[0] : _fail('a regular expression reference', $_[0]);
+}
+sub rx{
+	return ref($_[0]) eq 'Regexp'
+		? $_[0] : _fail('a regular expression reference', $_[0]);
+}
+
+sub instance{
+	my($obj, $class) = @_;
+
+	_fail('a class name', $class)
+		unless is_string($class);
+
+	return Scalar::Util::blessed($obj) && $obj->isa($class)
+		? $obj : _fail("an instance of $class", $obj);
+}
+
+sub invocant{
+	my($x) = @_;
+	if(ref $x){
+		if(Scalar::Util::blessed($x)){
+			return $x;
+		}
+	}
+	elsif(is_string($x)){
+		if(get_stash($x)){
+			$x =~ s/^:://;
+			$x =~ s/(?:main::)+//;
+			return $x;
+		}
+	}
+	_fail('an invocant', $x);
+}
+
+sub is_value{
+	return defined($_[0]) && !ref($_[0]) && ref(\$_[0]) ne 'GLOB';
+}
+sub is_string{
+	no warnings 'uninitialized';
+	return !ref($_[0]) && ref(\$_[0]) ne 'GLOB' && length($_[0]) > 0;
+}
+
+sub is_number{
+	return 0 if !defined($_[0]) || ref($_[0]);
+
+	return $_[0] =~ m{
+		\A \s*
+			[+-]?
+			(?= \d | \.\d)
+			\d*
+			(\.\d*)?
+			(?: [Ee] (?: [+-]? \d+) )?
+		\s* \z
+	}xms;
+}
+
+sub is_integer{
+	return 0 if !defined($_[0]) || ref($_[0]);
+
+	return $_[0] =~ m{
+		\A \s*
+			[+-]?
+			\d+
+		\s* \z
+	}xms;
+}
+
+sub get_stash{
+	my($invocant) = @_;
+
+	if(Scalar::Util::blessed($invocant)){
+		no strict 'refs';
+		return \%{ref($invocant) . '::'};
+	}
+	elsif(!is_string($invocant)){
+		return undef;
+	}
+
+	$invocant =~ s/^:://;
+
+	my $pack = *main::;
+	foreach my $part(split /::/, $invocant){
+		return undef unless $pack = $pack->{$part . '::'};
+	}
+	return *{$pack}{HASH};
+}
+
+sub anon_scalar{
+	my($s) = @_;
+	return \$s;  # not \$_[0]
+}
+
+sub neat{
+	my($s) = @_;
+
+	if(ref $s){
+		if(ref($s) eq 'CODE'){
+			return sprintf '\\&%s(0x%x)', scalar(get_code_info($s)), Scalar::Util::refaddr($s);
+		}
+		elsif(ref($s) eq 'Regexp'){
+			return qq{qr{$s}};
+		}
+		return overload::StrVal($s);
+	}
+	elsif(defined $s){
+		return "$s" if is_number($s);
+		return "$s" if is_glob_ref(\$s);
+
+		require B;
+		return B::perlstring($s);
+	}
+	else{
+		return 'undef';
+	}
+}
+
+
+sub install_subroutine{
+	_croak('Usage: install_subroutine(package, name => code, ...)') unless @_;
+
+	my $into = shift;
+	is_string($into)  or _fail('a package name', $into);
+
+	my $param = mkopt_hash(@_ == 1 ? shift : \@_, 'install_subroutine', 'CODE');
+
+	while(my($as, $code) = each %{$param}){
+		defined($code) or _fail('a CODE reference', $code);
+
+		my $slot = do{ no strict 'refs'; \*{ $into . '::' . $as } };
+
+		if(defined &{$slot}){
+			warnings::warnif(redefine => "Subroutine $as redefined");
+		}
+
+		no warnings 'redefine';
+		*{$slot} = \&{$code};
+	}
+	return;
+}
+sub uninstall_subroutine {
+	_croak('Usage: uninstall_subroutine(package, name, ...)') unless @_;
+
+	my $package = shift;
+
+	is_string($package) or _fail('a package name', $package);
+	my $stash = get_stash($package) or return 0;
+
+	my $param = mkopt_hash(@_ == 1 && is_hash_ref($_[0]) ? shift : \@_, 'install_subroutine', 'CODE');
+
+	require B;
+
+	while(my($name, $specified_code) = each %{$param}){
+		my $glob = $stash->{$name};
+
+		if(ref(\$glob) ne 'GLOB'){
+			if(ref $glob) {
+			    if(Scalar::Util::reftype $glob eq 'CODE'){
+				if(defined $specified_code &&
+				   $specified_code != $glob) {
+					next;
+				}
+			    }
+			    else {
+				warnings::warnif(misc => "Constant subroutine $name uninstalled");
+			    }
+			}
+			delete $stash->{$name};
+			next;
+		}
+
+		my $code = *{$glob}{CODE};
+		if(not defined $code){
+			next;
+		}
+
+		if(defined $specified_code && $specified_code != $code){
+			next;
+		}
+
+		if(B::svref_2object($code)->CONST){
+			warnings::warnif(misc => "Constant subroutine $name uninstalled");
+		}
+
+		delete $stash->{$name};
+
+		my $newglob = do{ no strict 'refs'; \*{$package . '::' . $name} }; # vivify
+
+		# copy all the slot except for CODE
+		foreach my $slot( qw(SCALAR ARRAY HASH IO FORMAT) ){
+			*{$newglob} = *{$glob}{$slot} if defined *{$glob}{$slot};
+		}
+	}
+
+	return;
+}
+
+sub get_code_info{
+	my($code) = @_;
+
+	is_code_ref($code) or _fail('a CODE reference', $code);
+
+	require B;
+	my $gv = B::svref_2object(\&{$code})->GV;
+	return unless $gv->isa('B::GV');
+	return wantarray ? ($gv->STASH->NAME, $gv->NAME) : join('::', $gv->STASH->NAME, $gv->NAME);
+}
+
+sub get_code_ref{
+	my($package, $name, @flags) = @_;
+
+	is_string($package) or _fail('a package name', $package);
+	is_string($name)    or _fail('a subroutine name', $name);
+
+	if(@flags){
+		if(grep{ $_ eq '-create' } @flags){
+			no strict 'refs';
+			return \&{$package . '::' . $name};
+		}
+		else{
+			_fail('a flag', @flags);
+		}
+	}
+
+	my $stash = get_stash($package) or return undef;
+
+	if(defined(my $glob = $stash->{$name})){
+		if(ref(\$glob) eq 'GLOB'){
+			return *{$glob}{CODE};
+		}
+		else{ # a stub or special constant
+			no strict 'refs';
+			return *{$package . '::' . $name}{CODE};
+		}
+	}
+	return undef;
+}
+
+sub curry{
+	my $is_method = !is_code_ref($_[0]);
+
+	my $proc;
+	$proc = shift if !$is_method;
+
+	my $args = \@_;
+
+	my @tmpl;
+
+	my $i = 0;
+	my $max_ph = -1;
+	my $min_ph =  0;
+
+	foreach my $arg(@_){
+		if(is_scalar_ref($arg) && is_integer($$arg)){
+			push @tmpl, sprintf '$_[%d]', $$arg;
+
+			if($$arg >= 0){
+				$max_ph = $$arg if $$arg > $max_ph;
+			}
+			else{
+				$min_ph = $$arg if $$arg < $min_ph;
+			}
+		}
+		elsif(defined($arg) && (\$arg) == \*_){
+			push @tmpl, '@_[$max_ph .. $#_ + $min_ph]';
+		}
+		else{
+			push @tmpl, sprintf '$args->[%d]', $i;
+		}
+		$i++;
+	}
+
+	$max_ph++;
+
+	my($pkg, $file, $line, $hints, $bitmask) = (caller 0 )[0, 1, 2, 8, 9];
+	my $body = sprintf <<'END_CXT', $pkg, $line, $file;
+BEGIN{ $^H = $hints; ${^WARNING_BITS} = $bitmask; }
+package %s;
+#line %s %s
+END_CXT
+
+	if($is_method){
+		my $selfp = shift @tmpl;
+		$proc     = shift @tmpl;
+		$body .= sprintf q{ sub {
+			my $self   = %s;
+			my $method = %s;
+			$self->$method(%s);
+		} }, $selfp, defined($proc) ? $proc : 'undef', join(q{,}, @tmpl);
+	}
+	else{
+		$body .= sprintf q{ sub { $proc->(%s) } }, join q{,}, @tmpl;
+	}
+	eval $body or die $@;
+}
+
+BEGIN{
+	our %modifiers;
+
+	my $initializer;
+	$initializer = sub{
+		require Hash::Util::FieldHash::Compat;
+		Hash::Util::FieldHash::Compat::fieldhash(\%modifiers);
+		undef $initializer;
+	};
+
+	sub modify_subroutine{
+		my $code   = code_ref shift;
+
+		if((@_ % 2) != 0){
+			_croak('Odd number of arguments for modify_subroutine()');
+		}
+		my %args   = @_;
+
+		my(@before, @around, @after);
+
+		@before = map{ code_ref $_ } @{array_ref delete $args{before}} if exists $args{before};
+		@around = map{ code_ref $_ } @{array_ref delete $args{around}} if exists $args{around};
+		@after  = map{ code_ref $_ } @{array_ref delete $args{after}}  if exists $args{after};
+
+		if(%args){
+			_fail('a modifier property', join ', ', keys %args);
+		}
+
+		my %props = (
+			before      => \@before,
+			around      => \@around,
+			after       => \@after,
+			current_ref => \$code,
+		);
+
+		#$code = curry($_, (my $tmp = $code), *_) for @around;
+		for my $ar_code(reverse @around){
+			my $next = $code;
+			$code = sub{ $ar_code->($next, @_) };
+		}
+		my($pkg, $file, $line, $hints, $bitmask) = (caller 0)[0, 1, 2, 8, 9];
+
+		my $context = sprintf <<'END_CXT', $pkg, $line, $file;
+BEGIN{ $^H = $hints; ${^WARNING_BITS} = $bitmask; }
+package %s;
+#line %s %s(modify_subroutine)
+END_CXT
+
+		my $modified = eval $context . q{sub{
+			$_->(@_) for @before;
+			if(wantarray){ # list context
+				my @ret = $code->(@_);
+				$_->(@_) for @after;
+				return @ret;
+			}
+			elsif(defined wantarray){ # scalar context
+				my $ret = $code->(@_);
+				$_->(@_) for @after;
+				return $ret;
+			}
+			else{ # void context
+				$code->(@_);
+				$_->(@_) for @after;
+				return;
+			}
+		}} or die $@;
+
+		$initializer->() if $initializer;
+
+		$modifiers{$modified} = \%props;
+		return $modified;
+	}
+
+	my %valid_modifiers = map{ $_ => undef } qw(before around after);
+
+	sub subroutine_modifier{
+		my $modified = code_ref shift;
+
+		my $props_ref = $modifiers{$modified};
+
+		unless(@_){ # subroutine_modifier($subr) - only checking
+			return defined $props_ref;
+		}
+		unless($props_ref){ # otherwise, it should be modified subroutines
+			_fail('a modified subroutine', $modified);
+		}
+
+		my($name, @subs) = @_;
+		(is_string($name) && exists $valid_modifiers{$name}) or _fail('a modifier property', $name);
+
+
+		my $property = $props_ref->{$name};
+		if(@subs){
+			if($name eq 'after'){
+				push @{$property}, map{ code_ref $_ } @subs;
+			}
+			else{
+				unshift @{$property}, reverse map{ code_ref $_ } @subs;
+			}
+
+			if($name eq 'around'){
+				my $current_ref = $props_ref->{current_ref};
+				for my $ar(reverse @subs){
+					my $base = $$current_ref;
+					$$current_ref = sub{ $ar->($base, @_) };
+				}
+			}
+		}
+		return @{$property} if defined wantarray;
+
+		return;
+	}
+}
+#
+# mkopt() and mkopt_hash() are originated from Data::OptList
+#
+
+my %test_for = (
+	CODE   => \&is_code_ref,
+	HASH   => \&is_hash_ref,
+	ARRAY  => \&is_array_ref,
+	SCALAR => \&is_scalar_ref,
+	GLOB   => \&is_glob_ref,
+);
+
+
+sub __is_a {
+	my ($got, $expected) = @_;
+
+	return scalar grep{ __is_a($got, $_) } @{$expected} if ref $expected;
+
+	my $t = $test_for{$expected};
+	return defined($t) ? $t->($got) : is_instance($got, $expected);
+}
+
+sub mkopt{
+	my($opt_list, $moniker, $require_unique, $must_be) = @_;
+
+	return [] unless defined $opt_list;
+
+	$opt_list = [
+		map { $_ => (ref $opt_list->{$_} ? $opt_list->{$_} : ()) } keys %$opt_list
+	] if is_hash_ref($opt_list);
+
+	is_array_ref($opt_list) or _fail('an ARRAY or HASH reference', $opt_list);
+
+	my @return;
+	my %seen;
+
+	my $vh = is_hash_ref($must_be);
+	my $validator = $must_be;
+
+	if(defined($validator) && (!$vh && !is_array_ref($validator) && !is_string($validator))){
+		_fail('a type name, or ARRAY or HASH reference', $validator);
+	}
+
+	for(my $i = 0; $i < @$opt_list; $i++) {
+		my $name = $opt_list->[$i];
+		my $value;
+
+		is_string($name) or _fail("a name in $moniker opt list", $name);
+
+		if($require_unique && $seen{$name}++) {
+			_croak("Validation failed: Multiple definitions provided for $name in $moniker opt list")
+		}
+
+		if   ($i == $#$opt_list)             { $value = undef;            }
+		elsif(not defined $opt_list->[$i+1]) { $value = undef; $i++       }
+		elsif(ref $opt_list->[$i+1])         { $value = $opt_list->[++$i] }
+		else                                 { $value = undef;            }
+
+		if (defined $value and defined( $vh ? ($validator = $must_be->{$name}) : $validator )){
+			unless(__is_a($value, $validator)) {
+				_croak("Validation failed: ".ref($value)."-ref values are not valid for $name in $moniker opt list");
+			}
+		}
+
+		push @return, [ $name => $value ];
+	}
+
+	return \@return;
+}
+
+sub mkopt_hash {
+	my($opt_list, $moniker, $must_be) = @_;
+	return {} unless $opt_list;
+
+	my %hash = map { $_->[0] => $_->[1] } @{ mkopt($opt_list, $moniker, 1, $must_be) };
+	return \%hash;
+}
+
+1;
+__END__
+
+=head1 NAME
+
+Data::Util::PurePerl - The Pure Perl backend for Data::Util
+
+=head1 DESCRIPTION
+
+This module is a backend for C<Data::Util>.
+
+Don't use this module directly; C<use Data::Util> instead.
+
+=cut

--- a/src/main/perl/lib/POSIX.pm
+++ b/src/main/perl/lib/POSIX.pm
@@ -61,8 +61,8 @@ sub strtod {
 }
 
 # Export tags for different groups of functions/constants
-# Native Perl's POSIX exports many constants by default
-# Only export constants that are actually implemented in this module
+# Native Perl's POSIX exports its commonly used constants and math helpers by
+# default.  Only export names that are actually implemented in this module.
 our @EXPORT = qw(
     O_RDONLY O_WRONLY O_RDWR O_CREAT O_EXCL O_NOCTTY O_TRUNC O_APPEND O_NONBLOCK
     WEXITSTATUS WIFEXITED WIFSIGNALED WIFSTOPPED WSTOPSIG WTERMSIG WCOREDUMP

--- a/src/main/perl/lib/XML/LibXML/Reader.pm
+++ b/src/main/perl/lib/XML/LibXML/Reader.pm
@@ -1,0 +1,84 @@
+package XML::LibXML::Reader;
+
+use strict;
+use warnings;
+use Carp qw(croak);
+use Exporter qw(import);
+use XML::LibXML;
+
+our $VERSION = $XML::LibXML::VERSION;
+
+use constant {
+    XML_READER_TYPE_NONE                    => 0,
+    XML_READER_TYPE_ELEMENT                 => 1,
+    XML_READER_TYPE_ATTRIBUTE               => 2,
+    XML_READER_TYPE_TEXT                    => 3,
+    XML_READER_TYPE_CDATA                   => 4,
+    XML_READER_TYPE_ENTITY_REFERENCE        => 5,
+    XML_READER_TYPE_ENTITY                  => 6,
+    XML_READER_TYPE_PROCESSING_INSTRUCTION  => 7,
+    XML_READER_TYPE_COMMENT                 => 8,
+    XML_READER_TYPE_DOCUMENT                => 9,
+    XML_READER_TYPE_DOCUMENT_TYPE           => 10,
+    XML_READER_TYPE_DOCUMENT_FRAGMENT       => 11,
+    XML_READER_TYPE_NOTATION                => 12,
+    XML_READER_TYPE_WHITESPACE              => 13,
+    XML_READER_TYPE_SIGNIFICANT_WHITESPACE  => 14,
+    XML_READER_TYPE_END_ELEMENT             => 15,
+    XML_READER_TYPE_END_ENTITY              => 16,
+    XML_READER_TYPE_XML_DECLARATION         => 17,
+};
+
+our @EXPORT = qw(
+    XML_READER_TYPE_NONE XML_READER_TYPE_ELEMENT XML_READER_TYPE_ATTRIBUTE
+    XML_READER_TYPE_TEXT XML_READER_TYPE_CDATA XML_READER_TYPE_ENTITY_REFERENCE
+    XML_READER_TYPE_ENTITY XML_READER_TYPE_PROCESSING_INSTRUCTION
+    XML_READER_TYPE_COMMENT XML_READER_TYPE_DOCUMENT XML_READER_TYPE_DOCUMENT_TYPE
+    XML_READER_TYPE_DOCUMENT_FRAGMENT XML_READER_TYPE_NOTATION
+    XML_READER_TYPE_WHITESPACE XML_READER_TYPE_SIGNIFICANT_WHITESPACE
+    XML_READER_TYPE_END_ELEMENT XML_READER_TYPE_END_ENTITY
+    XML_READER_TYPE_XML_DECLARATION
+);
+our @EXPORT_OK = @EXPORT;
+
+sub new {
+    my ($class, @arguments) = @_;
+    my %args = map { ref($_) eq 'HASH' ? %$_ : $_ } @arguments;
+    my $encoding = $args{encoding};
+    my $uri = defined $args{URI} ? "$args{URI}" : undef;
+    my $options = XML::LibXML->_parser_options(\%args);
+
+    return $class->_newForFile($args{location}, $encoding, $options)
+        if defined $args{location};
+    return $class->_newForString($args{string}, $uri, $encoding, $options)
+        if defined $args{string};
+    return $class->_newForIO($args{IO}, $uri, $encoding, $options)
+        if defined $args{IO};
+
+    croak 'XML::LibXML::Reader->new: specify location, string, or IO';
+}
+
+sub close {
+    my ($self) = @_;
+    return $self->_close == 0 ? 1 : 0;
+}
+
+sub DESTROY {
+    my ($self) = @_;
+    $self->_DESTROY if $self;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+XML::LibXML::Reader - forward XML reader backed by PerlOnJava's Java DOM module
+
+=head1 DESCRIPTION
+
+This compatibility layer exposes the core Reader constructors and element
+cursor operations implemented by PerlOnJava's Java C<XML::LibXML> module.
+
+=cut

--- a/src/main/perl/lib/YAML/Syck.pm
+++ b/src/main/perl/lib/YAML/Syck.pm
@@ -1,0 +1,53 @@
+package YAML::Syck;
+
+use strict;
+use warnings;
+use YAML::PP ();
+use JSON::PP ();
+
+# Pure-Perl bootstrap for the low-level entry points normally supplied by
+# YAML::Syck's libsyck XS extension.  The public CPAN module remains in charge
+# of its API wrappers; XSLoader evaluates this file only when that extension
+# asks for a PerlOnJava implementation.
+
+sub LoadYAML {
+    my ($yaml) = @_;
+    my @documents = YAML::PP::Load($yaml);
+    return wantarray ? \@documents : $documents[0];
+}
+
+sub DumpYAML {
+    return YAML::PP::Dump($_[0]);
+}
+
+sub LoadJSON {
+    return JSON::PP::decode_json($_[0]);
+}
+
+sub DumpJSON {
+    return JSON::PP->new->allow_nonref->encode($_[0]);
+}
+
+sub DumpYAMLFile {
+    my ($value, $fh) = @_;
+    return print {$fh} DumpYAML($value) ? 0 : 0 + $!;
+}
+
+sub DumpJSONFile {
+    my ($value, $fh) = @_;
+    return print {$fh} DumpJSON($value) ? 0 : 0 + $!;
+}
+
+sub DumpYAMLInto {
+    my ($value, $buffer) = @_;
+    $$buffer .= DumpYAML($value);
+    return 1;
+}
+
+sub DumpJSONInto {
+    my ($value, $buffer) = @_;
+    $$buffer .= DumpJSON($value);
+    return 1;
+}
+
+1;

--- a/src/test/resources/module/Data-Util/t/primitive-classification.t
+++ b/src/test/resources/module/Data-Util/t/primitive-classification.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use Test::More;
+use Data::Util qw(is_value is_string);
+
+ok(is_value('0'), 'non-reference scalar is a value');
+ok(!is_value(undef), 'undef is not a value');
+ok(!is_value([]), 'reference is not a value');
+ok(is_string('text'), 'non-empty string is a string');
+ok(!is_string(''), 'empty string is not a string');
+ok(!is_string(42), 'numeric-only scalar is not a string');
+
+my $values = [];
+ok(!is_string($values->[@$values]), 'missing array element is not a string');
+is(scalar(@$values), 0,
+    'XS-compatible string inspection does not vivify an aliased missing slot');
+
+done_testing;

--- a/src/test/resources/unit/array_deref_size_append.t
+++ b/src/test/resources/unit/array_deref_size_append.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $values = [];
+$values->[@$values] = 'first';
+$values->[@$values] = 'second';
+
+is_deeply($values, ['first', 'second'],
+    'dereferenced array size is the next append index');
+is(scalar(@$values), 2, 'dereferenced array has the expected size');
+
+my $probed = [];
+my $missing = $probed->[@$probed];
+is(scalar(@$probed), 0, 'fetching the next array slot does not extend the array');
+$probed->[@$probed] = 'value';
+is_deeply($probed, ['value'], 'append after a missing-slot fetch has no hole');
+
+sub inspect_missing { defined $_[0] }
+sub inspect_missing_scalar ($) { defined $_[0] }
+sub is_string_like {
+    no warnings 'uninitialized';
+    return !ref($_[0]) && ref(\$_[0]) ne 'GLOB' && length($_[0]) > 0;
+}
+my $argument = [];
+ok(!inspect_missing($argument->[@$argument]), 'missing array element is undef as an argument');
+is(scalar(@$argument), 0, 'passing a missing array element does not extend the array');
+
+my $prototyped_argument = [];
+ok(!inspect_missing_scalar($prototyped_argument->[@$prototyped_argument]),
+    'missing array element is undef for a scalar-prototype argument');
+is(scalar(@$prototyped_argument), 0,
+    'scalar-prototype argument does not extend a missing array element');
+
+my $referenced_argument = [];
+ok(!is_string_like($referenced_argument->[@$referenced_argument]),
+    'string predicate rejects a missing array element');
+is(scalar(@$referenced_argument), 1,
+    'taking a reference to an aliased missing argument extends its source array');
+
+done_testing;

--- a/src/test/resources/unit/cpan_tooling_posix_yaml_syck.t
+++ b/src/test/resources/unit/cpan_tooling_posix_yaml_syck.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+
+use POSIX;
+use YAML::Syck ();
+
+ok(defined &floor, 'POSIX exports floor by default');
+is(floor(3.75), 3, 'default floor export is callable');
+
+my $yaml = YAML::Syck::DumpYAML({answer => 42, names => ['Ada', 'Grace']});
+my $from_yaml = YAML::Syck::LoadYAML($yaml);
+is($from_yaml->{answer}, 42, 'YAML::Syck round trip preserves numbers');
+is_deeply($from_yaml->{names}, ['Ada', 'Grace'],
+    'YAML::Syck round trip preserves arrays');
+
+my $json = YAML::Syck::DumpJSON({answer => 42, ok => 1});
+my $from_json = YAML::Syck::LoadJSON($json);
+is_deeply($from_json, {answer => 42, ok => 1},
+    'JSON::Syck round trip uses the bundled JSON implementation');
+
+done_testing;

--- a/src/test/resources/unit/foreach_implicit_topic_callback.t
+++ b/src/test/resources/unit/foreach_implicit_topic_callback.t
@@ -1,0 +1,67 @@
+use strict;
+use warnings;
+use lib 'src/test/resources/unit/lib';
+use Test::More;
+use Local::ExternalAllU qw(all_u);
+
+sub all_values (&@) {
+    my $predicate = shift;
+    return undef unless @_;
+    $predicate->() or return 0 foreach @_;
+    return 1;
+}
+
+{
+    package Local::PredicateProvider;
+    sub all_values (&@) {
+        my $predicate = shift;
+        return undef unless @_;
+        $predicate->() or return 0 foreach @_;
+        return 1;
+    }
+
+    sub all_u (&@) {
+        my $predicate = shift;
+        return undef unless @_;
+        $predicate->() or return 0 foreach @_;
+        return 1;
+    }
+}
+
+BEGIN {
+    *imported_all_values = \&Local::PredicateProvider::all_values;
+    *Local::PredicateFacade::all_values = \&Local::PredicateProvider::all_values;
+    *twice_imported_all_values = \&Local::PredicateFacade::all_values;
+}
+
+my $single = all_values { $_ eq 'ger' } 'ger';
+ok($single, 'callback sees the implicit foreach topic');
+
+my $all_positive = all_values { $_ > 0 } 1, 2, 3;
+ok($all_positive, 'implicit topic is updated for each callback');
+
+my $has_negative = all_values { $_ > 0 } 1, -1, 3;
+ok(!$has_negative, 'callback sees a false implicit topic value');
+
+my $imported = imported_all_values { $_ eq 'ger' } 'ger';
+ok($imported, 'imported prototyped callback sees the provider loop topic');
+
+my $twice_imported = twice_imported_all_values { $_ eq 'ger' } 'ger';
+ok($twice_imported, 'twice-aliased prototyped callback sees the provider loop topic');
+
+my $all_u_result = all_u { $_ eq 'ger' } 'ger';
+ok($all_u_result, 'externally imported all_u callback sees its implicit topic');
+
+my $pattern = qr/ger/;
+my $all_u_regex = all_u { $_ =~ $pattern } 'ger';
+ok($all_u_regex, 'all_u callback captures and applies a compiled regex');
+
+my $tester = sub { $_[0] =~ $pattern };
+my $all_u_predicate = all_u { $tester->($_) } 'ger';
+ok($all_u_predicate, 'all_u callback invokes a captured predicate with the topic');
+
+my @all_u_list_context = all_u { $_ =~ $pattern } 'ger';
+is_deeply(\@all_u_list_context, [1],
+    'all_u callback preserves its implicit topic in list context');
+
+done_testing;

--- a/src/test/resources/unit/isa_operator_package_bareword.t
+++ b/src/test/resources/unit/isa_operator_package_bareword.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+    package Local::IsaBase;
+    package Local::IsaChild;
+    our @ISA = ('Local::IsaBase');
+}
+
+my $check = eval q{
+    use experimental 'isa';
+    sub { $_[0] isa Local::IsaBase }
+};
+
+ok(defined($check), 'isa package bareword compiles under strict subs')
+    or diag $@;
+ok($check->(bless({}, 'Local::IsaChild')), 'isa package bareword checks inheritance');
+ok(!$check->(bless({}, 'Local::Other')), 'isa package bareword rejects another class');
+
+done_testing;

--- a/src/test/resources/unit/lib/Local/ExternalAllU.pm
+++ b/src/test/resources/unit/lib/Local/ExternalAllU.pm
@@ -1,0 +1,16 @@
+package Local::ExternalAllU;
+
+use strict;
+use warnings;
+use Exporter qw(import);
+
+our @EXPORT_OK = qw(all_u);
+
+sub all_u (&@) {
+    my $predicate = shift;
+    return undef unless @_;
+    $predicate->() or return 0 foreach @_;
+    return 1;
+}
+
+1;

--- a/src/test/resources/unit/method_return_ref_ownership.t
+++ b/src/test/resources/unit/method_return_ref_ownership.t
@@ -1,0 +1,63 @@
+use strict;
+use warnings;
+use Test::More;
+use Scalar::Util qw(isweak weaken);
+
+{
+    package Local::TreeHolder;
+
+    sub new {
+        return bless {}, shift;
+    }
+
+    sub parse {
+        my $self = shift;
+        my $current = my $root = ['root'];
+        push @$current, my $parent = ['tag', 'body', {}, $current];
+        Scalar::Util::weaken($parent->[3]);
+        $current = $parent;
+        push @$current, my $child = ['tag', 'p', {}, $current];
+        Scalar::Util::weaken($child->[3]);
+        $self->{tree} = $root;
+        return $self;
+    }
+
+    sub tree { return $_[0]{tree} }
+}
+
+sub parse_tree {
+    return Local::TreeHolder->new->parse->tree;
+}
+
+my $tree = parse_tree();
+
+ok(defined($tree), 'reference returned from temporary invocant remains live');
+ok(defined($tree->[1][3]), 'weak child-to-root edge remains live');
+ok(isweak($tree->[1][3]), 'child-to-root edge remains weak');
+is($tree->[1][3], $tree, 'child-to-root edge points to returned root');
+ok(defined($tree->[1][4][3]), 'descendant weak parent remains live');
+is($tree->[1][4][3], $tree->[1],
+    'descendant weak parent points inside returned graph');
+
+sub parsed_nodes {
+    my $parsed = parse_tree();
+    my @nodes = @$parsed[1 .. $#$parsed];
+    return shift() ? [grep { $_->[0] eq 'tag' } @nodes] : \@nodes;
+}
+
+my @destination = ('root');
+{
+    my $nodes = parsed_nodes();
+    for my $node (@$nodes) {
+        $node->[3] = \@destination;
+        weaken($node->[3]);
+    }
+    splice @destination, 1, 0, @$nodes;
+}
+
+ok(defined($destination[1][4][3]),
+    'nested parse/slice return keeps descendant parent live');
+is($destination[1][4][3], $destination[1],
+    'nested parse/slice descendant points to inserted parent');
+
+done_testing;

--- a/src/test/resources/unit/overload_mutator_unshared.t
+++ b/src/test/resources/unit/overload_mutator_unshared.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+    package Local::UniqueMutableNumber;
+
+    use overload
+        '+=' => sub {
+            $_[0]{value} += $_[1];
+            return $_[0];
+        },
+        '=' => sub {
+            $main::unique_copy_calls++;
+            # Deliberately copy only the class's core field. An unnecessary
+            # copy would discard subclass state, as Math::BigInt::copy does.
+            return bless { value => $_[0]{value} }, ref $_[0];
+        };
+}
+
+our $unique_copy_calls = 0;
+my $number = bless {
+    value  => 23,
+    custom => 'preserved',
+}, 'Local::UniqueMutableNumber';
+
+$number += 23;
+
+is($number->{value}, 46, 'mutating overload updates an unshared object');
+is($number->{custom}, 'preserved', 'unshared mutation preserves subclass fields');
+is($unique_copy_calls, 0, 'copy constructor is skipped for an unshared object');
+
+done_testing;

--- a/src/test/resources/unit/regex_named_character_class_escape.t
+++ b/src/test/resources/unit/regex_named_character_class_escape.t
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+use charnames qw(:full);
+use Test::More;
+
+my $punctuation = "\x{ff08}.";
+like($punctuation, qr/[\N{FULLWIDTH LEFT PARENTHESIS}]./,
+    'named character remains escaped inside a character class');
+
+my $spaces = qr/[\N{U+200D}\N{U+2000}]/;
+like("\x{2000}", $spaces, 'named space matches inside a character class');
+like("\x{200d}", $spaces, 'named joiner matches inside a character class');
+unlike('x', $spaces, 'escape syntax is not treated as class members');
+
+done_testing;

--- a/src/test/resources/unit/regex_named_character_extended_capture.t
+++ b/src/test/resources/unit/regex_named_character_extended_capture.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use charnames qw(:full);
+use Test::More;
+
+my $leader = '### 02020nM2.01200024      h';
+ok($leader =~ /^\N{NUMBER SIGN}{3}\s(\d{5}[cdnpu]M2.0\d{7}\s{6}\w)/xms,
+    'named character remains significant under /x');
+is($1, '02020nM2.01200024      h',
+    'capture numbering and content follow a named character escape');
+
+my $faulty = 'this is not a leader';
+ok($faulty !~ /^\N{NUMBER SIGN}{3}\s(\d{5}[cdnpu]M2.0\d{7}\s{6}\w)/xms,
+    'named character is not treated as an /x comment');
+
+done_testing;

--- a/src/test/resources/unit/storable_dclone_weak_refs.t
+++ b/src/test/resources/unit/storable_dclone_weak_refs.t
@@ -1,0 +1,70 @@
+use strict;
+use warnings;
+use Test::More;
+use Scalar::Util qw(isweak weaken);
+use Storable qw(dclone);
+
+my $root = ['root'];
+my $parent = ['tag', 'ul', {}, $root];
+push @$root, $parent;
+my $child = ['tag', 'li', {}, $parent];
+push @$parent, $child;
+weaken($child->[3]);
+
+my $copy = dclone($root);
+undef $root;
+undef $parent;
+undef $child;
+
+my $copied_parent = $copy->[1];
+my $copied_child = $copied_parent->[4];
+ok(isweak($copied_child->[3]), 'dclone preserves weak references');
+ok(defined($copied_child->[3]), 'cloned weak reference remains live through a strong owner');
+is($copied_child->[3], $copied_parent,
+    'cloned weak reference points into the cloned graph');
+
+my $forward_target = [];
+my $forward_weak = $forward_target;
+weaken($forward_weak);
+my $forward_copy = dclone([$forward_weak, $forward_target]);
+
+ok(defined($forward_copy->[0]),
+    'weak edge preceding strong edge survives graph construction');
+ok(!isweak($forward_copy->[0]),
+    'first weak edge is promoted to strong like native Storable');
+is($forward_copy->[0], $forward_copy->[1],
+    'forward weak edge points to cloned strong referent');
+
+my $hash_parent = ['hash parent'];
+my $hash_child = ['child', $hash_parent];
+weaken($hash_child->[1]);
+push @$hash_parent, $hash_child;
+my $hash_copy = dclone({ parent => $hash_parent });
+
+ok(defined($hash_copy->{parent}[1][1]),
+    'hash-owned cloned referent keeps weak back-reference live');
+ok(isweak($hash_copy->{parent}[1][1]),
+    'hash-owned cloned back-reference remains weak');
+is($hash_copy->{parent}[1][1], $hash_copy->{parent},
+    'hash-owned cloned back-reference points to cloned parent');
+
+my $dom_root = ['root'];
+my $dom_parent = ['tag', 'body', {}, $dom_root];
+weaken($dom_parent->[3]);
+my $dom_child = ['tag', 'p', {}, $dom_parent];
+weaken($dom_child->[3]);
+push @$dom_parent, $dom_child;
+push @$dom_root, $dom_parent;
+my $dom_copy = dclone($dom_root);
+
+ok(defined($dom_copy->[1][3]),
+    'dclone return owner keeps a weakly linked root alive');
+ok(isweak($dom_copy->[1][3]), 'cloned child-to-root edge remains weak');
+is($dom_copy->[1][3], $dom_copy,
+    'cloned child-to-root edge points to returned root');
+ok(defined($dom_copy->[1][4][3]),
+    'descendant weak parent remains live in returned graph');
+is($dom_copy->[1][4][3], $dom_copy->[1],
+    'descendant weak parent points inside returned graph');
+
+done_testing;

--- a/src/test/resources/unit/try_catch_exception_object.t
+++ b/src/test/resources/unit/try_catch_exception_object.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use feature 'try';
+no warnings 'experimental::try';
+use Test::More;
+
+{
+    package Local::TryError;
+}
+
+my $object = bless { marker => 42 }, 'Local::TryError';
+my $caught;
+try {
+    die $object;
+}
+catch ($e) {
+    $caught = $e;
+}
+
+isa_ok($caught, 'Local::TryError', 'catch preserves a blessed die payload');
+is($caught->{marker}, 42, 'catch preserves the payload contents');
+is($caught, $object, 'catch receives the original reference');
+
+my $message;
+try {
+    die "plain failure\n";
+}
+catch ($e) {
+    $message = $e;
+}
+is($message, "plain failure\n", 'catch preserves ordinary string errors');
+
+done_testing;

--- a/src/test/resources/unit/try_catch_return_control_flow.t
+++ b/src/test/resources/unit/try_catch_return_control_flow.t
@@ -1,0 +1,32 @@
+use 5.34.0;
+use strict;
+use warnings;
+use feature 'try';
+use Test::More;
+
+sub return_from_try {
+    try {
+        return 'try result';
+    }
+    catch ($error) {
+        return 'wrong catch';
+    }
+    return 'continued after try';
+}
+
+sub return_from_catch {
+    try {
+        die "expected failure\n";
+    }
+    catch ($error) {
+        return "caught: $error";
+    }
+    return 'continued after catch';
+}
+
+is(return_from_try(), 'try result',
+    'return in try exits the containing subroutine');
+is(return_from_catch(), "caught: expected failure\n",
+    'return in catch exits the containing subroutine');
+
+done_testing;

--- a/src/test/resources/unit/xml_libxml_reader_core.t
+++ b/src/test/resources/unit/xml_libxml_reader_core.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw(tempfile);
+use XML::LibXML::Reader;
+
+my $xml = '<root><record id="1"><value>one</value></record><record id="2"/></root>';
+
+my $string_reader = XML::LibXML::Reader->new(string => $xml);
+ok($string_reader->nextElement('record'), 'finds an element by name');
+is($string_reader->name, 'record', 'reports the current element name');
+my $node = $string_reader->copyCurrentNode(1);
+is($node->getAttribute('id'), '1', 'deep copy retains attributes');
+is($node->getChildrenByTagName('value')->[0]->textContent, 'one',
+    'deep copy retains descendants');
+ok($string_reader->nextElement('record'), 'continues after the current element');
+is($string_reader->copyCurrentNode(1)->getAttribute('id'), '2',
+    'second matching element is returned');
+ok(!$string_reader->nextElement('record'), 'returns false at end of document');
+
+my ($fh, $filename) = tempfile();
+print {$fh} $xml;
+close $fh;
+my $file_reader = XML::LibXML::Reader->new(location => $filename);
+ok($file_reader->nextElement('value'), 'location constructor parses files');
+is($file_reader->copyCurrentNode(1)->textContent, 'one',
+    'file reader copies the current node');
+
+open my $input, '<', \$xml or die $!;
+my $io_reader = XML::LibXML::Reader->new(IO => $input);
+ok($io_reader->nextElement('record'), 'IO constructor parses filehandles');
+is($io_reader->copyCurrentNode(0)->getAttribute('id'), '1',
+    'shallow copy retains attributes');
+ok(!$io_reader->copyCurrentNode(0)->hasChildNodes,
+    'shallow copy omits descendants');
+
+my $bom_xml = "\xEF\xBB\xBF<root><record id=\"bom\"/></root>";
+my $bom_reader = XML::LibXML::Reader->new(string => $bom_xml);
+ok($bom_reader->nextElement('record'), 'UTF-8 BOM byte string is accepted');
+is($bom_reader->copyCurrentNode(1)->getAttribute('id'), 'bom',
+    'UTF-8 BOM is consumed before parsing');
+
+done_testing;


### PR DESCRIPTION
## Summary

- fix reusable compiler/runtime/tooling issues exposed by Template::Lace, Sledge::Plugin::JSONRPC, and Catmandu::Exporter::MAB2 without distribution preferences
- add Java-backed Data::Util scalar classification, YAML::Syck compatibility, XML::LibXML::Reader/BOM support, and POSIX/CPAN tooling fixes
- preserve object exception values, try/catch returns, named-character regexes, bareword isa operands, cloned weak references, and returned aggregate ownership
- skip overloaded copy constructors for unshared aggregate objects, preserving Math::BigInt family subclass fields during compound assignment

Log::ProgramInfo remains excluded because its installed test fails identically on system Perl when parsing the uname-derived nested log key.

## Test plan

- `make` — pass
- `make test-bundled-modules` — 384/384 files pass, zero skips/failures
- `JPERL_TEST_FILTER=sub_m make test-bundled-modules` — 4/4 Math::BigInt subclass files pass
- `./jcpan -t Template::Lace` — 2 files / 142 tests pass
- `./jcpan -t Sledge::Plugin::JSONRPC` — all 4 files pass (two optional POD skips)
- `./jcpan -t Catmandu::Exporter::MAB2` — 10 files / 92 tests pass
- new overload regression test validated with system Perl and both PerlOnJava backends

Generated with [Codex](https://openai.com/codex)
