### PR TITLE
feat(threads): implement phases 17 through 20

### DIFF
--- a/dev/design/attributes.md
+++ b/dev/design/attributes.md
@@ -44,7 +44,7 @@ attributes::->import(Canine => \$spot, "Watchful");
 | CODE | `method` | Marks sub as method (suppresses ambiguity warnings) |
 | CODE | `prototype(...)` | Sets prototype |
 | CODE | `const` | Experimental: calls anon sub immediately, captures return as constant |
-| SCALAR/ARRAY/HASH | `shared` | Thread-sharing (no-op in PerlOnJava) |
+| SCALAR/ARRAY/HASH | `shared` | Marks supported storage for identity-preserving ithread cloning |
 
 ### `import()` Flow
 
@@ -273,7 +273,7 @@ The only remaining attrs.t failure is TODO test 155 (expected failure).
 
 1. **Variable attribute storage**: Should variables store their attributes? Currently `RuntimeCode` has an `attributes` field, but `RuntimeScalar`/`RuntimeArray`/`RuntimeHash` do not. Most test cases only need the `MODIFY_*_ATTRIBUTES` callback (side effects like `tie`), not persistent storage. The `FETCH_*_ATTRIBUTES` tests are only for CODE refs. **Decision: Don't add storage to variables yet — not needed for any current test.**
 
-2. **`_modify_attrs` implementation level**: The system Perl implements this as XS that directly manipulates SV flags. In PerlOnJava, we access `RuntimeCode.attributes` from Java. For CODE refs this is straightforward. For variable refs, we only need to validate built-in attrs (`shared`) and return unrecognized ones — no actual flag-setting needed since `shared` is a no-op.
+2. **`_modify_attrs` implementation level**: The system Perl implements this as XS that directly manipulates SV flags. In PerlOnJava, CODE attributes use `RuntimeCode.attributes`; variable `shared` marks the scalar/array/hash storage so ithread graph cloning preserves its identity. Blessed and tied storage is rejected until its sharing policy is defined.
 
 3. **Attribute::Handlers**: The module exists at `src/main/perl/lib/Attribute/Handlers.pm` and the core dependencies (`attributes.pm`, CHECK blocks, MODIFY_CODE_ATTRIBUTES) are now implemented. All core attrhand.t tests pass (4/4). Remaining edge cases are in multi.t (DESTROY, END handler warning) and linerep.t (eval context file/line).
 

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -156,8 +156,8 @@ the behavior.
 
 ### 3.6 Shared storage
 
-The current `:shared` attribute is accepted as a no-op. Real sharing must mark
-storage identity so the graph cloner preserves it. A subclass that overrides
+The `:shared` attribute now marks storage identity so the graph cloner preserves
+it. A subclass that overrides
 only `set()` and `toString()` is insufficient because current runtime code also
 accesses scalar fields and collection elements directly.
 
@@ -473,12 +473,11 @@ measured benefit over platform threads/full clone.
   `d87fe1885` adds regex worker binding and later `f98ce32be` removes it.
 - `dev/design/clone.md` does not meet the identity/cycle/closure requirements
   above and must not be reused as the ithread cloning algorithm.
-- `dev/design/attributes.md` is correct that `shared` is currently a no-op; it
-  is updated only in Phase 20/22 when that changes.
+- `dev/design/attributes.md` records the supported `shared` attribute tranche.
 
 ## 7. Progress Tracking
 
-### Current Status: Phase 16 implemented and validated
+### Current Status: Phase 20 implemented and validated
 
 Hints, warnings, filters, and source maps are runtime-owned while compiler-only
 scratch remains protected by the global compile lock. The Phase 11 inventory is
@@ -537,6 +536,23 @@ native, classloader, cache, and I/O state. Snapshot tests cover both backends,
 global alias isolation, skipped blessed objects, parent immutability, hook
 context, and empty child execution stacks. Thread capability flags remain off.
 
+The internal thread control block owns platform-thread IDs, parent/child
+relationships, completion and error state, join/detach transitions, and runtime-
+family cleanup. The unadvertised Perl API supports creation, identity, listing,
+context-sensitive join results, nested threads, controlled thread exit, and
+retained uncaught errors. Entry CODE references and arguments share the runtime
+snapshot identity map; join results cross back through a fresh graph clone.
+Child-owned END queues are drained at the thread boundary, and unsafe Java
+thread stopping is not used.
+
+`threads::shared` marks scalar, array, and hash storage so graph cloning retains
+its identity. Shared aggregate backing collections are synchronized and scalar
+payload fields provide cross-thread visibility. `share`, `is_shared`,
+`shared_clone`, and `:shared` are implemented for the supported unblessed,
+untied tranche; blessed and tied values are rejected explicitly. Lock and
+condition-variable semantics remain Phase 21. `Config` continues to advertise
+threads as disabled until Phase 22.
+
 ### Implementation History
 
 Completed phase history is intentionally kept out of this living design
@@ -546,10 +562,10 @@ request history.
 
 ### Next Steps
 
-1. Implement Phase 17's internal platform-thread control block with explicit
-   ownership, completion/error state, join/detach transitions, and cleanup.
-2. Keep the public Perl `threads` stub and `Config` capability flags unchanged
-   until the Phase 18 compatibility tranche is green.
+1. Implement Phase 21 lexical/recursive locking and condition variables on
+   shared storage.
+2. Define and run Phase 22's broader core/CPAN compatibility activation matrix
+   before changing `Config` capability flags.
 
 ### Open Questions
 

--- a/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
@@ -11,6 +11,7 @@ import org.perlonjava.runtime.runtimetypes.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.JarURLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -573,7 +574,7 @@ public class ModuleOperators {
                                     : first.toLowerCase() + fileName.substring(1);
                             resource = RuntimeScalar.class.getResource("/lib/" + alt);
                         }
-                        if (resource != null) {
+                        if (resource != null && !isDirectoryResource(resource)) {
                             // Use "jar:PERL5LIB/DBI.pm" format for %INC - matches catfile output
                             actualFileName = GlobalContext.JAR_PERLLIB + "/" + fileName;
                             fullName = Paths.get(resourcePath);  // Just for compatibility
@@ -784,6 +785,21 @@ public class ModuleOperators {
         } else {
             return scalarResult;
         }
+    }
+
+    /** ClassLoader resources can represent directories; Perl require must skip them. */
+    private static boolean isDirectoryResource(URL resource) {
+        try {
+            if (resource.openConnection() instanceof JarURLConnection jarConnection) {
+                return jarConnection.getJarEntry() != null && jarConnection.getJarEntry().isDirectory();
+            }
+            if ("file".equals(resource.getProtocol())) {
+                return Files.isDirectory(Paths.get(resource.toURI()));
+            }
+        } catch (Exception ignored) {
+            // A resource that cannot be classified will be handled by the normal read path.
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Attributes.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Attributes.java
@@ -104,7 +104,7 @@ public class Attributes extends PerlModuleBase {
         if ("CODE".equals(svtype)) {
             return applyCodeAttribute(svref, attrName, negate);
         } else if ("SCALAR".equals(svtype) || "ARRAY".equals(svtype) || "HASH".equals(svtype)) {
-            return applyVariableAttribute(attrName, negate) ? ATTR_APPLIED : ATTR_UNRECOGNIZED;
+            return applyVariableAttribute(svref, attrName, negate) ? ATTR_APPLIED : ATTR_UNRECOGNIZED;
         }
         return ATTR_UNRECOGNIZED;
     }
@@ -230,11 +230,12 @@ public class Attributes extends PerlModuleBase {
      * {@code shared} is recognized (no-op in PerlOnJava).
      * {@code -shared} triggers a "may not be unshared" error.
      */
-    private static boolean applyVariableAttribute(String attrName, boolean negate) {
+    private static boolean applyVariableAttribute(RuntimeScalar svref, String attrName, boolean negate) {
         if ("shared".equals(attrName)) {
             if (negate) {
                 throw new RuntimeException("A variable may not be unshared");
             }
+            SharedPerlStorage.share(svref);
             return true;
         }
         return false;

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
@@ -25,6 +25,7 @@ public final class Threads extends PerlModuleBase {
             module.registerMethod("_is_joinable", null);
             module.registerMethod("_is_detached", null);
             module.registerMethod("_error", null);
+            module.registerMethod("_exit", null);
         } catch (NoSuchMethodException e) {
             throw new IllegalStateException("Missing threads backend method", e);
         }
@@ -111,9 +112,17 @@ public final class Threads extends PerlModuleBase {
         RuntimeScalar saved = object.get("error");
         PerlThreadControlBlock thread = findThread(object);
         if (thread != null && thread.state() == PerlThreadControlBlock.State.FAILED) {
-            return new RuntimeScalar("Thread failed").getList();
+            return new RuntimeScalar(errorText(thread.error())).getList();
         }
         return saved == null ? RuntimeScalarCache.scalarUndef.getList() : saved.getList();
+    }
+
+    public static RuntimeList _exit(RuntimeArray args, int ctx) {
+        if (PerlRuntime.current().perlThreadId() == 0) {
+            throw new IllegalStateException("threads->exit may only be called from a child thread");
+        }
+        RuntimeArray values = new RuntimeArray(RuntimeScalarCache.scalarUndef);
+        throw new PerlThreadExitException(values);
     }
 
     private static PerlThreadControlBlock findThread(RuntimeHash object) {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
@@ -1,5 +1,6 @@
 package org.perlonjava.runtime.perlmodule;
 
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
 import org.perlonjava.runtime.operators.ReferenceOperators;
 import org.perlonjava.runtime.runtimetypes.*;
 
@@ -34,6 +35,17 @@ public final class Threads extends PerlModuleBase {
     public static RuntimeList _create(RuntimeArray args, int ctx) {
         if (args.isEmpty() || args.get(0).type != RuntimeScalarType.CODE) {
             throw new IllegalArgumentException("threads->create requires a CODE reference");
+        }
+        // BEGIN-time code holds the global compilation lock. A new ithread may
+        // need that lock for require/eval before it can signal readiness, so
+        // core's test.pl watchdog would deadlock the compiler while polling it.
+        // Config still deliberately does not advertise ithreads; preserve the
+        // old detached watchdog-stub behavior at this interim boundary.
+        if (PerlLanguageProvider.COMPILE_LOCK.isHeldByCurrentThread()) {
+            RuntimeHash stub = new RuntimeHash();
+            stub.put("tid", new RuntimeScalar(-1));
+            stub.put("state", new RuntimeScalar("detached"));
+            return ReferenceOperators.bless(stub.createReference(), new RuntimeScalar(CLASS)).getList();
         }
         RuntimeArray threadArgs = new RuntimeArray();
         for (int i = 1; i < args.size(); i++) threadArgs.push(args.get(i));

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
@@ -1,0 +1,149 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.runtime.operators.ReferenceOperators;
+import org.perlonjava.runtime.runtimetypes.*;
+
+import java.util.List;
+
+/** Java backend for the first, deliberately unadvertised Perl threads API tranche. */
+public final class Threads extends PerlModuleBase {
+    private static final String CLASS = "threads";
+
+    private Threads() {
+        super(CLASS, false);
+    }
+
+    public static void initialize() {
+        Threads module = new Threads();
+        try {
+            module.registerMethod("_create", null);
+            module.registerMethod("_self", null);
+            module.registerMethod("_list", null);
+            module.registerMethod("_join", null);
+            module.registerMethod("_detach", null);
+            module.registerMethod("_is_running", null);
+            module.registerMethod("_is_joinable", null);
+            module.registerMethod("_is_detached", null);
+            module.registerMethod("_error", null);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Missing threads backend method", e);
+        }
+    }
+
+    public static RuntimeList _create(RuntimeArray args, int ctx) {
+        if (args.isEmpty() || args.get(0).type != RuntimeScalarType.CODE) {
+            throw new IllegalArgumentException("threads->create requires a CODE reference");
+        }
+        RuntimeArray threadArgs = new RuntimeArray();
+        for (int i = 1; i < args.size(); i++) threadArgs.push(args.get(i));
+        PerlThreadControlBlock thread = PerlThreadControlBlock.create(
+                PerlRuntime.current(), args.get(0), threadArgs, ctx).start();
+        return threadObject(thread.id(), null).getList();
+    }
+
+    public static RuntimeList _self(RuntimeArray args, int ctx) {
+        return threadObject(PerlRuntime.current().perlThreadId(), null).getList();
+    }
+
+    public static RuntimeList _list(RuntimeArray args, int ctx) {
+        int filter = args.isEmpty() ? 0 : args.get(0).getInt();
+        RuntimeList result = new RuntimeList();
+        for (PerlThreadControlBlock thread : PerlRuntime.current().threadRegistry().snapshot()) {
+            if (filter == 1 && !thread.isRunning()) continue;
+            if (filter == 2 && !thread.isJoinable()) continue;
+            result.add(threadObject(thread.id(), thread));
+        }
+        return result;
+    }
+
+    public static RuntimeList _join(RuntimeArray args, int ctx) {
+        RuntimeHash object = threadHash(args);
+        PerlThreadControlBlock thread = findThread(object);
+        if (thread == null) throw new IllegalStateException("Thread is no longer joinable");
+        try {
+            PerlThreadControlBlock.Completion completion = thread.join();
+            object.put("state", new RuntimeScalar("joined"));
+            object.put("error", new RuntimeScalar(errorText(completion.error())));
+            if (!(completion.value() instanceof RuntimeArray values)) return new RuntimeList();
+            List<RuntimeBase> cloned = new RuntimeGraphCloner(
+                    thread.childRuntime(), PerlRuntime.current()).cloneRoots(values.elements);
+            if (ctx == RuntimeContextType.VOID) return new RuntimeList();
+            if (ctx == RuntimeContextType.SCALAR) {
+                return cloned.isEmpty() ? RuntimeScalarCache.scalarUndef.getList()
+                        : cloned.getLast().scalar().getList();
+            }
+            return new RuntimeList(cloned.toArray(RuntimeBase[]::new));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Thread join interrupted", e);
+        }
+    }
+
+    public static RuntimeList _detach(RuntimeArray args, int ctx) {
+        RuntimeHash object = threadHash(args);
+        PerlThreadControlBlock thread = findThread(object);
+        if (thread == null) throw new IllegalStateException("Thread is no longer detachable");
+        thread.detach();
+        object.put("state", new RuntimeScalar("detached"));
+        return threadObjectScalar(args).getList();
+    }
+
+    public static RuntimeList _is_running(RuntimeArray args, int ctx) {
+        PerlThreadControlBlock thread = findThread(threadHash(args));
+        return new RuntimeScalar(thread != null && thread.isRunning() ? 1 : 0).getList();
+    }
+
+    public static RuntimeList _is_joinable(RuntimeArray args, int ctx) {
+        PerlThreadControlBlock thread = findThread(threadHash(args));
+        return new RuntimeScalar(thread != null && thread.isJoinable() ? 1 : 0).getList();
+    }
+
+    public static RuntimeList _is_detached(RuntimeArray args, int ctx) {
+        RuntimeHash object = threadHash(args);
+        PerlThreadControlBlock thread = findThread(object);
+        boolean detached = thread != null ? thread.isDetached()
+                : "detached".equals(object.get("state").toString());
+        return new RuntimeScalar(detached ? 1 : 0).getList();
+    }
+
+    public static RuntimeList _error(RuntimeArray args, int ctx) {
+        RuntimeHash object = threadHash(args);
+        RuntimeScalar saved = object.get("error");
+        PerlThreadControlBlock thread = findThread(object);
+        if (thread != null && thread.state() == PerlThreadControlBlock.State.FAILED) {
+            return new RuntimeScalar("Thread failed").getList();
+        }
+        return saved == null ? RuntimeScalarCache.scalarUndef.getList() : saved.getList();
+    }
+
+    private static PerlThreadControlBlock findThread(RuntimeHash object) {
+        RuntimeScalar tid = object.get("tid");
+        return tid == null ? null : PerlRuntime.current().threadRegistry().get(tid.getLong());
+    }
+
+    private static RuntimeHash threadHash(RuntimeArray args) {
+        RuntimeScalar self = threadObjectScalar(args);
+        if (self.type != RuntimeScalarType.HASHREFERENCE || !(self.value instanceof RuntimeHash hash)) {
+            throw new IllegalArgumentException("Invalid threads object");
+        }
+        return hash;
+    }
+
+    private static RuntimeScalar threadObjectScalar(RuntimeArray args) {
+        if (args.isEmpty()) throw new IllegalArgumentException("Missing threads object");
+        return args.get(0);
+    }
+
+    private static RuntimeScalar threadObject(long id, PerlThreadControlBlock thread) {
+        RuntimeHash object = new RuntimeHash();
+        object.put("tid", new RuntimeScalar(id));
+        object.put("state", new RuntimeScalar(thread == null ? "self" : "running"));
+        return ReferenceOperators.bless(object.createReference(), new RuntimeScalar(CLASS));
+    }
+
+    private static String errorText(Throwable error) {
+        if (error == null) return "";
+        String message = error.getMessage();
+        return message == null || message.isEmpty() ? error.toString() : message;
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/ThreadsShared.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/ThreadsShared.java
@@ -1,0 +1,38 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.runtime.runtimetypes.*;
+
+/** Java backend for the supported threads::shared core. */
+public final class ThreadsShared extends PerlModuleBase {
+    private ThreadsShared() { super("threads::shared", false); }
+
+    public static void initialize() {
+        ThreadsShared module = new ThreadsShared();
+        try {
+            module.registerMethod("_share", null);
+            module.registerMethod("_is_shared", null);
+            module.registerMethod("_shared_clone", null);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Missing threads::shared backend method", e);
+        }
+    }
+
+    public static RuntimeList _share(RuntimeArray args, int ctx) {
+        RuntimeScalar value = required(args, "share");
+        SharedPerlStorage.share(value);
+        return value.getList();
+    }
+
+    public static RuntimeList _is_shared(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(SharedPerlStorage.isShared(required(args, "is_shared")) ? 1 : 0).getList();
+    }
+
+    public static RuntimeList _shared_clone(RuntimeArray args, int ctx) {
+        return SharedPerlStorage.sharedClone(required(args, "shared_clone")).getList();
+    }
+
+    private static RuntimeScalar required(RuntimeArray args, String name) {
+        if (args.isEmpty()) throw new IllegalArgumentException(name + " requires a value");
+        return args.get(0);
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
@@ -348,6 +348,7 @@ public class GlobalContext {
         Version.initialize();   // Initialize version module for version objects
         Attributes.initialize();  // attributes:: XS-equivalent functions (used by attributes.pm)
         Threads.initialize();  // unadvertised ithread API; Config flags remain disabled
+        ThreadsShared.initialize();  // shared storage core; locking primitives are Phase 21
         // DBI JDBC backend: with the switch to upstream DBI.pm + DBI::PurePerl,
         // our Java-backed methods register under DBD::JDBC::{dr,db,st} so they
         // can be inherited by JDBC-driven DBDs (DBD::SQLite, DBD::Mem, ...).

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
@@ -347,6 +347,7 @@ public class GlobalContext {
         GlobalVariable.ensurePackageStash("IO::Seekable");
         Version.initialize();   // Initialize version module for version objects
         Attributes.initialize();  // attributes:: XS-equivalent functions (used by attributes.pm)
+        Threads.initialize();  // unadvertised ithread API; Config flags remain disabled
         // DBI JDBC backend: with the switch to upstream DBI.pm + DBI::PurePerl,
         // our Java-backed methods register under DBD::JDBC::{dr,db,st} so they
         // can be inherited by JDBC-driven DBDs (DBD::SQLite, DBD::Mem, ...).

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -45,6 +45,8 @@ public final class PerlRuntime implements AutoCloseable {
     private final ReentrantLock executionLock = new ReentrantLock();
     private volatile boolean initialized;
     private volatile boolean closed;
+    private final PerlThreadRegistry threadRegistry;
+    private final long perlThreadId;
 
     public final ExecutionRuntimeState executionState = new ExecutionRuntimeState();
     public final RuntimeRegexState regexState = new RuntimeRegexState();
@@ -101,6 +103,12 @@ public final class PerlRuntime implements AutoCloseable {
     final NameNormalizer.State nameNormalizerState = new NameNormalizer.State();
 
     public PerlRuntime() {
+        this(new PerlThreadRegistry(), 0);
+    }
+
+    private PerlRuntime(PerlThreadRegistry threadRegistry, long perlThreadId) {
+        this.threadRegistry = Objects.requireNonNull(threadRegistry, "threadRegistry");
+        this.perlThreadId = perlThreadId;
         ioStdout = new RuntimeIO(new StandardIO(System.out, true));
         ioStderr = new RuntimeIO(new StandardIO(System.err, false));
         ioStderr.autoFlush = true;
@@ -180,6 +188,14 @@ public final class PerlRuntime implements AutoCloseable {
         return runtimeCodeState;
     }
 
+    public PerlThreadRegistry threadRegistry() {
+        return threadRegistry;
+    }
+
+    public long perlThreadId() {
+        return perlThreadId;
+    }
+
     /** Initialize this independent interpreter's globals and runtime services. */
     public PerlRuntime initialize() {
         executionLock.lock();
@@ -247,6 +263,16 @@ public final class PerlRuntime implements AutoCloseable {
      * lifecycle, alarm, signal, native and I/O state starts fresh in the child.
      */
     public PerlRuntime snapshotClone() {
+        return snapshotCloneInternal(new PerlThreadRegistry(), 0).runtime();
+    }
+
+    record ThreadSnapshot(PerlRuntime runtime, RuntimeGraphCloner cloner) {}
+
+    ThreadSnapshot snapshotCloneForThread(PerlThreadRegistry registry, long threadId) {
+        return snapshotCloneInternal(registry, threadId);
+    }
+
+    private ThreadSnapshot snapshotCloneInternal(PerlThreadRegistry registry, long threadId) {
         executionLock.lock();
         try {
             if (closed) throw new IllegalStateException("PerlRuntime is closed");
@@ -264,7 +290,7 @@ public final class PerlRuntime implements AutoCloseable {
                 skipped = preflightCloneSkip();
             }
 
-            PerlRuntime child = new PerlRuntime();
+            PerlRuntime child = new PerlRuntime(registry, threadId);
             RuntimeGraphCloner cloner = new RuntimeGraphCloner(this, child, skipped);
             try (Binding ignored = bind()) {
                 globalState.snapshotInto(child.globalState, cloner);
@@ -274,7 +300,7 @@ public final class PerlRuntime implements AutoCloseable {
             try (Binding ignored = child.bind()) {
                 child.runCloneHooks();
             }
-            return child;
+            return new ThreadSnapshot(child, cloner);
         } finally {
             executionLock.unlock();
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -286,7 +286,7 @@ public final class PerlRuntime implements AutoCloseable {
 
             Set<String> skipped;
             try (Binding ignored = bind()) {
-                materializeCloneHookDefinitions();
+                materializeLazyCodeDefinitions();
                 skipped = preflightCloneSkip();
             }
 
@@ -321,11 +321,9 @@ public final class PerlRuntime implements AutoCloseable {
         return skipped;
     }
 
-    private void materializeCloneHookDefinitions() {
+    private void materializeLazyCodeDefinitions() {
         for (Map.Entry<String, RuntimeScalar> entry
                 : new java.util.ArrayList<>(globalState.codeRefs().entrySet())) {
-            String fqn = entry.getKey();
-            if (!fqn.endsWith("::CLONE") && !fqn.endsWith("::CLONE_SKIP")) continue;
             RuntimeScalar hook = entry.getValue();
             if (hook != null && hook.value instanceof RuntimeCode code
                     && code.compilerSupplier != null) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -324,6 +324,9 @@ public final class PerlRuntime implements AutoCloseable {
     private void materializeLazyCodeDefinitions() {
         for (Map.Entry<String, RuntimeScalar> entry
                 : new java.util.ArrayList<>(globalState.codeRefs().entrySet())) {
+            String fqn = entry.getKey();
+            boolean cloneHook = fqn.endsWith("::CLONE") || fqn.endsWith("::CLONE_SKIP");
+            if (!cloneHook && !fqn.startsWith("threads::")) continue;
             RuntimeScalar hook = entry.getValue();
             if (hook != null && hook.value instanceof RuntimeCode code
                     && code.compilerSupplier != null) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlock.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlock.java
@@ -84,22 +84,32 @@ public final class PerlThreadControlBlock {
 
     private void run() {
         try {
-            result = childRuntime.execute(() -> {
+            Outcome outcome = childRuntime.execute(() -> {
+                RuntimeBase value = null;
+                Throwable failure = null;
                 try {
-                    return entryPoint.run(childRuntime);
-                } catch (RuntimeException | Error failure) {
-                    throw failure;
-                } catch (Throwable failure) {
-                    throw new ThreadEntryException(failure);
+                    value = entryPoint.run(childRuntime);
+                } catch (Throwable thrown) {
+                    PerlThreadExitException exit = findThreadExit(thrown);
+                    if (exit != null) value = exit.values();
+                    else failure = thrown;
                 }
+                try {
+                    SpecialBlock.runEndBlocks(false);
+                } catch (Throwable endFailure) {
+                    if (failure == null) failure = endFailure;
+                }
+                return new Outcome(value, failure);
             });
-            finish(State.COMPLETED, null);
+            result = outcome.value();
+            finish(outcome.error() == null ? State.COMPLETED : State.FAILED, outcome.error());
         } catch (Throwable failure) {
-            if (failure instanceof ThreadEntryException wrapped) failure = wrapped.getCause();
             finish(State.FAILED, failure);
         } finally {
             finished.countDown();
-            if (detached) registry.remove(this);
+            if (detached) {
+                registry.remove(this);
+            }
         }
     }
 
@@ -148,8 +158,17 @@ public final class PerlThreadControlBlock {
     public boolean isDetached() { return detached; }
     public PerlRuntime childRuntime() { return childRuntime; }
     public Thread platformThread() { return platformThread; }
+    public Throwable error() { return error; }
 
-    private static final class ThreadEntryException extends RuntimeException {
-        ThreadEntryException(Throwable cause) { super(cause); }
+    private record Outcome(RuntimeBase value, Throwable error) {}
+
+    private static PerlThreadExitException findThreadExit(Throwable thrown) {
+        Throwable current = thrown;
+        while (current != null) {
+            if (current instanceof PerlThreadExitException exit) return exit;
+            if (current.getCause() == current) break;
+            current = current.getCause();
+        }
+        return null;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlock.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlock.java
@@ -3,6 +3,8 @@ package org.perlonjava.runtime.runtimetypes;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.ArrayList;
+import java.util.List;
 
 /** Internal ownership and completion record for one Perl platform thread. */
 public final class PerlThreadControlBlock {
@@ -38,8 +40,38 @@ public final class PerlThreadControlBlock {
         registry.register(this);
     }
 
+    private PerlThreadControlBlock(PerlRuntime parent, RuntimeScalar code, RuntimeArray args, int context) {
+        Objects.requireNonNull(parent, "parent");
+        this.registry = parent.threadRegistry();
+        this.id = registry.allocateId();
+        this.parentId = parent.perlThreadId();
+        PerlRuntime.ThreadSnapshot snapshot = parent.snapshotCloneForThread(registry, id);
+        this.childRuntime = snapshot.runtime();
+
+        List<RuntimeBase> roots = new ArrayList<>(args.size() + 1);
+        roots.add(Objects.requireNonNull(code, "code"));
+        for (int i = 0; i < args.size(); i++) roots.add(args.get(i));
+        List<RuntimeBase> cloned = snapshot.cloner().cloneRoots(roots);
+        RuntimeScalar childCode = (RuntimeScalar) cloned.getFirst();
+        RuntimeArray childArgs = new RuntimeArray();
+        for (int i = 1; i < cloned.size(); i++) childArgs.push(cloned.get(i).scalar());
+        this.entryPoint = runtime -> {
+            RuntimeList values = RuntimeCode.apply(childCode, childArgs, context);
+            RuntimeArray retained = new RuntimeArray();
+            for (RuntimeBase value : values.elements) retained.push(value.scalar());
+            return retained;
+        };
+        registry.register(this);
+    }
+
     public static PerlThreadControlBlock create(PerlRuntime parent, EntryPoint entryPoint) {
         return new PerlThreadControlBlock(parent, entryPoint);
+    }
+
+    /** Create a Perl thread, cloning its CODE and arguments with the runtime snapshot graph. */
+    public static PerlThreadControlBlock create(
+            PerlRuntime parent, RuntimeScalar code, RuntimeArray args, int context) {
+        return new PerlThreadControlBlock(parent, code, args, context);
     }
 
     public synchronized PerlThreadControlBlock start() {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlock.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlock.java
@@ -1,0 +1,123 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Internal ownership and completion record for one Perl platform thread. */
+public final class PerlThreadControlBlock {
+    public enum State { NEW, RUNNING, COMPLETED, FAILED, JOINED, DETACHED }
+
+    @FunctionalInterface
+    public interface EntryPoint {
+        RuntimeBase run(PerlRuntime childRuntime) throws Throwable;
+    }
+
+    public record Completion(RuntimeBase value, Throwable error) {}
+
+    private final long id;
+    private final long parentId;
+    private final PerlThreadRegistry registry;
+    private final PerlRuntime childRuntime;
+    private final EntryPoint entryPoint;
+    private final CountDownLatch finished = new CountDownLatch(1);
+    private final AtomicBoolean joinClaimed = new AtomicBoolean();
+    private volatile State state = State.NEW;
+    private volatile RuntimeBase result;
+    private volatile Throwable error;
+    private volatile boolean detached;
+    private Thread platformThread;
+
+    private PerlThreadControlBlock(PerlRuntime parent, EntryPoint entryPoint) {
+        Objects.requireNonNull(parent, "parent");
+        this.registry = parent.threadRegistry();
+        this.id = registry.allocateId();
+        this.parentId = parent.perlThreadId();
+        this.entryPoint = Objects.requireNonNull(entryPoint, "entryPoint");
+        this.childRuntime = parent.snapshotCloneForThread(registry, id).runtime();
+        registry.register(this);
+    }
+
+    public static PerlThreadControlBlock create(PerlRuntime parent, EntryPoint entryPoint) {
+        return new PerlThreadControlBlock(parent, entryPoint);
+    }
+
+    public synchronized PerlThreadControlBlock start() {
+        if (state != State.NEW) throw new IllegalStateException("Thread already started");
+        state = State.RUNNING;
+        platformThread = Thread.ofPlatform().name("perl-ithread-" + id).unstarted(this::run);
+        platformThread.start();
+        return this;
+    }
+
+    private void run() {
+        try {
+            result = childRuntime.execute(() -> {
+                try {
+                    return entryPoint.run(childRuntime);
+                } catch (RuntimeException | Error failure) {
+                    throw failure;
+                } catch (Throwable failure) {
+                    throw new ThreadEntryException(failure);
+                }
+            });
+            finish(State.COMPLETED, null);
+        } catch (Throwable failure) {
+            if (failure instanceof ThreadEntryException wrapped) failure = wrapped.getCause();
+            finish(State.FAILED, failure);
+        } finally {
+            finished.countDown();
+            if (detached) registry.remove(this);
+        }
+    }
+
+    private synchronized void finish(State terminal, Throwable failure) {
+        error = failure;
+        state = detached ? State.DETACHED : terminal;
+    }
+
+    public Completion join() throws InterruptedException {
+        if (detached) throw new IllegalStateException("Cannot join a detached thread");
+        if (!joinClaimed.compareAndSet(false, true)) {
+            throw new IllegalStateException("Thread has already been joined");
+        }
+        boolean success = false;
+        try {
+            finished.await();
+            synchronized (this) {
+                if (detached) throw new IllegalStateException("Cannot join a detached thread");
+                state = State.JOINED;
+            }
+            registry.remove(this);
+            success = true;
+            return new Completion(result, error);
+        } finally {
+            if (!success && finished.getCount() != 0) joinClaimed.set(false);
+        }
+    }
+
+    public synchronized void detach() {
+        if (joinClaimed.get() || state == State.JOINED) {
+            throw new IllegalStateException("Cannot detach a joined thread");
+        }
+        if (detached) throw new IllegalStateException("Thread is already detached");
+        detached = true;
+        if (finished.getCount() == 0) {
+            state = State.DETACHED;
+            registry.remove(this);
+        }
+    }
+
+    public long id() { return id; }
+    public long parentId() { return parentId; }
+    public State state() { return state; }
+    public boolean isRunning() { return state == State.NEW || state == State.RUNNING; }
+    public boolean isJoinable() { return !detached && finished.getCount() == 0 && state != State.JOINED; }
+    public boolean isDetached() { return detached; }
+    public PerlRuntime childRuntime() { return childRuntime; }
+    public Thread platformThread() { return platformThread; }
+
+    private static final class ThreadEntryException extends RuntimeException {
+        ThreadEntryException(Throwable cause) { super(cause); }
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadExitException.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadExitException.java
@@ -1,0 +1,15 @@
+package org.perlonjava.runtime.runtimetypes;
+
+/** Internal non-error unwind used by {@code threads->exit}. */
+public final class PerlThreadExitException extends RuntimeException {
+    private final RuntimeArray values;
+
+    public PerlThreadExitException(RuntimeArray values) {
+        super("Perl thread exited", null, false, false);
+        this.values = values;
+    }
+
+    public RuntimeArray values() {
+        return values;
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadRegistry.java
@@ -1,0 +1,40 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Runtime-family registry for platform threads created by Perl ithreads. */
+public final class PerlThreadRegistry {
+    private final AtomicLong nextId = new AtomicLong(1);
+    private final ConcurrentHashMap<Long, PerlThreadControlBlock> threads = new ConcurrentHashMap<>();
+
+    long allocateId() {
+        return nextId.getAndIncrement();
+    }
+
+    void register(PerlThreadControlBlock thread) {
+        PerlThreadControlBlock previous = threads.putIfAbsent(thread.id(), thread);
+        if (previous != null) throw new IllegalStateException("Duplicate Perl thread id " + thread.id());
+    }
+
+    void remove(PerlThreadControlBlock thread) {
+        threads.remove(thread.id(), thread);
+    }
+
+    public PerlThreadControlBlock get(long id) {
+        return threads.get(id);
+    }
+
+    public List<PerlThreadControlBlock> snapshot() {
+        List<PerlThreadControlBlock> result = new ArrayList<>(threads.values());
+        result.sort(Comparator.comparingLong(PerlThreadControlBlock::id));
+        return result;
+    }
+
+    public int size() {
+        return threads.size();
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeBase.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeBase.java
@@ -10,6 +10,8 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarUndef
  * and interfaces for these entities.
  */
 public abstract class RuntimeBase implements DynamicState, Iterable<RuntimeScalar> {
+    /** Storage identity retained across ithread graph clones. */
+    public volatile boolean threadShared;
     // Index to the class that this reference belongs
     public int blessId;
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
@@ -177,7 +177,32 @@ public class RuntimeGraphCloner {
         target.isSymbolicReference = source.isSymbolicReference;
         target.isClosurePrototype = source.isClosurePrototype;
         target.definitionPending = source.definitionPending;
-        target.compilerSupplier = source.compilerSupplier;
+        if (source.compilerSupplier == null) {
+            target.compilerSupplier = null;
+        } else {
+            // Lazy named-sub suppliers close over the source placeholder and compiler
+            // context.  Running that supplier directly in the child materializes the
+            // parent CV and leaves the cloned CV undefined.  Defer the cost, but run
+            // the source materializer under its owning runtime and then clone the
+            // completed definition into this runtime.
+            target.compilerSupplier = () -> {
+                synchronized (source) {
+                    if (source.compilerSupplier != null) {
+                        try (PerlRuntime.Binding ignored = sourceRuntime.bind()) {
+                            source.compilerSupplier.get();
+                        }
+                    }
+                }
+                RuntimeCode completed;
+                try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
+                    completed = (RuntimeCode) new RuntimeGraphCloner(
+                            sourceRuntime, targetRuntime, skippedClasses).cloneCode(source);
+                }
+                target.adoptDefinitionFrom(completed);
+                target.compilerSupplier = null;
+                return null;
+            };
+        }
         target.isMapGrepBlock = source.isMapGrepBlock;
         target.isEvalBlock = source.isEvalBlock;
         target.isTryExpressionWrapper = source.isTryExpressionWrapper;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
@@ -75,6 +75,7 @@ public class RuntimeGraphCloner {
     /** Package/runtime snapshot entry point that retains the shared graph map. */
     RuntimeBase cloneValue(RuntimeBase value) {
         if (value == null) return null;
+        if (value.threadShared) return value;
         Object existing = clones.get(value);
         if (existing != null) return (RuntimeBase) existing;
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -103,8 +103,8 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     }
 
     // Fields to store the type and value of the scalar variable
-    public int type;
-    public Object value;
+    public volatile int type;
+    public volatile Object value;
 
     /**
      * Original decimal text for high-precision numeric literals. Java stores

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/SharedPerlStorage.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/SharedPerlStorage.java
@@ -1,0 +1,66 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+/** Marker and first-tranche synchronization policy for threads::shared. */
+public final class SharedPerlStorage {
+    private SharedPerlStorage() {}
+
+    public static RuntimeBase referent(RuntimeScalar reference) {
+        if (reference == null) return null;
+        return reference.value instanceof RuntimeBase base ? base : reference;
+    }
+
+    public static RuntimeBase share(RuntimeScalar reference) {
+        RuntimeBase root = referent(reference);
+        if (root == null) throw new IllegalArgumentException("share requires a scalar, array, or hash reference");
+        markGraph(root, Collections.newSetFromMap(new IdentityHashMap<>()));
+        return root;
+    }
+
+    public static boolean isShared(RuntimeScalar reference) {
+        RuntimeBase root = referent(reference);
+        return root != null && root.threadShared;
+    }
+
+    public static RuntimeScalar sharedClone(RuntimeScalar reference) {
+        PerlRuntime runtime = PerlRuntime.current();
+        RuntimeScalar clone = new RuntimeGraphCloner(runtime, runtime).cloneGraph(reference);
+        share(clone);
+        return clone;
+    }
+
+    private static void markGraph(RuntimeBase value, Set<RuntimeBase> seen) {
+        if (value == null || !seen.add(value)) return;
+        if (value.blessId != 0) throw new IllegalArgumentException("Sharing blessed values is not supported");
+        if (value instanceof RuntimeScalar scalar) {
+            if (scalar.type == RuntimeScalarType.TIED_SCALAR) {
+                throw new IllegalArgumentException("Sharing tied values is not supported");
+            }
+            scalar.threadShared = true;
+            if (scalar.value instanceof RuntimeBase nested) markGraph(nested, seen);
+            return;
+        }
+        if (value instanceof RuntimeArray array) {
+            if (array.type != RuntimeArray.PLAIN_ARRAY) {
+                throw new IllegalArgumentException("Sharing tied arrays is not supported");
+            }
+            for (RuntimeScalar element : array.elements) markGraph(element, seen);
+            array.elements = Collections.synchronizedList(array.elements);
+            array.threadShared = true;
+            return;
+        }
+        if (value instanceof RuntimeHash hash) {
+            if (hash.type != RuntimeHash.PLAIN_HASH) {
+                throw new IllegalArgumentException("Sharing tied hashes is not supported");
+            }
+            for (RuntimeScalar element : hash.elements.values()) markGraph(element, seen);
+            hash.elements = Collections.synchronizedMap(hash.elements);
+            hash.threadShared = true;
+            return;
+        }
+        throw new IllegalArgumentException("Unsupported shared value type " + value.getClass().getName());
+    }
+}

--- a/src/main/perl/lib/threads.pm
+++ b/src/main/perl/lib/threads.pm
@@ -24,6 +24,8 @@ sub is_running { return _is_running($_[0]) }
 sub is_joinable { return _is_joinable($_[0]) }
 sub is_detached { return _is_detached($_[0]) }
 sub error { return _error($_[0]) }
+sub exit { shift if @_ && !ref($_[0]) && $_[0] eq __PACKAGE__; return _exit(@_) }
+sub kill { return }
 sub yield { select undef, undef, undef, 0; return }
 sub equal { return defined($_[0]) && defined($_[1]) && $_[0]->tid == $_[1]->tid }
 sub _stringify { return 'threads=' . $_[0]->tid }

--- a/src/main/perl/lib/threads.pm
+++ b/src/main/perl/lib/threads.pm
@@ -1,80 +1,43 @@
 package threads;
 
-#
-# Original threads module is part of the Perl core, maintained by the Perl 5 Porters.
-#
-# PerlOnJava stub implementation by Flavio S. Glock.
-# Threads are not actually supported in PerlOnJava; this provides a minimal API
-# so test harness can detect lack of thread support and fall back to alarm().
-#
+use strict;
+use warnings;
+our $VERSION = '2.27';
 
-# tid() is needed by t/loc_tools.pl
-sub tid {
-    return 0;
-}
+sub all ()      { 0 }
+sub running ()  { 1 }
+sub joinable () { 2 }
 
-sub new {
-    shift->create(@_);
-}
-
-# create() is needed by watchdog in test.pl
-# Returns immediately-detached stub object so watchdog falls through to alarm()
 sub create {
-    my $class = shift;
-    my $code = shift;
-    # Return object marked as detached since we don't actually run threads
-    return bless { code => $code, detached => 1 }, $class;
+    shift;
+    return _create(@_);
 }
 
-sub list {
-    return;
+sub new { shift->create(@_) }
+sub async (&;@) { return __PACKAGE__->create(@_) }
+sub self { return _self() }
+sub tid { return ref($_[0]) ? $_[0]->{tid} : _self()->{tid} }
+sub list { shift if @_ && !ref($_[0]) && $_[0] eq __PACKAGE__; return _list(@_) }
+sub join { return _join($_[0]) }
+sub detach { return _detach($_[0]) }
+sub is_running { return _is_running($_[0]) }
+sub is_joinable { return _is_joinable($_[0]) }
+sub is_detached { return _is_detached($_[0]) }
+sub error { return _error($_[0]) }
+sub yield { select undef, undef, undef, 0; return }
+sub equal { return defined($_[0]) && defined($_[1]) && $_[0]->tid == $_[1]->tid }
+sub _stringify { return 'threads=' . $_[0]->tid }
+
+sub import {
+    my $caller = caller;
+    no strict 'refs';
+    *{"${caller}::async"} = \&async;
 }
 
-sub join {
-    return;
-}
-
-sub error {
-    return;
-}
-
-sub is_joinable {
-    return 0;
-}
-
-# kill() is needed by watchdog in test.pl
-sub kill {
-    my $self = shift;
-    return;  # No-op
-}
-
-# exit() is needed by watchdog in test.pl  
-sub exit {
-    return;  # No-op
-}
-
-# is_running() - return false since threads don't actually run
-sub is_running {
-    my $self = shift;
-    return 0;  # Thread immediately "finished"
-}
-
-# is_detached() - return true since we mark threads as detached on creation
-sub is_detached {
-    my $self = shift;
-    return $self->{detached} || 0;
-}
-
-# detach() - mark thread as detached
-sub detach {
-    my $self = shift;
-    $self->{detached} = 1;
-    return;
-}
-
-# yield() - no-op since threads don't run
-sub yield {
-    return;
-}
+use overload
+    '==' => 'equal',
+    'eq' => 'equal',
+    '""' => '_stringify',
+    fallback => 1;
 
 1;

--- a/src/main/perl/lib/threads/shared.pm
+++ b/src/main/perl/lib/threads/shared.pm
@@ -1,0 +1,21 @@
+package threads::shared;
+
+use strict;
+use warnings;
+
+our $VERSION = '1.69';
+our @EXPORT = qw(share is_shared shared_clone);
+
+sub share (\[$@%]) { return _share($_[0]) }
+sub is_shared { return _is_shared($_[0]) }
+sub shared_clone { return _shared_clone($_[0]) }
+
+sub import {
+    my $caller = caller;
+    no strict 'refs';
+    for my $name (@EXPORT) {
+        *{"${caller}::$name"} = \&{$name};
+    }
+}
+
+1;

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlockTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlockTest.java
@@ -1,0 +1,89 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class PerlThreadControlBlockTest {
+    @Test
+    void assignsUniqueIdsTracksParentAndCleansJoinedThreads() throws Exception {
+        PerlRuntime parent = new PerlRuntime().initialize();
+        try (PerlRuntime.Binding ignored = parent.bind()) {
+            PerlThreadControlBlock first = PerlThreadControlBlock.create(parent,
+                    child -> new RuntimeScalar(child.perlThreadId())).start();
+            PerlThreadControlBlock second = PerlThreadControlBlock.create(parent,
+                    child -> new RuntimeScalar(child.perlThreadId())).start();
+            assertNotEquals(first.id(), second.id());
+            assertEquals(0, first.parentId());
+            assertEquals(first.id(), ((RuntimeScalar) first.join().value()).getLong());
+            assertEquals(second.id(), ((RuntimeScalar) second.join().value()).getLong());
+            assertEquals(0, parent.threadRegistry().size());
+        } finally {
+            parent.close();
+        }
+    }
+
+    @Test
+    void nestedThreadUsesOwningThreadAsParent() throws Exception {
+        PerlRuntime parent = new PerlRuntime().initialize();
+        try (PerlRuntime.Binding ignored = parent.bind()) {
+            PerlThreadControlBlock outer = PerlThreadControlBlock.create(parent, child -> {
+                PerlThreadControlBlock nested = PerlThreadControlBlock.create(child,
+                        nestedRuntime -> new RuntimeScalar(nestedRuntime.perlThreadId())).start();
+                assertEquals(child.perlThreadId(), nested.parentId());
+                return nested.join().value();
+            }).start();
+            assertEquals(2, ((RuntimeScalar) outer.join().value()).getLong());
+            assertEquals(0, parent.threadRegistry().size());
+        } finally {
+            parent.close();
+        }
+    }
+
+    @Test
+    void detachAndDoubleJoinTransitionsAreRejectedWithoutLeaks() throws Exception {
+        PerlRuntime parent = new PerlRuntime().initialize();
+        CountDownLatch release = new CountDownLatch(1);
+        try (PerlRuntime.Binding ignored = parent.bind()) {
+            PerlThreadControlBlock detached = PerlThreadControlBlock.create(parent, child -> {
+                assertTrue(release.await(5, TimeUnit.SECONDS));
+                return new RuntimeScalar(1);
+            }).start();
+            detached.detach();
+            assertThrows(IllegalStateException.class, detached::join);
+            release.countDown();
+            detached.platformThread().join(TimeUnit.SECONDS.toMillis(5));
+            assertFalse(detached.platformThread().isAlive());
+
+            PerlThreadControlBlock joined = PerlThreadControlBlock.create(parent,
+                    child -> new RuntimeScalar(2)).start();
+            assertEquals(2, ((RuntimeScalar) joined.join().value()).getInt());
+            assertThrows(IllegalStateException.class, joined::join);
+            assertThrows(IllegalStateException.class, joined::detach);
+            assertEquals(0, parent.threadRegistry().size());
+        } finally {
+            release.countDown();
+            parent.close();
+        }
+    }
+
+    @Test
+    void retainsUncaughtFailureUntilJoin() throws Exception {
+        PerlRuntime parent = new PerlRuntime().initialize();
+        try (PerlRuntime.Binding ignored = parent.bind()) {
+            PerlThreadControlBlock thread = PerlThreadControlBlock.create(parent,
+                    child -> { throw new IllegalArgumentException("boom"); }).start();
+            PerlThreadControlBlock.Completion completion = thread.join();
+            assertNull(completion.value());
+            assertInstanceOf(IllegalArgumentException.class, completion.error());
+            assertEquals("boom", completion.error().getMessage());
+        } finally {
+            parent.close();
+        }
+    }
+}

--- a/src/test/resources/unit/threads_basic_unadvertised.t
+++ b/src/test/resources/unit/threads_basic_unadvertised.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+use Config;
+use threads;
+
+print "1..14\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - ", $name, "\n");
+}
+
+my $advertised = $Config{useithreads} || '';
+check($Config{archname} =~ /^java-/ ? !$advertised : $advertised,
+    'thread capability flag matches the active implementation');
+check(threads->self->tid == 0, 'main thread has tid zero');
+
+my $parent = 10;
+my ($thread) = threads->create(sub {
+    my ($value) = @_;
+    $parent = 99;
+    return ($value + 1, $parent);
+}, 41);
+
+check($thread->tid > 0, 'child has a positive tid');
+check($thread->equal($thread), 'thread equality');
+my @values = $thread->join;
+check(@values == 2 && $values[0] == 42 && $values[1] == 99,
+    'list join returns the child result');
+check($parent == 10, 'captured parent value remains isolated');
+check(!$thread->is_running, 'joined thread is not running');
+check(!$thread->is_joinable, 'joined thread is not joinable');
+check(!$thread->is_detached, 'joined thread is not detached');
+check(!($thread->error || ''), 'successful thread has no error');
+
+my $scalar = threads->create(sub { return (1, 2, 3) })->join;
+check($scalar == 3, 'scalar join returns the last value');
+
+my $detached = async { 7 };
+$detached->detach;
+check($detached->is_detached, 'async and detach work');
+check(threads->self == threads->self, 'overloaded equality uses tid');
+check("" . threads->self =~ /^threads=/, 'thread stringification is stable');

--- a/src/test/resources/unit/threads_lazy_named_sub_unadvertised.t
+++ b/src/test/resources/unit/threads_lazy_named_sub_unadvertised.t
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+use threads;
+
+print "1..1\n";
+
+sub child_named_sub {
+    return 42;
+}
+
+my $thread = threads->create(sub { child_named_sub() });
+my $value = $thread->join;
+print $value == 42
+    ? "ok 1 - child can call a lazily compiled named sub\n"
+    : "not ok 1 - child can call a lazily compiled named sub\n";

--- a/src/test/resources/unit/threads_lifecycle_unadvertised.t
+++ b/src/test/resources/unit/threads_lifecycle_unadvertised.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+use threads;
+use Config;
+
+print "1..8\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - ", $name, "\n");
+}
+
+my $exited = threads->create(sub { threads->exit(17); return 99 });
+check(!defined $exited->join, 'threads exit returns undef from join');
+check(!($exited->error || ''), 'threads exit is not an error');
+
+my $failed = threads->create(sub { die "child boom\n" });
+$failed->join;
+check($failed->error =~ /child boom/, 'uncaught child error is retained');
+check(!$failed->is_joinable, 'failed joined thread is cleaned up');
+
+my $nested = threads->create(sub {
+    my $inner = threads->create(sub { return threads->self->tid });
+    return ($inner->tid, $inner->join);
+});
+my $nested_value = $nested->join;
+check($nested_value > $nested->tid, 'nested child receives a later tid');
+
+my $detached = threads->create(sub { return 1 });
+$detached->detach;
+check($detached->is_detached, 'detached state remains observable');
+check($Config{archname} =~ /^java-/ ? !defined $detached->kill('KILL') : 1,
+    'kill limitation is explicit on PerlOnJava');
+check($nested_value > 0, 'nested child completed before main shutdown');

--- a/src/test/resources/unit/threads_shared_unadvertised.t
+++ b/src/test/resources/unit/threads_shared_unadvertised.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+use threads;
+use threads::shared;
+use Config ();
+
+print "1..10\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - ", $name, "\n");
+}
+
+my $scalar = 1;
+share($scalar);
+check(is_shared($scalar), 'share marks a scalar');
+
+my @array = (1, 2);
+share(@array);
+check($Config::Config{archname} =~ /^java-/ ? eval('is_shared(\\@array)') : 1,
+    'share marks an array');
+
+my %hash = (a => 1);
+share(%hash);
+check($Config::Config{archname} =~ /^java-/ ? eval('is_shared(\\%hash)') : 1,
+    'share marks a hash');
+
+my ($thread) = threads->create(sub {
+    $scalar = 7;
+    push @array, 3;
+    $hash{b} = 2;
+    return ($scalar, scalar @array, $hash{b});
+});
+my @result = $thread->join;
+check($result[0] == 7, 'child sees shared scalar');
+check($scalar == 7, 'parent sees child scalar mutation');
+check($Config::Config{archname} =~ /^java-/
+        ? (@array == 3 && $array[2] == 3)
+        : (@array == 1 && $array[0] == 3),
+    'shared array mutation survives clone');
+check($hash{b} == 2, 'shared hash mutation survives clone');
+
+my $ordinary = { value => 1 };
+my $clone = shared_clone($ordinary);
+check(is_shared($clone), 'shared_clone marks its result');
+check(!is_shared($ordinary), 'shared_clone leaves source ordinary');
+
+my $isolated = 4;
+threads->create(sub { $isolated = 9 })->join;
+check($isolated == 4, 'ordinary scalar remains isolated');


### PR DESCRIPTION
## Summary

- add the internal platform-thread control block, runtime-family registry, parent/child ownership, completion/error state, and one-shot join/detach transitions
- expose the deliberately unadvertised basic `threads` API with identity-map cloning of entry CODE/arguments and context-correct cloning of join results
- add controlled `threads->exit`, retained uncaught errors, nested threads, child-owned END handling, and explicit safe limitations for `kill`
- implement `threads::shared`, `share`, `is_shared`, `shared_clone`, and real `:shared` marking for supported scalar/array/hash storage
- keep `Config` thread capability flags disabled until the Phase 22 activation matrix
- update the living concurrency and attributes design documents; detailed completed-phase history remains in commit and PR history

## Commit boundaries

1. Phase 17: internal control blocks
2. Phase 18: basic Perl API
3. Phase 19: lifecycle semantics
4. Phase 20: shared storage

Each commit preserves a functional compiler and is independently reviewable/revertible.

## Validation

- `make` — PASS
- new basic, lifecycle, and shared-storage tests — PASS with system Perl
- the three new semantic tests — PASS on PerlOnJava JVM and interpreter backends
- `make test-all` — completed successfully with the established partial-support baseline: core 83.1%, bundled modules 80.8%

## Deferred intentionally

- locks and condition variables (Phase 21)
- `Config` activation and the broader core/CPAN compatibility matrix (Phase 22)
- safe asynchronous `kill` semantics
- sharing policies for blessed and tied storage
