### PR TITLE
Fix Scalar::Watcher and Protocol::BitTorrent tooling

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -61,6 +61,7 @@ public class BytecodeInterpreter {
                 || scalar.captureRefCountOwned > 0
                 || scalar.referencedByScalarReference
                 || scalar.hasLiveSubstrLvalueObservers()
+                || scalar.hasWatchers()
                 || scalar.type == RuntimeScalarType.TIED_SCALAR
                 || scalar.type == RuntimeScalarType.READONLY_SCALAR;
     }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/ConvertBencode_XS.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/ConvertBencode_XS.java
@@ -1,0 +1,193 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.runtime.runtimetypes.*;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/** Java implementation of Convert::Bencode_XS. */
+public final class ConvertBencode_XS extends PerlModuleBase {
+    public ConvertBencode_XS() {
+        super("Convert::Bencode_XS", false);
+    }
+
+    public static void initialize() {
+        ConvertBencode_XS module = new ConvertBencode_XS();
+        try {
+            module.registerMethod("bencode", "bencode", "$");
+            module.registerMethod("bdecode", "bdecode", "$");
+            module.registerMethod("cleanse", "cleanse", "$");
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Missing Convert::Bencode_XS method", e);
+        }
+    }
+
+    public static RuntimeList bencode(RuntimeArray args, int ctx) {
+        StringBuilder encoded = new StringBuilder();
+        encode(encoded, args.get(0), coerce());
+        return new RuntimeScalar(encoded.toString()).getList();
+    }
+
+    private static void encode(StringBuilder out, RuntimeScalar value, boolean coerce) {
+        if (value.type == RuntimeScalarType.ARRAYREFERENCE) {
+            out.append('l');
+            RuntimeArray array = (RuntimeArray) value.value;
+            for (RuntimeScalar element : array.elements) encode(out, element, coerce);
+            out.append('e');
+            return;
+        }
+        if (value.type == RuntimeScalarType.HASHREFERENCE) {
+            out.append('d');
+            RuntimeHash hash = (RuntimeHash) value.value;
+            List<String> keys = new ArrayList<>(hash.elements.keySet());
+            keys.sort(Comparator.comparing(ConvertBencode_XS::bytes,
+                    ConvertBencode_XS::compareUnsigned));
+            for (String key : keys) {
+                appendString(out, key);
+                encode(out, hash.elements.get(key), coerce);
+            }
+            out.append('e');
+            return;
+        }
+        if (value.value instanceof RuntimeBase) {
+            throw new IllegalArgumentException("Cannot serialize this kind of reference: " + value);
+        }
+
+        String text = value.toString();
+        boolean nativeInteger = value.type == RuntimeScalarType.INTEGER;
+        if (nativeInteger || (coerce && isCanonicalInteger(text))) {
+            if (text.startsWith("+")) text = text.substring(1);
+            out.append('i').append(text).append('e');
+        } else {
+            appendString(out, text);
+        }
+    }
+
+    private static void appendString(StringBuilder out, String value) {
+        out.append(bytes(value).length).append(':').append(value);
+    }
+
+    private static boolean isCanonicalInteger(String value) {
+        if (!value.matches("[+-]?[0-9]+")) return false;
+        int start = value.startsWith("+") || value.startsWith("-") ? 1 : 0;
+        String digits = value.substring(start);
+        return digits.equals("0") || !digits.startsWith("0");
+    }
+
+    private static boolean coerce() {
+        return GlobalVariable.getGlobalVariable("Convert::Bencode_XS::COERCE").getBoolean();
+    }
+
+    private static byte[] bytes(String value) {
+        return value.getBytes(StandardCharsets.ISO_8859_1);
+    }
+
+    private static int compareUnsigned(byte[] left, byte[] right) {
+        int length = Math.min(left.length, right.length);
+        for (int i = 0; i < length; i++) {
+            int cmp = Integer.compare(left[i] & 0xff, right[i] & 0xff);
+            if (cmp != 0) return cmp;
+        }
+        return Integer.compare(left.length, right.length);
+    }
+
+    public static RuntimeList bdecode(RuntimeArray args, int ctx) {
+        RuntimeScalar input = args.get(0);
+        if (input.type != RuntimeScalarType.STRING && input.type != RuntimeScalarType.BYTE_STRING) {
+            throw new IllegalArgumentException("bdecode only accepts scalar strings");
+        }
+        Decoder decoder = new Decoder(input.toString());
+        RuntimeScalar result = decoder.value();
+        if (!decoder.atEnd()) decoder.fail("bad format");
+        return result.getList();
+    }
+
+    public static RuntimeList cleanse(RuntimeArray args, int ctx) {
+        RuntimeScalar scalar = args.get(0);
+        try {
+            scalar.set(new RuntimeScalar(new BigInteger(scalar.toString())));
+        } catch (NumberFormatException e) {
+            scalar.set(scalar.getLong());
+        }
+        return new RuntimeList();
+    }
+
+    private static final class Decoder {
+        private final String input;
+        private int position;
+
+        private Decoder(String input) { this.input = input; }
+        private boolean atEnd() { return position == input.length(); }
+
+        private RuntimeScalar value() {
+            if (atEnd()) return fail("overflow");
+            char token = input.charAt(position);
+            if (token == 'i') return integer();
+            if (token == 'l') return list();
+            if (token == 'd') return dictionary();
+            if (token >= '0' && token <= '9') return string();
+            return fail("bad format");
+        }
+
+        private RuntimeScalar integer() {
+            int start = ++position;
+            int end = input.indexOf('e', position);
+            if (end < 0) return fail("overflow");
+            String number = input.substring(start, end);
+            if (!number.matches("[+-]?[0-9]+")) return fail("invalid number");
+            position = end + 1;
+            return coerce() ? new RuntimeScalar(number) : numeric(number);
+        }
+
+        private RuntimeScalar numeric(String number) {
+            try { return new RuntimeScalar(new BigInteger(number)); }
+            catch (NumberFormatException e) { return fail("invalid number"); }
+        }
+
+        private RuntimeScalar string() {
+            int colon = input.indexOf(':', position);
+            if (colon < 0) return fail("overflow");
+            String lengthText = input.substring(position, colon);
+            if (!lengthText.matches("[0-9]+")) return fail("invalid number");
+            int length;
+            try { length = Integer.parseInt(lengthText); }
+            catch (NumberFormatException e) { return fail("invalid number"); }
+            position = colon + 1;
+            if (position + length > input.length()) return fail("overflow");
+            String result = input.substring(position, position + length);
+            position += length;
+            return new RuntimeScalar(result);
+        }
+
+        private RuntimeScalar list() {
+            position++;
+            RuntimeArray result = new RuntimeArray();
+            while (!atEnd() && input.charAt(position) != 'e') result.push(value());
+            if (atEnd()) return fail("bad format");
+            position++;
+            return result.createReference();
+        }
+
+        private RuntimeScalar dictionary() {
+            position++;
+            RuntimeHash result = new RuntimeHash();
+            while (!atEnd() && input.charAt(position) != 'e') {
+                if (!Character.isDigit(input.charAt(position))) return fail("dictionary keys must be strings");
+                String key = string().toString();
+                if (atEnd() || input.charAt(position) == 'e') return fail("dictionary key with no value");
+                result.put(key, value());
+            }
+            if (atEnd()) return fail("bad format");
+            position++;
+            return result.createReference();
+        }
+
+        private <T> T fail(String message) {
+            throw new IllegalArgumentException("bdecode error: " + message + ": pos "
+                    + position + ", " + input);
+        }
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/ScalarWatcher.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/ScalarWatcher.java
@@ -1,0 +1,70 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.runtime.operators.ReferenceOperators;
+import org.perlonjava.runtime.runtimetypes.*;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Java implementation of Scalar::Watcher's small XS magic interface. */
+public final class ScalarWatcher extends PerlModuleBase {
+    private static final AtomicLong NEXT_ID = new AtomicLong();
+    private static final String CANCELLER = "Scalar::Watcher::Canceller";
+    private static final String STATE = "_perlonjava_state";
+
+    private record Cancellation(WeakReference<RuntimeScalar> target, long id) {}
+
+    public ScalarWatcher() {
+        super("Scalar::Watcher", false);
+    }
+
+    public static void initialize() {
+        ScalarWatcher module = new ScalarWatcher();
+        try {
+            module.registerMethod("when_modified", "when_modified", "$&");
+            module.registerMethod("when_destroyed", "when_destroyed", "$&");
+            module.registerMethodInPackage(CANCELLER, "DESTROY", "cancel");
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Missing Scalar::Watcher method", e);
+        }
+    }
+
+    public static RuntimeList when_modified(RuntimeArray args, int ctx) {
+        return install(args, ctx, false);
+    }
+
+    public static RuntimeList when_destroyed(RuntimeArray args, int ctx) {
+        return install(args, ctx, true);
+    }
+
+    private static RuntimeList install(RuntimeArray args, int ctx, boolean destroyed) {
+        if (args.size() < 2 || args.get(1).type != RuntimeScalarType.CODE) {
+            throw new IllegalArgumentException("expected a CODE reference for watcher handler");
+        }
+        RuntimeScalar target = args.get(0);
+        RuntimeScalar callback = args.get(1);
+        long id = NEXT_ID.incrementAndGet();
+        if (destroyed) target.addDestroyedWatcher(id, callback);
+        else target.addModifiedWatcher(id, callback);
+
+        if (ctx == RuntimeContextType.VOID) return new RuntimeList();
+
+        RuntimeHash state = new RuntimeHash();
+        state.put(STATE, new RuntimeScalar(new Cancellation(new WeakReference<>(target), id)));
+        RuntimeScalar canceller = ReferenceOperators.bless(
+                state.createReferenceWithTrackedElements(), new RuntimeScalar(CANCELLER));
+        return canceller.getList();
+    }
+
+    public static RuntimeList cancel(RuntimeArray args, int ctx) {
+        if (!args.isEmpty()) {
+            RuntimeHash state = args.get(0).hashDeref();
+            RuntimeScalar holder = state.get(STATE);
+            if (holder != null && holder.value instanceof Cancellation cancellation) {
+                RuntimeScalar target = cancellation.target().get();
+                if (target != null) target.removeWatcher(cancellation.id());
+            }
+        }
+        return new RuntimeList();
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/XSLoader.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/XSLoader.java
@@ -192,6 +192,11 @@ public class XSLoader extends PerlModuleBase {
             
             return scalarTrue.getList();
         } catch (Exception e) {
+            if (System.getenv("JPERL_REQUIRE_DEBUG") != null) {
+                System.err.println("XSLoader Java backend initialization failed for "
+                        + moduleName + ": " + e);
+                e.printStackTrace(System.err);
+            }
             // No Java XS class found. If the module's @ISA already has a
             // functional pure-Perl parent (set by the .pm file before calling
             // XSLoader::load), the module can function through inheritance.

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
@@ -442,17 +442,21 @@ public class MortalList {
         // weak refs anywhere in the JVM. If weak refs exist (even to unblessed
         // data), we must still cascade decrements so their weak-ref entries
         // can be cleared when the referent's refCount reaches 0.
-        if (!RuntimeBase.blessedObjectExists() && !WeakRefRegistry.weakRefsExist()) return;
+        if (!RuntimeBase.blessedObjectExists() && !WeakRefRegistry.weakRefsExist()
+                && !RuntimeScalar.watcherCleanupNeeded()) return;
         // If the hash has outstanding references (e.g., from \%hash stored elsewhere),
         // do NOT clean up elements — the hash is still alive and its elements are
         // accessible through the reference. Cleanup will happen when the last
         // reference is released (in DestroyDispatch.callDestroy).
         if (hash.refCount > 0 || temporaryRootDirectlyReferences(hash)) return;
+        if (RuntimeScalar.watcherCleanupNeeded()) {
+            RuntimeScalar.notifyDestroyedWatchersRecursively(hash);
+        }
         if (hash.type == RuntimeHash.TIED_HASH && hash.elements instanceof TieHash tieHash) {
             tieHash.releaseTiedObject();
         }
         // Quick scan: skip if no value could transitively contain blessed/tracked refs.
-        boolean needsWalk = false;
+        boolean needsWalk = RuntimeScalar.watcherCleanupNeeded();
         for (RuntimeScalar val : hash.elements.values()) {
             if (val != null && (val.type & RuntimeScalarType.REFERENCE_BIT) != 0
                     && val.value instanceof RuntimeBase rb) {
@@ -511,12 +515,16 @@ public class MortalList {
         }
         // Skip container walks only when there are NO blessed objects AND NO
         // weak refs anywhere in the JVM (see scopeExitCleanupHash for details).
-        if (!RuntimeBase.blessedObjectExists() && !WeakRefRegistry.weakRefsExist()) return;
+        if (!RuntimeBase.blessedObjectExists() && !WeakRefRegistry.weakRefsExist()
+                && !RuntimeScalar.watcherCleanupNeeded()) return;
         // If the array has outstanding references (e.g., from \@array stored elsewhere),
         // do NOT clean up elements — the array is still alive and its elements are
         // accessible through the reference. Cleanup will happen when the last
         // reference is released (in DestroyDispatch.callDestroy).
         if (arr.refCount > 0 || temporaryRootDirectlyReferences(arr)) return;
+        if (RuntimeScalar.watcherCleanupNeeded()) {
+            RuntimeScalar.notifyDestroyedWatchersRecursively(arr);
+        }
         if (arr.type == RuntimeArray.TIED_ARRAY && arr.elements instanceof TieArray tieArray) {
             tieArray.releaseTiedObject();
         }
@@ -538,7 +546,7 @@ public class MortalList {
         //   3. Is a container (array/hash ref) that might hold nested blessed refs
         // For case 3, we peek one level deep to avoid false positives for arrays
         // of plain-data arrayrefs (like the life_bitpacked @grid).
-        boolean needsWalk = false;
+        boolean needsWalk = RuntimeScalar.watcherCleanupNeeded();
         for (RuntimeScalar elem : arr.elements) {
             if (elem == null || (elem.type & RuntimeScalarType.REFERENCE_BIT) == 0) continue;
             // Fast check: refCountOwned means this ref was properly tracked via setLarge

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -37,6 +37,82 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     /** Live substr lvalues that must be refreshed when this scalar is replaced. */
     private transient List<WeakReference<RuntimeSubstrLvalue>> substrLvalueObservers;
 
+    /** Perl magic-style callbacks installed by Scalar::Watcher. */
+    private transient Map<Long, RuntimeScalar> modifiedWatchers;
+    private transient Map<Long, RuntimeScalar> destroyedWatchers;
+    private transient boolean watcherDestroyNotified;
+    private transient int watcherMutationDepth;
+    private static volatile boolean watcherCleanupNeeded;
+
+    public void addModifiedWatcher(long id, RuntimeScalar callback) {
+        watcherCleanupNeeded = true;
+        if (modifiedWatchers == null) modifiedWatchers = new LinkedHashMap<>();
+        modifiedWatchers.put(id, callback);
+    }
+
+    public void addDestroyedWatcher(long id, RuntimeScalar callback) {
+        watcherCleanupNeeded = true;
+        if (destroyedWatchers == null) destroyedWatchers = new LinkedHashMap<>();
+        destroyedWatchers.put(id, callback);
+    }
+
+    public void removeWatcher(long id) {
+        if (modifiedWatchers != null) modifiedWatchers.remove(id);
+        if (destroyedWatchers != null) destroyedWatchers.remove(id);
+    }
+
+    public boolean hasWatchers() {
+        return (modifiedWatchers != null && !modifiedWatchers.isEmpty())
+                || (destroyedWatchers != null && !destroyedWatchers.isEmpty());
+    }
+
+    private void notifyModifiedWatchers() {
+        if (watcherMutationDepth > 0) return;
+        if (modifiedWatchers == null || modifiedWatchers.isEmpty()) return;
+        RuntimeArray args = new RuntimeArray(this);
+        for (RuntimeScalar callback : new ArrayList<>(modifiedWatchers.values())) {
+            RuntimeCode.apply(callback, args, RuntimeContextType.VOID);
+        }
+    }
+
+    private void notifyDestroyedWatchers() {
+        if (watcherDestroyNotified) return;
+        watcherDestroyNotified = true;
+        if (destroyedWatchers != null && !destroyedWatchers.isEmpty()) {
+            RuntimeArray args = new RuntimeArray(this);
+            for (RuntimeScalar callback : new ArrayList<>(destroyedWatchers.values())) {
+                RuntimeCode.apply(callback, args, RuntimeContextType.VOID);
+            }
+        }
+        if (modifiedWatchers != null) modifiedWatchers.clear();
+        if (destroyedWatchers != null) destroyedWatchers.clear();
+    }
+
+    public static boolean watcherCleanupNeeded() {
+        return watcherCleanupNeeded;
+    }
+
+    /** Fire destruction magic for scalar slots owned by a dying aggregate. */
+    public static void notifyDestroyedWatchersRecursively(RuntimeBase value) {
+        Set<RuntimeBase> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        notifyDestroyedWatchersRecursively(value, visited);
+    }
+
+    private static void notifyDestroyedWatchersRecursively(RuntimeBase value, Set<RuntimeBase> visited) {
+        if (value == null || !visited.add(value)) return;
+        Collection<RuntimeScalar> elements;
+        if (value instanceof RuntimeArray array) elements = array.elements;
+        else if (value instanceof RuntimeHash hash) elements = hash.elements.values();
+        else return;
+        for (RuntimeScalar scalar : elements) {
+            if (scalar == null) continue;
+            scalar.notifyDestroyedWatchers();
+            if (scalar.value instanceof RuntimeBase nested) {
+                notifyDestroyedWatchersRecursively(nested, visited);
+            }
+        }
+    }
+
     void registerSubstrLvalue(RuntimeSubstrLvalue observer) {
         if (substrLvalueObservers == null) {
             substrLvalueObservers = new ArrayList<>();
@@ -1431,16 +1507,19 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 this.formatPictureTainted = value.formatPictureTainted;
             }
             refreshSubstrLvalues();
+            notifyModifiedWatchers();
             return this;
         }
         if (this != value) {
             RuntimeScalar r = setLarge(value);
             RuntimePosLvalue.invalidatePos(this);
             refreshSubstrLvalues();
+            notifyModifiedWatchers();
             return r;
         }
         RuntimeScalar result = setLarge(value);
         refreshSubstrLvalues();
+        notifyModifiedWatchers();
         return result;
     }
 
@@ -1967,6 +2046,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.numericContextSeen = false;
         this.firstClassRegexScalar = false;
         this.formatPictureTainted = false;
+        notifyModifiedWatchers();
         return this;
     }
 
@@ -1983,6 +2063,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.numericContextSeen = false;
         this.firstClassRegexScalar = false;
         this.formatPictureTainted = false;
+        notifyModifiedWatchers();
         return this;
     }
 
@@ -2024,6 +2105,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.numericContextSeen = false;
         this.firstClassRegexScalar = false;
         this.formatPictureTainted = false;
+        notifyModifiedWatchers();
         return this;
     }
 
@@ -2041,6 +2123,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.numericContextSeen = false;
         this.firstClassRegexScalar = false;
         this.formatPictureTainted = false;
+        notifyModifiedWatchers();
         return this;
     }
 
@@ -2063,6 +2146,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         this.numericContextSeen = false;
         this.firstClassRegexScalar = false;
         this.formatPictureTainted = false;
+        notifyModifiedWatchers();
         return this;
     }
 
@@ -3321,6 +3405,13 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             if (scalar.refCount > 0 && scalar.type != RuntimeScalarType.TIED_SCALAR) return;
         }
 
+        // A captured lexical or an SV with an escaped scalar reference is still
+        // alive after its declaring scope exits. Its destruction watcher fires
+        // when the final owner later releases it, not at lexical scope exit.
+        if (scalar.captureCount == 0) {
+            scalar.notifyDestroyedWatchers();
+        }
+
         // Fast path: skip if no special state (most common case for integer/string vars).
         // When all three conditions are true, the entire method body is a no-op:
         // - refCountOwned=false → deferDecrementIfTracked returns immediately
@@ -3498,6 +3589,18 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     }
 
     public RuntimeScalar preAutoIncrement() {
+        watcherMutationDepth++;
+        RuntimeScalar result;
+        try {
+            result = preAutoIncrementWithoutWatcherNotification();
+        } finally {
+            watcherMutationDepth--;
+        }
+        notifyModifiedWatchers();
+        return result;
+    }
+
+    private RuntimeScalar preAutoIncrementWithoutWatcherNotification() {
         this.numericLiteralText = null;
         this.numericContextSeen = false;
         this.firstClassRegexScalar = false;
@@ -3608,6 +3711,18 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
 
     // Inlineable fast path for $v++
     public RuntimeScalar postAutoIncrement() {
+        watcherMutationDepth++;
+        RuntimeScalar result;
+        try {
+            result = postAutoIncrementWithoutWatcherNotification();
+        } finally {
+            watcherMutationDepth--;
+        }
+        notifyModifiedWatchers();
+        return result;
+    }
+
+    private RuntimeScalar postAutoIncrementWithoutWatcherNotification() {
         if (this.type == INTEGER && !(this.value instanceof BigInteger)) {
             long integerValue = ((Number) this.value).longValue();
             if (integerValue < Long.MAX_VALUE) {
@@ -3729,6 +3844,18 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     }
 
     public RuntimeScalar preAutoDecrement() {
+        watcherMutationDepth++;
+        RuntimeScalar result;
+        try {
+            result = preAutoDecrementWithoutWatcherNotification();
+        } finally {
+            watcherMutationDepth--;
+        }
+        notifyModifiedWatchers();
+        return result;
+    }
+
+    private RuntimeScalar preAutoDecrementWithoutWatcherNotification() {
         this.numericLiteralText = null;
         this.numericContextSeen = false;
         this.firstClassRegexScalar = false;
@@ -3753,7 +3880,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             case STRING, BYTE_STRING -> { // 2
                 // Handle numeric decrement
                 this.set(NumberParser.parseNumber(this));
-                return this.preAutoDecrement();
+                return this.preAutoDecrementWithoutWatcherNotification();
             }
             case UNDEF -> { // 3
                 this.type = RuntimeScalarType.INTEGER;
@@ -3762,7 +3889,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             case VSTRING -> { // 4
                 // Handle as numeric
                 this.set(NumberParser.parseNumber(this));
-                return this.preAutoDecrement();
+                return this.preAutoDecrementWithoutWatcherNotification();
             }
             case BOOLEAN -> { // 5
                 int intVal = (boolean) this.value ? 1 : 0;
@@ -3845,6 +3972,18 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     }
 
     public RuntimeScalar postAutoDecrement() {
+        watcherMutationDepth++;
+        RuntimeScalar result;
+        try {
+            result = postAutoDecrementWithoutWatcherNotification();
+        } finally {
+            watcherMutationDepth--;
+        }
+        notifyModifiedWatchers();
+        return result;
+    }
+
+    private RuntimeScalar postAutoDecrementWithoutWatcherNotification() {
         RuntimeScalar old = new RuntimeScalar(this);
         this.numericLiteralText = null;
         this.numericContextSeen = false;

--- a/src/test/resources/unit/convert_bencode_xs_java.t
+++ b/src/test/resources/unit/convert_bencode_xs_java.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use Test::More;
+
+BEGIN {
+    if (!eval { require Convert::Bencode_XS; 1 }) {
+        if ($^X =~ /jperl/) {
+            require XSLoader;
+            XSLoader::load('Convert::Bencode_XS', '0.06');
+            $Convert::Bencode_XS::COERCE = 1;
+        }
+        else {
+            plan skip_all => 'Convert::Bencode_XS required';
+        }
+    }
+}
+
+is Convert::Bencode_XS::bencode(12), 'i12e', 'encodes integer';
+is Convert::Bencode_XS::bencode('test'), '4:test', 'encodes string';
+is Convert::Bencode_XS::bencode({ b => 2, a => 1 }), 'd1:ai1e1:bi2ee', 'sorts dictionary keys by bytes';
+is_deeply Convert::Bencode_XS::bdecode('d1:ali1e1:xe1:bi2ee'), { a => [1, 'x'], b => 2 }, 'decodes nested values';
+ok !eval { Convert::Bencode_XS::bdecode('4:tes'); 1 }, 'rejects short string';
+ok !eval { Convert::Bencode_XS::bdecode('i12'); 1 }, 'rejects unterminated integer';
+
+done_testing;

--- a/src/test/resources/unit/scalar_watcher_java_xs.t
+++ b/src/test/resources/unit/scalar_watcher_java_xs.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use Test::More;
+
+BEGIN {
+    if (!eval { require Scalar::Watcher; 1 }) {
+        if ($^X =~ /jperl/) {
+            require XSLoader;
+            XSLoader::load('Scalar::Watcher', '0.002001');
+        }
+        else {
+            plan skip_all => 'Scalar::Watcher required';
+        }
+    }
+}
+
+my $modified;
+my $destroyed;
+{
+    my $value = 1;
+    my $cancel = Scalar::Watcher::when_modified($value, sub { $modified = $_[0] });
+    Scalar::Watcher::when_destroyed($value, sub { $destroyed = $_[0] });
+    $value = 2;
+    is $modified, 2, 'modification callback receives assigned value';
+    $value++;
+    is $modified, 3, 'modification callback receives incremented value';
+    undef $cancel;
+    $value = 4;
+    is $modified, 3, 'destroying canceller removes watcher';
+}
+is $destroyed, 4, 'destruction callback receives final value';
+
+my $nested_destroyed;
+{
+    my @values = ([4, 5]);
+    Scalar::Watcher::when_destroyed($values[0][1], sub { $nested_destroyed = $_[0] });
+    $values[0] = undef;
+}
+is $nested_destroyed, 5, 'destroying an aggregate notifies watched element slots';
+
+done_testing;


### PR DESCRIPTION
## Summary

- implement `Scalar::Watcher` through shared runtime scalar mutation and destruction hooks
- preserve watched scalar slot identity in the interpreter backend
- implement a Java `Convert::Bencode_XS` backend used by `Protocol::BitTorrent`
- expose Java XS initialization failures under `JPERL_REQUIRE_DEBUG`
- avoid distribution preferences in favor of compiler/runtime and Java XS support

## Validation

- `make`
- `./jcpan -t Scalar::Watcher` — 28 tests passed
- `./jcpan -t Protocol::BitTorrent` — 198 tests passed
- `./jcpan -t Transmission::AttributeRole` — 173 applicable tests passed
- focused regression tests with system Perl, JVM backend, and interpreter backend

`Module::Reader` was not changed because its upstream suite also fails under system Perl 5.42. The standalone `Convert::Bencode_XS` suite has one platform-sensitive ordering failure under system Perl, while the complete `Protocol::BitTorrent` suite passes with the Java backend.

Generated with [Codex](https://openai.com/codex)
