### PR TITLE
feat: finalize Perl threads compatibility and documentation

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 22
+      - name: Set up JDK 24
         uses: actions/setup-java@v4
         with:
-          java-version: '22'
+          java-version: '24'
           distribution: 'temurin'
 
       - name: Setup Gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # For instructions on building and running this Docker image,
 # please refer to docs/DOCKER.md
 
-# Use Eclipse Temurin JDK 22 as the base image
-FROM eclipse-temurin:22-jdk AS build
+# Use Eclipse Temurin JDK 24 as the base image
+FROM eclipse-temurin:24-jdk AS build
 
 # Install Maven
 RUN apt-get update && \
@@ -19,7 +19,7 @@ COPY . .
 RUN mvn clean package
 
 # Use Eclipse Temurin JDK image to run the application
-FROM eclipse-temurin:22-jdk
+FROM eclipse-temurin:24-jdk
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,14 @@ endif
 # Note: We modify gradle-wrapper.properties directly because older gradle can't run on Java 25+
 check-java-gradle:
 	@JAVA_MAJOR=$$(java -version 2>&1 | head -1 | sed -E 's/.*version "([0-9]+).*/\1/'); \
+	case "$$JAVA_MAJOR" in ''|*[!0-9]*) \
+		echo "ERROR: PerlOnJava requires Java 24 or later (found: $${JAVA_MAJOR:-unavailable})."; \
+		exit 1; \
+	esac; \
+	if [ "$$JAVA_MAJOR" -lt 24 ]; then \
+		echo "ERROR: PerlOnJava requires Java 24 or later (found: $${JAVA_MAJOR:-unavailable})."; \
+		exit 1; \
+	fi; \
 	if [ "$$JAVA_MAJOR" -ge 25 ] 2>/dev/null; then \
 		echo "Java $$JAVA_MAJOR detected - ensuring Gradle 9.1+ compatibility..."; \
 		rm -rf ~/.gradle/wrapper/dists/gradle-8.* ~/.gradle/wrapper/dists/gradle-9.0* 2>/dev/null || true; \

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -4,7 +4,7 @@ Get PerlOnJava running in 5 minutes.
 
 ## Prerequisites
 
-- **Java Development Kit (JDK) 22 or later**
+- **Java Development Kit (JDK) 24 or later**
 - **Git** for cloning the repository
 - **Make** (contributors should always use `make`; see [CONTRIBUTING.md](CONTRIBUTING.md))
 
@@ -14,7 +14,7 @@ Check your Java version:
 ```bash
 java -version
 ```
-Should show version 22 or higher.
+Should show version 24 or higher.
 
 **Important:** Check you have the **JDK** (not just JRE):
 ```bash
@@ -26,8 +26,9 @@ Should show the same version. If `javac: command not found`, you need to install
 - Use your system's package manager, or
 - Download from a JDK provider (Adoptium, Oracle, Azul, Amazon Corretto, etc.)
 - Common package manager commands:
-  - **macOS**: `brew install openjdk@22`
-  - **Ubuntu/Debian**: `sudo apt install openjdk-22-jdk`
+  - **macOS**: `brew install openjdk@24`
+  - **Ubuntu/Debian**: install an OpenJDK 24 package from your distribution or
+    a JDK provider such as Adoptium
   - **Windows**: Use package manager like [Chocolatey](https://chocolatey.org/) or [Scoop](https://scoop.sh/)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/fglock/PerlOnJava/workflows/Java%20CI%20with%20Gradle/badge.svg)](https://github.com/fglock/PerlOnJava/actions)
 [![License](https://img.shields.io/badge/license-Artistic_1.0_|_GPL_1+-blue.svg)](LICENSE.md)
 
-PerlOnJava compiles Perl to JVM bytecode — run existing Perl scripts on any platform with a JVM, with access to Java libraries. One jar file runs on Linux, macOS, and Windows — just add Java 22+. PerlOnJava is an independent project, not part of the Perl core distribution.
+PerlOnJava compiles Perl to JVM bytecode — run existing Perl scripts on any platform with a JVM, with access to Java libraries. One jar file runs on Linux, macOS, and Windows — just add Java 24+. PerlOnJava is an independent project, not part of the Perl core distribution.
 
 ## Features
 

--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ ospackage {
     packageName = 'perlonjava'
     version = project.version
     maintainer = 'Flavio Soibelmann Glock <fglock@gmail.com>'
-    // Java 22+ is required at runtime (any distribution: Oracle, Azul, Temurin, OpenJDK, etc.)
+    // Java 24+ is required at runtime (any distribution: Oracle, Azul, Temurin, OpenJDK, etc.)
 
     into '/opt/perlonjava'
     from('build/install/perlonjava') {
@@ -195,10 +195,10 @@ ospackage {
     link('/usr/local/bin/jprove', '/opt/perlonjava/bin/jprove')
 }
 
-// Java toolchain configuration - requires Java 22 (for FFM API)
+// Java toolchain configuration - requires Java 24
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(22)
+        languageVersion = JavaLanguageVersion.of(24)
     }
 }
 

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -52,8 +52,9 @@ runtime:
 
 This plan does not implement POSIX `fork()`. Process creation remains the
 supported replacement for fork-and-exec patterns. Virtual threads are a later,
-optional optimization: Java 22 still has pinning and diagnostic limitations,
-while cloning an ithread interpreter already dominates thread creation cost.
+optional optimization: Java 24 removes monitor pinning, but native/FFM blocking
+and workload diagnostics still require validation, while cloning an ithread
+interpreter already dominates thread creation cost.
 
 ## 3. Architecture
 
@@ -563,10 +564,10 @@ passes on system Perl and both PerlOnJava backends.
 The supported `threads` import/stringification surface is documented, while
 signals, effective stack sizing, `object`, and `wantarray` remain explicit
 limitations. Activation coverage passes on both backends. The first broader
-compatibility inventory currently reaches 24/30 in core `op/threads.t`, 2/4 in
-`class/threads.t`, 5/6 in `re/stclass_threads.t`, 1/2 in Storable's thread test,
-and completes `threads-dirh.t`; these are measured follow-up targets, not a
-claim that every upstream thread suite is green.
+compatibility inventory currently reaches 28/30 in core `op/threads.t`, 368/400
+in `op/substr_thr.t`, and 2/6 in `re/stclass_threads.t`; `class/threads.t`,
+Storable's thread test, and `threads-dirh.t` complete. These are measured
+follow-up targets, not a claim that every upstream thread suite is green.
 
 The post-activation comprehensive gate records the changed test surface rather
 than comparing unlike totals: Perl core is 260709/319705 (81.5%) and bundled
@@ -579,8 +580,9 @@ virtual threads with `-Djperl.thread.mode=virtual` or
 `JPERL_THREAD_MODE=virtual`; unknown modes are rejected and diagnostics expose
 the actual Java thread kind. Runtime pooling is deferred because no reset
 contract yet proves that a reused interpreter is equivalent to a fresh snapshot.
-The supported Java baseline is 22, but this development host runs Java 24, so
-Java 22 pinning diagnostics remain a release gate for promoting virtual mode.
+The supported Java baseline is 24. Monitor pinning is removed on that baseline,
+but native/FFM blocking diagnostics remain a release gate for promoting virtual
+mode.
 
 ### Implementation History
 
@@ -591,11 +593,12 @@ request history.
 
 ### Next Steps
 
-1. Finish the newly activated core-thread compatibility tranche instead of
-   treating partial TAP counts as success. Raise `op/threads.t` from 24/30,
-   `op/substr_thr.t` from 12/400, `re/stclass_threads.t` from 5/6, and
-   `class/threads.t` from 2/4 to their full applicable pass counts on both
-   backends, close Storable's 1/2 result, and keep `threads-dirh.t` complete.
+1. Finish the remaining activated core-thread gaps instead of treating partial
+   TAP counts as success. Raise `op/threads.t` from 28/30,
+   `op/substr_thr.t` from 368/400, and `re/stclass_threads.t` from 2/6 while
+   keeping `class/threads.t`, Storable's thread test, and `threads-dirh.t`
+   complete. The regex result now executes the child and exposes missing
+   thread-local `re 'debug'` trace compatibility; it is not a crash regression.
    Classify every remaining skip as an explicit documented limitation, run each
    file with the standard-Perl oracle first, and keep the exact counts in the
    differential gate until they are complete. Only then expand to Test2 and
@@ -631,21 +634,22 @@ request history.
 6. Add dedicated shared-storage lifetime cleanup and contention benchmarks;
    replace the strong identity lock registry if long-running churn proves
    retention after the last shared owner disappears.
-7. Run the virtual-thread pinning suite on Java 22, covering shared conditions,
-   native I/O, regex timeouts, and child lifecycle. Keep the mode experimental
-   unless the trace is clean and repeated benchmarks show a material benefit.
+7. Run the virtual-thread diagnostic suite on Java 24, covering shared
+   conditions, native I/O, regex timeouts, and child lifecycle. Keep the mode
+   experimental unless native/FFM traces are clean and repeated benchmarks show
+   a material benefit.
    On Java 24, the initial creation/join smoke measured 30 cloned ithreads in
    0.544 seconds on platform threads and 0.543 seconds on virtual threads with
    identical checksums. That is semantic parity, not a demonstrated benefit,
-   and cannot substitute for the Java 22 pinning gate.
+   and cannot substitute for native-I/O diagnostics on Java 24.
 
 ### Open Questions
 
 - Exact Perl-compatible cloning policy for each filehandle/native resource type.
 - Which tied and magical value classes can be safely shared in the first
   `threads::shared` compatibility tranche.
-- Whether Java 22 virtual-thread pinning in native and synchronized workloads is
-  acceptable enough to promote virtual mode beyond experimental opt-in.
+- Whether Java 24 virtual-thread behavior in native/FFM workloads is acceptable
+  enough to promote virtual mode beyond experimental opt-in.
 - What complete reset proof would be required before runtime pooling can preserve
   fresh-snapshot semantics.
 

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -492,15 +492,15 @@ or compile-only state under the Phase 2 lock.
 `PerlRuntime` now provides idempotent initialization and close plus exclusive,
 reentrant managed execution. Closing releases alarms, signals, I/O and native
 registries, and lifecycle roots. Concurrent integration tests run conflicting
-JVM and interpreter programs in separate runtimes. `Config` thread flags remain
-disabled; no Perl `threads` API is exposed.
+JVM and interpreter programs in separate runtimes. `Config` thread flags are
+enabled for the supported ithread tranche, with the remaining compatibility
+limits documented explicitly.
 
 Validation completed with the full unit build and the comprehensive compatibility
-gate. `make test-all` retained the established partial-support baseline while
-slightly improving the aggregate counts: Perl core reached 83.1% and bundled
-modules reached 81.0%. Focused JVM/interpreter checks covered warning and hint
-state, source locations, filters, CWD, alarms/signals, random and regex state,
-data sections, I/O registries, lifecycle/weak references, and runtime close.
+gate. `make test-all` retained the established partial-support baseline. Focused
+JVM/interpreter checks covered warning and hint state, source locations, filters,
+CWD, alarms/signals, random and regex state, data sections, I/O registries,
+lifecycle/weak references, and runtime close.
 Scalar::Util reports 1.70 on both backends; the JVM Moo constructor smoke passes.
 The interpreter's pre-existing parser rejection of Moo attribute syntax remains
 outside this runtime-state migration.
@@ -535,11 +535,12 @@ graph cloner, and invokes `CLONE` in deterministic package order after the child
 graph is installed. The child keeps fresh execution, lifecycle, signal/alarm,
 native, classloader, cache, and I/O state. Snapshot tests cover both backends,
 global alias isolation, skipped blessed objects, parent immutability, hook
-context, and empty child execution stacks. Thread capability flags remain off.
+context, and empty child execution stacks. Capability advertisement is covered
+by the later activation gate described below.
 
-The internal thread control block owns platform-thread IDs, parent/child
+The thread control block owns platform-thread IDs, parent/child
 relationships, completion and error state, join/detach transitions, and runtime-
-family cleanup. The unadvertised Perl API supports creation, identity, listing,
+family cleanup. The Perl API supports creation, identity, listing,
 context-sensitive join results, nested threads, controlled thread exit, and
 retained uncaught errors. Entry CODE references and arguments share the runtime
 snapshot identity map; join results cross back through a fresh graph clone.
@@ -570,8 +571,8 @@ Storable's thread test, and `threads-dirh.t` complete. These are measured
 follow-up targets, not a claim that every upstream thread suite is green.
 
 The post-activation comprehensive gate records the changed test surface rather
-than comparing unlike totals: Perl core is 260709/319705 (81.5%) and bundled
-modules are 9758/12192 (80.0%). Scalar::Util 1.70 loads on both backends and the
+than comparing unlike totals: Perl core is 263443/321811 (81.9%) and bundled
+modules are 9966/12339 (80.8%). Scalar::Util 1.70 loads on both backends and the
 JVM Moo constructor smoke passes; the interpreter retains its previously
 documented Moo attribute-syntax parser limitation.
 
@@ -583,6 +584,24 @@ contract yet proves that a reused interpreter is equivalent to a fresh snapshot.
 The supported Java baseline is 24. Monitor pinning is removed on that baseline,
 but native/FFM blocking diagnostics remain a release gate for promoting virtual
 mode.
+
+The public documentation now treats the feature matrix as the canonical support
+table, records the implementation in the changelog and roadmap, explains runtime
+ownership and snapshot cloning, and documents the Java 24 requirement and
+virtual-thread opt-in. Self-checking examples demonstrate isolated create/join
+and shared lock/condition workflows on system Perl and both PerlOnJava backends.
+Link validation covers the updated documentation.
+
+Shared lock state no longer permanently retains every storage root ever locked.
+The lock registry uses weak identity keys while preserving one recursive lock
+per live root; condition waiters remain strongly held only while a waiter is
+published. Focused contention and collection tests cover both properties.
+
+Java 24 virtual-thread diagnostics cover shared conditions, regex timeouts,
+thread lifecycle, and representative native FFM identity calls without a
+pinning trace or semantic delta. A platform/virtual inherited-descriptor probe
+failed identically in the current host environment, so broader native I/O and
+callback coverage remains required before virtual mode can be promoted.
 
 ### Implementation History
 
@@ -603,45 +622,17 @@ request history.
    file with the standard-Perl oracle first, and keep the exact counts in the
    differential gate until they are complete. Only then expand to Test2 and
    native-callback thread suites.
-2. Make `docs/reference/feature-matrix.md` the canonical user-facing
-   compatibility table for multiplicity, `threads`, and `threads::shared`.
-   Replace its obsolete "Threading not supported" claim with the measured
-   supported API, `Config` flags, clone-versus-shared identity rules, and an
-   explicit limitations table covering signals, effective stack sizing,
-   blessed/tied shared values, native callbacks/resources, and experimental
-   virtual threads. Link the detailed concurrency reference from its table of
-   contents and module sections.
-3. Add a `docs/about/changelog.md` work-in-progress entry for Phases 1-23 and
-   reconcile the concurrency roadmap with the shipped multiplicity/ithread
-   tranche. Update the relevant reference pages: describe per-runtime ownership
-   and snapshot cloning in `docs/reference/architecture.md`, document the
-   `useithreads`/`usethreads`/`usemultiplicity` values and virtual-thread opt-in
-   in the configuration/CLI reference, and correct
-   `docs/reference/memory-management.md`, which still says Perl threads and the
-   reference-count overlay are single-threaded.
-4. Add runnable examples under `examples/` for isolated create/join and shared
-   lock/condition workflows, link them from `examples/README.md`, and validate
-   each with system Perl plus both PerlOnJava backends. Update
-   `examples/http_server_plack/README.md` and `PERFORMANCE.md` to distinguish
-   that example's deliberately single-event-loop architecture from the now
-   available Perl ithread capability; do not imply that one captured PSGI
-   runtime is concurrently callable.
-5. Add documentation acceptance checks to the compatibility tranche: run link
-   validation, compile every new example with system Perl and `jperl -c`, execute
-   it on the JVM and interpreter backends with bounded timeouts, and retain a
-   focused API/limitation matrix test so documentation cannot advertise an
-   unsupported thread method or sharing class.
-6. Add dedicated shared-storage lifetime cleanup and contention benchmarks;
-   replace the strong identity lock registry if long-running churn proves
-   retention after the last shared owner disappears.
-7. Run the virtual-thread diagnostic suite on Java 24, covering shared
-   conditions, native I/O, regex timeouts, and child lifecycle. Keep the mode
-   experimental unless native/FFM traces are clean and repeated benchmarks show
-   a material benefit.
+2. Expand compatibility coverage to Test2 and native callback/resource suites,
+   defining an explicit clone or rejection policy for each native handle class.
+3. Extend the Java 24 virtual-thread diagnostic matrix to real native I/O and
+   callback workloads on supported CI hosts. Keep the mode experimental unless
+   those traces are clean and repeated benchmarks show a material benefit.
    On Java 24, the initial creation/join smoke measured 30 cloned ithreads in
    0.544 seconds on platform threads and 0.543 seconds on virtual threads with
    identical checksums. That is semantic parity, not a demonstrated benefit,
    and cannot substitute for native-I/O diagnostics on Java 24.
+4. Define and prove a complete reset contract before considering runtime pooling;
+   a pooled interpreter must be observably equivalent to a fresh snapshot.
 
 ### Open Questions
 

--- a/dev/design/inline-cache.md
+++ b/dev/design/inline-cache.md
@@ -316,7 +316,7 @@ INVOKEDYNAMIC add(
 
 **Disadvantages**:
 - More complex to implement
-- Requires Java 7+ (PerlOnJava already requires Java 21)
+- Requires Java 7+ (PerlOnJava already requires Java 24)
 - Harder to debug
 
 ## Validation

--- a/dev/design/maven-central-publishing.md
+++ b/dev/design/maven-central-publishing.md
@@ -55,7 +55,7 @@ a polished automated release including review and first-Portal validation.
 | Group ID | `org.perlonjava` in Gradle and Maven |
 | Artifact ID | `perlonjava` |
 | Version | `5.44.0` |
-| Runtime Java version | Java 22+ |
+| Runtime Java version | Java 24+ |
 | Standalone artifact | Shaded executable JAR; currently replaces the unclassified main JAR |
 | POM project metadata | Incomplete; URL is still the Maven example URL |
 | Sources JAR | Missing |
@@ -275,7 +275,7 @@ Create a dedicated GitHub Actions workflow with these properties:
 
 1. Trigger manually or from a published GitHub release, not on ordinary pushes.
 2. Require a release tag and verify it against every project version source.
-3. Build and test with Java 22 through the existing `make` gate.
+3. Build and test with Java 24 through the existing `make` gate.
 4. Require the normal Ubuntu and Windows CI jobs to pass before publishing.
 5. Publish exactly once from Ubuntu.
 6. Use GitHub environment protection for the production publishing job.
@@ -286,7 +286,8 @@ Create a dedicated GitHub Actions workflow with these properties:
 9. Enable automatic publication only after at least one successful release and
    rollback/recovery documentation exists.
 
-Do not use Java 21 in the release workflow; PerlOnJava requires Java 22+.
+Do not use an older Java release in the release workflow; PerlOnJava requires
+Java 24+.
 
 **Exit gate:** a dry-run workflow proves tag validation, artifact provenance,
 secret isolation, and single-uploader behavior.

--- a/dev/presentations/German_Perl_Raku_Workshop_2026/slide-deck-plan.md
+++ b/dev/presentations/German_Perl_Raku_Workshop_2026/slide-deck-plan.md
@@ -47,7 +47,7 @@
 - Perl compiler and runtime for the JVM
 - Compiles to native JVM bytecode — same as Java, Kotlin, Scala
 - Not an interpreter wrapping a Perl binary
-- Targets Perl 5.42+ semantics. Requires Java 22+.
+- Targets Perl 5.42+ semantics. Requires Java 24+.
 
 **Slide 4 — Why the JVM?**
 - 30 years of JIT optimization — hot code becomes native machine code

--- a/dev/presentations/German_Perl_Raku_Workshop_2026/slides-part1-intro.md
+++ b/dev/presentations/German_Perl_Raku_Workshop_2026/slides-part1-intro.md
@@ -34,7 +34,7 @@ This is a common scenario in enterprise environments. Many companies have large 
 - Not an interpreter wrapping a Perl binary
 - Targets Perl 5.42+ semantics
 
-**Requires:** Java 22+ (any JDK)
+**Requires:** Java 24+ (any JDK)
 
 Note:
 PerlOnJava generates real JVM bytecode — the same kind of instructions that javac produces. This means Perl code gets all the JVM benefits: cross-platform, Java library access, JVM tooling.

--- a/dev/presentations/German_Perl_Raku_Workshop_2026/slides.md
+++ b/dev/presentations/German_Perl_Raku_Workshop_2026/slides.md
@@ -35,7 +35,7 @@ A common scenario in enterprise environments. Large Perl codebases that work wel
 - Not an interpreter wrapping a Perl binary
 - Targets **Perl 5.42+** semantics
 
-**Requires:** Java 22+ (any JDK)
+**Requires:** Java 24+ (any JDK)
 
 Note:
 PerlOnJava generates real JVM bytecode — the same instructions that javac produces. Perl code gets all JVM benefits: cross-platform execution, Java library access, JVM tooling.

--- a/dev/presentations/blogs_perl_org_jcpan_2026/blog-post-long.md
+++ b/dev/presentations/blogs_perl_org_jcpan_2026/blog-post-long.md
@@ -180,7 +180,7 @@ Some things just can't work on the JVM:
 
 ## Cross-Platform, Single Artifact
 
-PerlOnJava runs on Linux, macOS, and Windows. Same JAR everywhere — the JVM's "write once, run anywhere" actually delivers here. Your deployment is Java 22+, the JAR, and the wrapper scripts.
+PerlOnJava runs on Linux, macOS, and Windows. Same JAR everywhere — the JVM's "write once, run anywhere" actually delivers here. Your deployment is Java 24+, the JAR, and the wrapper scripts.
 
 The project includes a **Dockerfile** for containerized deployments and a **Debian package recipe** (`make deb`) for system installation.
 

--- a/dev/presentations/blogs_perl_org_jcpan_2026/blog-post.md
+++ b/dev/presentations/blogs_perl_org_jcpan_2026/blog-post.md
@@ -1,6 +1,6 @@
 # PerlOnJava - CPAN client for the JVM
 
-[PerlOnJava](https://github.com/fglock/PerlOnJava) now includes `jcpan`, a CPAN client that installs pure Perl modules without needing `make` or a C compiler. It runs on Linux, macOS, and Windows - just add Java 22+.
+[PerlOnJava](https://github.com/fglock/PerlOnJava) now includes `jcpan`, a CPAN client that installs pure Perl modules without needing `make` or a C compiler. It runs on Linux, macOS, and Windows - just add Java 24+.
 
 ## Installing modules
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,9 @@ Technical reference documentation:
 - **[Bundled Modules](reference/bundled-modules.md)** - Complete list of included modules
 - **[XS Compatibility](reference/xs-compatibility.md)** - XS modules and Java implementations
 - **[CLI Options](reference/cli-options.md)** - Command-line reference
+- **[Concurrency](reference/feature-matrix.md#concurrency-and-perl-threads)** - Multiplicity, ithreads, shared storage, and limitations
+- **[Runtime Configuration](reference/configure.md#runtime-thread-configuration)** - Thread capability flags and execution mode
+- **[Memory Management](reference/memory-management.md)** - JVM GC, deterministic destruction, weak references, and threads
 - **[Testing](reference/testing.md)** - Test suite information
 - **[Architecture](reference/architecture.md)** - How PerlOnJava works
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -4,6 +4,18 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 
 ## Work in progress
 
+- Add Perl interpreter multiplicity and the supported ithread tranche across
+  the JVM and interpreter backends. Mutable execution state is owned by
+  independent `PerlRuntime` instances; child threads receive identity-aware
+  snapshots, while `threads::shared` preserves explicitly shared
+  scalar/array/hash storage. Implement create/join/detach and lifecycle/error
+  inspection, nested threads, child-only exit, `CLONE`/`CLONE_SKIP`, recursive
+  locks, condition variables, and compatible imports/stringification.
+  `Config` now reports `useithreads`, `usethreads`, and `usemultiplicity` as
+  `define`. Platform threads remain the default and virtual threads are an
+  experimental opt-in. Thread signals, effective stack sizing, blessed/tied
+  shared values, and some upstream core/native-callback suites remain limited;
+  see the [feature matrix](../reference/feature-matrix.md#concurrency-and-perl-threads).
 - CPAN/compiler tooling: unblock `Template::Lace`, `Sledge::Plugin::JSONRPC`,
   and `Catmandu::Exporter::MAB2` without distribution preferences. Add
   Java-backed `Data::Util` scalar inspection, a `YAML::Syck` compatibility
@@ -186,7 +198,6 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
   - locale pragma
   - utf8 pragma
   - bytes pragma
-  - threads pragma
   - vmsish pragma
   - Constant folding - in ConstantFoldingVisitor.java
   - Overload operators: `++`, `--`.

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -44,6 +44,12 @@ These capabilities are implemented and available in the current release:
 - **Overload Pragma** — Arithmetic, comparison, string, dereference, and regex overloading. Method name resolution for `overload::nil` pattern. See [Feature Matrix — overload](../reference/feature-matrix.md#pragmas).
 - **DBI with JDBC** — Full DBI API backed by JDBC drivers. See [Feature Matrix — DBI](../reference/feature-matrix.md#dbi-module).
 - **I/O Subsystem** — Sockets, I/O layers (`:raw`, `:utf8`, `:crlf`, `:encoding()`), in-memory files, pipes, file descriptor duplication, `flock`, tied handles.
+- **Multiplicity and Perl ithreads** — Mutable interpreter state is owned by
+  `PerlRuntime`; `Config` advertises `useithreads`, `usethreads`, and
+  `usemultiplicity`. The supported `threads` and `threads::shared` tranche
+  includes isolated create/join, shared scalar/array/hash storage, recursive
+  locks, and condition variables on both backends. See the
+  [feature matrix](../reference/feature-matrix.md#concurrency-and-perl-threads).
 - **Pack/Unpack** — Full template support for binary data manipulation. See `dev/design/pack_unpack_architecture.md`.
 - **Subroutine Prototypes and Signatures** — All prototype characters supported; formal parameter signatures implemented.
 - **`format`/`write`** — Report generation with `formline` and `$^A` accumulator.
@@ -52,7 +58,7 @@ These capabilities are implemented and available in the current release:
 - **CI/CD Pipeline** — GitHub Actions testing on Ubuntu and Windows.
 - **Startup Performance** — Lazy initialization of expensive JNA calls ($( and $) variables). See `dev/design/pr328-startup-performance.md`.
 - **FFM Migration** — Replaced JNR-POSIX with Java's Foreign Function & Memory API (JEP 454), eliminating `sun.misc.Unsafe` warnings on Java 24+. Migrated `chmod`, `kill`, `stat`, `lstat`, `link`, `fcntl`, `isatty`, `getpwnam`, `umask`, `waitpid`, and other POSIX calls. See `dev/design/ffm_migration.md` and PR #380.
-- **Docker Image** — Multi-stage `Dockerfile` with Eclipse Temurin JDK 22. Includes `jperl`, `jcpan`, `jperldoc`, `jprove` in `/usr/local/bin`.
+- **Docker Image** — Multi-stage `Dockerfile` with Eclipse Temurin JDK 24. Includes `jperl`, `jcpan`, `jperldoc`, `jprove` in `/usr/local/bin`.
 - **Debian Package** — `.deb` packaging via Gradle `ospackage` plugin (`make deb`). Installs to `/opt/perlonjava` with symlinks in `/usr/local/bin` and bundled SBOM.
 
 ---
@@ -139,9 +145,9 @@ See `dev/design/jsr223-perlonjava-web.md`.
 
 ### JDK Compatibility Matrix
 
-PerlOnJava requires Java 22+ (FFM API). Remaining work:
+PerlOnJava requires Java 24+. Remaining work:
 
-- Test and document compatibility with JDK 22, 23, 24, and future LTS releases.
+- Test and document compatibility with JDK 24 and future releases.
 - Ensure CI runs against multiple JDK versions.
 - Track JDK deprecations that affect PerlOnJava (e.g., `sun.misc.Unsafe` removal timeline).
 
@@ -259,16 +265,11 @@ See `dev/design/concurrency.md` for the comprehensive design covering multiplici
 
 ### Multiplicity
 
-Enable multiple independent Perl runtimes within a single JVM process.
-
-**Why it matters:**
-- Enables fork emulation, ithreads, and concurrent web request handling.
-- Required for true JSR-223 thread safety.
-- Unblocks production web server deployments.
-
-**Approach (hybrid):**
-1. Classloader-based isolation for quick prototyping (1-2 months).
-2. Gradual de-static-ification of runtime state into `PerlRuntime` instances (4-6 months).
+Multiple independent `PerlRuntime` instances and snapshot cloning are now
+implemented. Remaining work is compatibility hardening: close the applicable
+core/CPAN thread-suite gaps, prove native callback isolation, and define a
+reset contract before considering runtime pooling. Multiplicity alone does not
+make one JSR-223 engine or one captured PSGI app concurrently callable.
 
 ### Fork Emulation
 
@@ -280,12 +281,18 @@ Implement `fork()` via runtime cloning + thread. Currently returns `undef`.
 
 ### Threads (ithreads)
 
-Implement Perl's `threads` module using JVM threads with per-thread runtime cloning.
+The supported ithread tranche is shipped: snapshot-based variable isolation,
+create/join/detach and lifecycle inspection, nested threads and child exit,
+`threads::shared` storage, recursive locks, and condition variables. Platform
+threads are the default; virtual threads are experimental.
 
-- Variable isolation per thread (copy on creation).
-- `:shared` attribute for synchronized cross-thread variables.
-- Thread-local special variables, caches, and I/O handles.
-- `exit` semantics: exit current thread only.
+Remaining work:
+
+- Complete the currently partial applicable core suites and Storable thread test.
+- Implement thread signals and the remaining `object`/`wantarray` surface.
+- Decide whether effective per-thread stack sizing can be exposed safely.
+- Validate native callback/resource behavior and virtual-thread diagnostics on
+  the supported Java 24 baseline.
 
 ---
 
@@ -337,4 +344,3 @@ These features are unlikely to be implemented due to fundamental JVM constraints
 - **DBM file support** — `dbmclose`/`dbmopen` not implemented; use DBI instead.
 - **Source filters** — `Filter::Util::Call` style source manipulation is not planned.
 - **`Opcode.pm`** — Requires Perl opcode tree internals that don't exist in PerlOnJava's compilation model.
-

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -85,7 +85,7 @@ Modify the `Dockerfile` to include additional dependencies:
 
 ```dockerfile
 # Add JDBC driver
-FROM eclipse-temurin:22-jdk
+FROM eclipse-temurin:24-jdk
 COPY --from=build /app/target/perlonjava-5.44.0.jar /app/perlonjava.jar
 COPY path/to/driver.jar /app/drivers/
 ENV CLASSPATH=/app/drivers/driver.jar
@@ -96,5 +96,4 @@ ENTRYPOINT ["java", "-jar", "/app/perlonjava.jar"]
 
 - [Installation Guide](installation.md) - Build without Docker
 - [Database Access](../guides/database-access.md) - Using JDBC drivers
-
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -24,7 +24,7 @@
 10. [Troubleshooting](#troubleshooting)
 
 ## Prerequisites
-- JDK 22 or later
+- JDK 24 or later
 - Maven, or the included Gradle wrapper (recommended)
 - Optional: JDBC drivers for database connectivity
 
@@ -149,7 +149,7 @@ See [Database Access Guide](../guides/database-access.md) for detailed connectio
 ## Build Notes
 - Maven builds use `maven-shade-plugin` for creating the shaded JAR
 - Gradle builds use the Shadow plugin
-- Both configurations target Java 22
+- Both configurations target Java 24
 
 ## Java Library Upgrades
 
@@ -245,7 +245,7 @@ On Windows, use `gradlew.bat --version`. The wrapper version is defined in
 
 ### Java Version Compatibility
 
-PerlOnJava compiles for Java 22 and requires JDK 22 or later. Use the included
+PerlOnJava compiles for Java 24 and requires JDK 24 or later. Use the included
 wrapper so the Gradle version stays aligned with the project. For compatibility
 details beyond the checked-in wrapper, consult Gradle's
 [Java compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html).

--- a/docs/guides/java-integration.md
+++ b/docs/guides/java-integration.md
@@ -269,7 +269,7 @@ See also:
 If `getEngineByName("perl")` returns null:
 1. Ensure `perlonjava-*.jar` is in classpath
 2. Check `META-INF/services/javax.script.ScriptEngineFactory` exists in JAR
-3. Verify Java 22 or later is being used
+3. Verify Java 24 or later is being used
 
 ### ClassNotFoundException
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -189,6 +189,23 @@ the user-facing summary, the relationship to the GC literature
 (Bacon 2004, Blackburn & McKinley 2003, *The Garbage Collection Handbook*),
 and a comparison with Perl 5 / JVM finalization.
 
+#### Runtime ownership and ithread snapshots
+
+Mutable interpreter state is owned by a `PerlRuntime`, including package
+globals, dynamic scope, warnings and hints, regex state, caller stacks,
+lifecycle queues, signal/alarm state, I/O registries, and runtime caches.
+Managed execution binds the appropriate runtime to the current Java thread and
+prevents accidental cross-runtime access.
+
+Creating a Perl ithread takes an identity-aware snapshot. Ordinary scalars,
+arrays, hashes, closures, aliases, cycles, and weak edges are cloned into the
+child and subsequently evolve independently. `CLONE_SKIP` is evaluated in the
+parent and `CLONE` runs after the child graph is installed. Java I/O/native
+resources are conservatively not duplicated. Storage marked through
+`threads::shared` is the exception: its backing identity is retained across the
+snapshot and guarded by shared locks and condition variables. See the
+[concurrency feature matrix](feature-matrix.md#concurrency-and-perl-threads).
+
 ## Interpreter Backend Details
 
 The interpreter provides an alternative execution path:

--- a/docs/reference/bundled-modules.md
+++ b/docs/reference/bundled-modules.md
@@ -155,9 +155,10 @@ suite:
 The remaining ~80 failing test files cluster around features that are
 deliberately out of scope or genuinely unimplemented:
 
-- **`threads` / `fork`** — PerlOnJava has neither.  The handful of
-  tests that exercise `share`, `lock`, or fork-based DEMOLISH timing
-  cannot pass and are expected to fail.
+- **Thread/fork-specific Moose tests** — PerlOnJava now supports the documented
+  ithread and `threads::shared` tranche, including `share` and `lock`, but the
+  upstream Moose thread files have not all been promoted to the compatibility
+  gate. True `fork` and fork-based DEMOLISH timing remain unsupported.
 - **Numeric warning messages** (`Argument "x" isn't numeric in addition`)
   — PerlOnJava does not emit these specific warning categories yet.
 - **Stack-trace shape** — frames inside generated method modifiers
@@ -384,7 +385,7 @@ These are loaded automatically or via `use`:
 | `PadWalker` | Perl + Java | `peek_sub`, `closed_over`, `set_closed_over`; no `peek_my`, `peek_our`, or `var_name` yet |
 | `Class::XSAccessor` / `Class::XSAccessor::Array` | Perl | Pure-Perl replacement for the CPAN XS accessors; no entersub optimizer |
 | `Class::MOP` | Perl | Upstream 2.4000 source |
-| `Moose` | Perl | Upstream 2.4000 source; ~99% of upstream tests pass (no threads). See note below. |
+| `Moose` | Perl | Upstream 2.4000 source; ~99% of upstream tests pass. PerlOnJava ithreads are available, but Moose's thread-specific suite remains only partially classified. See note below. |
 | `B` | Perl | `svref_2object`, `B::CV`/`GV`/`STASH`, `CVf_ANON`, etc. — enough for `Class::MOP::get_code_info` and `B::Deparse`. |
 | `B::Flags` | Perl | Portable `flagspv`/`privatepv` names for the subset of OP/SV state exposed by `B`. |
 

--- a/docs/reference/cli-options.md
+++ b/docs/reference/cli-options.md
@@ -207,6 +207,28 @@ jperl [options] [program | -e 'command'] [arguments]
   ./jperl script.pl
   ```
 
+### Thread execution mode
+
+- **`JPERL_THREAD_MODE`** — Select the Java carrier used by newly created
+  Perl ithreads. `platform` is the stable default; `virtual` enables the
+  experimental virtual-thread policy.
+
+  ```bash
+  JPERL_THREAD_MODE=virtual ./jperl threaded.pl
+  ```
+
+The equivalent JVM property is `-Djperl.thread.mode=virtual`, supplied through
+`JPERL_OPTS` when using the launcher:
+
+```bash
+JPERL_OPTS='-Djperl.thread.mode=virtual' ./jperl threaded.pl
+```
+
+Virtual mode currently claims semantic parity only. It has not demonstrated a
+material speedup and still requires native-I/O diagnostics on the supported
+Java 24 baseline described in the
+[concurrency feature matrix](feature-matrix.md#concurrency-and-perl-threads).
+
 ## Combining Options
 
 Options can be combined for powerful one-liners:

--- a/docs/reference/configure.md
+++ b/docs/reference/configure.md
@@ -15,6 +15,24 @@ The `Configure.pl` script manages configuration settings and dependencies for Pe
 Run the script directly from the repository root. Its shebang selects the system
 Perl, and its required Perl modules are listed at the top of the script.
 
+## Runtime thread configuration
+
+`Configure.pl` does not toggle Perl thread support. The bundled Perl `Config`
+module reports the shipped runtime capabilities directly:
+
+| Key | Value | Meaning |
+|---|---|---|
+| `useithreads` | `define` | Snapshot-based Perl interpreter threads are available. |
+| `usethreads` | `define` | The supported Perl thread API is enabled. |
+| `usemultiplicity` | `define` | Independent `PerlRuntime` instances are supported in one JVM. |
+
+Platform Java threads are the stable default. The experimental virtual-thread
+executor is selected process-wide with `JPERL_THREAD_MODE=virtual` or the JVM
+property `-Djperl.thread.mode=virtual`; `platform` selects the default
+explicitly. Unknown values are rejected. See
+[CLI Options](cli-options.md#thread-execution-mode) and the
+[feature matrix](feature-matrix.md#concurrency-and-perl-threads).
+
 ## Options
 
 ### Help and Information

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -28,8 +28,9 @@
     - [Core modules](#core-modules)
     - [Non-core modules](#non-core-modules)
     - [DBI module](#dbi-module)
-14. [Features Incompatible with JVM](#features-incompatible-with-jvm)
-15. [Optimizations](#optimizations)
+14. [Concurrency and Perl Threads](#concurrency-and-perl-threads)
+15. [Features Incompatible with JVM](#features-incompatible-with-jvm)
+16. [Optimizations](#optimizations)
 
 ---
 
@@ -57,7 +58,10 @@ PerlOnJava implements most core Perl features with some key differences:
 
 ❌ Not Supported:
 - XS modules and C integration
-- Threading
+- `fork`
+
+🟡 Supported with limitations:
+- Perl ithreads and `threads::shared` (see [Concurrency and Perl Threads](#concurrency-and-perl-threads))
 
 ---
 
@@ -602,7 +606,7 @@ The `:encoding()` layer supports all encodings provided by Java's `Charset.forNa
 - ✅  **Stash manipulation**: Alternative ways to create constants like: `$constant::{_CAN_PCS} = \$const`.
 - ✅  **`reset("A-Z")`** resetting global variables is implemented.
 - ✅  **Single-quote as package separator**: Legacy `$a'b` style package separator is supported.
-- ❌  **Thread-safe `@_`, `$_`, and regex variables**: Thread safety for global special variables is missing.
+- ✅  **Runtime-owned `@_`, `$_`, and regex state**: Each ithread receives an isolated runtime snapshot.
 - ❌  **Compiler flags**:  The special variables `$^H`, `%^H`, `${^WARNING_BITS}` are not implemented.
 - ✅  **`caller` operator**: `caller` returns `($package, $filename, $line)`.
   - ❌  **Extended call stack information**: extra debug information like `(caller($level))[9]` is not implemented.<br>
@@ -685,6 +689,11 @@ The `:encoding()` layer supports all encodings provided by Java's `Charset.forNa
 - ✅  **Benchmark** use the same version as Perl.
 - ✅  **Carp**: `carp`, `cluck`, `croak`, `confess`, `longmess`, `shortmess` are implemented.
 - ✅  **Config** module.
+- 🟡  **threads** module: isolated create/join, identity, listing, detach,
+  state inspection, child exit, errors, `async`, `yield`, and supported import
+  options. See [Concurrency and Perl Threads](#concurrency-and-perl-threads).
+- 🟡  **threads::shared** module: shared scalar/array/hash storage, recursive
+  lexical locks, condition variables, and supported graph cloning.
 - ✅  **Cwd** module
 - ✅  **Data::Dumper**: use the same version as Perl.
 - ✅  **DirHandle** module.
@@ -818,6 +827,44 @@ The DBI module provides seamless integration with JDBC drivers:
 
 #### Statement Handle Attributes
 - `NAME`, `NAME_lc`, `NAME_uc`, `NUM_OF_FIELDS`, `NUM_OF_PARAMS`, `Database`
+
+---
+
+## Concurrency and Perl Threads
+
+PerlOnJava implements interpreter multiplicity and a measured subset of Perl
+ithreads on both the JVM compiler and bytecode interpreter backends.
+
+| Capability | Status | Notes |
+|---|---|---|
+| `Config` flags | ✅ | `useithreads`, `usethreads`, and `usemultiplicity` are `define`. |
+| Runtime isolation | ✅ | Mutable globals, dynamic state, hints, warnings, regex state, lifecycle queues, signals, alarms, and I/O registries are runtime-owned. |
+| `threads->create`, `async`, `join`, `detach` | ✅ | A child receives a snapshot; ordinary parent and child values then evolve independently. Join results are cloned back to the caller. |
+| Identity and state | ✅ | `self`, `tid`, `list`, equality, running/joinable/detached checks, errors, nested threads, and child-only `threads->exit` are supported. |
+| `threads::shared` | 🟡 | `share`, `is_shared`, `shared_clone`, and `:shared` support unblessed, untied scalar/array/hash graphs. Shared identity crosses the snapshot boundary. |
+| Locks and conditions | ✅ | Recursive lexical `lock`, `cond_wait`, absolute `cond_timedwait`, `cond_signal`, and `cond_broadcast` are supported. |
+| Platform threads | ✅ | Stable default. |
+| Virtual threads | 🟡 | Experimental process-wide opt-in; semantic parity is measured, but no performance benefit or complete native-I/O diagnostic clearance on Java 24 is claimed. |
+
+The clone-versus-share rule is important: ordinary references are cloned with
+aliasing and cycles preserved inside the child graph, but they are not the same
+storage as their parent counterparts. Values explicitly shared through
+`threads::shared` retain common backing storage.
+
+### Current limitations
+
+| Limitation | Effect |
+|---|---|
+| Thread signals | `threads->kill` is not implemented. |
+| Effective stack sizing | Standard `stack_size` import syntax is accepted for source compatibility, but JVM stack sizing remains runtime-managed. |
+| Additional introspection | `threads->object` and `wantarray` are not implemented. |
+| Shared object classes | Blessed and tied values are rejected by the supported `share`/`shared_clone` tranche. |
+| Native resources and callbacks | Java I/O/native handles are not portably duplicated into child snapshots; native callback thread isolation remains suite-specific. |
+| Upstream suite coverage | Core compatibility remains partial: measured results include `op/threads.t` 28/30, `op/substr_thr.t` 368/400, and `re/stclass_threads.t` 2/6; `class/threads.t`, Storable's thread test, and `threads-dirh.t` complete. The regex suite now executes its child and exposes unsupported thread-local `re 'debug'` trace parity. |
+| PSGI | Availability of ithreads does not make one captured PSGI application runtime concurrently callable. `Plack::Handler::Netty` advertises `psgi.multithread => \0`. |
+
+The complete design and measured validation record is in
+[Concurrency and runtime isolation](../../dev/design/concurrency.md).
 
 ---
 

--- a/docs/reference/memory-management.md
+++ b/docs/reference/memory-management.md
@@ -116,8 +116,10 @@ ones are:
 - `Internals::SvREFCNT($ref)` returns an approximate count rather than
   the raw value Perl 5 would report — useful for `weaken`/`DESTROY`
   invariants, not for byte-for-byte refcount fidelity.
-- `fork` and Perl-level `threads` are not supported by the JVM backend;
-  the refcount overlay is single-threaded.
+- `fork` is not implemented. Perl ithreads are supported through isolated
+  runtime snapshots, and lifecycle/refcount registries are runtime-owned.
+  Explicitly shared scalar/array/hash storage uses synchronized visibility and
+  locking; blessed and tied values remain outside the supported shared tranche.
 - `local($@, $!, $?)` around `DESTROY`: only `$@` is currently saved and
   restored.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,9 @@ Featured example:
 
 - [`pagi/`](pagi/) — an asynchronous HTTP application running on
   `PAGI::Server` with PerlOnJava's native `async`/`await` support.
+- [`threads/`](threads/) — isolated ithread create/join and shared
+  lock/condition workflows, with self-checking scripts that also run on
+  standard threaded Perl.
 
 Note:
 
@@ -25,4 +28,3 @@ Note:
 - Ensure that any new Perl scripts added to the src/test/resources directory follow the project's testing conventions.
 
 - If you add new example scripts to this directory, consider documenting their purpose and usage to help other developers.
-

--- a/examples/http_server_plack/PERFORMANCE.md
+++ b/examples/http_server_plack/PERFORMANCE.md
@@ -46,19 +46,21 @@ Tests streaming response path with responder callbacks.
 1. **Zero Failed Requests**: 100% success rate across all tests (26,000 total requests)
 2. **High Throughput**: 30k+ req/sec for simple responses
 3. **Low Latency**: Sub-5ms average latency even at high concurrency
-4. **Scales Well**: Performance improves with concurrency (single-threaded event loop benefits)
+4. **Scales Well for I/O**: The single-runtime event-loop design handled the measured request concurrency
 5. **Streaming Support**: Minimal performance impact (~50% of sync, still excellent)
 
 ### Performance Characteristics
 
-- **Single-threaded**: Uses one Netty event loop thread (PerlOnJava limitation)
+- **Single application runtime**: This handler deliberately avoids concurrent
+  callbacks into one captured PSGI app. PerlOnJava itself supports explicit,
+  isolated ithreads.
 - **Async I/O**: Handles high concurrency efficiently via Netty's NIO
 - **Memory Efficient**: No buffering of responses, constant memory usage
 - **CPU Bound**: Performance limited by single-thread CPU usage, not I/O
 
 ### Bottlenecks Identified
 
-1. **Single Thread Limit**: Cannot utilize multiple CPU cores
+1. **Single PSGI Runtime Limit**: One handler instance does not run the same app concurrently across cores
    - Mitigation: Run multiple instances behind load balancer (standard approach)
    
 2. **Streaming Overhead**: ~50% performance vs synchronous responses
@@ -77,7 +79,9 @@ Tests streaming response path with responder callbacks.
    - Database queries, API calls, file I/O all benefit from async model
    
 2. **CPU-Bound Apps**: Consider implications
-   - Heavy computation blocks other requests (single-threaded)
+   - Heavy computation blocks other requests in this single-runtime handler
+   - Applications may use explicit ithreads for isolated work, but the handler
+     still advertises `psgi.multithread => \0`
    - Solution: Offload to background workers
    
 3. **High-Traffic Sites**: Run multiple instances
@@ -97,5 +101,6 @@ Tests streaming response path with responder callbacks.
 ✅ **Scalable**: Handles high concurrency efficiently  
 ✅ **Memory efficient**: Constant memory usage, no leaks  
 
-The single-threaded limitation is by design (PerlOnJava thread-safety) and can be
-addressed with standard horizontal scaling approaches.
+The single-runtime limitation belongs to this handler design, not to the
+availability of Perl ithreads. Horizontal scaling remains the recommended way
+to run multiple PSGI application runtimes concurrently.

--- a/examples/http_server_plack/README.md
+++ b/examples/http_server_plack/README.md
@@ -8,7 +8,8 @@ A complete working example demonstrating how to run PSGI applications on PerlOnJ
 
 - **General PSGI support** - Any PSGI-compatible app can be adapted
 - **High-performance async I/O** - Netty handles 10k+ concurrent connections on a single thread
-- **Single-threaded model** - Compatible with PerlOnJava's no-threads/no-fork constraints
+- **Single-runtime PSGI model** - The handler deliberately confines one app
+  runtime even though PerlOnJava applications can create explicit ithreads
 - **Standard PSGI 1.1** - Full compliance with streaming and delayed response support
 
 ## Architecture
@@ -185,17 +186,22 @@ Framework-specific experiments are kept in `dev/sandbox/http_server/` until they
 
 ## Concurrency Model
 
-**Single-threaded async I/O** - Uses Netty's event loop (`NioEventLoopGroup(1)`) to handle concurrent connections without threads/fork:
+**Single-runtime async I/O** - Uses a Netty event loop to handle concurrent
+connections without concurrent callbacks into the captured PSGI application:
 
 ✅ **Good for:** I/O-bound apps (databases, APIs, file serving)  
 ✅ **Handles:** Thousands of concurrent connections efficiently  
 ⚠️ **Limitation:** CPU-bound request handlers may block other requests
 
-This design avoids PerlOnJava's thread-safety constraints while still providing excellent performance for typical web applications.
+PerlOnJava supports isolated Perl ithreads, but that capability does not make a
+single captured PSGI runtime concurrently callable. The handler therefore
+advertises `psgi.multithread => \0`. Applications may explicitly create
+ithreads for isolated work, subject to the documented thread limitations.
 
 ## Limitations
 
-- **Single-threaded** - CPU-intensive handlers block other requests
+- **Single application runtime** - CPU-intensive handlers block other requests;
+  the handler does not provide a pool of concurrently callable app runtimes
 
 ## Performance
 

--- a/examples/threads/README.md
+++ b/examples/threads/README.md
@@ -1,0 +1,38 @@
+# Perl ithreads
+
+These examples cover the two fundamental PerlOnJava ithread models:
+
+- [`isolated_create_join.pl`](isolated_create_join.pl) creates an ithread from
+  a runtime snapshot, returns a child-owned result through `join`, and proves
+  that an ordinary captured scalar remains isolated in the parent.
+- [`shared_lock_condition.pl`](shared_lock_condition.pl) marks a scalar with
+  `:shared`, protects it with lexical `lock`, and coordinates parent and child
+  with `cond_wait` and `cond_signal`. The condition is always checked in a loop
+  so an early signal or spurious wakeup cannot violate the state transition.
+
+Run either example from the repository root:
+
+```bash
+./jperl examples/threads/isolated_create_join.pl
+./jperl examples/threads/shared_lock_condition.pl
+```
+
+The same source runs on standard threaded Perl:
+
+```bash
+perl examples/threads/isolated_create_join.pl
+perl examples/threads/shared_lock_condition.pl
+```
+
+PerlOnJava supports platform threads by default. Virtual threads are an
+experimental process-wide execution mode; selecting them does not change Perl
+snapshot or shared-storage semantics:
+
+```bash
+JPERL_OPTS=-Djperl.thread.mode=virtual \
+  ./jperl examples/threads/isolated_create_join.pl
+```
+
+Thread signals, effective per-thread stack sizing, and sharing tied or blessed
+values are outside the currently supported tranche. A captured PSGI runtime is
+also not made concurrently callable merely by enabling ithreads.

--- a/examples/threads/isolated_create_join.pl
+++ b/examples/threads/isolated_create_join.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use threads;
+
+my $parent_value = 10;
+my $worker = threads->create(sub {
+    my ($increment) = @_;
+    $parent_value += $increment;
+    return {
+        tid   => threads->self->tid,
+        value => $parent_value,
+    };
+}, 7);
+
+my $result = $worker->join;
+die "child did not run in an independent ithread\n"
+    unless $result->{tid} > 0 && $result->{value} == 17;
+die "child mutation escaped its runtime snapshot\n"
+    unless $parent_value == 10;
+
+print "child $result->{tid} returned $result->{value}; parent remains $parent_value\n";

--- a/examples/threads/shared_lock_condition.pl
+++ b/examples/threads/shared_lock_condition.pl
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use threads;
+use threads::shared;
+
+my $state :shared = 0;
+
+my $worker = threads->create(sub {
+    lock($state);
+    cond_wait($state) until $state == 1;
+    $state = 2;
+    cond_signal($state);
+    return 'worker finished';
+});
+
+{
+    lock($state);
+    $state = 1;
+    cond_signal($state);
+    cond_wait($state) until $state == 2;
+}
+
+my $result = $worker->join;
+die "shared condition workflow failed\n"
+    unless $state == 2 && $result eq 'worker finished';
+
+print "shared state reached $state after the worker signal\n";

--- a/jperl
+++ b/jperl
@@ -51,7 +51,15 @@ JVM_OPTS="--enable-native-access=ALL-UNNAMED"
 
 # Java 23+ warns about sun.misc.Unsafe usage (JEP 471). Add flag to suppress
 # warnings from transitive libraries (ASM, ICU4J, etc.) that still use it.
+if ! command -v java >/dev/null 2>&1; then
+    echo "ERROR: PerlOnJava requires Java 24 or later; java was not found in PATH." >&2
+    exit 1
+fi
 JAVA_VERSION=$(java -version 2>&1 | head -1 | sed 's/.*version "\([0-9]*\).*/\1/')
+if ! [[ "$JAVA_VERSION" =~ ^[0-9]+$ ]] || [ "$JAVA_VERSION" -lt 24 ]; then
+    echo "ERROR: PerlOnJava requires Java 24 or later (found: ${JAVA_VERSION:-unknown})." >&2
+    exit 1
+fi
 if [ "$JAVA_VERSION" -ge 23 ] 2>/dev/null; then
     JVM_OPTS="$JVM_OPTS --sun-misc-unsafe-memory-access=allow"
 fi

--- a/jperl.bat
+++ b/jperl.bat
@@ -28,10 +28,20 @@ rem Override via `JPERL_OPTS=-Xmx<size>` in the environment if needed.
 
 rem Java 23+ warns about sun.misc.Unsafe usage (JEP 471). Add flag to suppress
 rem warnings from transitive libraries (ASM, ICU4J, etc.) that still use it.
+set JAVA_VERSION=
 for /f "tokens=3" %%v in ('java -version 2^>^&1 ^| findstr /i "version"') do (
     for /f "tokens=1 delims=." %%m in ("%%~v") do (
+        set JAVA_VERSION=%%m
         if %%m GEQ 23 set JVM_OPTS=%JVM_OPTS% --sun-misc-unsafe-memory-access=allow
     )
+)
+if not defined JAVA_VERSION (
+    echo ERROR: PerlOnJava requires Java 24 or later; java was not found in PATH. 1>&2
+    exit /b 1
+)
+if %JAVA_VERSION% LSS 24 (
+    echo ERROR: PerlOnJava requires Java 24 or later ^(found: %JAVA_VERSION%^). 1>&2
+    exit /b 1
 )
 
 rem During Maven tests the packaged JAR does not exist yet. Use compiled

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
     <url>http://maven.apache.org</url>
 
     <properties>
-        <maven.compiler.source>22</maven.compiler.source>
-        <maven.compiler.target>22</maven.compiler.target>
+        <maven.compiler.source>24</maven.compiler.source>
+        <maven.compiler.target>24</maven.compiler.target>
         <jperl.launcher>${project.basedir}/jperl</jperl.launcher>
     </properties>
 

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
@@ -33,7 +33,25 @@ public final class Threads extends PerlModuleBase {
     }
 
     public static RuntimeList _create(RuntimeArray args, int ctx) {
-        if (args.isEmpty() || args.get(0).type != RuntimeScalarType.CODE) {
+        int codeIndex = 0;
+        if (!args.isEmpty() && args.get(0).type == RuntimeScalarType.HASHREFERENCE) {
+            // Perl's creation options (notably stack_size) are advisory here:
+            // JVM thread stack sizing is owned by PerlThreadExecutionPolicy.
+            codeIndex = 1;
+        }
+        if (args.size() <= codeIndex) {
+            throw new IllegalArgumentException("threads->create requires a CODE reference");
+        }
+        RuntimeScalar code = args.get(codeIndex);
+        if (code.type != RuntimeScalarType.CODE && !RuntimeScalarType.isReference(code)) {
+            String name = code.toString();
+            if (!name.contains("::")) {
+                name = org.perlonjava.backend.bytecode.InterpreterState.currentPackage.get()
+                        + "::" + name;
+            }
+            code = GlobalVariable.getGlobalCodeRef(name);
+        }
+        if (code.type != RuntimeScalarType.CODE) {
             throw new IllegalArgumentException("threads->create requires a CODE reference");
         }
         // BEGIN-time code holds the global compilation lock. A new ithread may
@@ -48,9 +66,9 @@ public final class Threads extends PerlModuleBase {
             return ReferenceOperators.bless(stub.createReference(), new RuntimeScalar(CLASS)).getList();
         }
         RuntimeArray threadArgs = new RuntimeArray();
-        for (int i = 1; i < args.size(); i++) threadArgs.push(args.get(i));
+        for (int i = codeIndex + 1; i < args.size(); i++) threadArgs.push(args.get(i));
         PerlThreadControlBlock thread = PerlThreadControlBlock.create(
-                PerlRuntime.current(), args.get(0), threadArgs, ctx).start();
+                PerlRuntime.current(), code, threadArgs, ctx).start();
         return threadObject(thread.id(), null).getList();
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
@@ -372,12 +372,11 @@ public class RuntimeGraphCloner {
         clones.put(source, target);
         copyBase(source, target);
         target.type = source.type;
-        for (Map.Entry<String, RuntimeScalar> entry : source.elements.entrySet()) {
-            RuntimeScalar cloned = (RuntimeScalar) cloneValue(entry.getValue());
-            try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
-                target.elements.put(entry.getKey(), cloned);
-            }
-        }
+        // A stash is a live view over the runtime's canonical global slot maps,
+        // not an independently-owned hash. GlobalRuntimeState snapshots those
+        // maps separately. Replaying the source view through HashSpecialVariable
+        // would perform semantic typeglob assignments in the child and can clear
+        // slots that were already cloned (notably a package's @ISA array).
         return target;
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/SharedPerlStorage.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/SharedPerlStorage.java
@@ -1,8 +1,11 @@
 package org.perlonjava.runtime.runtimetypes;
 
-import java.util.Collections;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -13,8 +16,8 @@ import java.util.concurrent.locks.ReentrantLock;
 
 /** Marker and first-tranche synchronization policy for threads::shared. */
 public final class SharedPerlStorage {
-    private static final Map<RuntimeBase, LockState> LOCKS =
-            Collections.synchronizedMap(new IdentityHashMap<>());
+    private static final WeakIdentityRegistry<RuntimeBase, LockState> LOCKS =
+            new WeakIdentityRegistry<>();
     private static final Map<RuntimeBase, ArrayDeque<Waiter>> WAITERS =
             Collections.synchronizedMap(new IdentityHashMap<>());
 
@@ -22,6 +25,58 @@ public final class SharedPerlStorage {
 
     private static final class LockState {
         final ReentrantLock lock = new ReentrantLock();
+    }
+
+    /** Weak keys with explicit identity equality, independent of referent equals/hashCode. */
+    private static final class WeakIdentityRegistry<K, V> {
+        private final ReferenceQueue<K> staleKeys = new ReferenceQueue<>();
+        private final Map<IdentityWeakReference<K>, V> entries = new HashMap<>();
+
+        synchronized V computeIfAbsent(K key, java.util.function.Function<K, V> factory) {
+            expungeStaleEntries();
+            IdentityWeakReference<K> lookup = new IdentityWeakReference<>(key);
+            V value = entries.get(lookup);
+            if (value != null) return value;
+            value = factory.apply(key);
+            entries.put(new IdentityWeakReference<>(key, staleKeys), value);
+            return value;
+        }
+
+        synchronized int expungeStaleEntries() {
+            int removed = 0;
+            IdentityWeakReference<?> stale;
+            while ((stale = (IdentityWeakReference<?>) staleKeys.poll()) != null) {
+                if (entries.remove(stale) != null) removed++;
+            }
+            return removed;
+        }
+    }
+
+    private static final class IdentityWeakReference<T> extends WeakReference<T> {
+        private final int identityHash;
+
+        IdentityWeakReference(T referent) {
+            super(referent);
+            identityHash = System.identityHashCode(referent);
+        }
+
+        IdentityWeakReference(T referent, ReferenceQueue<T> queue) {
+            super(referent, queue);
+            identityHash = System.identityHashCode(referent);
+        }
+
+        @Override
+        public int hashCode() {
+            return identityHash;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) return true;
+            if (!(other instanceof IdentityWeakReference<?> reference)) return false;
+            Object referent = get();
+            return referent != null && referent == reference.get();
+        }
     }
 
     private record Waiter(CountDownLatch latch) {}
@@ -170,9 +225,15 @@ public final class SharedPerlStorage {
     }
 
     private static LockState lockState(RuntimeBase root) {
-        synchronized (LOCKS) {
-            return LOCKS.computeIfAbsent(root, ignored -> new LockState());
-        }
+        return LOCKS.computeIfAbsent(root, ignored -> new LockState());
+    }
+
+    static int expungeStaleLocksForTesting() {
+        return LOCKS.expungeStaleEntries();
+    }
+
+    static ReentrantLock lockForTesting(RuntimeBase root) {
+        return lockState(root).lock;
     }
 
     private static RuntimeBase requireShared(RuntimeScalar reference, String operation) {

--- a/src/main/perl/lib/threads.pm
+++ b/src/main/perl/lib/threads.pm
@@ -9,7 +9,15 @@ sub running ()  { 1 }
 sub joinable () { 2 }
 
 sub create {
+    my $caller = caller;
     shift;
+    my $code_index = ref($_[0]) eq 'HASH' ? 1 : 0;
+    if (defined($_[$code_index]) && !ref($_[$code_index])
+            && $_[$code_index] !~ /::/) {
+        my @args = @_;
+        $args[$code_index] = "${caller}::$args[$code_index]";
+        return _create(@args);
+    }
     return _create(@_);
 }
 

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeStashSnapshotTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeStashSnapshotTest.java
@@ -1,0 +1,55 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.app.cli.CompilerOptions;
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("unit")
+class PerlRuntimeStashSnapshotTest {
+
+    @Test
+    void stashCloneDoesNotReplayTypeglobWritesOverClonedArrays() throws Exception {
+        for (boolean interpreter : new boolean[]{false, true}) {
+            PerlRuntime parent = new PerlRuntime();
+            try {
+                run(parent, interpreter, ""
+                        + "our @ordinary = ('ordinary'); "
+                        + "package SnapshotParent; sub inherited { 42 } "
+                        + "package SnapshotChild; our @ISA = ('SnapshotParent'); "
+                        + "package main; 1");
+
+                PerlRuntime child = parent.snapshotClone();
+                try {
+                    assertEquals("1:ordinary:1:SnapshotParent:42",
+                            run(child, interpreter, "join q(:), "
+                                    + "scalar(@ordinary), @ordinary, "
+                                    + "scalar(@SnapshotChild::ISA), @SnapshotChild::ISA, "
+                                    + "SnapshotChild->inherited"));
+                    assertEquals("1:ordinary:1:SnapshotParent:42",
+                            run(parent, interpreter, "join q(:), "
+                                    + "scalar(@ordinary), @ordinary, "
+                                    + "scalar(@SnapshotChild::ISA), @SnapshotChild::ISA, "
+                                    + "SnapshotChild->inherited"));
+                } finally {
+                    child.close();
+                }
+            } finally {
+                parent.close();
+            }
+        }
+    }
+
+    private static String run(PerlRuntime runtime, boolean interpreter, String source)
+            throws Exception {
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            CompilerOptions options = new CompilerOptions();
+            options.fileName = "<runtime-stash-snapshot>";
+            options.useInterpreter = interpreter;
+            options.code = source;
+            return PerlLanguageProvider.executePerlCode(options, false).scalar().toString();
+        }
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/SharedPerlStorageTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/SharedPerlStorageTest.java
@@ -1,0 +1,84 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class SharedPerlStorageTest {
+    @Test
+    void liveRootReusesOneRecursiveLockAndSerializesContenders() throws Exception {
+        RuntimeScalar root = new RuntimeScalar(1);
+        SharedPerlStorage.shareValue(root);
+        ReentrantLock lock = SharedPerlStorage.lockForTesting(root);
+        assertSame(lock, SharedPerlStorage.lockForTesting(root));
+
+        AtomicInteger inside = new AtomicInteger();
+        AtomicInteger maximum = new AtomicInteger();
+        CountDownLatch start = new CountDownLatch(1);
+        FutureTask<Void> firstTask = contender(lock, inside, maximum, start);
+        FutureTask<Void> secondTask = contender(lock, inside, maximum, start);
+        Thread first = Thread.ofPlatform().unstarted(firstTask);
+        Thread second = Thread.ofPlatform().unstarted(secondTask);
+        first.start();
+        second.start();
+        start.countDown();
+        firstTask.get(5, TimeUnit.SECONDS);
+        secondTask.get(5, TimeUnit.SECONDS);
+
+        assertFalse(first.isAlive());
+        assertFalse(second.isAlive());
+        assertEquals(1, maximum.get(), "shared root must have one exclusion domain");
+    }
+
+    @Test
+    void ephemeralSharedRootsDoNotRemainStronglyHeldByLockRegistry() throws Exception {
+        WeakReference<RuntimeScalar> root = registerEphemeralLock();
+
+        for (int attempt = 0; attempt < 100 && root.get() != null; attempt++) {
+            System.gc();
+            byte[] pressure = new byte[256 * 1024];
+            assertEquals(256 * 1024, pressure.length);
+            Thread.sleep(10);
+        }
+
+        assertNull(root.get(), "ephemeral shared root should become collectible");
+        int removed = 0;
+        for (int attempt = 0; attempt < 100 && removed == 0; attempt++) {
+            removed += SharedPerlStorage.expungeStaleLocksForTesting();
+            if (removed == 0) Thread.sleep(10);
+        }
+        assertTrue(removed > 0, "collected lock entry should be drained from its reference queue");
+    }
+
+    private static WeakReference<RuntimeScalar> registerEphemeralLock() {
+        RuntimeScalar root = new RuntimeScalar(1);
+        SharedPerlStorage.shareValue(root);
+        SharedPerlStorage.lockForTesting(root);
+        return new WeakReference<>(root);
+    }
+
+    private static FutureTask<Void> contender(ReentrantLock lock, AtomicInteger inside,
+                                              AtomicInteger maximum, CountDownLatch start) {
+        return new FutureTask<>(() -> {
+            assertTrue(start.await(5, TimeUnit.SECONDS));
+            lock.lock();
+            try {
+                maximum.accumulateAndGet(inside.incrementAndGet(), Math::max);
+                Thread.sleep(20);
+                inside.decrementAndGet();
+            } finally {
+                lock.unlock();
+            }
+            return null;
+        });
+    }
+}

--- a/src/test/resources/unit/threads_create_forms.t
+++ b/src/test/resources/unit/threads_create_forms.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+use threads;
+
+print "1..4\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - ", $name, "\n");
+}
+
+sub named_entry { return $_[0] + 1 }
+
+my $with_options = threads->create({ stack_size => 0 }, sub { return 7 });
+check($with_options->join == 7, 'create accepts an options hash before CODE');
+check(!$with_options->error, 'options-hash thread has no error');
+
+my $by_name = threads->create('named_entry', 8);
+check($by_name->join == 9, 'create resolves a named entry subroutine');
+check(!$by_name->error, 'named-entry thread has no error');

--- a/src/test/resources/unit/threads_inheritance_clone.t
+++ b/src/test/resources/unit/threads_inheritance_clone.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use threads;
+
+print "1..3\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - ", $name, "\n");
+}
+
+package ThreadParent;
+sub inherited { return 42 }
+
+package ThreadChild;
+our @ISA = ('ThreadParent');
+
+package main;
+check(ThreadChild->inherited == 42, 'parent resolves inherited method');
+my $thread = threads->create(sub {
+    return join ':', @ThreadChild::ISA, ThreadChild->inherited;
+});
+check($thread->join eq 'ThreadParent:42', 'child preserves ISA and method lookup');
+check(!$thread->error, 'child inherited call has no thread error');


### PR DESCRIPTION
## Summary

- require Java 24 consistently in Gradle, Maven, CI, Docker, launchers, and current documentation
- complete supported `threads->create` option/named-entry forms and preserve cloned package inheritance by treating stashes as child-runtime live views
- publish multiplicity, ithread, sharing, virtual-thread, and limitation documentation, with self-checking isolated/shared examples
- replace the permanent shared-lock identity map with a weak identity registry while preserving one recursive lock per live shared root
- update the living concurrency plan with exact current compatibility totals and only genuinely remaining work

## Compatibility results

- `op/threads.t`: 28/30
- `op/substr_thr.t`: 368/400
- `re/stclass_threads.t`: 2/6
- `class/threads.t`: 4/4
- Storable thread test: 2/2
- `threads-dirh.t`: complete (0/0 on this platform)

The remaining failures are recorded as follow-up work rather than advertised as supported behavior. The lower `stclass_threads.t` count reflects that the child now really executes and exposes missing thread-local `re 'debug'` trace compatibility.

## Validation

- post-rebase `make`: PASS (all unit shards and shadow JAR)
- `make test-all`: exit 0
  - Perl core: 263443/321811 (81.9%)
  - bundled modules: 9966/12339 (80.8%)
  - `re/pat.t`: 1098/1302
  - `run/switches.t`: 74/142
- `make check-links`: 537 links, 0 errors
- new Perl semantic tests: PASS under system Perl and both PerlOnJava backends
- thread examples: compile and execute successfully under system Perl, JVM, and interpreter backends
- Java 24 platform/virtual diagnostics: shared conditions, regex timeout, lifecycle, and representative native FFM calls pass without a pinning trace

See `dev/design/concurrency.md` for the supported surface, implementation history pointer, limitations, and next steps.
