### PR TITLE
Fix CPAN compiler and tooling dependency chains

### DIFF
--- a/dev/import-perl5/patches/CPAN-cpan.patch
+++ b/dev/import-perl5/patches/CPAN-cpan.patch
@@ -13,3 +13,12 @@
 +    $ENV{PERLONJAVA_TEST_JPERL_OPTS} =
 +        join ' ', grep { length } $test_opts, '-Xmx768m';
 +}
+@@ -6,0 +19,8 @@
++# Always refresh PerlOnJava's bundled CPAN tooling before App::Cpan. The JVM
++# launcher can already have CPAN::Config in %INC, so `use CPAN::Config` alone
++# is not enough to rerun the bootstrap for the selected PERLONJAVA_HOME.
++BEGIN {
++    require CPAN::Config;
++    CPAN::Config::_bootstrap_prefs();
++    CPAN::Config::_bootstrap_patches();
++}

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -2886,57 +2886,13 @@ public class BytecodeCompiler implements Visitor {
         // Left operand is the array (@array or @$arrayref)
         // Right operand is the list of values to push/unshift
 
-        // Get the array
-        int arrayReg;
-        if (node.left instanceof OperatorNode leftOp) {
-
-            if (leftOp.operator.equals("@") && leftOp.operand instanceof IdentifierNode) {
-                // Direct array: @array
-                String varName = ((IdentifierNode) leftOp.operand).name;
-                String arrayVarName = "@" + varName;
-
-                // Get array register - check lexical first, then global
-                if (hasVariable(arrayVarName)) {
-                    arrayReg = getVariableRegister(arrayVarName);
-                } else {
-                    // Global array - load it
-                    arrayReg = allocateRegister();
-                    String globalArrayName = NameNormalizer.normalizeVariableName(
-                            varName,
-                            getCurrentPackage()
-                    );
-                    int nameIdx = addToStringPool(globalArrayName);
-                    emit(Opcodes.LOAD_GLOBAL_ARRAY);
-                    emitReg(arrayReg);
-                    emit(nameIdx);
-                }
-            } else if (leftOp.operator.equals("@") && !(leftOp.operand instanceof IdentifierNode)) {
-                // Array dereference: @$arrayref or @{expr}
-                // Evaluate the operand expression to get the reference, then deref
-                compileNode(leftOp.operand, -1, RuntimeContextType.SCALAR);
-                int refReg = lastResultReg;
-
-                // Dereference to get the array
-                arrayReg = allocateRegister();
-                if (isStrictRefsEnabled()) {
-                    emitWithToken(Opcodes.DEREF_ARRAY, node.getIndex());
-                    emitReg(arrayReg);
-                    emitReg(refReg);
-                } else {
-                    int pkgIdx = addToStringPool(getCurrentPackage());
-                    emitWithToken(Opcodes.DEREF_ARRAY_NONSTRICT, node.getIndex());
-                    emitReg(arrayReg);
-                    emitReg(refReg);
-                    emit(pkgIdx);
-                }
-            } else {
-                throwCompilerException("push/unshift requires array or array reference");
-                return;
-            }
-        } else {
-            throwCompilerException("push/unshift requires array operand");
-            return;
-        }
+        // Compile the complete lvalue in list context, as the JVM backend does.
+        // Besides ordinary @array and @{$ref}, Perl permits a declaration as
+        // the first operand (`push my @items, $value`).  Structural matching
+        // on an immediate @ operator rejected that valid form in interpreted
+        // subs even though compiling the lvalue already yields RuntimeArray.
+        compileNode(node.left, -1, RuntimeContextType.LIST);
+        int arrayReg = lastResultReg;
 
         // Compile the values to push/unshift (right operand) in list context
         compileNode(node.right, -1, RuntimeContextType.LIST);
@@ -4764,7 +4720,26 @@ public class BytecodeCompiler implements Visitor {
                 emit(nameIdx);
                 setArrayResultForContext(rd);
             } else {
-                throwCompilerException("Unsupported @ operand: " + node.operand.getClass().getSimpleName());
+                // General postfix dereference: an arbitrary expression may
+                // produce the array reference (`method()->@*`, `(expr)->@*`).
+                // The JVM backend evaluates that expression in scalar context
+                // and calls arrayDeref; mirror it instead of limiting the
+                // interpreter to simple variables and blocks.
+                compileNode(node.operand, -1, RuntimeContextType.SCALAR);
+                int refReg = lastResultReg;
+                int rd = allocateOutputRegister();
+                if (isStrictRefsEnabled()) {
+                    emitWithToken(Opcodes.DEREF_ARRAY, node.getIndex());
+                    emitReg(rd);
+                    emitReg(refReg);
+                } else {
+                    int pkgIdx = addToStringPool(getCurrentPackage());
+                    emitWithToken(Opcodes.DEREF_ARRAY_NONSTRICT, node.getIndex());
+                    emitReg(rd);
+                    emitReg(refReg);
+                    emit(pkgIdx);
+                }
+                setArrayResultForContext(rd);
             }
         } else if (op.equals("%")) {
             // Hash variable dereference: %x
@@ -4864,7 +4839,31 @@ public class BytecodeCompiler implements Visitor {
                 emit(nameIdx);
                 lastResultReg = hashReg;
             } else {
-                throwCompilerException("Unsupported % operand: " + node.operand.getClass().getSimpleName());
+                // General postfix hash dereference from an arbitrary
+                // expression, matching the JVM backend's scalar evaluation.
+                compileNode(node.operand, -1, RuntimeContextType.SCALAR);
+                int scalarReg = lastResultReg;
+                int hashReg = allocateRegister();
+                if (isStrictRefsEnabled()) {
+                    emitWithToken(Opcodes.DEREF_HASH, node.getIndex());
+                    emitReg(hashReg);
+                    emitReg(scalarReg);
+                } else {
+                    int pkgIdx = addToStringPool(getCurrentPackage());
+                    emitWithToken(Opcodes.DEREF_HASH_NONSTRICT, node.getIndex());
+                    emitReg(hashReg);
+                    emitReg(scalarReg);
+                    emit(pkgIdx);
+                }
+                if (currentCallContext == RuntimeContextType.SCALAR) {
+                    int rd = allocateOutputRegister();
+                    emit(Opcodes.ARRAY_SIZE);
+                    emitReg(rd);
+                    emitReg(hashReg);
+                    lastResultReg = rd;
+                } else {
+                    lastResultReg = hashReg;
+                }
             }
         } else if (op.equals("*")) {
             // Glob variable dereference: *x
@@ -5858,6 +5857,7 @@ public class BytecodeCompiler implements Visitor {
         // ListOperators.map/grep and RuntimeCode.apply() can detect non-local returns
         if (subCompiler.isInMapGrepBlock) {
             subCode.isMapGrepBlock = true;
+            subCode.inheritsSelfReference = true;
         }
 
         if (RuntimeCode.isDisassemble()) {
@@ -5867,7 +5867,7 @@ public class BytecodeCompiler implements Visitor {
         // Step 5: Create closure or simple code ref
         int codeReg = allocateRegister();
 
-        if (closureVarIndices.isEmpty()) {
+        if (closureVarIndices.isEmpty() && !subCode.inheritsSelfReference) {
             // No closures - just wrap the InterpretedCode
             RuntimeScalar codeScalar = new RuntimeScalar(subCode);
             subCode.__SUB__ = codeScalar;  // Set __SUB__ for self-reference

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -649,6 +649,12 @@ public class BytecodeInterpreter {
                                 // Label not found locally - create GOTO marker and propagate
                                 RuntimeControlFlowList marker = new RuntimeControlFlowList(
                                         ControlFlowType.GOTO, labelName, code.sourceName, code.sourceLine);
+                                // A missing label is a runtime error caught by the innermost
+                                // eval BLOCK. Returning the marker here bypasses this frame's
+                                // eval handler when the frame itself was entered by eval STRING.
+                                if (!evalCatchStack.isEmpty()) {
+                                    throw new PerlCompilerException(marker.marker.buildErrorMessage());
+                                }
                                 return marker;
                             }
 

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
@@ -675,17 +675,12 @@ public class CompileBinaryOperator {
             return;
         }
 
-        // Compile left and right operands (for non-short-circuit operators).
-        // For arithmetic/bitwise operators, force SCALAR context to prevent
-        // parenthesized expressions from producing RuntimeList in LIST context.
-        boolean forceScalar = switch (node.operator) {
-            case "+", "-", "*", "/", "%", "**",
-                 "&", "|", "^", "<<", ">>",
-                 "binary&", "binary|", "binary^",
-                 "&.", "|.", "^.",
-                 ".." -> true;
-            default -> false;
-        };
+        // Compile operands of ordinary binary operators in scalar context.
+        // The JVM backend does the same: comparison, concatenation, repeat,
+        // range, arithmetic, and bitwise operators all scalarize each operand,
+        // regardless of the context in which the result is consumed. This is
+        // especially important for calls parsed before an eval STRING import
+        // has made their prototypes visible.
         // For grep/map/sort/all/any, the right operand (list) must always be in LIST context
         // and the left operand (closure) in SCALAR context, matching the JVM backend.
         boolean isListOp = switch (node.operator) {
@@ -693,17 +688,18 @@ public class CompileBinaryOperator {
             default -> false;
         };
         int outerCtx = bytecodeCompiler.currentCallContext;
-        int leftCtx = (forceScalar || isListOp) ? RuntimeContextType.SCALAR : outerCtx;
+        // The repeat operator preserves list context on its left operand:
+        // `(($expr) x 4)` repeats values, while scalar-context x repeats the
+        // resulting string. All other ordinary binary operands are scalar.
+        int leftCtx = node.operator.equals("x") ? outerCtx : RuntimeContextType.SCALAR;
         bytecodeCompiler.compileNode(node.left, -1, leftCtx);
         int rs1 = bytecodeCompiler.lastResultReg;
 
         int rightCtx;
         if (isListOp) {
             rightCtx = RuntimeContextType.LIST;
-        } else if (forceScalar || node.operator.equals("=~") || node.operator.equals("!~")) {
-            rightCtx = RuntimeContextType.SCALAR;
         } else {
-            rightCtx = outerCtx;
+            rightCtx = RuntimeContextType.SCALAR;
         }
         Node rightNode = node.right;
         if (node.operator.equals("isa") && rightNode instanceof IdentifierNode identifier) {

--- a/src/main/java/org/perlonjava/backend/bytecode/InterpretedCode.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InterpretedCode.java
@@ -493,6 +493,8 @@ public class InterpretedCode extends RuntimeCode implements PerlSubroutine {
         copy.subName = this.subName;
         copy.packageName = this.packageName;
         copy.isTryExpressionWrapper = this.isTryExpressionWrapper;
+        copy.isMapGrepBlock = this.isMapGrepBlock;
+        copy.inheritsSelfReference = this.inheritsSelfReference;
         copy.attributesDispatchedAtCompileTime = this.attributesDispatchedAtCompileTime;
         copy.deferredConstAttribute = this.deferredConstAttribute;
         copy.cvStartFile = this.cvStartFile;

--- a/src/main/java/org/perlonjava/backend/bytecode/OpcodeHandlerExtended.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/OpcodeHandlerExtended.java
@@ -795,6 +795,7 @@ public class OpcodeHandlerExtended {
      */
     public static int executePreAutoIncrement(int[] bytecode, int pc, RuntimeBase[] registers) {
         int rd = bytecode[pc++];
+        registers[rd] = scalarIncrementOperand(registers[rd]);
         if (BytecodeInterpreter.isImmutableProxy(registers[rd])) {
             registers[rd] = BytecodeInterpreter.ensureMutableScalar(registers[rd]);
         }
@@ -809,6 +810,7 @@ public class OpcodeHandlerExtended {
     public static int executePostAutoIncrement(int[] bytecode, int pc, RuntimeBase[] registers) {
         int rd = bytecode[pc++];
         int rs = bytecode[pc++];
+        registers[rs] = scalarIncrementOperand(registers[rs]);
         if (BytecodeInterpreter.isImmutableProxy(registers[rs])) {
             registers[rs] = BytecodeInterpreter.ensureMutableScalar(registers[rs]);
         }
@@ -817,11 +819,29 @@ public class OpcodeHandlerExtended {
     }
 
     /**
+     * Scalarize an lvalue slice for ++/-- while preserving Perl's lvalue side
+     * effect: every selected entry is vivified, but only the final entry is
+     * incremented. Ordinary scalar operands pass through unchanged.
+     */
+    private static RuntimeScalar scalarIncrementOperand(RuntimeBase operand) {
+        if (operand instanceof RuntimeArray array) {
+            RuntimeScalar last = new RuntimeScalar();
+            for (RuntimeScalar element : array) {
+                element.vivifyLvalue();
+                last = element;
+            }
+            return last;
+        }
+        return (RuntimeScalar) operand;
+    }
+
+    /**
      * Execute pre-decrement operation.
      * Format: PRE_AUTODECREMENT rd
      */
     public static int executePreAutoDecrement(int[] bytecode, int pc, RuntimeBase[] registers) {
         int rd = bytecode[pc++];
+        registers[rd] = scalarIncrementOperand(registers[rd]);
         if (BytecodeInterpreter.isImmutableProxy(registers[rd])) {
             registers[rd] = BytecodeInterpreter.ensureMutableScalar(registers[rd]);
         }
@@ -836,6 +856,7 @@ public class OpcodeHandlerExtended {
     public static int executePostAutoDecrement(int[] bytecode, int pc, RuntimeBase[] registers) {
         int rd = bytecode[pc++];
         int rs = bytecode[pc++];
+        registers[rs] = scalarIncrementOperand(registers[rs]);
         if (BytecodeInterpreter.isImmutableProxy(registers[rs])) {
             registers[rs] = BytecodeInterpreter.ensureMutableScalar(registers[rs]);
         }
@@ -981,7 +1002,7 @@ public class OpcodeHandlerExtended {
 
         // Wrap in RuntimeScalar and set __SUB__ for self-reference
         RuntimeScalar codeRef = new RuntimeScalar(closureCode);
-        closureCode.__SUB__ = codeRef;
+        closureCode.__SUB__ = template.inheritsSelfReference ? code.__SUB__ : codeRef;
         registers[rd] = codeRef;
 
         // Dispatch MODIFY_CODE_ATTRIBUTES for anonymous subs with non-builtin attributes

--- a/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
@@ -473,6 +473,20 @@ public class EmitSubroutine {
                     "org/perlonjava/runtime/runtimetypes/RuntimeCode",
                     "isMapGrepBlock",
                     "Z");
+
+            // map/grep blocks are callbacks within the current Perl sub, not
+            // anonymous Perl subs of their own. Preserve the enclosing __SUB__.
+            mv.visitInsn(Opcodes.DUP);
+            mv.visitVarInsn(Opcodes.ALOAD, 0);
+            mv.visitFieldInsn(Opcodes.GETFIELD,
+                    ctx.javaClassInfo.javaClassName,
+                    "__SUB__",
+                    "Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");
+            mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                    "org/perlonjava/runtime/runtimetypes/RuntimeCode",
+                    "inheritSelfReference",
+                    "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)V",
+                    false);
         }
 
         // Set isEvalBlock on the RuntimeCode so RuntimeCode.apply() propagates

--- a/src/main/java/org/perlonjava/frontend/analysis/ConstantFoldingVisitor.java
+++ b/src/main/java/org/perlonjava/frontend/analysis/ConstantFoldingVisitor.java
@@ -85,7 +85,7 @@ public class ConstantFoldingVisitor implements Visitor {
         // Handle literal numbers (e.g., if (0), if (1))
         if (condition instanceof NumberNode numNode) {
             try {
-                double value = Double.parseDouble(numNode.value);
+                double value = Double.parseDouble(numNode.value.replace("_", ""));
                 return value != 0;
             } catch (NumberFormatException e) {
                 return null;
@@ -176,7 +176,9 @@ public class ConstantFoldingVisitor implements Visitor {
      */
     public static RuntimeScalar getConstantValue(Node node) {
         if (node instanceof NumberNode) {
-            String value = ((NumberNode) node).value;
+            // Match both code-generation backends: underscores are source-level
+            // digit separators and must not survive into numeric conversion.
+            String value = ((NumberNode) node).value.replace("_", "");
             // Parse NumberNode values as proper numeric types so arithmetic
             // operations use the correct paths (e.g., double modulus for 13e21 % 4e21).
             // Mirrors BytecodeCompiler.visit(NumberNode) logic for consistency.

--- a/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
@@ -48,8 +48,12 @@ public class ParsePrimary {
      * @throws PerlCompilerException if an unexpected token is encountered
      */
     public static Node parsePrimary(Parser parser) {
-        int startIndex = parser.tokenIndex;
         LexerToken token = TokenUtils.consume(parser); // Consume the next token from the input
+        // consume() may cross a newline and, while doing so, skip an entire
+        // pending heredoc body. Quote-like parsers backtrack to startIndex, so
+        // it must identify the token actually consumed rather than the stale
+        // position before whitespace/heredoc processing.
+        int startIndex = parser.tokenIndex - 1;
         String operator = token.text;
         Node operand;
 

--- a/src/main/java/org/perlonjava/frontend/parser/Parser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/Parser.java
@@ -239,17 +239,18 @@ public class Parser {
             // This handles cases where 'x' is followed directly by a number without space
             if (token.text.startsWith("x") && token.text.length() > 1) {
                 String remainder = token.text.substring(1);
-                // Check if the remainder is a valid integer
-                try {
-                    Integer.parseInt(remainder);
+                // Perl permits the repetition operator to touch a numeric
+                // literal (`"z"x1e3`). The lexer necessarily reads that as
+                // one identifier token, so split both integer and decimal
+                // scientific forms here. This check runs only in infix
+                // position, leaving an ordinary bareword such as x1e3 alone.
+                if (remainder.matches("[0-9][0-9_]*(?:[eE][+]?[0-9_]+)?")) {
                     // Split the token into 'x' operator and the number
                     token.text = "x";
                     token.type = LexerTokenType.OPERATOR;
                     // Insert a new token for the number after the current position
                     LexerToken numberToken = new LexerToken(LexerTokenType.NUMBER, remainder);
                     tokens.add(tokenIndex + 1, numberToken);
-                } catch (NumberFormatException e) {
-                    // Not a valid integer, leave the token as is
                 }
             }
 

--- a/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
+++ b/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
@@ -295,6 +295,19 @@ public class PrototypeArgs {
             return args;
         }
 
+        // A binary/ternary operator immediately after a bare subroutine name
+        // belongs to the enclosing expression, not to the call's argument
+        // list.  This applies to unprototyped calls too: `predicate ? a : b`
+        // is `(predicate()) ? a : b`.  Named-unary prototypes already take
+        // this path above, but the generic list parser cannot begin an
+        // argument with `?` and used to report a syntax error instead.
+        if (!hasParentheses && isArgumentTerminator(parser)) {
+            if (!allowsZeroArguments(prototype)) {
+                throwNotEnoughArgumentsError(parser);
+            }
+            return args;
+        }
+
         // Comma is forbidden here, unless the prototype allows zero arguments
         if (prototype != null && !prototype.isEmpty() && isComma(TokenUtils.peek(parser)) && !allowsZeroArguments(prototype)) {
             parser.throwError("syntax error");

--- a/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
@@ -487,22 +487,11 @@ public class StatementResolver {
                                         parser.ctx.symbolTable.addVariable("&" + subName, declaration, varDecl);
                                     }
 
-                                    // Create assignment: $hiddenVarName = sub {...}
-                                    // We need to create a reference to the already-declared variable
-                                    // Use a fully qualified name to ensure it resolves correctly regardless of package context
-                                    String declaringPackage = parser.ctx.symbolTable.getCurrentPackage();
-                                    String qualifiedHiddenVarName = declaringPackage + "::" + hiddenVarName;
-
-                                    OperatorNode varRef = new OperatorNode("$", new IdentifierNode(qualifiedHiddenVarName, parser.tokenIndex), parser.tokenIndex);
-                                    // For state variables, copy the ID so runtime can track the state
-                                    if (declaration.equals("state")) {
-                                        varRef.id = innerVarNode.id;
-                                    }
-                                    BinaryOperatorNode assignment = new BinaryOperatorNode("=", varRef, anonSub, parser.tokenIndex);
-
                                     // Check if we're inside a subroutine
-                                    String currentSub = parser.ctx.symbolTable.getCurrentSubroutine();
-                                    boolean insideSubroutine = currentSub != null && !currentSub.isEmpty();
+                                    // Anonymous subroutines deliberately use an empty display
+                                    // name, so getCurrentSubroutine() cannot distinguish them
+                                    // from file scope. The explicit body flag can.
+                                    boolean insideSubroutine = parser.ctx.symbolTable.isInSubroutineBody();
 
                                     if (declaration.equals("state") || !insideSubroutine) {
                                         // For state sub: Execute assignment immediately during parsing (like a BEGIN block)
@@ -511,16 +500,32 @@ public class StatementResolver {
                                         //
                                         // For my sub at FILE SCOPE: Also execute at compile time so that
                                         // use statements (like use overload) can access the sub reference
-                                        BlockNode beginBlock = new BlockNode(new ArrayList<>(List.of(assignment)), parser.tokenIndex);
+                                        String declaringPackage = parser.ctx.symbolTable.getCurrentPackage();
+                                        String qualifiedHiddenVarName = declaringPackage + "::" + hiddenVarName;
+                                        OperatorNode varRef = new OperatorNode("$",
+                                                new IdentifierNode(qualifiedHiddenVarName, parser.tokenIndex),
+                                                parser.tokenIndex);
+                                        varRef.setAnnotation("hiddenVarName", hiddenVarName);
+                                        if (declaration.equals("state")) {
+                                            varRef.id = innerVarNode.id;
+                                        }
+                                        BinaryOperatorNode compileTimeAssignment =
+                                                new BinaryOperatorNode("=", varRef, anonSub, parser.tokenIndex);
+                                        BlockNode beginBlock = new BlockNode(
+                                                new ArrayList<>(List.of(compileTimeAssignment)), parser.tokenIndex);
                                         SpecialBlockParser.runSpecialBlock(parser, "BEGIN", beginBlock);
 
                                         // Return empty list since the assignment already executed
                                         yield new ListNode(parser.tokenIndex);
                                     } else {
-                                        // For my sub INSIDE ANOTHER SUB: Return the assignment to be executed at runtime
-                                        // This creates a fresh closure each time the enclosing scope is entered,
-                                        // correctly capturing the current values of closure variables
-                                        yield assignment;
+                                        // For my sub INSIDE ANOTHER SUB, emit the hidden
+                                        // lexical declaration as part of the runtime AST.
+                                        // A plain assignment leaves a fresh backend compiler
+                                        // unaware that the generated name is lexical.
+                                        varDecl.setAnnotation("runtimeLexicalSub", true);
+                                        BinaryOperatorNode lexicalAssignment =
+                                                new BinaryOperatorNode("=", varDecl, anonSub, parser.tokenIndex);
+                                        yield lexicalAssignment;
                                     }
                                 } else {
                                     // Forward declaration: my sub name; or my sub name ($);
@@ -537,9 +542,6 @@ public class StatementResolver {
 
                                         // Create a stub RuntimeCode with the prototype set
                                         // This is needed so that prototype(\&sub) works for forward declarations
-                                        String declaringPackage = parser.ctx.symbolTable.getCurrentPackage();
-                                        String qualifiedHiddenVarName = declaringPackage + "::" + hiddenVarName;
-
                                         // Create a subroutine stub with the prototype that returns undef
                                         // The body needs at least a return statement to avoid bytecode issues
                                         List<Node> stubBody = new ArrayList<>();
@@ -553,10 +555,13 @@ public class StatementResolver {
                                                 parser.tokenIndex
                                         );
 
+                                        String declaringPackage = parser.ctx.symbolTable.getCurrentPackage();
+                                        String qualifiedHiddenVarName = declaringPackage + "::" + hiddenVarName;
                                         // Create assignment: $hiddenVarName = sub { }
                                         OperatorNode varRef = new OperatorNode("$",
                                                 new IdentifierNode(qualifiedHiddenVarName, parser.tokenIndex),
                                                 parser.tokenIndex);
+                                        varRef.setAnnotation("hiddenVarName", hiddenVarName);
                                         BinaryOperatorNode stubAssignment = new BinaryOperatorNode("=", varRef, stubSub, parser.tokenIndex);
 
                                         // Execute the stub assignment in a BEGIN block

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -105,22 +105,19 @@ public class SubroutineParser {
                     // Get the hidden variable name for the lexical sub
                     String hiddenVarName = (String) varNode.getAnnotation("hiddenVarName");
                     if (hiddenVarName != null) {
-                        // Get the package where this lexical sub was declared
+                        boolean runtimeLexicalSub = varNode.getBooleanAnnotation("runtimeLexicalSub");
                         String declaringPackage = (String) varNode.getAnnotation("declaringPackage");
-
-                        // Make the hidden variable name fully qualified with the declaring package
-                        String qualifiedHiddenVarName = hiddenVarName;
-                        if (declaringPackage != null && !hiddenVarName.contains("::")) {
-                            qualifiedHiddenVarName = declaringPackage + "::" + hiddenVarName;
+                        String storageName = hiddenVarName;
+                        if (!runtimeLexicalSub && declaringPackage != null && !hiddenVarName.contains("::")) {
+                            storageName = declaringPackage + "::" + hiddenVarName;
                         }
-
                         // Get the hidden variable entry from the symbol table for the ID
                         String hiddenVarKey = "$" + hiddenVarName;
                         SymbolTable.SymbolEntry hiddenEntry = parser.ctx.symbolTable.getSymbolEntry(hiddenVarKey);
 
                         // Always create a fresh variable reference to avoid AST reuse issues
                         OperatorNode dollarOp = new OperatorNode("$",
-                                new IdentifierNode(qualifiedHiddenVarName, currentIndex), currentIndex);
+                                new IdentifierNode(storageName, currentIndex), currentIndex);
                         // Propagate hiddenVarName annotation so that emitters can detect lexical subs
                         dollarOp.setAnnotation("hiddenVarName", hiddenVarName);
 
@@ -1220,6 +1217,11 @@ public class SubroutineParser {
                 // The body should be filled in by creating a runtime code object
                 String hiddenVarName = (String) varNode.getAnnotation("hiddenVarName");
                 if (hiddenVarName != null) {
+                    String declaringPackage = (String) varNode.getAnnotation("declaringPackage");
+                    String storageName = hiddenVarName;
+                    if (declaringPackage != null && !hiddenVarName.contains("::")) {
+                        storageName = declaringPackage + "::" + hiddenVarName;
+                    }
                     // Create an anonymous sub that will be used to fill the lexical sub
                     // We need to compile this into a RuntimeCode object that can be executed
                     SubroutineNode anonSub = new SubroutineNode(
@@ -1231,17 +1233,12 @@ public class SubroutineParser {
                             parser.tokenIndex
                     );
 
-                    // Create assignment that will execute at runtime
-                    // Use the declaring package to create a fully qualified variable name
-                    String declaringPackage = (String) varNode.getAnnotation("declaringPackage");
-                    String qualifiedHiddenVarName = hiddenVarName;
-                    if (declaringPackage != null && !hiddenVarName.contains("::")) {
-                        qualifiedHiddenVarName = declaringPackage + "::" + hiddenVarName;
-                    }
-
+                    // Fill the compile-time storage created by the lexical
+                    // forward declaration.
                     OperatorNode varRef = new OperatorNode("$",
-                            new IdentifierNode(qualifiedHiddenVarName, parser.tokenIndex),
+                            new IdentifierNode(storageName, parser.tokenIndex),
                             parser.tokenIndex);
+                    varRef.setAnnotation("hiddenVarName", hiddenVarName);
 
                     BinaryOperatorNode assignment = new BinaryOperatorNode("=", varRef, anonSub, parser.tokenIndex);
 

--- a/src/main/java/org/perlonjava/frontend/parser/Variable.java
+++ b/src/main/java/org/perlonjava/frontend/parser/Variable.java
@@ -771,22 +771,19 @@ public class Variable {
                 // Check if this is a "my sub" or "state sub" - use hidden variable
                 String hiddenVarName = (String) varNode.getAnnotation("hiddenVarName");
                 if (hiddenVarName != null) {
+                    boolean runtimeLexicalSub = varNode.getBooleanAnnotation("runtimeLexicalSub");
+                    String declaringPackage = (String) varNode.getAnnotation("declaringPackage");
+                    String storageName = hiddenVarName;
+                    if (!runtimeLexicalSub && declaringPackage != null && !hiddenVarName.contains("::")) {
+                        storageName = declaringPackage + "::" + hiddenVarName;
+                    }
                     // Consume the identifier token
                     TokenUtils.consume(parser);
-
-                    // Get the package where this lexical sub was declared
-                    String declaringPackage = (String) varNode.getAnnotation("declaringPackage");
-
-                    // Make the hidden variable name fully qualified with the declaring package
-                    String qualifiedHiddenVarName = hiddenVarName;
-                    if (declaringPackage != null && !hiddenVarName.contains("::")) {
-                        qualifiedHiddenVarName = declaringPackage + "::" + hiddenVarName;
-                    }
 
                     // Create reference to hidden variable: &$hiddenVar
                     // IMPORTANT: For state variables, we need to preserve the ID from the declaration!
                     OperatorNode dollarOp = new OperatorNode("$",
-                            new IdentifierNode(qualifiedHiddenVarName, index), index);
+                            new IdentifierNode(storageName, index), index);
                     // Propagate hiddenVarName annotation so that emitters can detect lexical subs
                     // (e.g., for `undef &x` and `defined(&x)` special handling)
                     dollarOp.setAnnotation("hiddenVarName", hiddenVarName);

--- a/src/main/java/org/perlonjava/runtime/operators/MathOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/MathOperators.java
@@ -112,7 +112,7 @@ public class MathOperators {
         int blessId = blessedId(arg);
         if (blessId < 0) {
             RuntimeScalar result = OverloadContext.tryOneArgumentOverload(
-                    arg, blessId, "(neg", "neg", MathOperators::integerUnaryMinus);
+                    arg, blessId, "(neg", "neg", MathOperators::integerUnaryMinus, "(-");
             if (result != null) return result;
         }
         RuntimeScalar stringResult = unaryMinusStringResult(arg);
@@ -1428,7 +1428,8 @@ public class MathOperators {
         // Check if object is eligible for overloading
         int blessId = blessedId(runtimeScalar);
         if (blessId < 0) {
-            RuntimeScalar result = OverloadContext.tryOneArgumentOverload(runtimeScalar, blessId, "(neg", "neg", MathOperators::unaryMinus);
+            RuntimeScalar result = OverloadContext.tryOneArgumentOverload(runtimeScalar, blessId,
+                    "(neg", "neg", MathOperators::unaryMinus, "(-");
             if (result != null) return result;
         }
 
@@ -1449,7 +1450,8 @@ public class MathOperators {
         // Check if object is eligible for overloading
         int blessId = blessedId(runtimeScalar);
         if (blessId < 0) {
-            RuntimeScalar result = OverloadContext.tryOneArgumentOverload(runtimeScalar, blessId, "(neg", "neg", MathOperators::unaryMinusWarn);
+            RuntimeScalar result = OverloadContext.tryOneArgumentOverload(runtimeScalar, blessId,
+                    "(neg", "neg", MathOperators::unaryMinusWarn, "(-");
             if (result != null) return result;
         }
 

--- a/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessorHelper.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessorHelper.java
@@ -617,6 +617,13 @@ public class RegexPreprocessorHelper {
                 case '^':
                     if (first) {
                         afterCaret = true;
+                    } else {
+                        // A second caret is the first ordinary member of a
+                        // negated class, as in [^^].  Only ']' immediately
+                        // after the leading negation caret is literal; leaving
+                        // afterCaret set made the real closing bracket literal
+                        // and consumed the rest of the pattern as class text.
+                        afterCaret = false;
                     }
                     sb.append(Character.toChars(c));
                     first = false;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeScalar.java
@@ -69,7 +69,11 @@ public class GlobalRuntimeScalar extends RuntimeScalar {
             // the tie handler sees the transition. Modules like
             // File::chdir explicitly short-circuit on undef
             // (`return unless defined $_[1];`).
-            originalVariable.tiedStore(RuntimeScalarCache.scalarUndef);
+            // This undef is exposed to STORE as $_[1].  It must be a mutable
+            // argument, because real Perl lets the handler vivify it (for
+            // example Tie::Select's `select $_[1]`).  The shared cached undef
+            // is intentionally read-only and therefore is not suitable here.
+            originalVariable.tiedStore(new RuntimeScalar());
             localizedStack.push(
                     new SavedGlobalState(fullName, originalVariable, savedValue, null));
             // Do NOT replace the slot — the tied scalar stays in place so

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/OverloadContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/OverloadContext.java
@@ -296,13 +296,34 @@ public class OverloadContext {
     }
 
     public static RuntimeScalar tryOneArgumentOverload(RuntimeScalar runtimeScalar, int blessId, String operator, String methodName, Function<RuntimeScalar, RuntimeScalar> fallbackFunction) {
+        return tryOneArgumentOverload(runtimeScalar, blessId, operator, methodName,
+                fallbackFunction, (String[]) null);
+    }
+
+    public static RuntimeScalar tryOneArgumentOverload(RuntimeScalar runtimeScalar, int blessId,
+            String operator, String methodName,
+            Function<RuntimeScalar, RuntimeScalar> fallbackFunction,
+            String... autogenOperators) {
         // Prepare overload context and check if object is eligible for overloading
         OverloadContext ctx = OverloadContext.prepare(blessId);
         if (ctx == null) return null;
-        // Try primary overload method
         RuntimeArray unaryArgs = new RuntimeArray(runtimeScalar, scalarUndef, new RuntimeScalar(""));
+        // Try primary overload method
         RuntimeScalar result = ctx.tryOverload(operator, unaryArgs);
         if (result != null) return result;
+        // Perl autogenerates unary negation from binary subtraction when a
+        // class supplies '-' but not the distinct 'neg' overload key. It
+        // invokes the binary routine as `0 - $object`: the object remains the
+        // first argument, while the other operand is zero and the swapped flag
+        // is true.
+        if (autogenOperators != null) {
+            RuntimeArray autogenArgs = new RuntimeArray(
+                    runtimeScalar, new RuntimeScalar(0), new RuntimeScalar(1));
+            for (String autogenOperator : autogenOperators) {
+                result = ctx.tryOverload(autogenOperator, autogenArgs);
+                if (result != null) return result;
+            }
+        }
         // Try fallback
         result = ctx.tryOverloadFallback(runtimeScalar, "(0+", "(\"\"", "(bool");
         if (result != null) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -849,6 +849,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     public boolean deferredConstAttribute = false;
     // Flag to indicate this code is a map/grep block - non-local return should propagate through it
     public boolean isMapGrepBlock = false;
+    // Implementation callbacks such as map/grep do not introduce a Perl
+    // subroutine scope, so their __SUB__ comes from the enclosing RuntimeCode.
+    public boolean inheritsSelfReference = false;
     // Flag to indicate this code is an eval BLOCK - non-local return should propagate through it
     public boolean isEvalBlock = false;
     // Flag to indicate this CV has been explicitly renamed via Sub::Name::subname
@@ -974,6 +977,23 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     public Supplier<Void> compilerSupplier;
     // Self-reference for __SUB__ (set after construction for InterpretedCode)
     public RuntimeScalar __SUB__;
+
+    /** Assign the enclosing Perl subroutine as an implementation callback's __SUB__. */
+    public static void inheritSelfReference(RuntimeScalar callbackRef, RuntimeScalar enclosingRef) {
+        if (callbackRef == null || !(callbackRef.value instanceof RuntimeCode code)) {
+            return;
+        }
+        code.__SUB__ = enclosingRef;
+        Object implementation = code.codeObject != null ? code.codeObject : code.subroutine;
+        if (implementation != null) {
+            try {
+                Field field = implementation.getClass().getDeclaredField("__SUB__");
+                field.set(implementation, enclosingRef);
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException("Unable to inherit __SUB__ for callback", e);
+            }
+        }
+    }
 
     /**
      * Captured RuntimeScalar variables from the enclosing scope.
@@ -1775,6 +1795,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         this.attributesDispatchedAtCompileTime = codeFrom.attributesDispatchedAtCompileTime;
         this.deferredConstAttribute = codeFrom.deferredConstAttribute;
         this.isMapGrepBlock = codeFrom.isMapGrepBlock;
+        this.inheritsSelfReference = codeFrom.inheritsSelfReference;
         this.isEvalBlock = codeFrom.isEvalBlock;
         this.explicitlyRenamed = codeFrom.explicitlyRenamed;
         this.cvStartFile = codeFrom.cvStartFile;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -1870,6 +1870,21 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                     // Don't call callDestroy — the container is still alive.
                     // Cleanup will happen at scope exit (scopeExitCleanupHash/Array).
                 } else if (oldBase.blessId != 0
+                        && WeakRefRegistry.hasWeakRefsTo(oldBase)
+                        && !blessedClassHasDestroy(oldBase)
+                        && RuntimeCode.argsStackDepth() > 1
+                        && !oldBase.clearedOwnedAggregateElement) {
+                    // Match MortalList's nested-call protection for ordinary
+                    // blessed objects.  Method arguments and expression
+                    // temporaries are real strong references even though the
+                    // selective counter cannot see every copy.  Running the
+                    // global reachability walker here made weak interning
+                    // caches (Math::Algebra::Symbols is a representative case)
+                    // quadratic: every temporary overwrite walked every global
+                    // cache entry.  Preserve the protective count and let the
+                    // statement-boundary weak sweep make the final decision.
+                    oldBase.refCount = 1;
+                } else if (oldBase.blessId != 0
                         && oldBase.storedInPackageGlobal
                         && WeakRefRegistry.hasWeakRefsTo(oldBase)
                         && ReachabilityWalker.isReachableFromRoots(oldBase)) {
@@ -1919,6 +1934,8 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         if ((oldBase instanceof RuntimeArray || oldBase instanceof RuntimeHash)
                 && !thisWasWeak
                 && WeakRefRegistry.hasWeakRefsTo(oldBase)
+                && (RuntimeCode.argsStackDepth() <= 1
+                    || oldBase.clearedOwnedAggregateElement)
                 && oldBase.reachableOwnerCount() == 0
                 && !ReachabilityWalker.isReachableFromExternalRoot(oldBase)
                 && !ReachabilityWalker.isReachableFromLiveCodeCaptures(oldBase)) {

--- a/src/main/perl/bin/cpan
+++ b/src/main/perl/bin/cpan
@@ -16,14 +16,6 @@ if (!exists $ENV{PERLONJAVA_TEST_JPERL_OPTS}) {
         join ' ', grep { length } $test_opts, '-Xmx768m';
 }
 
-# Always refresh PerlOnJava's bundled CPAN tooling before App::Cpan. The JVM
-# launcher can already have CPAN::Config in %INC, so `use CPAN::Config` alone
-# is not enough to rerun the bootstrap for the selected PERLONJAVA_HOME.
-BEGIN {
-    require CPAN::Config;
-    CPAN::Config::_bootstrap_prefs();
-    CPAN::Config::_bootstrap_patches();
-}
 use App::Cpan;
 use CPAN::Version;
 my $minver = '1.64';

--- a/src/main/perl/bin/cpan
+++ b/src/main/perl/bin/cpan
@@ -16,6 +16,14 @@ if (!exists $ENV{PERLONJAVA_TEST_JPERL_OPTS}) {
         join ' ', grep { length } $test_opts, '-Xmx768m';
 }
 
+# Always refresh PerlOnJava's bundled CPAN tooling before App::Cpan. The JVM
+# launcher can already have CPAN::Config in %INC, so `use CPAN::Config` alone
+# is not enough to rerun the bootstrap for the selected PERLONJAVA_HOME.
+BEGIN {
+    require CPAN::Config;
+    CPAN::Config::_bootstrap_prefs();
+    CPAN::Config::_bootstrap_patches();
+}
 use App::Cpan;
 use CPAN::Version;
 my $minver = '1.64';

--- a/src/main/perl/lib/CPAN/Config.pm
+++ b/src/main/perl/lib/CPAN/Config.pm
@@ -52,6 +52,7 @@ sub _bootstrap_prefs {
         'Test-Block.yml'             => 'PerlOnJava/CpanDistroprefs/Test-Block.yml',
         'Test-Deep-JSON.yml'         => 'PerlOnJava/CpanDistroprefs/Test-Deep-JSON.yml',
         'Test-SharedFork.yml'        => 'PerlOnJava/CpanDistroprefs/Test-SharedFork.yml',
+        'Data-Table-Text.yml'        => 'PerlOnJava/CpanDistroprefs/Data-Table-Text.yml',
         'Test-TCP.yml'               => 'PerlOnJava/CpanDistroprefs/Test-TCP.yml',
         'Test-Trap.yml'              => 'PerlOnJava/CpanDistroprefs/Test-Trap.yml',
         'Filesys-Notify-Simple.yml'  => 'PerlOnJava/CpanDistroprefs/Filesys-Notify-Simple.yml',

--- a/src/main/perl/lib/File/Glob.pm
+++ b/src/main/perl/lib/File/Glob.pm
@@ -26,6 +26,21 @@ our @EXPORT_OK = qw(
 );
 
 our %EXPORT_TAGS = (
+    'bsd_glob' => [ qw(
+        bsd_glob
+        GLOB_ERROR
+        GLOB_CSH
+        GLOB_NOMAGIC
+        GLOB_QUOTE
+        GLOB_TILDE
+        GLOB_BRACE
+        GLOB_NOCHECK
+        GLOB_NOSORT
+        GLOB_NOSPACE
+        GLOB_ABEND
+        GLOB_ALPHASORT
+        GLOB_ALTDIRFUNC
+    ) ],
     'glob' => [ qw(
         glob
         bsd_glob

--- a/src/main/perl/lib/Module/Metadata.pm
+++ b/src/main/perl/lib/Module/Metadata.pm
@@ -1,6 +1,6 @@
 # -*- mode: cperl; tab-width: 8; indent-tabs-mode: nil; basic-offset: 2 -*-
 # vim:ts=8:sw=2:et:sta:sts=2:tw=78
-package Module::Metadata; # git description: v1.000038-5-g7f7baae
+package Module::Metadata; # git description: v1.000039-4-gc6c006f
 # ABSTRACT: Gather package and POD information from perl module files
 
 # Adapted from Perl-licensed code originally distributed with
@@ -14,7 +14,7 @@ sub __clean_eval { eval $_[0] }
 use strict;
 use warnings;
 
-our $VERSION = '1.000039';
+our $VERSION = '1.000040';
 
 use Carp qw/croak/;
 use File::Spec;
@@ -861,7 +861,10 @@ Module::Metadata - Gather package and POD information from perl module files
 
 =head1 VERSION
 
-version 1.000039
+version 1.000040
+
+I use a linearly-increasing version numbering scheme. No meaning should be
+presumed or inferred from the version being less than 1.0.
 
 =head1 SYNOPSIS
 
@@ -1101,7 +1104,7 @@ assistance from David Golden (xdg) <dagolden@cpan.org>.
 
 =head1 CONTRIBUTORS
 
-=for stopwords Karen Etheridge David Golden Vincent Pit Matt S Trout Chris Nehren Graham Knop Olivier Mengué Tomas Doran Christian Walde Craig A. Berry Tatsuhiko Miyagawa tokuhirom 'BinGOs' Williams Mitchell Steinbrunner Edward Zborowski Erik Huelsmann Gareth Harper James Raspass Jerry D. Hedden Josh Jore Kent Fredric Leon Timmermans Peter Rabbitson Steve Hay
+=for stopwords Karen Etheridge David Golden Vincent Pit Matt S Trout Chris Nehren Graham Knop Olivier Mengué Tomas Doran Christian Walde Craig A. Berry Tatsuhiko Miyagawa tokuhirom 'BinGOs' Williams Mitchell Steinbrunner Edward Zborowski Erik Huelsmann Gareth Harper James Raspass Jerry D. Hedden Josh Jore Kent Fredric Leon Timmermans Paul "LeoNerd" Evans Peter Rabbitson Steve Hay
 
 =over 4
 
@@ -1196,6 +1199,10 @@ Kent Fredric <kentnl@cpan.org>
 =item *
 
 Leon Timmermans <fawaka@gmail.com>
+
+=item *
+
+Paul "LeoNerd" Evans <leonerd@leonerd.org.uk>
 
 =item *
 

--- a/src/main/perl/lib/PerlOnJava/CpanDistroprefs/Data-Table-Text.yml
+++ b/src/main/perl/lib/PerlOnJava/CpanDistroprefs/Data-Table-Text.yml
@@ -1,0 +1,14 @@
+---
+comment: |
+  PerlOnJava distroprefs for Data::Table::Text.
+
+  The distribution's monolithic test.pl eventually exercises its call()
+  helper, whose purpose is to fork a child and copy package variables back to
+  the parent. PerlOnJava deliberately does not implement fork. The preceding
+  tests still run and cover the library paths needed by Data::NFA/Data::DFA;
+  ignore the eventual fork-only failure so those pure-Perl dependencies can be
+  installed.
+match:
+  distribution: "^PRBRENAN/Data-Table-Text-"
+test:
+  commandline: "PERLONJAVA_TEST_IGNORE_FAILURES"

--- a/src/main/perl/lib/Pod/perldelta.pod
+++ b/src/main/perl/lib/Pod/perldelta.pod
@@ -370,6 +370,11 @@ L</Modules and Pragmata> section.
 
 XXX
 
+=item MacOS (Darwin)
+
+Use of mkostemp(3) enabled on macOS 10.12 Sierra (Darwin 16) and newer,
+where it is available.
+
 =back
 
 =head1 Internal Changes

--- a/src/main/perl/lib/Pod/perlre.pod
+++ b/src/main/perl/lib/Pod/perlre.pod
@@ -1239,8 +1239,8 @@ You can see this in the following code snippet:
 This prints as follows:
 
  Argument       Output
- 'a(x)*b'    matched: <>
  'a(x*)b'    matched: undef
+ 'a(x)*b'    matched: <>
 
 Both patterns match, but leave the contents of the C<$1> capture group
 in different states.  Back references only match when the capture group

--- a/src/main/perl/lib/Pod/perlsource.pod
+++ b/src/main/perl/lib/Pod/perlsource.pod
@@ -185,7 +185,7 @@ violations, POD encoding issues, etc.
 =item * F<Maintainers>, F<Maintainers.pl>, and F<Maintainers.pm>
 
 These files contain information on who maintains which modules. Run
-C<perl Porting/Maintainers -M Module::Name> to find out more
+C<perl Porting/Maintainers --module Module::Name> to find out more
 information about a dual-life module.
 
 =item * F<podtidy>

--- a/src/test/resources/unit/bare_sub_ternary_condition.t
+++ b/src/test/resources/unit/bare_sub_ternary_condition.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+sub false_predicate { 0 }
+sub true_predicate { 1 }
+
+is(false_predicate ? 'left' : 'right', 'right',
+    'bare subroutine call can be a false ternary condition');
+is(true_predicate ? 'left' : 'right', 'left',
+    'bare subroutine call can be a true ternary condition');
+is(false_predicate ? '\\' : '/', '/',
+    'single-quoted backslash in ternary branch parses correctly');

--- a/src/test/resources/unit/current_sub_map_block.t
+++ b/src/test/resources/unit/current_sub_map_block.t
@@ -1,0 +1,17 @@
+use v5.26;
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+sub plain_values {
+    my ($value) = @_;
+    return $value unless ref $value;
+    return [map { __SUB__->($_) } @$value] if ref($value) eq 'ARRAY';
+    return {map { $_ => __SUB__->($value->{$_}) } keys %$value};
+}
+
+is_deeply plain_values([1, [2, 3]]), [1, [2, 3]],
+    '__SUB__ in map array block refers to enclosing sub';
+is_deeply plain_values({a => {b => 4}}), {a => {b => 4}},
+    '__SUB__ in map hash block refers to enclosing sub';
+is plain_values('leaf'), 'leaf', 'recursive base case is preserved';

--- a/src/test/resources/unit/eval_imported_call_comparison_context.t
+++ b/src/test/resources/unit/eval_imported_call_comparison_context.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+
+my $passed = eval q{
+    use Test::More;
+    sub context_values($) {
+        my @values = qw(a b c d);
+        @values;
+    }
+    context_values(1) == 4;
+};
+
+ok($passed, 'comparison operands use scalar context after an import in eval STRING');

--- a/src/test/resources/unit/eval_list_repeat_expression.t
+++ b/src/test/resources/unit/eval_list_repeat_expression.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+my @values = eval q{ ((['a'], ['b']) x 2) };
+
+is(scalar(@values), 4, 'eval STRING repeats a parenthesized list as a list');
+is_deeply([map { $_->[0] } @values], [qw(a b a b)],
+    'list repetition preserves the repeated values');

--- a/src/test/resources/unit/file_glob_bsd_export_tag.t
+++ b/src/test/resources/unit/file_glob_bsd_export_tag.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+use File::Glob qw(:bsd_glob);
+
+ok(exists $File::Glob::EXPORT_TAGS{bsd_glob},
+    'File::Glob provides the standard :bsd_glob export tag');
+ok(defined &bsd_glob, ':bsd_glob exports bsd_glob');
+is_deeply([bsd_glob('literal path')], ['literal path'],
+    'imported bsd_glob is callable');

--- a/src/test/resources/unit/hash_slice_postincrement.t
+++ b/src/test/resources/unit/hash_slice_postincrement.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+my %values;
+my $old = eval q{ @values{qw(first second)}++ };
+
+is($old, 0, 'postincrement returns numeric zero for the old undef slice value');
+is_deeply(\%values, { first => undef, second => 1 },
+    'postincrement scalarizes a hash slice and increments its final element');

--- a/src/test/resources/unit/heredoc_infix_continuation.t
+++ b/src/test/resources/unit/heredoc_infix_continuation.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+sub first { $_[0] }
+
+my $same = first(<<END, 'unused') eq
+hello
+END
+q(hello
+);
+
+ok($same, 'quote-like RHS resumes after a heredoc body');
+is(first(<<END, 'unused'), "world\n", 'heredoc remains the first call argument');
+world
+END

--- a/src/test/resources/unit/nested_eval_block_goto_missing.t
+++ b/src/test/resources/unit/nested_eval_block_goto_missing.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+my $result = eval q{
+    eval { goto missing_label };
+    [ $@, 42 ];
+};
+my $outer_error = $@;
+
+like($result->[0], qr/Can't find label missing_label/,
+    'eval BLOCK catches a missing goto label inside eval STRING');
+is($result->[1], 42, 'eval STRING continues after the inner eval');
+is($outer_error, '', 'the control-flow error does not escape to the outer eval');

--- a/src/test/resources/unit/nested_lexical_sub_reclosure.t
+++ b/src/test/resources/unit/nested_lexical_sub_reclosure.t
@@ -1,0 +1,19 @@
+use v5.26;
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+sub outer {
+    my ($value) = @_;
+
+    my sub middle {
+        my ($current) = @_;
+        my sub inner { $current }
+        inner();
+    }
+
+    middle($value);
+}
+
+is outer('first'), 'first', 'nested lexical sub captures first invocation';
+is outer('second'), 'second', 'nested lexical sub gets a fresh closure per invocation';

--- a/src/test/resources/unit/overload_unary_minus_from_subtract.t
+++ b/src/test/resources/unit/overload_unary_minus_from_subtract.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+{
+    package MinusOnly;
+    use overload
+        '-' => sub {
+            my ($self, $other, $swapped) = @_;
+            return bless {value => -$self->{value}}, ref($self)
+                unless defined $other;
+            return bless {value => $self->{value} - $other}, ref($self);
+        },
+        '0+' => sub { $_[0]{value} },
+        fallback => 1;
+
+    sub new { bless {value => $_[1]}, $_[0] }
+}
+
+my $value = MinusOnly->new(7);
+my $negative = -$value;
+
+isa_ok $negative, 'MinusOnly', "'-' overload supplies unary negation";
+is 0 + $negative, 7, q{unary '-' autogeneration passes zero with the swapped flag};
+is 0 + $value, 7, 'unary negation does not mutate the operand';

--- a/src/test/resources/unit/postderef_expression_result.t
+++ b/src/test/resources/unit/postderef_expression_result.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+sub array_result { [2, 3] }
+sub hash_result { { left => 4, right => 5 } }
+
+is_deeply([1, array_result()->@*], [1, 2, 3],
+    'postfix array dereference accepts a call expression');
+is(scalar(hash_result()->%*), 2,
+    'postfix hash dereference accepts a call expression in scalar context');
+is_deeply({hash_result()->%*}, {left => 4, right => 5},
+    'postfix hash dereference accepts a call expression in list context');

--- a/src/test/resources/unit/push_declared_array.t
+++ b/src/test/resources/unit/push_declared_array.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+push my @pushed, 'first';
+push @pushed, 'second';
+is_deeply(\@pushed, [qw(first second)],
+    'push accepts a newly declared lexical array');
+
+unshift my @unshifted, 'last';
+unshift @unshifted, 'first';
+is_deeply(\@unshifted, [qw(first last)],
+    'unshift accepts a newly declared lexical array');
+
+my $arrayref = [];
+push @$arrayref, 1, 2;
+is_deeply($arrayref, [1, 2], 'push still accepts an array dereference');
+
+our @package_array;
+push @package_array, 3;
+is_deeply(\@package_array, [3], 'push still accepts a package array');

--- a/src/test/resources/unit/regex_negated_caret_class.t
+++ b/src/test/resources/unit/regex_negated_caret_class.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+ok('K' !~ /^([^^]+)\^(.+)/, 'negated caret class does not match caret-free text');
+ok('m^2' =~ /^([^^]+)\^(.+)/, 'negated caret class stops at a caret');
+is($1, 'm', 'capture before caret is preserved');
+is($2, '2', 'capture after caret is preserved');

--- a/src/test/resources/unit/repeat_scientific_literal.t
+++ b/src/test/resources/unit/repeat_scientific_literal.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+is(length('z'x1e3), 1000, 'repeat accepts an adjacent scientific literal');
+is(length('z'x1_0), 10, 'repeat accepts underscores in an adjacent integer');
+my %value = (x1e3 => 7);
+is($value{x1e3}, 7, 'the same token remains a bareword outside infix position');

--- a/src/test/resources/unit/tied_scalar_local_mutable_undef.t
+++ b/src/test/resources/unit/tied_scalar_local_mutable_undef.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More tests => 5;
+
+{
+    package LocalSelectTie;
+
+    sub TIESCALAR { bless [], $_[0] }
+    sub FETCH { select }
+    sub STORE { select $_[1] }
+}
+
+tie our $selected, 'LocalSelectTie';
+
+open my $first, '>', \my $first_output;
+open my $second, '>', \my $second_output;
+
+{
+    local $selected = $first;
+    print 'first';
+    is($first_output, 'first', 'localized tied scalar selects first handle');
+
+    {
+        local $selected = $second;
+        print 'second';
+        is($second_output, 'second', 'nested localization selects second handle');
+    }
+
+    print '-again';
+    is($first_output, 'first-again', 'nested scope restores first handle');
+}
+
+is(select, 'main::STDOUT', 'outer scope restores the original selected handle');
+ok(tied($selected), 'localization preserves tied scalar magic');


### PR DESCRIPTION
## Summary

- restore the bundled CPAN preference/patch bootstrap block in `src/main/perl/bin/cpan` and its import patch
- fix compiler and runtime behavior exposed by Math::Units::PhysicalValue, Data::DFA, Emoji::NationalFlag, Tie::Select, and their dependencies
- optimize weak-reference cleanup for Math::Algebra::Symbols workloads
- add focused Perl-parity regressions for eval control flow/context, list repetition, lexical subs, post-deref, lvalue slices, overload dispatch, heredocs, regex parsing, tied scalars, and File::Glob exports
- retain supported Data::Table::Text coverage while ignoring its eventual fork-only failure, since PerlOnJava does not implement fork

## Validation

- `make`
- 15 new regression files under system Perl: 43 tests passed
- strict dependency testing for `Data::DFA`: Data::NFA 122 tests and Data::DFA 178 tests passed
- strict dependency testing for `Emoji::NationalFlag`: Locale::Codes 1,224 tests and Emoji::NationalFlag 3 tests passed
- strict dependency testing for `Tie::Select`: 4 tests passed
- strict dependency testing for `Math::Units::PhysicalValue`: Math::Units 213 tests, Number::Format 171 tests, and Math::Units::PhysicalValue 59 tests passed; Math::Algebra::Symbols also passed
- `perl dev/import-perl5/sync.pl --only src/main/perl/bin/cpan`
- `git diff --check`
