### PR TITLE
fix: complete Perl threads lifecycle follow-ups

### DIFF
--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -1,8 +1,8 @@
 # Perl Threads Implementation Plan
 
 **Status:** Active implementation plan
-**Version:** 2.0
-**Date:** 2026-08-11
+**Version:** 2.1
+**Date:** 2026-08-12
 **Supersedes:** the previous `concurrency.md` proposal and
 `dev/prompts/multiplicity-v2-plan.md`
 
@@ -565,7 +565,7 @@ passes on system Perl and both PerlOnJava backends.
 The supported `threads` import/stringification surface is documented, while
 signals, effective stack sizing, `object`, and `wantarray` remain explicit
 limitations. Activation coverage passes on both backends. The first broader
-compatibility inventory currently reaches 28/30 in core `op/threads.t`, 368/400
+compatibility inventory currently reaches 29/30 in core `op/threads.t`, 368/400
 in `op/substr_thr.t`, and 2/6 in `re/stclass_threads.t`; `class/threads.t`,
 Storable's thread test, and `threads-dirh.t` complete. These are measured
 follow-up targets, not a claim that every upstream thread suite is green.
@@ -598,10 +598,21 @@ per live root; condition waiters remain strongly held only while a waiter is
 published. Focused contention and collection tests cover both properties.
 
 Java 24 virtual-thread diagnostics cover shared conditions, regex timeouts,
-thread lifecycle, and representative native FFM identity calls without a
-pinning trace or semantic delta. A platform/virtual inherited-descriptor probe
-failed identically in the current host environment, so broader native I/O and
-callback coverage remains required before virtual mode can be promoted.
+thread lifecycle, representative native FFM identity calls, child-created file
+I/O, and Test2 IPC without a pinning trace or semantic delta. A platform/virtual
+inherited-descriptor probe failed identically in the current host environment,
+so broader native callback coverage remains required before virtual mode can be
+promoted.
+
+Test2's general thread suites now pass, including the six-assertion IPC
+acceptance test on platform and virtual threads. This required preserving genuine
+closure captures through END dispatch and synchronizing the compiled-CV registry
+used by concurrent lazy materialization; no Test2-specific patch was added.
+
+Runtime pooling remains disabled. `PerlRuntime.close()` is a terminal operation,
+not a reset, and representative package, regex, and execution state deliberately
+remains observable on the closed object. The complete fresh-runtime equivalence
+contract and state inventory live in `runtime-pooling-reset-contract.md`.
 
 ### Implementation History
 
@@ -613,17 +624,17 @@ request history.
 ### Next Steps
 
 1. Finish the remaining activated core-thread gaps instead of treating partial
-   TAP counts as success. Raise `op/threads.t` from 28/30,
-   `op/substr_thr.t` from 368/400, and `re/stclass_threads.t` from 2/6 while
+   TAP counts as success. Raise the final parser case in `op/threads.t` and the
+   remaining partial results in `op/substr_thr.t` and `re/stclass_threads.t` while
    keeping `class/threads.t`, Storable's thread test, and `threads-dirh.t`
    complete. The regex result now executes the child and exposes missing
    thread-local `re 'debug'` trace compatibility; it is not a crash regression.
    Classify every remaining skip as an explicit documented limitation, run each
    file with the standard-Perl oracle first, and keep the exact counts in the
-   differential gate until they are complete. Only then expand to Test2 and
-   native-callback thread suites.
-2. Expand compatibility coverage to Test2 and native callback/resource suites,
-   defining an explicit clone or rejection policy for each native handle class.
+   differential gate until they are complete.
+2. Expand native callback/resource coverage beyond the passing POSIX identity,
+   child-file I/O, regex, and Test2 IPC diagnostics, defining an explicit clone
+   or rejection policy for each native handle class.
 3. Extend the Java 24 virtual-thread diagnostic matrix to real native I/O and
    callback workloads on supported CI hosts. Keep the mode experimental unless
    those traces are clean and repeated benchmarks show a material benefit.
@@ -631,8 +642,9 @@ request history.
    0.544 seconds on platform threads and 0.543 seconds on virtual threads with
    identical checksums. That is semantic parity, not a demonstrated benefit,
    and cannot substitute for native-I/O diagnostics on Java 24.
-4. Define and prove a complete reset contract before considering runtime pooling;
-   a pooled interpreter must be observably equivalent to a fresh snapshot.
+4. Implement every item in `runtime-pooling-reset-contract.md` before considering
+   runtime pooling; a pooled interpreter must be observably equivalent to a
+   fresh snapshot.
 
 ### Open Questions
 
@@ -649,4 +661,5 @@ request history.
 - `dev/prompts/multiplicity-v2-plan.md` — historical incremental plan
 - `dev/design/clone.md` — historical clone exploration, not the ithread cloner
 - `dev/design/attributes.md` — current attribute behavior
+- `dev/design/runtime-pooling-reset-contract.md` — required proof before pooling
 - `dev/design/fork_open_emulation.md` — process/fork-related alternatives

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -456,13 +456,125 @@ single-threaded PSGI environment.
 Acceptance: the supported compatibility matrix is green and the compiler is
 fully functional with ithreads advertised.
 
-### Phase 23 — Optional virtual threads and runtime pooling
+### Phase 23 — Optional virtual threads
 
 After correctness and diagnostics are stable, benchmark an opt-in virtual-thread
-executor and reusable runtime pools. Neither is required for Perl compatibility.
+executor. Virtual threads are not required for Perl compatibility and remain an
+experimental process-wide choice until the complete platform-thread compatibility
+matrix also passes in virtual mode.
 
-Acceptance: no semantic change, no pinning surprise in supported workloads, and
-measured benefit over platform threads/full clone.
+Acceptance: no semantic change or native/FFM surprise in supported workloads.
+Promotion beyond experimental additionally requires a measured benefit over
+platform threads; runtime-clone cost must not be mistaken for scheduler cost.
+
+### Phase 24 — Final core syntax compatibility
+
+Finish the remaining `op/threads.t` postfix create/join expression without a
+thread-specific parser shortcut that changes ordinary anonymous-sub precedence.
+
+Acceptance: `op/threads.t` reaches 30/30 on JVM and interpreter backends while
+`class/threads.t` remains 4/4 and `threads-dirh.t` continues to exit cleanly.
+
+### Phase 25 — Snapshot graph integrity under large suites
+
+Remove null-payload and CODE-root cloning failures exposed by the large regex
+thread wrappers. Preserve graph identity, weak edges, and source immutability;
+do not repair these failures by sharing ordinary child values with the parent.
+
+Acceptance: `pat_psycho_thr.t`, `pat_rt_report_thr.t`, `pat_thr.t`,
+`regexp_unicode_prop_thr.t`, and `speed_thr.t` reach their direct, unthreaded
+suite baselines without clone exceptions on either backend.
+
+### Phase 26 — Scalar lvalue and magic parity
+
+Fix the ordinary `index`/`substr` lvalue, warning, overload, reference-
+stringification, and lexical-magic behavior exposed by their thread wrappers.
+Treat failures present in the direct suite as language/operator gaps rather than
+thread-cloning failures.
+
+Acceptance: direct and threaded forms both reach `index_thr.t` 415/415 and
+`substr_thr.t` 400/400 on JVM and interpreter backends.
+
+### Phase 27 — Regex runtime concurrency and debug state
+
+Complete runtime ownership and synchronization for user-defined Unicode
+properties and clone the lexical `re 'debug'` configuration and diagnostic
+routing required by threaded regex compilation.
+
+Acceptance: `user_prop_race_thr.t` reaches 3/3 within its bounded deadlines and
+`stclass_threads.t` reaches 6/6 with parent/child trace equivalence.
+
+### Phase 28 — General regex parity exposed by thread wrappers
+
+Implement the remaining parser/runtime features in `pat_re_eval`, `reg_email`,
+`regexp_qr_embed`, Unicode-property, conditional, control-verb, and lookbehind
+coverage. These are shared regex-language gaps, not permission to special-case
+the `_thr.t` harness.
+
+Acceptance: every applicable regex `_thr.t` wrapper has zero assertion delta
+from its direct companion suite and neither path terminates early.
+
+### Phase 29 — Complete and truthful `threads` API
+
+Implement current-thread/class-form `detach`, thread signals, `object`,
+`wantarray`, exit/context options, exit status, and the stack-size API where the
+JVM can honor it. Unsupported platform guarantees must fail clearly; capability
+methods must never advertise a silent no-op such as the current `kill` stub.
+
+Acceptance: system-Perl-validated API tests cover object and class forms,
+success/error/exit lifecycle, watchdog cancellation, import options, and
+capability reporting on both backends.
+
+### Phase 30 — Resource inheritance and Test2 stress
+
+Define inherited pipe, descriptor, and filehandle behavior for thread snapshots.
+Preserve the already-green default Test2 thread/IPC suites, then enable the
+applicable timeout and opt-in thread stress paths without changing Test2.
+
+Acceptance: `ipc_wait_timeout.t` observes Perl-compatible inherited-pipe
+behavior; default Test2 remains green; `AUTHOR_TESTING` and
+`T2_DO_THREAD_TESTS` thread suites form a separately reported stress gate.
+
+### Phase 31 — Native callbacks and handle ownership
+
+Define clone, child-owned creation, or explicit rejection for every native
+handle class. Bind callbacks to their captured runtime and make provider/handle
+registries safe under concurrent child creation and deterministic cleanup.
+
+Acceptance: Net::SSLeay `61_threads-cb-crash.t` and
+`62_threads-ctx_new-deadlock.t` pass without watchdog, deadlock, cross-runtime
+handle leakage, or callback misbinding; applicable thread-emulated server paths
+in the wider Net::SSLeay suite retain their non-thread baseline.
+
+### Phase 32 — Advanced shared values
+
+Extend `threads::shared` only where identity, magic, tie callbacks, locking, and
+clone behavior are defined. Blessed, tied, or magical graphs remain explicit
+errors until their complete semantics are proven.
+
+Acceptance: each newly supported value category has standard-Perl-validated
+identity, mutation, lock/condition, clone, destruction, and stress coverage.
+
+### Phase 33 — Compatibility completion, documentation, and examples
+
+Run the complete applicable core, Test2, Storable, and native thread matrix;
+update the feature matrix from raw results; and add a realistic dynamic
+map/reduce example that shares only its scheduler while returning worker-local
+aggregates through `join`.
+
+Acceptance: platform threads pass all supported tests on JVM and interpreter
+backends; every remaining skip is an explicit platform or unsupported-feature
+decision; virtual mode has no semantic delta; example output is deterministic
+across system Perl and all supported modes.
+
+### Phase 34 — Optional runtime pooling
+
+Consider reusable runtimes only after the fresh-runtime equivalence contract is
+implemented in full. Pooling is neither a Perl threads requirement nor a reason
+to weaken close/snapshot isolation.
+
+Acceptance: every item in `runtime-pooling-reset-contract.md` passes and reuse
+has a measured benefit over a fresh snapshot.
 
 ## 6. Known Reference Material and Warnings
 
@@ -478,7 +590,7 @@ measured benefit over platform threads/full clone.
 
 ## 7. Progress Tracking
 
-### Current Status: Phases 21–23 implemented; activation hardening continues
+### Current Status: Phase 23 implemented; compatibility hardening begins next
 
 Hints, warnings, filters, and source maps are runtime-owned while compiler-only
 scratch remains protected by the global compile lock. The Phase 11 inventory is
@@ -623,28 +735,24 @@ request history.
 
 ### Next Steps
 
-1. Finish the remaining activated core-thread gaps instead of treating partial
-   TAP counts as success. Raise the final parser case in `op/threads.t` and the
-   remaining partial results in `op/substr_thr.t` and `re/stclass_threads.t` while
-   keeping `class/threads.t`, Storable's thread test, and `threads-dirh.t`
-   complete. The regex result now executes the child and exposes missing
-   thread-local `re 'debug'` trace compatibility; it is not a crash regression.
-   Classify every remaining skip as an explicit documented limitation, run each
-   file with the standard-Perl oracle first, and keep the exact counts in the
-   differential gate until they are complete.
-2. Expand native callback/resource coverage beyond the passing POSIX identity,
-   child-file I/O, regex, and Test2 IPC diagnostics, defining an explicit clone
-   or rejection policy for each native handle class.
-3. Extend the Java 24 virtual-thread diagnostic matrix to real native I/O and
-   callback workloads on supported CI hosts. Keep the mode experimental unless
-   those traces are clean and repeated benchmarks show a material benefit.
-   On Java 24, the initial creation/join smoke measured 30 cloned ithreads in
-   0.544 seconds on platform threads and 0.543 seconds on virtual threads with
-   identical checksums. That is semantic parity, not a demonstrated benefit,
-   and cannot substitute for native-I/O diagnostics on Java 24.
-4. Implement every item in `runtime-pooling-reset-contract.md` before considering
-   runtime pooling; a pooled interpreter must be observably equivalent to a
-   fresh snapshot.
+1. After PR 939 merges, implement Phases 24–28 as independent, always-green PRs:
+   final core syntax, snapshot graph integrity, scalar operator parity, regex
+   concurrency/debug state, and then general regex parity. For every `_thr.t`
+   result, record the direct companion suite in the same run and require zero
+   thread-induced delta rather than comparing aggregate TAP counts alone.
+2. Implement Phases 29–32 independently: truthful API behavior, resource
+   inheritance and Test2 stress, native callback/handle ownership, and only then
+   additional shared value categories. Preserve the green anchors after every
+   PR: `class/threads.t`, `threads-dirh.t`, Storable threads, and default Test2
+   thread/IPC coverage.
+3. Complete Phase 33 with the full platform-thread matrix on both backends,
+   followed by virtual-mode parity. Add `examples/threads/dynamic_map_reduce.pl`
+   to demonstrate a small shared scheduler, isolated worker-local hashes, and
+   deterministic join aggregation; do not claim a performance benefit from the
+   example.
+4. Keep virtual threads experimental until native callback diagnostics and
+   repeated benchmarks justify promotion. Keep runtime pooling disabled until
+   the separate Phase 34 reset contract proves fresh-runtime equivalence.
 
 ### Open Questions
 

--- a/dev/design/runtime-pooling-reset-contract.md
+++ b/dev/design/runtime-pooling-reset-contract.md
@@ -1,0 +1,101 @@
+# Runtime Pooling Reset Contract
+
+## Status
+
+Runtime pooling is deferred. `PerlRuntime.close()` is a terminal resource-release
+operation, not a reset operation, and a closed runtime deliberately rejects
+`bind`, `initialize`, and `execute`. Reusing it would currently expose state that
+a newly constructed runtime does not contain.
+
+This document defines the proof required before a pool may be implemented. It
+does not authorize clearing state opportunistically or enabling pooling behind
+an experimental flag.
+
+## Fresh-runtime equivalence
+
+A reusable runtime must expose the same observable state as a newly constructed
+`PerlRuntime` initialized under the same process configuration. Reset is not
+equivalent merely because no task is running and open handles were closed.
+
+For workloads `A` and `B`, the required differential is:
+
+```text
+run A; reset; run B  ==  new runtime; run B
+```
+
+The equality applies to Perl results, diagnostics, exceptions, package and CODE
+visibility, file descriptors, callbacks, cache behavior, destruction timing,
+thread registries, and Java-side runtime inspection. It must hold after normal
+return, `die`, timeout, child-thread creation, detached child completion, and
+partial initialization failure.
+
+## State inventory
+
+The runtime owns all of the following reset domains. Every domain needs either
+an explicit reset implementation and differential test or a written proof that
+the state is immutable process configuration.
+
+| Domain | Representative state | Current `close()` coverage |
+|---|---|---|
+| Package graph | globals, CODE refs, stashes, classes, aliases, `%INC`, generated classloader | retained |
+| Execution | caller/dynamic stacks, special variables, END/INIT/CHECK blocks, eval frames, taint, async queues | retained |
+| Regex | matches/captures, `pos`, `/o`, match-once, compiled and Unicode-property caches | retained |
+| Dispatch/compilation | eval classes, method handles, inline caches, pad constants, compiler/source maps | retained |
+| MRO and module services | method resolution, filters, module guards, shim-loading markers | retained |
+| Lifecycle | weak references, mortal queues, tracked owners, destruction roots | partially released |
+| Threads | registry membership, detached workers, shared storage/lock ownership, waiters | not resettable while live |
+| Process services | signals, alarms, random state, pending fork-open, native/module registries | partially released |
+| I/O | standard-handle replacement/visibility, selected/last handles, open-handle registry, diamond state, file-test cache | open resources released; topology retained |
+| Data/debug/native | DATA sections, debugger state, pointer packing, Net::SSLeay queues/state | partially released |
+| Identity/counters | bless and compiled-code identities, eval filenames, callsite IDs, name-normalizer state | retained |
+
+`close()` currently cancels the active alarm, clears queued signals, closes
+registered handles, resets Net::SSLeay and mortal state, and clears selected
+native/I/O and operator registries before marking the runtime closed. That is a
+correct terminal lifecycle, but it is intentionally insufficient for pooling.
+
+## Acceptance checklist
+
+Pooling remains disabled until all items below are complete:
+
+- [ ] Introduce one exclusive lifecycle transition that prevents reset while
+  execution, compilation, callbacks, ithreads, detached children, shared-lock
+  ownership, or condition waiters remain active.
+- [ ] Define whether core bootstrap state is reconstructed or restored from an
+  immutable template; user package/CODE/class state and `%INC` must never leak.
+- [ ] Recreate standard I/O wrappers and glob topology without closing borrowed
+  JVM streams, and restore selected/last-handle and visibility defaults.
+- [ ] Drain END/destruction work according to normal Perl semantics before
+  clearing lifecycle roots; prove weak references and rescued objects do not
+  cross tenants.
+- [ ] Clear every state domain in the inventory, including counters and caches,
+  without retaining generated classes or prior workload object graphs.
+- [ ] Restore process-derived defaults (`cwd`, environment view, random policy,
+  warning/feature defaults) according to an explicitly documented checkout
+  contract.
+- [ ] Reject or quarantine a runtime after reset failure; a partially reset
+  runtime must never return to the pool.
+- [ ] Prove `A; reset; B == fresh; B` on both compiler backends across globals,
+  closures, eval/require, regex, warnings/hints, MRO, I/O, lifecycle, signals,
+  native modules, DATA, debugger state, and exceptions.
+- [ ] Add concurrency/stress coverage for checkout ownership, cancellation,
+  detached-thread completion, repeated churn, and shared-storage lifetime.
+- [ ] Add retention measurements showing that workload classloaders, package
+  graphs, handles, and shared-lock entries become collectible after reset.
+- [ ] Benchmark against fresh construction and snapshot cloning. Enable pooling
+  only for a measured benefit large enough to justify the new lifecycle risk.
+
+## Current automated guard
+
+`PerlRuntimePoolingResetContractTest` records the present negative contract:
+close is terminal, closed runtimes cannot be rebound or executed, and package,
+regex-cache, and execution settings retained by the terminal object differ from
+a fresh runtime. The test prevents a future pool from treating `close()` as a
+reset without first replacing this negative proof with the full equivalence
+suite above.
+
+## Related documents
+
+- `dev/design/concurrency.md` — multiplicity, ithreads, and virtual-thread policy
+- `docs/reference/architecture.md` — public runtime ownership overview
+- `docs/reference/memory-management.md` — lifecycle and weak-reference behavior

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -860,7 +860,7 @@ storage as their parent counterparts. Values explicitly shared through
 | Additional introspection | `threads->object` and `wantarray` are not implemented. |
 | Shared object classes | Blessed and tied values are rejected by the supported `share`/`shared_clone` tranche. |
 | Native resources and callbacks | Java I/O/native handles are not portably duplicated into child snapshots; native callback thread isolation remains suite-specific. |
-| Upstream suite coverage | Core compatibility remains partial: measured results include `op/threads.t` 28/30, `op/substr_thr.t` 368/400, and `re/stclass_threads.t` 2/6; `class/threads.t`, Storable's thread test, and `threads-dirh.t` complete. The regex suite now executes its child and exposes unsupported thread-local `re 'debug'` trace parity. |
+| Upstream suite coverage | Core compatibility remains partial: measured results include `op/threads.t` 29/30, `op/substr_thr.t` 368/400, and `re/stclass_threads.t` 2/6; `class/threads.t`, Storable's thread test, `threads-dirh.t`, and Test2's thread IPC acceptance test complete. The regex suite now executes its child and exposes unsupported thread-local `re 'debug'` trace parity. |
 | PSGI | Availability of ithreads does not make one captured PSGI application runtime concurrently callable. `Plack::Handler::Netty` advertises `psgi.multithread => \0`. |
 
 The complete design and measured validation record is in

--- a/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
+++ b/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
@@ -593,8 +593,9 @@ public class PerlLanguageProvider {
                     // file-scoped lexicals are destroyed before END block dispatch.
                     MortalList.flush();
 
-                    // Genuine captures remain live while an END block can reach their
-                    // closure. Ready captures were already processed at scope exit.
+                    // Destroy unrelated file lexicals before END while retaining
+                    // captures reachable from queued END blocks or package CODE.
+                    MortalList.flushDeferredCapturesBeforeEnd();
                     CallerStack.push("main", ctx.compilerOptions.fileName, 0);
                     try {
                         runEndBlocks();
@@ -625,6 +626,7 @@ public class PerlLanguageProvider {
         } catch (Throwable t) {
             if (isMainProgram) {
                 MortalList.flush();  // Flush file-scoped lexical cleanup before END
+                MortalList.flushDeferredCapturesBeforeEnd();
                 CallerStack.push("main", ctx.compilerOptions.fileName, 0);
                 try {
                     runEndBlocks(false);  // Don't reset $? on exception path

--- a/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
+++ b/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
@@ -593,20 +593,16 @@ public class PerlLanguageProvider {
                     // file-scoped lexicals are destroyed before END block dispatch.
                     MortalList.flush();
 
-                    // Process captured variables whose scope has exited but whose
-                    // refCount was deferred because captureCount > 0. The interpreter
-                    // captures ALL visible lexicals for eval STRING support, inflating
-                    // captureCount on variables that closures don't actually use.
-                    // Now that all scopes have exited, it's safe to decrement.
-                    // This must happen before END blocks so that DBIC's LeakTracer
-                    // (which runs in an END block) sees objects properly DESTROY'd.
-                    MortalList.flushDeferredCaptures();
-
+                    // Genuine captures remain live while an END block can reach their
+                    // closure. Ready captures were already processed at scope exit.
                     CallerStack.push("main", ctx.compilerOptions.fileName, 0);
                     try {
                         runEndBlocks();
                     } finally {
                         CallerStack.pop();
+                        // END may itself fail; captured cleanup still belongs after
+                        // the attempted END dispatch and before runtime teardown.
+                        MortalList.flushDeferredCaptures();
                     }
                     // Global destruction: walk stashes for tracked blessed objects
                     GlobalDestruction.runGlobalDestruction();
@@ -629,12 +625,12 @@ public class PerlLanguageProvider {
         } catch (Throwable t) {
             if (isMainProgram) {
                 MortalList.flush();  // Flush file-scoped lexical cleanup before END
-                MortalList.flushDeferredCaptures();  // Process captured vars (see above)
                 CallerStack.push("main", ctx.compilerOptions.fileName, 0);
                 try {
                     runEndBlocks(false);  // Don't reset $? on exception path
                 } finally {
                     CallerStack.pop();
+                    MortalList.flushDeferredCaptures();  // Live captures outlast END
                 }
                 RuntimeIO.closeAllHandles();
             }

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
@@ -1228,7 +1228,7 @@ public class CompileAssignment {
 
                     bytecodeCompiler.lastResultReg = valueReg;
                 } else if (leftOp.operator.equals("substr")) {
-                    bytecodeCompiler.compileNode(node.left, -1, rhsContext);
+                    bytecodeCompiler.compileNode(node.left, -1, RuntimeContextType.LVALUE);
                     int lvalueReg = bytecodeCompiler.lastResultReg;
 
                     bytecodeCompiler.emit(Opcodes.SET_SCALAR);

--- a/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
@@ -950,7 +950,7 @@ public class EmitVariable {
                     // Fall through for unsupported ref aliasing targets (global vars, etc.)
                 }
 
-                int lhsContext = isCallableLvalueTarget(node.left)
+                int lhsContext = isScalarLvalueTarget(node.left)
                         ? RuntimeContextType.LVALUE
                         : RuntimeContextType.SCALAR;
                 node.left.accept(emitterVisitor.with(lhsContext));   // emit the variable
@@ -1064,7 +1064,12 @@ public class EmitVariable {
         return false;
     }
 
-    private static boolean isCallableLvalueTarget(Node node) {
+    private static boolean isScalarLvalueTarget(Node node) {
+        if (node instanceof OperatorNode operator) {
+            return operator.operator.equals("substr")
+                    || operator.operator.equals("pos")
+                    || operator.operator.equals("vec");
+        }
         if (!(node instanceof BinaryOperatorNode binop)) {
             return false;
         }

--- a/src/main/java/org/perlonjava/frontend/parser/ListParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ListParser.java
@@ -222,6 +222,20 @@ public class ListParser {
                     expr.elements.add(parser.parseExpression(parser.getPrecedence(",")));
                     token = TokenUtils.peek(parser);
                     if (isComma(token)) {
+                        // Perl accepts a fat comma immediately before a postfix
+                        // dereference as a separator terminating an indirect
+                        // call's argument list:
+                        //
+                        //     create threads sub { ... } =>->join->()()
+                        //
+                        // Consume only that separator here.  The surrounding
+                        // expression parser must see the arrow so it binds to
+                        // the completed call, rather than treating `->` as the
+                        // start of another list argument.
+                        if (token.text.equals("=>") && isFollowedByArrow(parser)) {
+                            TokenUtils.consume(parser);
+                            break;
+                        }
                         token = consumeCommas(parser);
                     } else {
                         break;
@@ -243,6 +257,16 @@ public class ListParser {
 
     static boolean isComma(LexerToken token) {
         return token.text.equals(",") || token.text.equals("=>");
+    }
+
+    private static boolean isFollowedByArrow(Parser parser) {
+        int index = parser.tokenIndex + 1;
+        while (index < parser.tokens.size()
+                && parser.tokens.get(index).type == LexerTokenType.WHITESPACE) {
+            index++;
+        }
+        return index < parser.tokens.size()
+                && parser.tokens.get(index).text.equals("->");
     }
 
     static LexerToken consumeCommas(Parser parser) {

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -1433,6 +1433,7 @@ public class SubroutineParser {
         // This prevents hitting JVM's 255 constructor argument limit for named subs
         // in modules like Perl::Tidy that have 200+ lexicals in scope.
         Set<String> usedVars = null;
+        Set<String> explicitlyUsedVars;
         {
             Set<String> usedVarSet = new HashSet<>();
             Set<String> declaredVarSet = new LinkedHashSet<>();
@@ -1440,6 +1441,7 @@ public class SubroutineParser {
                     new VariableCollectorVisitor(usedVarSet, declaredVarSet);
             block.accept(collector);
             placeholder.lexicalVariableNames = declaredVarSet;
+            explicitlyUsedVars = usedVarSet;
             if (!collector.hasEvalString()) {
                 usedVars = usedVarSet;
             }
@@ -1520,7 +1522,13 @@ public class SubroutineParser {
                     default -> throw new IllegalStateException("Unexpected value: " + sigil);
                 };
                 paramList.add(capturedVar);
-                capturedNames.add(entry.decl().equals("our") ? null : entry.name());
+                // Eval STRING requires conservatively retaining every visible
+                // runtime value, but that implementation capture is not a
+                // semantic closure edge. Record only names explicitly used by
+                // the sub AST for lifecycle/reachability decisions.
+                capturedNames.add(!entry.decl().equals("our")
+                        && explicitlyUsedVars.contains(entry.name())
+                        ? entry.name() : null);
                 // System.out.println("Capture " + entry.decl() + " " + entry.name() + " as " + variableName);
             }
         }

--- a/src/main/java/org/perlonjava/runtime/operators/Operator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Operator.java
@@ -388,7 +388,7 @@ public class Operator {
             if (replacement != null) {
                 throw new PerlCompilerException("substr outside of string");
             }
-            if (warnEnabled) {
+            if (warnEnabled && ctx != RuntimeContextType.LVALUE) {
                 WarnDie.warn(new RuntimeScalar("substr outside of string"),
                         RuntimeScalarCache.scalarEmptyString);
             }
@@ -427,7 +427,7 @@ public class Operator {
                 int adjustedLength = length + offset;
                 if (adjustedLength < 0) {
                     // Adjusted length is negative - warn and return undef
-                    if (warnEnabled) {
+                    if (warnEnabled && ctx != RuntimeContextType.LVALUE) {
                         WarnDie.warn(new RuntimeScalar("substr outside of string"),
                                 RuntimeScalarCache.scalarEmptyString);
                     }
@@ -455,7 +455,7 @@ public class Operator {
 
         // Only warn/error for positive offsets that exceed string length
         if (offset > strLength) {
-            if (warnEnabled) {
+            if (warnEnabled && ctx != RuntimeContextType.LVALUE) {
                 WarnDie.warn(new RuntimeScalar("substr outside of string"),
                         RuntimeScalarCache.scalarEmptyString);
             }

--- a/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
+++ b/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
@@ -670,11 +670,9 @@ public class WarnDie {
         getGlobalVariable("main::?").set(exitCode);
         // Flush file-scoped lexical cleanup before END blocks
         MortalList.flush();
-        // Process deferred captures (captured blessed refs whose scope has exited).
-        // This must happen before END blocks so that DBIC's leak tracer sees
-        // objects as properly collected. Without this, exit() via plan skip_all
-        // skips the normal cleanup path in PerlLanguageProvider.
-        MortalList.flushDeferredCaptures();
+        // Match normal shutdown: destroy captures unrelated to END now, while
+        // preserving values reachable by END/global CODE until END completes.
+        MortalList.flushDeferredCapturesBeforeEnd();
         try {
             runEndBlocks(false);  // Don't reset $? - we just set it to the exit code
         } catch (Throwable t) {
@@ -682,6 +680,8 @@ public class WarnDie {
             String errorMessage = ErrorMessageUtil.stringifyException(t);
             System.err.println(errorMessage);
             throw new PerlExitException(1);
+        } finally {
+            MortalList.flushDeferredCaptures();
         }
         // Global destruction: walk stashes for tracked blessed objects
         GlobalDestruction.runGlobalDestruction();

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
@@ -51,14 +51,14 @@ public final class Threads extends PerlModuleBase {
             }
             code = GlobalVariable.getGlobalCodeRef(name);
         }
-        if (code.type != RuntimeScalarType.CODE) {
-            throw new IllegalArgumentException("threads->create requires a CODE reference");
-        }
+        // Perl accepts a reference-valued entry here and creates the ithread;
+        // the child then fails with "Not a CODE reference". Keeping creation
+        // asynchronous preserves join/error lifecycle and core diagnostics.
         // BEGIN-time code holds the global compilation lock. A new ithread may
         // need that lock for require/eval before it can signal readiness, so
         // core's test.pl watchdog would deadlock the compiler while polling it.
-        // Config still deliberately does not advertise ithreads; preserve the
-        // old detached watchdog-stub behavior at this interim boundary.
+        // Preserve the detached watchdog behavior at this compile-time boundary;
+        // starting a real child here could deadlock on the enclosing compile lock.
         if (PerlLanguageProvider.COMPILE_LOCK.isHeldByCurrentThread()) {
             RuntimeHash stub = new RuntimeHash();
             stub.put("tid", new RuntimeScalar(-1));
@@ -94,7 +94,12 @@ public final class Threads extends PerlModuleBase {
         try {
             PerlThreadControlBlock.Completion completion = thread.join();
             object.put("state", new RuntimeScalar("joined"));
-            object.put("error", new RuntimeScalar(errorText(completion.error())));
+            String error = errorText(completion.error());
+            object.put("error", new RuntimeScalar(error));
+            if (!error.isEmpty()) {
+                RuntimeIO.getStderr().write(
+                        "Thread " + thread.id() + " terminated abnormally: " + error + "\n");
+            }
             if (!(completion.value() instanceof RuntimeArray values)) return new RuntimeList();
             List<RuntimeBase> cloned = new RuntimeGraphCloner(
                     thread.childRuntime(), PerlRuntime.current()).cloneRoots(values.elements);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeState.java
@@ -97,8 +97,8 @@ public final class GlobalRuntimeState {
         return deletedCodeRefPins;
     }
 
-    Map<Integer, RuntimeScalar> compiledCodeRefs() {
-        return compiledCodeRefs;
+    synchronized RuntimeScalar getCompiledCodeRef(int id) {
+        return compiledCodeRefs.get(id);
     }
 
     Map<String, Integer> localizedCodeRefDepth() {
@@ -270,7 +270,7 @@ public final class GlobalRuntimeState {
     }
 
     /** Copy package-owned interpreter state through one ithread graph cloner. */
-    void snapshotInto(GlobalRuntimeState target, RuntimeGraphCloner cloner) {
+    synchronized void snapshotInto(GlobalRuntimeState target, RuntimeGraphCloner cloner) {
         cloneMap(scalarValues, target.scalarValues, cloner, RuntimeScalar.class);
         cloneMap(arrayValues, target.arrayValues, cloner, RuntimeArray.class);
         cloneMap(hashValues, target.hashValues, cloner, RuntimeHash.class);
@@ -305,7 +305,8 @@ public final class GlobalRuntimeState {
     }
 
     /** Copy CV ids registered by a named sub that was materialized after snapshot. */
-    void snapshotCompiledCodeRefsInto(GlobalRuntimeState target, RuntimeGraphCloner cloner) {
+    synchronized void snapshotCompiledCodeRefsInto(
+            GlobalRuntimeState target, RuntimeGraphCloner cloner) {
         for (Map.Entry<Integer, RuntimeScalar> entry : compiledCodeRefs.entrySet()) {
             RuntimeScalar cloned = (RuntimeScalar) cloner.cloneValue(entry.getValue());
             RuntimeScalar existing = target.compiledCodeRefs.get(entry.getKey());

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
@@ -109,10 +109,6 @@ public class GlobalVariable {
         return globalState().deletedCodeRefPins();
     }
 
-    private static Map<Integer, RuntimeScalar> compiledCodeRefs() {
-        return globalState().compiledCodeRefs();
-    }
-
     private static Map<String, Integer> localizedCodeRefDepth() {
         return globalState().localizedCodeRefDepth();
     }
@@ -1597,7 +1593,7 @@ public class GlobalVariable {
     }
 
     public static RuntimeScalar getCompiledCodeRef(int id) {
-        RuntimeScalar ref = compiledCodeRefs().get(id);
+        RuntimeScalar ref = globalState().getCompiledCodeRef(id);
         return ref != null ? ref : new RuntimeScalar();
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
@@ -244,16 +244,14 @@ public class MortalList {
      * For each scalar, schedule a refCount decrement via
      * {@link #deferDecrementIfTracked}, then flush the pending list.
      * <p>
-     * Called from PerlLanguageProvider after the main script's
-     * {@code MortalList.flush()} and before END blocks, so that
-     * blessed objects whose refCount was kept elevated by interpreter
-     * closure captures (which capture ALL visible lexicals, not just
-     * referenced ones) have DESTROY fire before END block leak checks.
+     * Called from PerlLanguageProvider after END blocks, so that blessed
+     * objects retained by genuine live closures remain available to END.
+     * Interpreter closure over-capture can keep unrelated values alive until
+     * this boundary, but cannot justify destroying real captures before END.
      * <p>
-     * This is safe because at this point ALL lexical scopes have exited
-     * (the main script has returned). Closures installed in stashes still
-     * hold JVM references to the RuntimeScalar, but the selective
-     * refCount should reflect that the declaring scope is gone.
+     * At this point all lexical scopes and END blocks have exited. Closures can
+     * still hold JVM references to the RuntimeScalar, but selective refCount
+     * cleanup may now proceed into global destruction.
      */
     public static void flushDeferredCaptures() {
         LifecycleRuntimeState state = state();
@@ -269,8 +267,7 @@ public class MortalList {
         // After flushing deferred captures, clear weak refs for objects that
         // were rescued by DESTROY (e.g., Schema::DESTROY self-save pattern).
         // This must happen AFTER the flush above so that all pending refCount
-        // decrements have been processed, and BEFORE END blocks run so that
-        // DBIC's assert_empty_weakregistry sees the weak refs as undef.
+        // decrements have been processed and before global destruction.
         DestroyDispatch.clearRescuedWeakRefs();
 
         // Final sweep: clear weak refs for ALL remaining blessed objects.
@@ -282,7 +279,7 @@ public class MortalList {
         // leaks. Clearing weak refs here is safe because:
         // 1. Only weak refs are cleared — the Java objects remain alive
         // 2. CODE refs are excluded (they may still be called from stashes)
-        // 3. END blocks (where leak checks run) execute AFTER this point
+        // 3. END blocks have completed, so real closure captures are no longer needed
         WeakRefRegistry.clearAllBlessedWeakRefs();
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
@@ -175,8 +175,9 @@ public class MortalList {
      * Called from {@link RuntimeScalar#scopeExitCleanup} for non-CODE
      * blessed references that are captured by closures.
      * <p>
-     * These entries are processed by {@link #flushDeferredCaptures()} after
-     * the main script returns, before END blocks run.
+     * After the main script returns, entries unrelated to END are processed by
+     * {@link #flushDeferredCapturesBeforeEnd()}; retained entries are drained
+     * by {@link #flushDeferredCaptures()} after END blocks run.
      */
     public static void addDeferredCapture(RuntimeScalar scalar) {
         LifecycleRuntimeState state = state();
@@ -281,6 +282,35 @@ public class MortalList {
         // 2. CODE refs are excluded (they may still be called from stashes)
         // 3. END blocks have completed, so real closure captures are no longer needed
         WeakRefRegistry.clearAllBlessedWeakRefs();
+    }
+
+    /**
+     * Release scope-exited captures that cannot be reached by an END block or
+     * a package CODE slot, while retaining genuine END-visible captures for
+     * the unconditional post-END drain in {@link #flushDeferredCaptures()}.
+     *
+     * This preserves Perl's ordering: unrelated file lexicals are destroyed
+     * before END, but values captured by code that END can invoke stay alive
+     * until END has completed.
+     */
+    public static void flushDeferredCapturesBeforeEnd() {
+        LifecycleRuntimeState state = state();
+        if (state.deferredCaptures.isEmpty()) return;
+
+        Set<RuntimeBase> endReachable = ReachabilityWalker.walkEndBlockRoots();
+        boolean found = false;
+        for (int i = state.deferredCaptures.size() - 1; i >= 0; i--) {
+            RuntimeScalar scalar = state.deferredCaptures.get(i);
+            boolean retained = endReachable.contains(scalar)
+                    || (scalar.value instanceof RuntimeBase base && endReachable.contains(base));
+            if (retained) continue;
+
+            deferDecrementIfTracked(scalar);
+            state.deferredCaptures.remove(i);
+            removeFromDeferredSet(scalar);
+            found = true;
+        }
+        if (found) flush();
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ReachabilityWalker.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ReachabilityWalker.java
@@ -186,6 +186,79 @@ public class ReachabilityWalker {
         return reachable;
     }
 
+    /**
+     * Return the graph that must remain live while END blocks execute.
+     *
+     * Package CODE slots and queued END blocks are the only seeds. Captures
+     * are followed from both: they are real Perl ownership paths at this
+     * lifecycle boundary, unlike the conservative lexical seeds used by the
+     * general weak-reference sweep.
+     */
+    static Set<RuntimeBase> walkEndBlockRoots() {
+        ReachabilityWalker walker = new ReachabilityWalker();
+        java.util.ArrayDeque<RuntimeBase> todo = new java.util.ArrayDeque<>();
+
+        for (Map.Entry<String, RuntimeScalar> entry : GlobalVariable.globalCodeRefs.entrySet()) {
+            RuntimeScalar codeRef = entry.getValue();
+            if (codeRef == null || !(codeRef.value instanceof RuntimeCode code)) continue;
+
+            // The registry also contains anonymous/eval compilation artifacts.
+            // Those are implementation caches, not Perl package CODE roots;
+            // following them would retain every lexical conservatively captured
+            // for eval STRING. A genuinely callable package sub has a stable
+            // package/sub name and remains a valid path for END to invoke.
+            if (code.subName == null || code.subName.isEmpty()
+                    || code.subName.equals("__ANON__")
+                    || code.packageName == null || code.packageName.isEmpty()
+                    || code.packageName.startsWith("(eval")
+                    || (code.cvStartFile != null && code.cvStartFile.startsWith("(eval"))) {
+                continue;
+            }
+            walker.visitScalar(codeRef, todo);
+        }
+        walker.addReachable(SpecialBlock.getEndBlocks(), todo);
+        walker.bfsEndBlockRoots(todo);
+        return walker.reachable;
+    }
+
+    /**
+     * Traverse only semantic closure edges for END lifetime decisions.
+     * RuntimeCode.capturedScalars and reflective capture arrays also contain
+     * transient eval STRING captures attached while named code executes; those
+     * implementation edges must not extend a file lexical's Perl lifetime.
+     * closedOverVariables is populated from the closure's explicit lexical
+     * environment by both generated and interpreted backends.
+     */
+    private void bfsEndBlockRoots(java.util.ArrayDeque<RuntimeBase> todo) {
+        while (!todo.isEmpty()) {
+            RuntimeBase cur = todo.removeFirst();
+            if (cur instanceof RuntimeHash hash) {
+                if (hash.elements instanceof HashSpecialVariable) continue;
+                for (RuntimeScalar value : hash.elements.values()) {
+                    addReachable(value, todo);
+                    visitScalar(value, todo);
+                }
+            } else if (cur instanceof RuntimeArray array) {
+                for (RuntimeScalar value : array.elements) {
+                    addReachable(value, todo);
+                    visitScalar(value, todo);
+                }
+            } else if (cur instanceof RuntimeCode code) {
+                visitCodePadConstants(code, todo);
+                if (code.closedOverVariables != null) {
+                    for (RuntimeBase captured : code.closedOverVariables.values()) {
+                        addReachable(captured, todo);
+                        if (captured instanceof RuntimeScalar scalar) {
+                            visitScalar(scalar, todo);
+                        }
+                    }
+                }
+            } else if (cur instanceof RuntimeScalar scalar) {
+                visitScalar(scalar, todo);
+            }
+        }
+    }
+
     private void bfs(java.util.ArrayDeque<RuntimeBase> todo, boolean walkCaptures) {
         while (!todo.isEmpty()) {
             RuntimeBase cur = todo.removeFirst();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
@@ -84,6 +84,7 @@ public class RuntimeGraphCloner {
             clones.put(value, value);
             return value;
         }
+        if (value instanceof RuntimeCode code) return cloneCode(code);
         if (value instanceof RuntimeStash stash) return cloneStash(stash);
         if (value instanceof RuntimeGlob glob) return cloneGlob(glob);
         if (value instanceof RuntimeScalar scalar) return cloneScalar(scalar);

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimePoolingResetContractTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimePoolingResetContractTest.java
@@ -1,0 +1,43 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Guards the negative reset contract until fresh-equivalent pooling exists. */
+@Tag("unit")
+class PerlRuntimePoolingResetContractTest {
+
+    @Test
+    void closeIsTerminalRatherThanAReusableResetTransition() {
+        PerlRuntime runtime = new PerlRuntime().initialize();
+
+        runtime.close();
+
+        assertTrue(runtime.isClosed());
+        assertThrows(IllegalStateException.class, runtime::bind);
+        assertThrows(IllegalStateException.class, runtime::initialize);
+        assertThrows(IllegalStateException.class, () -> runtime.execute(() -> "reused"));
+    }
+
+    @Test
+    void closeDoesNotMakeRetainedStateFreshEquivalent() {
+        PerlRuntime used = new PerlRuntime();
+        PerlRuntime fresh = new PerlRuntime();
+
+        used.globalState.scalarValues().put(
+                "PoolingContract::tenant", new RuntimeScalar("first"));
+        used.regexState.optimizedRegexCache.put(7, new RuntimeScalar("compiled"));
+        used.executionState.taintMode = true;
+
+        used.close();
+
+        assertTrue(used.globalState.scalarValues().containsKey("PoolingContract::tenant"));
+        assertFalse(fresh.globalState.scalarValues().containsKey("PoolingContract::tenant"));
+        assertFalse(used.regexState.optimizedRegexCache.isEmpty());
+        assertTrue(fresh.regexState.optimizedRegexCache.isEmpty());
+        assertTrue(used.executionState.taintMode);
+        assertFalse(fresh.executionState.taintMode);
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/SharedPerlStorageTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/SharedPerlStorageTest.java
@@ -33,6 +33,8 @@ class SharedPerlStorageTest {
         start.countDown();
         firstTask.get(5, TimeUnit.SECONDS);
         secondTask.get(5, TimeUnit.SECONDS);
+        first.join(5_000);
+        second.join(5_000);
 
         assertFalse(first.isAlive());
         assertFalse(second.isAlive());

--- a/src/test/resources/unit/end_capture_destruction_order.t
+++ b/src/test/resources/unit/end_capture_destruction_order.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+
+our @destroyed;
+
+{
+    package EndCaptureOrderGuard;
+
+    sub new {
+        my $self = bless {}, $_[0];
+        eval '$self';
+        return $self;
+    }
+
+    sub DESTROY { push @main::destroyed, ref $_[0] }
+}
+
+my $instance = EndCaptureOrderGuard->new;
+
+END {
+    print "1..1\n";
+    my $destroyed_before_end = @destroyed == 1
+        && $destroyed[0] eq 'EndCaptureOrderGuard';
+    print($destroyed_before_end ? "ok 1" : "not ok 1",
+        " - eval capture does not delay lexical destruction past END\n");
+}

--- a/src/test/resources/unit/substr_lvalue_warning.t
+++ b/src/test/resources/unit/substr_lvalue_warning.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+
+print "1..4\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - ", $name, "\n");
+}
+
+my $warnings = 0;
+local $SIG{__WARN__} = sub {
+    ++$warnings if $_[0] =~ /^substr outside of string/;
+};
+
+my $string = 'abc';
+my $read = substr($string, 99, 1);
+check(!defined($read), 'out-of-range rvalue substr returns undef');
+check($warnings == 1, 'out-of-range rvalue substr warns once');
+
+$warnings = 0;
+my $error = '';
+eval { substr($string, 99, 1) = ''; 1 } or $error = $@;
+check($warnings == 0, 'out-of-range lvalue substr does not warn before assignment');
+check($error =~ /^substr outside of string/,
+    'out-of-range lvalue substr dies on assignment');

--- a/src/test/resources/unit/threads_end_captured_lifetime.t
+++ b/src/test/resources/unit/threads_end_captured_lifetime.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+
+use threads;
+
+print "1..1\n";
+our $destroyed = 0;
+
+{
+    package ThreadEndCaptureGuard;
+
+    sub new { bless {}, $_[0] }
+    sub value { 42 }
+    sub DESTROY { ++$main::destroyed }
+}
+
+my $instance = ThreadEndCaptureGuard->new;
+sub captured_owner { $instance->value }
+
+END {
+    my $ok = !$destroyed && captured_owner() == 42;
+    print($ok ? "ok 1" : "not ok 1",
+        " - captured package lexical remains alive through END\n");
+}
+
+threads->create(sub { captured_owner(); return 1 });

--- a/src/test/resources/unit/threads_native_resource_diagnostics.t
+++ b/src/test/resources/unit/threads_native_resource_diagnostics.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+
+use File::Temp qw(tempdir);
+use POSIX ();
+use threads;
+
+print "1..4\n";
+my $test = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$test;
+    print($condition ? "ok " : "not ok ", $test, " - $name\n");
+}
+
+my $directory = tempdir(CLEANUP => 1);
+my $path = "$directory/child.txt";
+my $thread = threads->create(sub {
+    my ($child_path) = @_;
+    my @identity = (POSIX::getuid(), POSIX::geteuid(), POSIX::getgid(), POSIX::getegid());
+
+    open my $output, '>', $child_path or die "open $child_path: $!";
+    print {$output} join(':', @identity), "\n";
+    close $output or die "close $child_path: $!";
+
+    my $anchor = qr{\G(?:[\x81-\x9F\xE0-\xFC][\x00-\xFF]|[\x00-\xFF])*?};
+    my $matched = (('A' x 8192) . 'B') =~ /(?:${anchor}B)/;
+    return [@identity, defined($matched) ? 1 : 0];
+}, $path);
+
+my $result = $thread->join;
+check(($thread->error || '') eq '', 'native/resource child completed without an error');
+check(scalar(@$result) == 5, 'native identity and regex result crossed the join boundary');
+check($result->[4], 'deep regex completed inside the child runtime');
+
+open my $input, '<', $path or die "open $path: $!";
+chomp(my $written = <$input>);
+close $input;
+check($written eq join(':', @$result[0 .. 3]),
+    'parent observes child-created file contents');

--- a/src/test/resources/unit/threads_postfix_create_and_invalid_entry.t
+++ b/src/test/resources/unit/threads_postfix_create_and_invalid_entry.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use threads;
+
+print "1..4\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - ", $name, "\n");
+}
+
+my $postfix = create threads sub {
+    my $value = 'postfix';
+    return sub { return sub { return $value } };
+}=>->join->()();
+check($postfix eq 'postfix', 'fat comma permits a postfix thread call chain');
+
+my $invalid = threads->create({}, []);
+check(defined($invalid), 'reference-valued invalid entry creates a thread');
+$invalid->join;
+check($invalid->error =~ /Not a CODE reference/,
+    'invalid entry failure is retained on the thread');
+check(!$invalid->is_running, 'invalid entry thread reaches a terminal state');


### PR DESCRIPTION
## Summary

- preserve genuine closure captures through END dispatch, fixing premature parent resource destruction exposed by ithreads
- synchronize compiled-CV registration, lookup, and snapshot iteration during concurrent lazy materialization
- make Test2 IPC threading complete on platform and virtual threads without a Test2-specific patch
- match Perl's asynchronous invalid thread-entry failure and abnormal-join diagnostic
- support direct interpreter `RuntimeCode` roots while cloning thread entry arguments/results
- correct substr lvalue context so assignment dies without an extra construction-time warning
- add Java 24 native/resource diagnostics and a concrete fresh-runtime equivalence contract that keeps unsafe pooling disabled
- update the living plan and feature matrix with exact measured support and remaining work

## Differential result

The supplied PR933→PR937 comparison showed +2,856 passing assertions and one apparent `run/switches.t` loss. Investigation found no genuine switches regression: 74/142 is the stable PR931/PR932/current result, and threaded in-place assertions 123–125 all pass. PR933's 75 was a one-run fluctuation without retained raw TAP.

Current focused compatibility:

- `op/threads.t`: 29/30 (up from 28/30)
- `op/substr_thr.t`: 368/400; remaining failures mirror ordinary substr/operator gaps
- `class/threads.t`: 4/4
- Test2 `try_it_threads.t`: 6/6 on platform and virtual threads (up from 0/6)
- native/resource diagnostic: 4/4 on system Perl, JVM, interpreter, and virtual-thread mode

The final `op/threads.t` failure is the unusual print-context `=>->join->()()` parser association. The broader reassociation attempt was rejected after testing because it bound `join` to the anonymous sub instead of the thread object; it remains explicitly tracked rather than being masked.

## Validation

- post-rebase `make`: PASS (all unit shards, 7m35s)
- `make check-links`: 537 links, 0 errors
- new Perl tests validated with system Perl first
- substr and native/resource diagnostics pass JVM and interpreter backends
- Test2 IPC acceptance passes platform and Java 24 virtual threads, with no pinning trace
- `git diff --check`: clean

See `dev/design/concurrency.md` and `dev/design/runtime-pooling-reset-contract.md`.
