### PR TITLE
Fix CPAN async and chemistry compiler/tooling failures

### DIFF
--- a/dev/design/cpan-compiler-tooling-batch.md
+++ b/dev/design/cpan-compiler-tooling-batch.md
@@ -1,0 +1,81 @@
+# CPAN compiler and tooling compatibility batch
+
+## Goal
+
+Make the system-Perl-compatible surfaces of the following targets work through
+`jcpan`, fixing reusable compiler, runtime, and CPAN tooling behavior instead of
+adding distribution preferences:
+
+- `Catalyst::Plugin::AuthenCookie`
+- `App::Timestamper::WithElapsed`
+- `Chemistry::File::SMILES`
+- `Net::DRI`
+- `Catalyst::Action::FromPSGI`
+
+Reuse bundled Java providers such as BouncyCastle when native CPAN dependencies
+need equivalent primitives.
+
+## Baseline
+
+| Target | System Perl | PerlOnJava baseline |
+| --- | --- | --- |
+| Catalyst::Plugin::AuthenCookie | Current system `HTTP::Cookies` discards the test's already-expired March 2020 cookie, so the upstream assertion is no longer green | Outside compatibility target |
+| App::Timestamper::WithElapsed | 2 files / 4 assertions pass | output subprocess spins after consuming redirected stdin because `select` never reports EOF |
+| Chemistry::File::SMILES | 9 files / 82 assertions pass | 8 files pass; `t/parse.t` hits invalid JVM bytecode for `local undef $/` |
+| Net::DRI | Fails under Perl 5.42, including an illegal `{1.4}` regex in the distribution itself | Outside compatibility target |
+| Catalyst::Action::FromPSGI | Not needed for differential diagnosis | Passes after normal prerequisite resolution |
+
+## Implementation phases
+
+1. Support the legacy `local undef $var` form in both compiler backends.
+2. Make standard-input readiness report EOF without spinning async event loops.
+3. Re-run target suites, the full project suite, and orphan-process checks.
+
+## Progress tracking
+
+### Current status: Complete (2026-08-12)
+
+### Completed phases
+
+- [x] Baseline and system-Perl differential checks (2026-08-12)
+  - Confirmed SMILES and Timestamper pass under system Perl.
+  - Excluded Net::DRI because its current distribution fails under system Perl.
+  - Confirmed Catalyst::Action::FromPSGI passes after dependency resolution.
+- [x] Phase 1: compiler support for `local undef` (2026-08-12)
+  - Both JVM and interpreter compilers now treat `local undef $var` as the
+    ordinary undef expression that Perl's parser exposes.
+  - Removed the invalid JVM operand-stack path that crashed ASM frame merging.
+  - Files: `EmitOperatorLocal.java`, `BytecodeCompiler.java`, `local_undef.t`.
+- [x] Phase 2: standard-input EOF readiness (2026-08-12)
+  - Standard descriptors now participate in the common `RuntimeIO` descriptor
+    lookup.
+  - Unix standard-input readiness uses native `poll(2)` through the existing FFM
+    layer, including the Linux/macOS `nfds_t` ABI difference.
+  - `StandardIO` records EOF from `sysread`, allowing async loops to stop instead
+    of polling forever.
+  - Files: `FFMPosixInterface.java`, `FFMPosixLinux.java`, `StandardIO.java`,
+    `FileDescriptorTable.java`, `RuntimeIO.java`, `stdin_select_eof.t`.
+- [x] Phase 3: end-to-end verification (2026-08-12)
+  - `App::Timestamper::WithElapsed`: 2 files / 4 assertions pass.
+  - `Chemistry::File::SMILES`: 9 files / 81 assertions pass; one optional POD
+    test skips because Test::Pod is not installed.
+  - `Catalyst::Action::FromPSGI`: 3 files / 18 assertions pass.
+  - Full `make` passes; the parallel unit suite reports 399 tests completed and
+    2 skipped.
+  - Both new unit tests were validated under system Perl before PerlOnJava.
+
+### Next steps
+
+1. No remaining work for the system-Perl-compatible requested surface.
+
+### Open questions
+
+- `Catalyst::Plugin::AuthenCookie` has a date-sensitive upstream assertion for a
+  March 2020 cookie which current system `HTTP::Cookies` discards as expired.
+- `Net::DRI` 0.96 fails under current system Perl, including a distribution
+  regex using the invalid quantifier `{1.4}`.
+
+## References
+
+- [Module porting guide](../../docs/guides/module-porting.md)
+- Skill: `debug-perlonjava`

--- a/dev/design/cpan-compiler-tooling-batch.md
+++ b/dev/design/cpan-compiler-tooling-batch.md
@@ -51,6 +51,9 @@ need equivalent primitives.
     lookup.
   - Unix standard-input readiness uses native `poll(2)` through the existing FFM
     layer, including the Linux/macOS `nfds_t` ABI difference.
+  - Windows standard-input readiness uses the existing FFM layer to inspect CRT
+    descriptors and Win32 disk, pipe, console, and EOF state without consuming
+    input.
   - `StandardIO` records EOF from `sysread`, allowing async loops to stop instead
     of polling forever.
   - Files: `FFMPosixInterface.java`, `FFMPosixLinux.java`, `StandardIO.java`,

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -3979,6 +3979,15 @@ public class BytecodeCompiler implements Visitor {
             }
             throwCompilerException("Unsupported our operand: " + node.operand.getClass().getSimpleName());
         } else if (op.equals("local")) {
+            // `local undef $var` is parsed by Perl as local(undef($var)).
+            // It performs the undef operation without registering restoration
+            // state for local(), so compile the operand as an ordinary expression.
+            if (node.operand instanceof OperatorNode operandOp
+                    && operandOp.operator.equals("undef")) {
+                compileNode(node.operand, -1, currentCallContext);
+                return;
+            }
+
             // local $x - temporarily localize a global variable
             // The operand will be OperatorNode("$", IdentifierNode("x"))
             if (node.operand instanceof OperatorNode sigilOp) {

--- a/src/main/java/org/perlonjava/backend/jvm/EmitOperatorLocal.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitOperatorLocal.java
@@ -21,6 +21,17 @@ public class EmitOperatorLocal {
         boolean isDeclaredReference = node.annotations != null &&
                 Boolean.TRUE.equals(node.annotations.get("isDeclaredReference"));
 
+        // Perl accepts the legacy spelling `local undef $/`, but parses it as
+        // local(undef($/)): the target is simply undefined and is not restored
+        // when the scope exits.  There is no lvalue for local() itself to save.
+        // Falling through to the generic localization path used to consume the
+        // undef result in VOID context and then invoke pushLocalVariable() with
+        // an empty operand stack, producing invalid JVM bytecode.
+        if (node.operand instanceof OperatorNode opNode && opNode.operator.equals("undef")) {
+            node.operand.accept(emitterVisitor);
+            return;
+        }
+
         if (node.operand instanceof OperatorNode opNode && opNode.operator.equals("$")) {
             // Check if the variable is global or 'our' variable
             if (opNode.operand instanceof IdentifierNode idNode) {

--- a/src/main/java/org/perlonjava/runtime/io/FileDescriptorTable.java
+++ b/src/main/java/org/perlonjava/runtime/io/FileDescriptorTable.java
@@ -162,13 +162,8 @@ public class FileDescriptorTable {
         if (handle instanceof ProcessInputHandle pih) {
             return pih.isReadReady();
         }
-        if (handle instanceof StandardIO) {
-            // stdin: check System.in.available()
-            try {
-                return System.in.available() > 0;
-            } catch (Exception e) {
-                return false;
-            }
+        if (handle instanceof StandardIO standardIO) {
+            return standardIO.isReadReady();
         }
         // For unknown handle types, report as ready to avoid blocking
         return true;

--- a/src/main/java/org/perlonjava/runtime/io/StandardIO.java
+++ b/src/main/java/org/perlonjava/runtime/io/StandardIO.java
@@ -182,7 +182,7 @@ public class StandardIO implements IOHandle {
         if (inputStream == null) {
             return false;
         }
-        if (!FFMPosix.isWindows() && FFMPosix.get().pollReadReady(fileno)) {
+        if (FFMPosix.get().pollReadReady(fileno)) {
             return true;
         }
         try {

--- a/src/main/java/org/perlonjava/runtime/io/StandardIO.java
+++ b/src/main/java/org/perlonjava/runtime/io/StandardIO.java
@@ -3,6 +3,7 @@ package org.perlonjava.runtime.io;
 import org.perlonjava.runtime.runtimetypes.RuntimeIO;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalarCache;
+import org.perlonjava.runtime.nativ.ffm.FFMPosix;
 
 import java.io.BufferedOutputStream;
 import java.io.IOException;
@@ -174,6 +175,24 @@ public class StandardIO implements IOHandle {
     }
 
     @Override
+    public boolean isReadReady() {
+        if (isEOF) {
+            return true;
+        }
+        if (inputStream == null) {
+            return false;
+        }
+        if (!FFMPosix.isWindows() && FFMPosix.get().pollReadReady(fileno)) {
+            return true;
+        }
+        try {
+            return inputStream.available() > 0;
+        } catch (IOException e) {
+            return true;
+        }
+    }
+
+    @Override
     public RuntimeScalar fileno() {
         return new RuntimeScalar(fileno);
     }
@@ -203,6 +222,7 @@ public class StandardIO implements IOHandle {
 
                 if (bytesRead == -1) {
                     // EOF
+                    isEOF = true;
                     return new RuntimeScalar("");
                 }
 

--- a/src/main/java/org/perlonjava/runtime/nativ/ffm/FFMPosixInterface.java
+++ b/src/main/java/org/perlonjava/runtime/nativ/ffm/FFMPosixInterface.java
@@ -148,6 +148,19 @@ public interface FFMPosixInterface {
      * @return 1 if terminal, 0 if not
      */
     int isatty(int fd);
+
+    /**
+     * Poll a native descriptor without blocking for readable data, EOF, or an
+     * error condition.  POSIX reports EOF as readable, which Java's
+     * {@code InputStream.available()} cannot distinguish from a temporarily
+     * empty pipe.
+     *
+     * @param fd native file descriptor
+     * @return true when a read would not block
+     */
+    default boolean pollReadReady(int fd) {
+        return false;
+    }
     
     // ==================== PTY/Terminal Functions ====================
     

--- a/src/main/java/org/perlonjava/runtime/nativ/ffm/FFMPosixLinux.java
+++ b/src/main/java/org/perlonjava/runtime/nativ/ffm/FFMPosixLinux.java
@@ -38,6 +38,7 @@ public class FFMPosixLinux implements FFMPosixInterface {
     private static MethodHandle getegidHandle;
     private static MethodHandle getppidHandle;
     private static MethodHandle isattyHandle;
+    private static MethodHandle pollHandle;
     private static MethodHandle umaskHandle;
     
     // Method handles that need errno capture
@@ -187,6 +188,14 @@ public class FFMPosixLinux implements FFMPosixInterface {
             isattyHandle = linker.downcallHandle(
                 stdlib.find("isatty").orElseThrow(),
                 FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT)
+            );
+
+            // int poll(struct pollfd *fds, nfds_t nfds, int timeout)
+            pollHandle = linker.downcallHandle(
+                stdlib.find("poll").orElseThrow(),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS,
+                    IS_MACOS ? ValueLayout.JAVA_INT : ValueLayout.JAVA_LONG,
+                    ValueLayout.JAVA_INT)
             );
             
             umaskHandle = linker.downcallHandle(
@@ -853,6 +862,30 @@ public class FFMPosixLinux implements FFMPosixInterface {
             return (int) isattyHandle.invokeExact(fd);
         } catch (Throwable e) {
             return 0;
+        }
+    }
+
+    @Override
+    public boolean pollReadReady(int fd) {
+        ensureInitialized();
+        try (Arena arena = Arena.ofConfined()) {
+            // pollfd is { int fd; short events; short revents } on Linux and macOS.
+            MemorySegment pollfd = arena.allocate(8, 4);
+            pollfd.set(ValueLayout.JAVA_INT, 0, fd);
+            pollfd.set(ValueLayout.JAVA_SHORT, 4, (short) 0x0001); // POLLIN
+            pollfd.set(ValueLayout.JAVA_SHORT, 6, (short) 0);
+            int result = IS_MACOS
+                    ? (int) pollHandle.invokeExact(pollfd, 1, 0)
+                    : (int) pollHandle.invokeExact(pollfd, 1L, 0);
+            if (result <= 0) {
+                return false;
+            }
+            short revents = pollfd.get(ValueLayout.JAVA_SHORT, 6);
+            // POLLIN, POLLERR, POLLHUP, and POLLNVAL all mean a read will not
+            // wait for future input (it will return data, EOF, or an error).
+            return (revents & (0x0001 | 0x0008 | 0x0010 | 0x0020)) != 0;
+        } catch (Throwable e) {
+            return false;
         }
     }
     

--- a/src/main/java/org/perlonjava/runtime/nativ/ffm/FFMPosixWindows.java
+++ b/src/main/java/org/perlonjava/runtime/nativ/ffm/FFMPosixWindows.java
@@ -59,6 +59,12 @@ public class FFMPosixWindows implements FFMPosixInterface {
     private static MethodHandle winReadHandle;
     private static MethodHandle winWriteHandle;
     private static MethodHandle winLseekHandle;
+    private static MethodHandle winGetOsfHandle;
+    private static MethodHandle winGetFileType;
+    private static MethodHandle winPeekNamedPipe;
+    private static MethodHandle winGetLastError;
+    private static MethodHandle winGetConsoleMode;
+    private static MethodHandle winGetNumberOfConsoleInputEvents;
     
     /**
      * Initialize FFM bindings for MSVCRT low-level FD operations on Windows.
@@ -69,6 +75,7 @@ public class FFMPosixWindows implements FFMPosixInterface {
         try {
             Linker linker = Linker.nativeLinker();
             SymbolLookup ucrt = SymbolLookup.libraryLookup("ucrtbase", Arena.global());
+            SymbolLookup kernel32 = SymbolLookup.libraryLookup("kernel32", Arena.global());
             
             // int _pipe(int *pfds, unsigned int psize, int textmode)
             winPipeHandle = linker.downcallHandle(
@@ -110,6 +117,42 @@ public class FFMPosixWindows implements FFMPosixInterface {
             winLseekHandle = linker.downcallHandle(
                 ucrt.find("_lseek").orElseThrow(),
                 FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.JAVA_INT, ValueLayout.JAVA_INT, ValueLayout.JAVA_INT)
+            );
+
+            // intptr_t _get_osfhandle(int fd)
+            winGetOsfHandle = linker.downcallHandle(
+                ucrt.find("_get_osfhandle").orElseThrow(),
+                FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT)
+            );
+
+            // DWORD GetFileType(HANDLE handle)
+            winGetFileType = linker.downcallHandle(
+                kernel32.find("GetFileType").orElseThrow(),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS)
+            );
+
+            // BOOL PeekNamedPipe(HANDLE, void *, DWORD, DWORD *, DWORD *, DWORD *)
+            winPeekNamedPipe = linker.downcallHandle(
+                kernel32.find("PeekNamedPipe").orElseThrow(),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                    ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_INT,
+                    ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS)
+            );
+
+            winGetLastError = linker.downcallHandle(
+                kernel32.find("GetLastError").orElseThrow(),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT)
+            );
+
+            // Console handles need an event-count check; other character
+            // devices such as NUL are immediately readable at EOF.
+            winGetConsoleMode = linker.downcallHandle(
+                kernel32.find("GetConsoleMode").orElseThrow(),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS)
+            );
+            winGetNumberOfConsoleInputEvents = linker.downcallHandle(
+                kernel32.find("GetNumberOfConsoleInputEvents").orElseThrow(),
+                FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS)
             );
             
             fdOpsInitialized = true;
@@ -366,6 +409,59 @@ public class FFMPosixWindows implements FFMPosixInterface {
             return (fd >= 0 && fd <= 2) ? 1 : 0;
         }
         return 0;
+    }
+
+    @Override
+    public boolean pollReadReady(int fd) {
+        try (Arena arena = Arena.ofConfined()) {
+            ensureFdOpsInitialized();
+            long rawHandle = (long) winGetOsfHandle.invokeExact(fd);
+            if (rawHandle == -1L) {
+                return false;
+            }
+
+            MemorySegment handle = MemorySegment.ofAddress(rawHandle);
+            int fileType = (int) winGetFileType.invokeExact(handle);
+
+            // Regular files never block: EOF is readable just like on POSIX.
+            if (fileType == 0x0001) { // FILE_TYPE_DISK
+                return true;
+            }
+
+            if (fileType == 0x0003) { // FILE_TYPE_PIPE
+                MemorySegment bytesAvailable = arena.allocate(ValueLayout.JAVA_INT);
+                int ok = (int) winPeekNamedPipe.invokeExact(
+                    handle, MemorySegment.NULL, 0, MemorySegment.NULL,
+                    bytesAvailable, MemorySegment.NULL
+                );
+                if (ok != 0) {
+                    return bytesAvailable.get(ValueLayout.JAVA_INT, 0) > 0;
+                }
+
+                int error = (int) winGetLastError.invokeExact();
+                // A closed or disconnected pipe makes read return EOF/error
+                // immediately, and is therefore readable for select().
+                return error == 109  // ERROR_BROKEN_PIPE
+                    || error == 232  // ERROR_NO_DATA
+                    || error == 233; // ERROR_PIPE_NOT_CONNECTED
+            }
+
+            if (fileType == 0x0002) { // FILE_TYPE_CHAR
+                MemorySegment mode = arena.allocate(ValueLayout.JAVA_INT);
+                int isConsole = (int) winGetConsoleMode.invokeExact(handle, mode);
+                if (isConsole == 0) {
+                    // NUL and other redirected character devices do not wait
+                    // for future console input.
+                    return true;
+                }
+                MemorySegment eventCount = arena.allocate(ValueLayout.JAVA_INT);
+                int ok = (int) winGetNumberOfConsoleInputEvents.invokeExact(handle, eventCount);
+                return ok != 0 && eventCount.get(ValueLayout.JAVA_INT, 0) > 0;
+            }
+        } catch (Throwable e) {
+            return false;
+        }
+        return false;
     }
     
     // ==================== PTY/Terminal Functions ====================

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
@@ -275,7 +275,16 @@ public class RuntimeIO extends RuntimeScalar {
      * Looks up a RuntimeIO by its assigned fileno.
      */
     public static RuntimeIO getByFileno(int fd) {
-        return registry().filenoToIO.get(fd);
+        RuntimeIO io = registry().filenoToIO.get(fd);
+        if (io != null) {
+            return io;
+        }
+        return switch (fd) {
+            case StandardIO.STDIN_FILENO -> getStdin();
+            case StandardIO.STDOUT_FILENO -> getStdout();
+            case StandardIO.STDERR_FILENO -> getStderr();
+            default -> null;
+        };
     }
 
     /**

--- a/src/test/resources/unit/local_undef.t
+++ b/src/test/resources/unit/local_undef.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+use Test::More tests => 6;
+
+$/ = "record";
+is($/, 'record', 'input record separator starts defined');
+
+{
+    local undef $/;
+    ok(!defined($/), 'local undef clears the target');
+}
+
+ok(!defined($/), 'local undef does not restore the target');
+
+sub slurp_with_legacy_local_undef {
+    my ($fh) = @_;
+    local undef $/;
+    return <$fh>;
+}
+
+my $input = "first\nsecond\n";
+open my $fh, '<', \$input or die $!;
+is(slurp_with_legacy_local_undef($fh), $input,
+    'legacy local undef idiom slurps a handle');
+
+my $callback = sub {
+    local undef $/;
+    return defined($/) ? 'defined' : 'undef';
+};
+
+is($callback->(), 'undef', 'local undef compiles inside a closure');
+ok(!defined($/), 'closure leaves the target undefined');

--- a/src/test/resources/unit/stdin_select_eof.t
+++ b/src/test/resources/unit/stdin_select_eof.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+my $readable = '';
+vec($readable, fileno(STDIN), 1) = 1;
+
+is(select($readable, undef, undef, 0.1), 1,
+    'select reports redirected stdin EOF as readable');
+is(vec($readable, fileno(STDIN), 1), 1,
+    'select retains the stdin readiness bit at EOF');


### PR DESCRIPTION
## Summary

- compile the legacy `local undef $var` form correctly in both execution backends
- make standard-input EOF visible to `select` and IO::Async through native `poll(2)` readiness
- add system-Perl-validated regressions and document the CPAN compatibility investigation

## CPAN verification

- `App::Timestamper::WithElapsed`: 2 files / 4 assertions pass
- `Chemistry::File::SMILES`: 9 files / 81 assertions pass; optional Test::Pod test skips
- `Catalyst::Action::FromPSGI`: 3 files / 18 assertions pass
- `Catalyst::Plugin::AuthenCookie`: excluded because its March 2020 cookie assertion now fails under system Perl
- `Net::DRI` 0.96: excluded because the distribution fails under system Perl 5.42, including an invalid `{1.4}` regex

## Test plan

- [x] validate new unit tests with system Perl
- [x] run new unit tests with the JVM and interpreter backends
- [x] run the requested system-Perl-compatible CPAN suites
- [x] run full `make`

Generated with [Codex](https://openai.com/codex)
