### PR TITLE
feat: complete Perl threads phases 21-23

### DIFF
--- a/dev/bench/README.md
+++ b/dev/bench/README.md
@@ -25,6 +25,7 @@ under PerlOnJava (and optionally system Perl for comparison). Use them to:
 | `benchmark_regex.pl` | Regex compilation and matching |
 | `benchmark_refcount_store.pl` | Tracked reference stores after `weaken()` activates lifecycle bookkeeping |
 | `benchmark_string.pl` | String operations (concat, substr, etc.) |
+| `benchmark_threads.pl` | Ithread snapshot, creation, scheduling, and join overhead |
 
 ## Running
 

--- a/dev/bench/benchmark_threads.pl
+++ b/dev/bench/benchmark_threads.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Time::HiRes qw(time);
+use threads;
+
+my $iterations = shift // 10;
+die "iterations must be a positive integer\n"
+    unless $iterations =~ /^\d+$/ && $iterations > 0;
+
+my $start = time;
+my $checksum = 0;
+for my $batch (1 .. $iterations) {
+    my @workers = map {
+        my $value = $_;
+        threads->create(sub { $value + 1 });
+    } 1 .. 10;
+    $checksum += $_->join for @workers;
+}
+my $elapsed = time - $start;
+
+printf "threads=%d elapsed=%.6f checksum=%d\n",
+    $iterations * 10, $elapsed, $checksum;

--- a/dev/design/attributes.md
+++ b/dev/design/attributes.md
@@ -44,7 +44,14 @@ attributes::->import(Canine => \$spot, "Watchful");
 | CODE | `method` | Marks sub as method (suppresses ambiguity warnings) |
 | CODE | `prototype(...)` | Sets prototype |
 | CODE | `const` | Experimental: calls anon sub immediately, captures return as constant |
-| SCALAR/ARRAY/HASH | `shared` | Marks supported storage for identity-preserving ithread cloning |
+| SCALAR/ARRAY/HASH | `shared` | Marks storage for identity-preserving ithread cloning and `threads::shared` synchronization |
+
+The `shared` attribute is active when `threads::shared` is loaded. Shared
+scalars, arrays, and hashes retain identity across ithread cloning and support
+the locking and condition-variable operations described in
+`dev/design/concurrency.md`. It is not a general deep-sharing marker for tied
+or otherwise unsupported magic objects; callers should use
+`threads::shared::shared_clone` for supported aggregate graphs.
 
 ### `import()` Flow
 

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -591,22 +591,53 @@ request history.
 
 ### Next Steps
 
-1. Close the measured Phase 22 compatibility gaps in core `op/threads.t`,
-   `class/threads.t`, `re/stclass_threads.t`, and Storable before expanding to
-   Test2 and native-callback thread suites.
-2. Add dedicated shared-storage lifetime cleanup and contention benchmarks;
+1. Finish the newly activated core-thread compatibility tranche instead of
+   treating partial TAP counts as success. Raise `op/threads.t` from 24/30,
+   `op/substr_thr.t` from 12/400, `re/stclass_threads.t` from 5/6, and
+   `class/threads.t` from 2/4 to their full applicable pass counts on both
+   backends, close Storable's 1/2 result, and keep `threads-dirh.t` complete.
+   Classify every remaining skip as an explicit documented limitation, run each
+   file with the standard-Perl oracle first, and keep the exact counts in the
+   differential gate until they are complete. Only then expand to Test2 and
+   native-callback thread suites.
+2. Make `docs/reference/feature-matrix.md` the canonical user-facing
+   compatibility table for multiplicity, `threads`, and `threads::shared`.
+   Replace its obsolete "Threading not supported" claim with the measured
+   supported API, `Config` flags, clone-versus-shared identity rules, and an
+   explicit limitations table covering signals, effective stack sizing,
+   blessed/tied shared values, native callbacks/resources, and experimental
+   virtual threads. Link the detailed concurrency reference from its table of
+   contents and module sections.
+3. Add a `docs/about/changelog.md` work-in-progress entry for Phases 1-23 and
+   reconcile the concurrency roadmap with the shipped multiplicity/ithread
+   tranche. Update the relevant reference pages: describe per-runtime ownership
+   and snapshot cloning in `docs/reference/architecture.md`, document the
+   `useithreads`/`usethreads`/`usemultiplicity` values and virtual-thread opt-in
+   in the configuration/CLI reference, and correct
+   `docs/reference/memory-management.md`, which still says Perl threads and the
+   reference-count overlay are single-threaded.
+4. Add runnable examples under `examples/` for isolated create/join and shared
+   lock/condition workflows, link them from `examples/README.md`, and validate
+   each with system Perl plus both PerlOnJava backends. Update
+   `examples/http_server_plack/README.md` and `PERFORMANCE.md` to distinguish
+   that example's deliberately single-event-loop architecture from the now
+   available Perl ithread capability; do not imply that one captured PSGI
+   runtime is concurrently callable.
+5. Add documentation acceptance checks to the compatibility tranche: run link
+   validation, compile every new example with system Perl and `jperl -c`, execute
+   it on the JVM and interpreter backends with bounded timeouts, and retain a
+   focused API/limitation matrix test so documentation cannot advertise an
+   unsupported thread method or sharing class.
+6. Add dedicated shared-storage lifetime cleanup and contention benchmarks;
    replace the strong identity lock registry if long-running churn proves
    retention after the last shared owner disappears.
-3. Run the virtual-thread pinning suite on Java 22, covering shared conditions,
+7. Run the virtual-thread pinning suite on Java 22, covering shared conditions,
    native I/O, regex timeouts, and child lifecycle. Keep the mode experimental
-unless the trace is clean and repeated benchmarks show a material benefit.
-On Java 24, the initial creation/join smoke measured 30 cloned ithreads in
-0.544 seconds on platform threads and 0.543 seconds on virtual threads with
-identical checksums. That is semantic parity, not a demonstrated benefit, and
-cannot substitute for the Java 22 pinning gate.
-4. Update user-facing thread documentation after the compatibility tranche is
-   stable: supported API table, resource-cloning policy, native callback limits,
-   and migration examples for `threads::shared`.
+   unless the trace is clean and repeated benchmarks show a material benefit.
+   On Java 24, the initial creation/join smoke measured 30 cloned ithreads in
+   0.544 seconds on platform threads and 0.543 seconds on virtual threads with
+   identical checksums. That is semantic parity, not a demonstrated benefit,
+   and cannot substitute for the Java 22 pinning gate.
 
 ### Open Questions
 

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -477,7 +477,7 @@ measured benefit over platform threads/full clone.
 
 ## 7. Progress Tracking
 
-### Current Status: Phase 20 implemented and validated
+### Current Status: Phases 21–23 implemented; activation hardening continues
 
 Hints, warnings, filters, and source maps are runtime-owned while compiler-only
 scratch remains protected by the global compile lock. The Phase 11 inventory is
@@ -550,8 +550,37 @@ its identity. Shared aggregate backing collections are synchronized and scalar
 payload fields provide cross-thread visibility. `share`, `is_shared`,
 `shared_clone`, and `:shared` are implemented for the supported unblessed,
 untied tranche; blessed and tied values are rejected explicitly. Lock and
-condition-variable semantics remain Phase 21. `Config` continues to advertise
-threads as disabled until Phase 22.
+condition-variable semantics are implemented in Phase 21, and Phase 22 now
+advertises the supported ithread surface through `Config`.
+
+Shared storage now has recursive, lexical `lock` ownership and condition
+variables with atomic waiter publication, full recursive release/reacquisition,
+absolute timed waits, FIFO signal, and broadcast. JVM and interpreter backends
+both emit the lock cleanup boundary. The focused lock/condition stress suite
+passes on system Perl and both PerlOnJava backends.
+
+`Config` now advertises `useithreads`, `usethreads`, and `usemultiplicity`.
+The supported `threads` import/stringification surface is documented, while
+signals, effective stack sizing, `object`, and `wantarray` remain explicit
+limitations. Activation coverage passes on both backends. The first broader
+compatibility inventory currently reaches 24/30 in core `op/threads.t`, 2/4 in
+`class/threads.t`, 5/6 in `re/stclass_threads.t`, 1/2 in Storable's thread test,
+and completes `threads-dirh.t`; these are measured follow-up targets, not a
+claim that every upstream thread suite is green.
+
+The post-activation comprehensive gate records the changed test surface rather
+than comparing unlike totals: Perl core is 260709/319705 (81.5%) and bundled
+modules are 9758/12192 (80.0%). Scalar::Util 1.70 loads on both backends and the
+JVM Moo constructor smoke passes; the interpreter retains its previously
+documented Moo attribute-syntax parser limitation.
+
+Platform threads remain the default. An experimental process-wide opt-in selects
+virtual threads with `-Djperl.thread.mode=virtual` or
+`JPERL_THREAD_MODE=virtual`; unknown modes are rejected and diagnostics expose
+the actual Java thread kind. Runtime pooling is deferred because no reset
+contract yet proves that a reused interpreter is equivalent to a fresh snapshot.
+The supported Java baseline is 22, but this development host runs Java 24, so
+Java 22 pinning diagnostics remain a release gate for promoting virtual mode.
 
 ### Implementation History
 
@@ -562,17 +591,32 @@ request history.
 
 ### Next Steps
 
-1. Implement Phase 21 lexical/recursive locking and condition variables on
-   shared storage.
-2. Define and run Phase 22's broader core/CPAN compatibility activation matrix
-   before changing `Config` capability flags.
+1. Close the measured Phase 22 compatibility gaps in core `op/threads.t`,
+   `class/threads.t`, `re/stclass_threads.t`, and Storable before expanding to
+   Test2 and native-callback thread suites.
+2. Add dedicated shared-storage lifetime cleanup and contention benchmarks;
+   replace the strong identity lock registry if long-running churn proves
+   retention after the last shared owner disappears.
+3. Run the virtual-thread pinning suite on Java 22, covering shared conditions,
+   native I/O, regex timeouts, and child lifecycle. Keep the mode experimental
+unless the trace is clean and repeated benchmarks show a material benefit.
+On Java 24, the initial creation/join smoke measured 30 cloned ithreads in
+0.544 seconds on platform threads and 0.543 seconds on virtual threads with
+identical checksums. That is semantic parity, not a demonstrated benefit, and
+cannot substitute for the Java 22 pinning gate.
+4. Update user-facing thread documentation after the compatibility tranche is
+   stable: supported API table, resource-cloning policy, native callback limits,
+   and migration examples for `threads::shared`.
 
 ### Open Questions
 
 - Exact Perl-compatible cloning policy for each filehandle/native resource type.
 - Which tied and magical value classes can be safely shared in the first
   `threads::shared` compatibility tranche.
-- Which core/CPAN thread suites define the Phase 22 minimum activation matrix.
+- Whether Java 22 virtual-thread pinning in native and synchronized workloads is
+  acceptable enough to promote virtual mode beyond experimental opt-in.
+- What complete reset proof would be required before runtime pooling can preserve
+  fresh-snapshot semantics.
 
 ## Related Documents
 

--- a/dev/modules/plack_handler_netty.md
+++ b/dev/modules/plack_handler_netty.md
@@ -139,20 +139,22 @@ Netty is the optimal backend for a JVM-based Perl web server:
 |---------|-------------|
 | **Battle-tested** | Used by Twitter, Apple, Facebook; powers Elasticsearch, Cassandra |
 | **Async I/O** | Non-blocking event loop handles 10k+ concurrent connections |
-| **Single-threaded compatible** | **CRITICAL**: PerlOnJava doesn't support threads/fork yet; Netty's single event loop model is perfect |
+| **Single-runtime handler** | Explicit Perl ithreads are available, while one PSGI app remains confined to its captured runtime |
 | **HTTP/2 support** | Modern protocol support for free |
 | **WebSocket native** | First-class support for real-time apps |
 | **Zero dependencies** | Single JAR (netty-all), no native libs required |
 | **Active development** | Regular releases, strong Java ecosystem |
 
 The existing `examples/http_server/` prototype already demonstrates Netty + PerlOnJava
-integration with a custom request handler, using a **single-threaded event loop** to
-avoid race conditions in PerlOnJava's global state. Plack::Handler::Netty **standardizes**
-this by implementing the PSGI interface.
+integration with a custom request handler. Plack::Handler::Netty **standardizes**
+this by implementing the PSGI interface. Explicit Perl ithreads are supported,
+but the handler does not treat availability of ithreads as permission for
+concurrent callbacks into its single captured application runtime.
 
-**Concurrency Model**: Uses Netty's async I/O to handle multiple concurrent connections
-on a single thread. CPU-bound handlers can block other requests, but I/O-bound apps
-(most web apps) work efficiently.
+**Concurrency Model**: Uses Netty's asynchronous I/O for concurrent connections,
+but advertises `psgi.multithread => \0` because the PSGI app is single-runtime.
+Applications can create explicit ithreads for isolated work; CPU-bound request
+handlers can still reduce throughput.
 
 ### Why PSGI/Plack?
 
@@ -236,7 +238,7 @@ must construct this hash from Netty's `io.netty.handler.codec.http.HttpRequest` 
 | psgi.url_scheme | `http` or `https` | `"http"` |
 | psgi.input | Body stream | `IO::Handle` wrapping body bytes |
 | psgi.errors | Error log handle | `*STDERR` |
-| psgi.multithread | Boolean | `\0` (PerlOnJava doesn't support threads) |
+| psgi.multithread | Boolean | `\0` (one captured PSGI runtime; explicit ithreads remain available) |
 | psgi.multiprocess | Boolean | `\0` (PerlOnJava doesn't support fork) |
 | psgi.run_once | Boolean | `\0` (persistent server) |
 | psgi.nonblocking | Boolean | `\1` (Netty is async) |
@@ -360,7 +362,7 @@ public class NettyPSGIServer {
 - Accept PSGI `$app` coderef as constructor argument
 - Implement full PSGI env hash construction
 - Handle PSGI array response format
-- **Use single-threaded event loop** (NioEventLoopGroup(1)) to avoid thread-safety issues
+- Keep callbacks into the captured PSGI application runtime serialized
 
 **Estimated effort**: 2 days
 
@@ -694,7 +696,7 @@ Add to `Plack::Handler::Netty->new(%args)`:
 - `backlog` - TCP backlog queue size
 - `keepalive` - HTTP keep-alive timeout
 - `max_request_size` - Request body size limit
-- ~~`workers`~~ - **Not supported**: PerlOnJava doesn't support threads/fork yet; always single-threaded
+- ~~`workers`~~ - **Not supported**: the handler does not expose process workers or concurrent app runtimes
 
 **Estimated effort**: 1 day
 
@@ -725,7 +727,7 @@ Add:
 - SYNOPSIS with examples
 - CONFIGURATION section
 - PERFORMANCE notes
-- CAVEATS (single-threaded, no fork support)
+- CAVEATS (single PSGI application runtime, explicit ithreads available, no fork support)
 - SEE ALSO links
 
 **Estimated effort**: 1 day
@@ -1325,7 +1327,7 @@ dev/sandbox/http_server/
 | Dancer2 Type::Tiny bug still present | High | High | Fix Type::Tiny scoping bug first (dancer2_support.md Issue 3) |
 | Performance worse than Starman | Medium | Medium | Profile with JFR, optimize hot paths |
 | Streaming responses break event loop | Medium | High | Test with large responses, use Netty's streaming APIs correctly |
-| CPU-bound handlers block all requests | High | Medium | **Known limitation**: Document that PerlOnJava is single-threaded |
+| CPU-bound handlers block other requests | High | Medium | Use explicit ithreads for isolated work and keep handlers nonblocking |
 
 ## Success Metrics
 

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -2432,6 +2432,10 @@ public class BytecodeInterpreter {
                                 pc = InlineOpcodeHandler.executeTied(bytecode, pc, registers);
                             }
 
+                            case Opcodes.LOCK -> {
+                                pc = InlineOpcodeHandler.executeLock(bytecode, pc, registers);
+                            }
+
                             // Miscellaneous operators with context-sensitive signatures
                             case Opcodes.CHMOD, Opcodes.UNLINK, Opcodes.UTIME, Opcodes.RENAME, Opcodes.LINK,
                                  Opcodes.READLINK, Opcodes.UMASK, Opcodes.GETC, Opcodes.FILENO, Opcodes.QX,

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -784,6 +784,16 @@ public class CompileOperator {
             case "binary~" -> emitSimpleUnary(bytecodeCompiler, node, Opcodes.BITWISE_NOT_BINARY);
             case "~." -> emitSimpleUnary(bytecodeCompiler, node, Opcodes.BITWISE_NOT_STRING);
             case "defined" -> visitDefined(bytecodeCompiler, node);
+            case "lock" -> {
+                bytecodeCompiler.compileNode(node.operand, -1, RuntimeContextType.SCALAR);
+                int valueReg = bytecodeCompiler.lastResultReg;
+                int rd = bytecodeCompiler.allocateOutputRegister();
+                bytecodeCompiler.emit(Opcodes.LOCK);
+                bytecodeCompiler.emitReg(rd);
+                bytecodeCompiler.emitReg(valueReg);
+                bytecodeCompiler.emit(bytecodeCompiler.currentCallContext);
+                bytecodeCompiler.lastResultReg = rd;
+            }
             case "wantarray" -> { int rd = bytecodeCompiler.allocateOutputRegister(); bytecodeCompiler.emit(Opcodes.WANTARRAY); bytecodeCompiler.emitReg(rd); bytecodeCompiler.emitReg(2); bytecodeCompiler.lastResultReg = rd; }
             case "time" -> { int rd = bytecodeCompiler.allocateOutputRegister(); bytecodeCompiler.emit(Opcodes.TIME_OP); bytecodeCompiler.emitReg(rd); bytecodeCompiler.lastResultReg = rd; }
             case "wait" -> { int rd = bytecodeCompiler.allocateOutputRegister(); bytecodeCompiler.emit(Opcodes.WAIT_OP); bytecodeCompiler.emitReg(rd); bytecodeCompiler.lastResultReg = rd; }

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -2375,6 +2375,14 @@ public class Disassemble {
                                 .append(", ctx=").append(tiedCtx).append(")\n");
                         break;
                     }
+                    case Opcodes.LOCK: {
+                        rd = interpretedCode.bytecode[pc++];
+                        int valueReg = interpretedCode.bytecode[pc++];
+                        int lockCtx = interpretedCode.bytecode[pc++];
+                        sb.append("LOCK r").append(rd).append(" = lock(r").append(valueReg)
+                                .append(", ctx=").append(lockCtx).append(")\n");
+                        break;
+                    }
                     case Opcodes.QX: {
                         // Format: QX rd argsReg ctx (MiscOpcodeHandler pattern)
                         rd = interpretedCode.bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
@@ -1427,6 +1427,15 @@ public class InlineOpcodeHandler {
         return pc;
     }
 
+    public static int executeLock(int[] bytecode, int pc, RuntimeBase[] registers) {
+        int rd = bytecode[pc++];
+        int valueReg = bytecode[pc++];
+        int ctx = bytecode[pc++];
+        if (ctx == RuntimeContextType.RUNTIME) ctx = ((RuntimeScalar) registers[2]).getInt();
+        registers[rd] = TieOperators.lock(ctx, registers[valueReg]);
+        return pc;
+    }
+
     // =========================================================================
     // MISC COLD OPS
     // =========================================================================

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -2452,6 +2452,9 @@ public class Opcodes {
     /** Restore lexical hints after leaving a nested block. Format: SET_CALL_SITE_HINTS hints. */
     public static final short SET_CALL_SITE_HINTS = 515;
 
+    /** lock($shared): rd = TieOperators.lock(ctx, valueReg). */
+    public static final short LOCK = 516;
+
     private Opcodes() {
     } // Utility class - no instantiation
 }

--- a/src/main/java/org/perlonjava/frontend/analysis/FindDeclarationVisitor.java
+++ b/src/main/java/org/perlonjava/frontend/analysis/FindDeclarationVisitor.java
@@ -51,7 +51,7 @@ public class FindDeclarationVisitor implements Visitor {
     }
 
     /**
-     * Static method to check if a block contains either local or defer statements.
+     * Static method to check if a block contains local, defer, or lock statements.
      * This is used to determine if scope cleanup (popToLocalLevel) is needed.
      *
      * @param blockNode The AST node to search within
@@ -101,7 +101,8 @@ public class FindDeclarationVisitor implements Visitor {
      */
     @Override
     public void visit(OperatorNode node) {
-        if (this.operatorName.equals(node.operator) || "delete_local".equals(node.operator)) {
+        if (this.operatorName.equals(node.operator) || "delete_local".equals(node.operator)
+                || "lock".equals(node.operator)) {
             containsLocalOperator = true;
             operatorNode = node;
         }

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -1531,7 +1531,7 @@ public class OperatorParser {
             List<String> nonBuiltinAttrs = new ArrayList<>();
             for (String attr : attributes) {
                 if ("shared".equals(attr)) {
-                    // 'shared' is a no-op (no threads in PerlOnJava)
+                    // 'shared' is handled by threads::shared after declaration.
                     continue;
                 }
                 nonBuiltinAttrs.add(attr);

--- a/src/main/java/org/perlonjava/runtime/operators/TieOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/TieOperators.java
@@ -315,7 +315,7 @@ public class TieOperators {
      * Implements Perl's lock() builtin function.
      * 
      * <p>In threaded Perl, lock() places an advisory lock on a shared variable.
-     * In non-threaded Perl (and PerlOnJava), it's a no-op that returns its argument.</p>
+     * The lock is recursive and is released by the dynamic-scope cleanup stack.</p>
      *
      * <p>The prototype for lock is \[$@%&*] so the argument is passed as a reference.</p>
      *
@@ -324,11 +324,11 @@ public class TieOperators {
      * @return for scalar refs, the dereferenced value; for arrays/hashes, the reference
      */
     public static RuntimeScalar lock(int ctx, RuntimeBase... scalars) {
-        // No-op in non-threaded Perl - return the argument appropriately
         if (scalars.length == 0) {
             return scalarUndef;
         }
         RuntimeScalar variable = scalars[0].getFirst();
+        SharedPerlStorage.lock(variable);
         // For scalar references, dereference to get the value
         // For other reference types (arrays, hashes), return the reference itself
         return switch (variable.type) {

--- a/src/main/java/org/perlonjava/runtime/operators/TieOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/TieOperators.java
@@ -328,7 +328,12 @@ public class TieOperators {
             return scalarUndef;
         }
         RuntimeScalar variable = scalars[0].getFirst();
-        SharedPerlStorage.lock(variable);
+        // A threaded perl still accepts lock() as a compatibility no-op until
+        // threads::shared is loaded.  Core's op/lock.t relies on this behavior
+        // for ordinary scalar, aggregate, and code slots.
+        if (GlobalVariable.getGlobalHash("main::INC").elements.containsKey("threads/shared.pm")) {
+            SharedPerlStorage.lock(variable);
+        }
         // For scalar references, dereference to get the value
         // For other reference types (arrays, hashes), return the reference itself
         return switch (variable.type) {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Attributes.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Attributes.java
@@ -227,7 +227,7 @@ public class Attributes extends PerlModuleBase {
 
     /**
      * Apply a built-in variable attribute.
-     * {@code shared} is recognized (no-op in PerlOnJava).
+     * {@code shared} marks supported storage for identity-preserving ithread sharing.
      * {@code -shared} triggers a "may not be unshared" error.
      */
     private static boolean applyVariableAttribute(RuntimeScalar svref, String attrName, boolean negate) {
@@ -558,7 +558,10 @@ public class Attributes extends PerlModuleBase {
         // Filter built-in attributes
         List<String> nonBuiltinAttrs = new ArrayList<>();
         for (String attr : attributes) {
-            if ("shared".equals(attr)) continue;
+            if ("shared".equals(attr)) {
+                SharedPerlStorage.shareValue(variable);
+                continue;
+            }
             nonBuiltinAttrs.add(attr);
         }
         if (nonBuiltinAttrs.isEmpty()) return;

--- a/src/main/java/org/perlonjava/runtime/perlmodule/PlackHandlerNetty.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/PlackHandlerNetty.java
@@ -687,7 +687,9 @@ public class PlackHandlerNetty extends PerlModuleBase {
             // Wrap in a new RuntimeScalar to ensure it's stored correctly
             env.put("psgi.errors", new RuntimeScalar(RuntimeIO.getStderr()));
 
-            // psgi.multithread - \0 (PerlOnJava doesn't support threads)
+            // psgi.multithread - \0: this handler owns one captured PerlRuntime.
+            // Explicit Perl ithreads are supported, but availability of ithreads
+            // does not make concurrent callbacks into one PSGI app safe.
             env.put("psgi.multithread", new RuntimeScalar(0));
 
             // psgi.multiprocess - \0 (PerlOnJava doesn't support fork)

--- a/src/main/java/org/perlonjava/runtime/perlmodule/ThreadsShared.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/ThreadsShared.java
@@ -12,6 +12,10 @@ public final class ThreadsShared extends PerlModuleBase {
             module.registerMethod("_share", null);
             module.registerMethod("_is_shared", null);
             module.registerMethod("_shared_clone", null);
+            module.registerMethod("_cond_wait", null);
+            module.registerMethod("_cond_timedwait", null);
+            module.registerMethod("_cond_signal", null);
+            module.registerMethod("_cond_broadcast", null);
         } catch (NoSuchMethodException e) {
             throw new IllegalStateException("Missing threads::shared backend method", e);
         }
@@ -29,6 +33,37 @@ public final class ThreadsShared extends PerlModuleBase {
 
     public static RuntimeList _shared_clone(RuntimeArray args, int ctx) {
         return SharedPerlStorage.sharedClone(required(args, "shared_clone")).getList();
+    }
+
+    public static RuntimeList _cond_wait(RuntimeArray args, int ctx) {
+        RuntimeScalar condition = required(args, "cond_wait");
+        RuntimeScalar lock = args.size() > 1 ? args.get(1) : condition;
+        SharedPerlStorage.conditionWait(condition, lock);
+        return new RuntimeScalar(1).getList();
+    }
+
+    public static RuntimeList _cond_timedwait(RuntimeArray args, int ctx) {
+        RuntimeScalar condition = required(args, "cond_timedwait");
+        if (args.size() < 2) throw new IllegalArgumentException("cond_timedwait requires a timeout");
+        RuntimeScalar lock = args.size() > 2 ? args.get(2) : condition;
+        boolean signalled = SharedPerlStorage.conditionTimedWait(condition, lock, args.get(1).getDouble());
+        return (signalled ? new RuntimeScalar(1) : RuntimeScalarCache.scalarUndef).getList();
+    }
+
+    public static RuntimeList _cond_signal(RuntimeArray args, int ctx) {
+        if (!SharedPerlStorage.conditionSignal(required(args, "cond_signal"), false)) {
+            org.perlonjava.runtime.operators.WarnDie.warn(
+                    new RuntimeScalar("cond_signal() called on unlocked variable"), new RuntimeScalar());
+        }
+        return new RuntimeScalar(1).getList();
+    }
+
+    public static RuntimeList _cond_broadcast(RuntimeArray args, int ctx) {
+        if (!SharedPerlStorage.conditionSignal(required(args, "cond_broadcast"), true)) {
+            org.perlonjava.runtime.operators.WarnDie.warn(
+                    new RuntimeScalar("cond_broadcast() called on unlocked variable"), new RuntimeScalar());
+        }
+        return new RuntimeScalar(1).getList();
     }
 
     private static RuntimeScalar required(RuntimeArray args, String name) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/DiamondIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/DiamondIO.java
@@ -29,6 +29,7 @@ public class DiamondIO {
         String inPlaceExtension;
         boolean inPlaceEdit;
         Path tempFilePath;
+        RuntimeIO selectedHandleBeforeInPlace;
 
         void clear() {
             currentReader = null;
@@ -40,6 +41,7 @@ public class DiamondIO {
             inPlaceExtension = null;
             inPlaceEdit = false;
             tempFilePath = null;
+            selectedHandleBeforeInPlace = null;
         }
     }
 
@@ -110,6 +112,7 @@ public class DiamondIO {
                 // If there's no current reader, try to open the next file
                 if (state.currentReader == null) {
                     if (!openNextFile()) {
+                        finishInPlaceEditing();
                         state.eofReached = true;
                         return scalarUndef;
                     }
@@ -241,6 +244,9 @@ public class DiamondIO {
 
             // CRITICAL: Update selectedHandle so print statements without explicit filehandle
             // write to the original file during in-place editing
+            if (state.selectedHandleBeforeInPlace == null) {
+                state.selectedHandleBeforeInPlace = RuntimeIO.getSelectedHandle();
+            }
             RuntimeIO.setSelectedHandle(state.currentWriter);
         }
 
@@ -250,5 +256,14 @@ public class DiamondIO {
         getGlobalIO("main::ARGV").set(state.currentReader);
 
         return state.currentReader != null;
+    }
+
+    /** Restore the handle selected before diamond in-place editing began. */
+    private static void finishInPlaceEditing() {
+        State state = state();
+        if (state.selectedHandleBeforeInPlace != null) {
+            RuntimeIO.setSelectedHandle(state.selectedHandleBeforeInPlace);
+            state.selectedHandleBeforeInPlace = null;
+        }
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeState.java
@@ -304,6 +304,21 @@ public final class GlobalRuntimeState {
         // Class loaders, caches, named IO and formats are child-owned/fresh.
     }
 
+    /** Copy CV ids registered by a named sub that was materialized after snapshot. */
+    void snapshotCompiledCodeRefsInto(GlobalRuntimeState target, RuntimeGraphCloner cloner) {
+        for (Map.Entry<Integer, RuntimeScalar> entry : compiledCodeRefs.entrySet()) {
+            RuntimeScalar cloned = (RuntimeScalar) cloner.cloneValue(entry.getValue());
+            RuntimeScalar existing = target.compiledCodeRefs.get(entry.getKey());
+            if (existing != null && existing != cloned) {
+                throw new IllegalStateException("Compiled CODE reference id collision during lazy thread clone: "
+                        + entry.getKey());
+            }
+            target.compiledCodeRefs.put(entry.getKey(), cloned);
+        }
+        target.nextCompiledCodeRefId = Math.max(target.nextCompiledCodeRefId,
+                nextCompiledCodeRefId);
+    }
+
     private static <T extends RuntimeBase> void cloneMap(
             Map<String, T> source, Map<String, T> target,
             RuntimeGraphCloner cloner, Class<T> type) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -294,6 +294,7 @@ public final class PerlRuntime implements AutoCloseable {
             RuntimeGraphCloner cloner = new RuntimeGraphCloner(this, child, skipped);
             try (Binding ignored = bind()) {
                 globalState.snapshotInto(child.globalState, cloner);
+                runtimeCodeState.snapshotCompiledMetadataInto(child.runtimeCodeState);
             }
             child.currentDirectory = currentDirectory;
             child.initialized = true;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlock.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlock.java
@@ -6,7 +6,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.ArrayList;
 import java.util.List;
 
-/** Internal ownership and completion record for one Perl platform thread. */
+/** Internal ownership and completion record for one Perl ithread. */
 public final class PerlThreadControlBlock {
     public enum State { NEW, RUNNING, COMPLETED, FAILED, JOINED, DETACHED }
 
@@ -77,7 +77,7 @@ public final class PerlThreadControlBlock {
     public synchronized PerlThreadControlBlock start() {
         if (state != State.NEW) throw new IllegalStateException("Thread already started");
         state = State.RUNNING;
-        platformThread = Thread.ofPlatform().name("perl-ithread-" + id).unstarted(this::run);
+        platformThread = PerlThreadExecutionPolicy.configured().unstarted(id, this::run);
         platformThread.start();
         return this;
     }
@@ -158,6 +158,8 @@ public final class PerlThreadControlBlock {
     public boolean isDetached() { return detached; }
     public PerlRuntime childRuntime() { return childRuntime; }
     public Thread platformThread() { return platformThread; }
+    public String javaThreadName() { return platformThread == null ? null : platformThread.getName(); }
+    public boolean isVirtualThread() { return platformThread != null && platformThread.isVirtual(); }
     public Throwable error() { return error; }
 
     private record Outcome(RuntimeBase value, Throwable error) {}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadExecutionPolicy.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadExecutionPolicy.java
@@ -1,0 +1,49 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import java.util.Locale;
+import java.util.Objects;
+
+/** Selects the Java thread implementation used to execute Perl ithreads. */
+public final class PerlThreadExecutionPolicy {
+    static final String MODE_PROPERTY = "jperl.thread.mode";
+    static final String MODE_ENVIRONMENT = "JPERL_THREAD_MODE";
+    private static final PerlThreadExecutionPolicy CONFIGURED =
+            resolve(System.getProperty(MODE_PROPERTY), System.getenv(MODE_ENVIRONMENT));
+
+    public enum Mode { PLATFORM, VIRTUAL }
+
+    private final Mode mode;
+
+    private PerlThreadExecutionPolicy(Mode mode) {
+        this.mode = Objects.requireNonNull(mode, "mode");
+    }
+
+    /** Resolve the process-wide opt-in. The stable default remains platform threads. */
+    public static PerlThreadExecutionPolicy configured() {
+        return CONFIGURED;
+    }
+
+    static PerlThreadExecutionPolicy resolve(String propertyValue, String environmentValue) {
+        String value = propertyValue != null ? propertyValue : environmentValue;
+        if (value == null || value.isBlank()) return new PerlThreadExecutionPolicy(Mode.PLATFORM);
+
+        return switch (value.strip().toLowerCase(Locale.ROOT)) {
+            case "platform" -> new PerlThreadExecutionPolicy(Mode.PLATFORM);
+            case "virtual" -> new PerlThreadExecutionPolicy(Mode.VIRTUAL);
+            default -> throw new IllegalArgumentException(
+                    "Unsupported Perl thread mode '" + value + "'; expected platform or virtual");
+        };
+    }
+
+    public Mode mode() {
+        return mode;
+    }
+
+    public Thread unstarted(long id, Runnable task) {
+        Objects.requireNonNull(task, "task");
+        String name = "perl-ithread-" + id;
+        return mode == Mode.VIRTUAL
+                ? Thread.ofVirtual().name(name).unstarted(task)
+                : Thread.ofPlatform().name(name).unstarted(task);
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCodeRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCodeRuntimeState.java
@@ -53,6 +53,15 @@ public final class RuntimeCodeRuntimeState {
         return "(eval " + nextRuntimeEvalId++ + ")";
     }
 
+    /**
+     * Copy immutable compile-time descriptors referenced by cloned CODE objects.
+     * Runtime eval results, generated-class caches, inline caches, and allocation
+     * counters deliberately remain private to the fresh child runtime.
+     */
+    void snapshotCompiledMetadataInto(RuntimeCodeRuntimeState child) {
+        child.evalContexts.putAll(evalContexts);
+    }
+
     RuntimeCode cachedInlineMethod(int callsiteId, int blessId, int methodHash) {
         int index = callsiteId & (METHOD_CALL_CACHE_SIZE - 1);
         return inlineCacheBlessId[index] == blessId

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
@@ -193,6 +193,13 @@ public class RuntimeGraphCloner {
                         }
                     }
                 }
+                // Lazy compilation may have registered eval STRING descriptors
+                // after the thread's initial runtime snapshot.  Copy only that
+                // compiled metadata before installing the completed child CODE.
+                sourceRuntime.runtimeCodeState().snapshotCompiledMetadataInto(
+                        targetRuntime.runtimeCodeState());
+                sourceRuntime.globalState().snapshotCompiledCodeRefsInto(
+                        targetRuntime.globalState(), this);
                 RuntimeCode completed;
                 try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
                     completed = (RuntimeCode) new RuntimeGraphCloner(

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/SharedPerlStorage.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/SharedPerlStorage.java
@@ -1,12 +1,30 @@
 package org.perlonjava.runtime.runtimetypes;
 
 import java.util.Collections;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 /** Marker and first-tranche synchronization policy for threads::shared. */
 public final class SharedPerlStorage {
+    private static final Map<RuntimeBase, LockState> LOCKS =
+            Collections.synchronizedMap(new IdentityHashMap<>());
+    private static final Map<RuntimeBase, ArrayDeque<Waiter>> WAITERS =
+            Collections.synchronizedMap(new IdentityHashMap<>());
+
     private SharedPerlStorage() {}
+
+    private static final class LockState {
+        final ReentrantLock lock = new ReentrantLock();
+    }
+
+    private record Waiter(CountDownLatch latch) {}
 
     public static RuntimeBase referent(RuntimeScalar reference) {
         if (reference == null) return null;
@@ -15,6 +33,11 @@ public final class SharedPerlStorage {
 
     public static RuntimeBase share(RuntimeScalar reference) {
         RuntimeBase root = referent(reference);
+        return shareValue(root);
+    }
+
+    /** Mark declaration storage directly, without manufacturing a reference wrapper. */
+    public static RuntimeBase shareValue(RuntimeBase root) {
         if (root == null) throw new IllegalArgumentException("share requires a scalar, array, or hash reference");
         markGraph(root, Collections.newSetFromMap(new IdentityHashMap<>()));
         return root;
@@ -30,6 +53,134 @@ public final class SharedPerlStorage {
         RuntimeScalar clone = new RuntimeGraphCloner(runtime, runtime).cloneGraph(reference);
         share(clone);
         return clone;
+    }
+
+    /** Acquire a recursive advisory lock until the surrounding Perl scope exits. */
+    public static RuntimeBase lock(RuntimeScalar reference) {
+        RuntimeBase root = requireShared(reference, "lock");
+        LockState state = lockState(root);
+        state.lock.lock();
+        DynamicVariableManager.pushLocalVariable(new DynamicState() {
+            @Override
+            public void dynamicSaveState() {
+                // The acquisition precedes registration so failed acquisition cannot leak a guard.
+            }
+
+            @Override
+            public void dynamicRestoreState() {
+                state.lock.unlock();
+            }
+
+            @Override
+            public Object dynamicSuspendState() {
+                state.lock.unlock();
+                return null;
+            }
+
+            @Override
+            public void dynamicResumeState(Object token) {
+                state.lock.lock();
+            }
+        });
+        return root;
+    }
+
+    /** Wait indefinitely, atomically publishing the waiter before releasing the lock. */
+    public static boolean conditionWait(RuntimeScalar conditionReference, RuntimeScalar lockReference) {
+        return conditionWait(conditionReference, lockReference, 0, false);
+    }
+
+    /** Wait until an absolute Unix timestamp (seconds), returning false on timeout. */
+    public static boolean conditionTimedWait(RuntimeScalar conditionReference,
+                                             RuntimeScalar lockReference,
+                                             double deadlineSeconds) {
+        return conditionWait(conditionReference, lockReference, deadlineSeconds, true);
+    }
+
+    public static boolean conditionSignal(RuntimeScalar conditionReference, boolean broadcast) {
+        RuntimeBase condition = requireShared(conditionReference,
+                broadcast ? "cond_broadcast" : "cond_signal");
+        if (!lockState(condition).lock.isHeldByCurrentThread()) {
+            return false;
+        }
+
+        List<Waiter> wake = new ArrayList<>();
+        synchronized (WAITERS) {
+            ArrayDeque<Waiter> queue = WAITERS.get(condition);
+            if (queue != null) {
+                if (broadcast) {
+                    while (!queue.isEmpty()) wake.add(queue.removeFirst());
+                } else if (!queue.isEmpty()) {
+                    wake.add(queue.removeFirst());
+                }
+                if (queue.isEmpty()) WAITERS.remove(condition);
+            }
+        }
+        for (Waiter waiter : wake) waiter.latch().countDown();
+        return true;
+    }
+
+    private static boolean conditionWait(RuntimeScalar conditionReference,
+                                         RuntimeScalar lockReference,
+                                         double deadlineSeconds,
+                                         boolean timed) {
+        RuntimeBase condition = requireShared(conditionReference,
+                timed ? "cond_timedwait" : "cond_wait");
+        RuntimeBase lockRoot = requireShared(lockReference,
+                timed ? "cond_timedwait" : "cond_wait");
+        ReentrantLock lock = lockState(lockRoot).lock;
+        if (!lock.isHeldByCurrentThread()) {
+            throw new IllegalStateException((timed ? "cond_timedwait" : "cond_wait")
+                    + "() called on unlocked variable");
+        }
+
+        Waiter waiter = new Waiter(new CountDownLatch(1));
+        synchronized (WAITERS) {
+            WAITERS.computeIfAbsent(condition, ignored -> new ArrayDeque<>()).addLast(waiter);
+        }
+
+        int holds = lock.getHoldCount();
+        for (int i = 0; i < holds; i++) lock.unlock();
+        boolean signalled = false;
+        try {
+            if (timed) {
+                long nanos = Math.max(0L, (long) ((deadlineSeconds
+                        - System.currentTimeMillis() / 1000.0) * 1_000_000_000L));
+                signalled = waiter.latch().await(nanos, TimeUnit.NANOSECONDS);
+            } else {
+                waiter.latch().await();
+                signalled = true;
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting on shared condition", interrupted);
+        } finally {
+            if (!signalled) {
+                synchronized (WAITERS) {
+                    ArrayDeque<Waiter> queue = WAITERS.get(condition);
+                    if (queue != null) {
+                        queue.remove(waiter);
+                        if (queue.isEmpty()) WAITERS.remove(condition);
+                    }
+                }
+            }
+            for (int i = 0; i < holds; i++) lock.lock();
+        }
+        return signalled;
+    }
+
+    private static LockState lockState(RuntimeBase root) {
+        synchronized (LOCKS) {
+            return LOCKS.computeIfAbsent(root, ignored -> new LockState());
+        }
+    }
+
+    private static RuntimeBase requireShared(RuntimeScalar reference, String operation) {
+        RuntimeBase root = referent(reference);
+        if (root == null || !root.threadShared) {
+            throw new IllegalArgumentException(operation + " requires a shared variable");
+        }
+        return root;
     }
 
     private static void markGraph(RuntimeBase value, Set<RuntimeBase> seen) {

--- a/src/main/perl/lib/Config.pm
+++ b/src/main/perl/lib/Config.pm
@@ -261,9 +261,11 @@ my $startperl = $is_windows
     d_flock => 'define',
     d_fcntl_can_lock => 'define',
 
-    ## # Threading
-    ## useithreads => 'define',
-    ## usethreads => 'define',
+    # Interpreter threading and multiplicity are provided by isolated
+    # PerlRuntime instances backed by JVM threads.
+    useithreads => 'define',
+    usethreads => 'define',
+    usemultiplicity => 'define',
 
     # Sizes (Java platform - 64-bit integer model)
     shortsize => '2',

--- a/src/main/perl/lib/Plack/Handler/Netty.pm
+++ b/src/main/perl/lib/Plack/Handler/Netty.pm
@@ -306,7 +306,8 @@ The handler provides all required PSGI 1.1 environment keys:
 
 =item * C<psgi.errors> - Error log (STDERR)
 
-=item * C<psgi.multithread> - \0 (PerlOnJava doesn't support threads)
+=item * C<psgi.multithread> - \0. PerlOnJava supports explicit ithreads, but
+this handler owns one application runtime and does not invoke it concurrently.
 
 =item * C<psgi.multiprocess> - \0 (PerlOnJava doesn't support fork)
 

--- a/src/main/perl/lib/threads.pm
+++ b/src/main/perl/lib/threads.pm
@@ -31,15 +31,65 @@ sub equal { return defined($_[0]) && defined($_[1]) && $_[0]->tid == $_[1]->tid 
 sub _stringify { return 'threads=' . $_[0]->tid }
 
 sub import {
+    shift;
     my $caller = caller;
+    my @exports = ('async');
+
+    while (my $option = shift) {
+        if ($option eq 'yield' || $option eq ':all') {
+            push @exports, 'yield';
+        }
+        elsif ($option =~ /^str/i) {
+            overload->import('""' => \&tid);
+        }
+        elsif ($option =~ /^(?:stack|exit)/i) {
+            my $value = shift;
+            require Carp;
+            Carp::croak("threads: Missing argument for option: $option")
+                unless defined $value;
+            # PerlOnJava owns JVM stack sizing and threads->exit is always
+            # thread-only. Accept the standard import spellings so portable
+            # programs can declare their intent without changing semantics.
+        }
+        else {
+            require Carp;
+            Carp::croak("threads: Unknown import option: $option");
+        }
+    }
+
     no strict 'refs';
-    *{"${caller}::async"} = \&async;
+    *{"${caller}::$_"} = \&{$_} for @exports;
 }
 
 use overload
     '==' => 'equal',
-    'eq' => 'equal',
+    '!=' => sub { !equal(@_) },
     '""' => '_stringify',
     fallback => 1;
 
 1;
+
+__END__
+
+=head1 NAME
+
+threads - PerlOnJava interpreter threads
+
+=head1 IMPORT OPTIONS
+
+C<async> is exported by default. C<yield> and C<:all> also export C<yield>.
+C<stringify> changes string conversion of a thread object from the stable
+C<threads=ID> form to its numeric thread ID.
+
+The standard C<stack_size> and C<exit> declarations are accepted for source
+compatibility. JVM stack sizing is runtime-managed, and C<threads-E<gt>exit>
+always exits only the calling child ithread. Missing values and unknown import
+options are errors.
+
+=head1 COMPATIBILITY
+
+The supported lifecycle is C<create>/C<async>, C<self>, C<tid>, C<list>,
+C<join>, and C<detach>, together with state and error inspection. Thread
+signals (C<kill>), per-thread stack sizing, C<object>, and C<wantarray> are not
+yet implemented. Shared storage, locks, and condition variables are provided
+by L<threads::shared> for its documented scalar, array, and hash tranche.

--- a/src/main/perl/lib/threads/shared.pm
+++ b/src/main/perl/lib/threads/shared.pm
@@ -4,11 +4,16 @@ use strict;
 use warnings;
 
 our $VERSION = '1.69';
-our @EXPORT = qw(share is_shared shared_clone);
+our @EXPORT = qw(share is_shared shared_clone cond_wait cond_timedwait
+                 cond_signal cond_broadcast);
 
 sub share (\[$@%]) { return _share($_[0]) }
 sub is_shared { return _is_shared($_[0]) }
 sub shared_clone { return _shared_clone($_[0]) }
+sub cond_wait (\[$@%];\[$@%]) { return _cond_wait(@_) }
+sub cond_timedwait (\[$@%]$;\[$@%]) { return _cond_timedwait(@_) }
+sub cond_signal (\[$@%]) { return _cond_signal($_[0]) }
+sub cond_broadcast (\[$@%]) { return _cond_broadcast($_[0]) }
 
 sub import {
     my $caller = caller;

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlockTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlockTest.java
@@ -18,6 +18,8 @@ class PerlThreadControlBlockTest {
                     child -> new RuntimeScalar(child.perlThreadId())).start();
             PerlThreadControlBlock second = PerlThreadControlBlock.create(parent,
                     child -> new RuntimeScalar(child.perlThreadId())).start();
+            assertEquals("perl-ithread-" + first.id(), first.javaThreadName());
+            assertEquals(first.platformThread().isVirtual(), first.isVirtualThread());
             assertNotEquals(first.id(), second.id());
             assertEquals(0, first.parentId());
             assertEquals(first.id(), ((RuntimeScalar) first.join().value()).getLong());

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlThreadExecutionPolicyTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlThreadExecutionPolicyTest.java
@@ -1,0 +1,61 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class PerlThreadExecutionPolicyTest {
+    @Test
+    void defaultsToPlatformThreadsAndAllowsEnvironmentOptIn() {
+        assertEquals(PerlThreadExecutionPolicy.Mode.PLATFORM,
+                PerlThreadExecutionPolicy.resolve(null, null).mode());
+        assertEquals(PerlThreadExecutionPolicy.Mode.VIRTUAL,
+                PerlThreadExecutionPolicy.resolve(null, "virtual").mode());
+    }
+
+    @Test
+    void systemPropertyTakesPrecedenceOverEnvironment() {
+        assertEquals(PerlThreadExecutionPolicy.Mode.PLATFORM,
+                PerlThreadExecutionPolicy.resolve("platform", "virtual").mode());
+        assertEquals(PerlThreadExecutionPolicy.Mode.VIRTUAL,
+                PerlThreadExecutionPolicy.resolve(" VIRTUAL ", "platform").mode());
+    }
+
+    @Test
+    void rejectsUnknownModes() {
+        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+                () -> PerlThreadExecutionPolicy.resolve("pooled", null));
+        assertTrue(failure.getMessage().contains("platform or virtual"));
+    }
+
+    @Test
+    void processConfigurationIsImmutable() {
+        assertSame(PerlThreadExecutionPolicy.configured(), PerlThreadExecutionPolicy.configured());
+    }
+
+    @Test
+    void createsNamedPlatformAndVirtualThreadsWithEquivalentCompletion() throws Exception {
+        assertThread(PerlThreadExecutionPolicy.resolve("platform", null), false, 41);
+        assertThread(PerlThreadExecutionPolicy.resolve("virtual", null), true, 42);
+    }
+
+    private static void assertThread(
+            PerlThreadExecutionPolicy policy, boolean virtual, long id) throws Exception {
+        CountDownLatch ran = new CountDownLatch(1);
+        Thread thread = policy.unstarted(id, ran::countDown);
+
+        assertEquals("perl-ithread-" + id, thread.getName());
+        assertEquals(virtual, thread.isVirtual());
+        assertEquals(Thread.State.NEW, thread.getState());
+
+        thread.start();
+        assertTrue(ran.await(5, TimeUnit.SECONDS));
+        thread.join(TimeUnit.SECONDS.toMillis(5));
+        assertFalse(thread.isAlive());
+    }
+}

--- a/src/test/resources/unit/threads_basic_unadvertised.t
+++ b/src/test/resources/unit/threads_basic_unadvertised.t
@@ -12,8 +12,8 @@ sub check {
 }
 
 my $advertised = $Config{useithreads} || '';
-check($Config{archname} =~ /^java-/ ? !$advertised : $advertised,
-    'thread capability flag matches the active implementation');
+check($advertised eq 'define',
+    'thread capability flag advertises the active implementation');
 check(threads->self->tid == 0, 'main thread has tid zero');
 
 my $parent = 10;
@@ -41,4 +41,4 @@ my $detached = async { 7 };
 $detached->detach;
 check($detached->is_detached, 'async and detach work');
 check(threads->self == threads->self, 'overloaded equality uses tid');
-check("" . threads->self =~ /^threads=/, 'thread stringification is stable');
+check("" . threads->self =~ /^threads=/, 'default thread stringification is stable');

--- a/src/test/resources/unit/threads_compatibility_activation.t
+++ b/src/test/resources/unit/threads_compatibility_activation.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Config;
+use threads qw(:all stringify stack_size 65536 exit thread_only);
+
+print "1..10\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - ", $name, "\n");
+}
+
+check($Config{useithreads} eq 'define', 'Config advertises ithreads');
+check($Config{usethreads} eq 'define', 'Config advertises threads');
+check($Config{usemultiplicity} eq 'define', 'Config advertises multiplicity');
+check(defined &async, 'async is exported by default');
+check(defined &yield, ':all exports yield');
+check(!defined yield(), 'yield returns undef');
+check("" . threads->self eq threads->self->tid,
+    'stringify option renders the thread id');
+
+my $unknown = eval q{ package UnknownImport; threads->import('bogus'); 1 };
+check(!$unknown && $@ =~ /threads: Unknown import option: bogus/,
+    'unknown import options are rejected');
+my $missing = eval q{ package MissingImport; threads->import('stack_size'); 1 };
+check(!$missing && $@ =~ /threads: Missing argument for option: stack_size/,
+    'missing import arguments are rejected');
+
+my $thread = async { threads->self->tid };
+check($thread->join > 0, 'activated async creates an isolated ithread');

--- a/src/test/resources/unit/threads_eval_string.t
+++ b/src/test/resources/unit/threads_eval_string.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use threads;
+use threads::shared;
+
+print "1..3\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - ", $name, "\n");
+}
+
+sub redefine_from_string {
+    eval 'no warnings; sub eval_string_target { 42 }; 1' or die $@;
+    return eval_string_target();
+}
+
+sub call_eval_sub {
+    return redefine_from_string();
+}
+
+my $thread = threads->create(sub { return call_eval_sub() });
+check($thread->join == 42, 'child first-caller materializes cloned eval site');
+check(!$thread->error, 'child eval leaves no thread error');
+check(redefine_from_string() == 42, 'parent executes materialized eval site');

--- a/src/test/resources/unit/threads_inplace_edit.t
+++ b/src/test/resources/unit/threads_inplace_edit.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use File::Temp qw(tempfile);
+use threads;
+
+print "1..3\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - ", $name, "\n");
+}
+
+my ($source, $path) = tempfile();
+print {$source} "before\n";
+close $source;
+
+@ARGV = ($path);
+local $^I = '';
+while (<>) {
+    threads->create(sub { return 1 })->join;
+    print "after\n";
+}
+
+check(1, 'stdout is restored after threaded in-place editing');
+open my $result, '<', $path or die "Cannot read $path: $!";
+my $contents = do { local $/; <$result> };
+close $result;
+check($contents eq "after\n", 'in-place output replaces the source contents');
+check(unlink($path), 'temporary edited file is removed');

--- a/src/test/resources/unit/threads_lock_compatibility.t
+++ b/src/test/resources/unit/threads_lock_compatibility.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use threads;
+
+print "1..3\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - ", $name, "\n");
+}
+
+my ($scalar, @array, %hash);
+
+check(\lock($scalar) == \$scalar,
+    'scalar lock is compatible before threads::shared loads');
+check(lock(@array) == \@array,
+    'array lock is compatible before threads::shared loads');
+check(lock(%hash) == \%hash,
+    'hash lock is compatible before threads::shared loads');

--- a/src/test/resources/unit/threads_lock_conditions_unadvertised.t
+++ b/src/test/resources/unit/threads_lock_conditions_unadvertised.t
@@ -1,0 +1,128 @@
+use strict;
+use warnings;
+use threads;
+use threads::shared;
+use Time::HiRes qw(time usleep);
+
+print "1..12\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - ", $name, "\n");
+}
+
+my $recursive :shared = 3;
+{
+    lock($recursive);
+    {
+        lock($recursive);
+        ++$recursive;
+    }
+    ++$recursive;
+}
+check($recursive == 5, 'lock is recursive');
+
+my $exceptional :shared = 0;
+eval {
+    lock($exceptional);
+    $exceptional = 1;
+    die "leave locked scope\n";
+};
+my $after_exception = threads->create(sub {
+    lock($exceptional);
+    return ++$exceptional;
+})->join;
+check($after_exception == 2, 'exceptional scope exit releases lock');
+
+my $condition :shared;
+my $ready :shared = 0;
+my $go :shared = 0;
+my @waiters = map {
+    threads->create(sub {
+        lock($condition);
+        ++$ready;
+        cond_wait($condition) until $go;
+        return 1;
+    })
+} 1 .. 2;
+
+my $saw_both;
+for (1 .. 500) {
+    {
+        lock($condition);
+        if ($ready == 2) {
+            $saw_both = 1;
+            $go = 1;
+            cond_broadcast($condition);
+            last;
+        }
+    }
+    usleep(10_000);
+}
+check($saw_both, 'both condition waiters registered');
+my $woken = 0;
+for my $waiter (@waiters) {
+    my $result = $waiter->join;
+    ++$woken if $result == 1;
+}
+check($woken == 2, 'cond_broadcast wakes all waiters');
+
+my $signal_condition :shared;
+my $signal_lock :shared;
+my $signal_ready :shared = 0;
+my $signal_value :shared = 0;
+my $one = threads->create(sub {
+    lock($signal_lock);
+    $signal_ready = 1;
+    cond_wait($signal_condition, $signal_lock) until $signal_value;
+    return $signal_value;
+});
+usleep(10_000) until $signal_ready;
+{
+    lock($signal_condition);
+    $signal_value = 7;
+    cond_signal($signal_condition);
+}
+check($one->join == 7, 'two-variable cond_wait wakes after cond_signal');
+
+my $timed :shared;
+my ($timed_result, $elapsed, $still_locked);
+{
+    lock($timed);
+    my $start = time;
+    $timed_result = cond_timedwait($timed, $start + 0.10);
+    $elapsed = time - $start;
+    $still_locked = eval { cond_signal($timed); 1 };
+}
+check(!defined($timed_result), 'cond_timedwait returns undef on timeout');
+check($elapsed >= 0.07, 'cond_timedwait honors absolute deadline');
+check($still_locked, 'cond_timedwait reacquires lock after timeout');
+
+my $counter :shared = 0;
+my @workers = map {
+    threads->create(sub {
+        for (1 .. 100) {
+            lock($counter);
+            ++$counter;
+        }
+        return 1;
+    })
+} 1 .. 4;
+$_->join for @workers;
+check($counter == 400, 'lock serializes concurrent mutation');
+
+my $unlocked_warning = '';
+{
+    local $SIG{__WARN__} = sub { $unlocked_warning .= $_[0] };
+    cond_signal($condition);
+}
+check($unlocked_warning =~ /unlocked variable/,
+    'cond_signal diagnoses an unlocked condition');
+
+my $ordinary = 0;
+my $ordinary_error = eval 'lock($ordinary); 1';
+check((!$ordinary_error && $@ =~ /shared/),
+    'lock rejects an ordinary variable');
+
+check(1, 'phase 21 lock and condition test completed');


### PR DESCRIPTION
## Summary

- Phase 21: implement recursive lexical locks and condition variables for shared storage on both backends
- Phase 22: advertise the supported ithread surface through Config and document compatibility limits
- Phase 23: add an experimental virtual-thread opt-in while keeping platform threads as the default
- update the living plan with the measured upstream compatibility matrix and the next documentation/test tranche

## Validation

- `make`: PASS (399 tests, 2 skipped)
- focused Phase 21/22 tests: PASS on JVM and interpreter
- new/changed Perl tests: PASS on system Perl
- virtual-mode basic and lock/condition suites: PASS on Java 24
- Scalar::Util 1.70: PASS on JVM and interpreter
- JVM Moo constructor smoke: PASS
- `make test-all`: completed
  - Perl core: 260709/319705 (81.5%)
  - bundled modules: 9758/12192 (80.0%)

The activated upstream thread inventory currently reaches 24/30 in
`op/threads.t`, 2/4 in `class/threads.t`, 5/6 in `re/stclass_threads.t`, 1/2 in
Storable's thread test, and completes `threads-dirh.t`. These measured gaps are
recorded as follow-up work.

## Phase 23 status

Platform threads remain the default. Virtual threads require
`-Djperl.thread.mode=virtual` or `JPERL_THREAD_MODE=virtual`. The Java 24 smoke
benchmark measured 30 create/join operations at 0.544s platform versus 0.543s
virtual with identical output, so no performance claim is made. Java 22 pinning
diagnostics remain required before promotion, and runtime pooling is deferred
until a complete safe-reset proof exists.
