### PR TITLE
Fix master build runtime merge errors

### DIFF
--- a/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
@@ -96,7 +96,7 @@ public class MortalList {
     }
 
     private static boolean temporaryRootDirectlyReferences(RuntimeBase target) {
-        for (RuntimeBase root : temporaryRoots.get()) {
+        for (RuntimeBase root : state().temporaryRoots) {
             if (root == target) return true;
             if (root instanceof RuntimeList list) {
                 for (RuntimeBase value : list.elements) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
@@ -900,15 +900,6 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
         return result;
     }
 
-    /** Install an already-cloned scalar slot without Perl assignment/FETCH semantics. */
-    public void putClonedElement(String key, RuntimeScalar value) {
-        elements.put(key, value);
-        if (value != null) {
-            value.markContainerOwner(this);
-            RuntimeScalar.incrementRefCountForContainerStore(value);
-        }
-    }
-
     @Override
     public RuntimeScalar createReferenceWithTrackedElements() {
         // Birth-track anonymous hashes: set refCount=0 so setLarge() can


### PR DESCRIPTION
## Summary

- remove the duplicate `RuntimeHash.putClonedElement` method left by overlapping merges
- route the remaining temporary-root lookup through the per-runtime lifecycle state
- restore compilation and the full unit-test build on current `master`

## Test plan

- `make` — passed (`BUILD SUCCESSFUL` in 4m 23s)

Generated with [Codex](https://openai.com/codex)
