### PR TITLE
fix(parser): complete core threads syntax compatibility

### DIFF
--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -467,10 +467,16 @@ Acceptance: no semantic change or native/FFM surprise in supported workloads.
 Promotion beyond experimental additionally requires a measured benefit over
 platform threads; runtime-clone cost must not be mistaken for scheduler cost.
 
-### Phase 24 — Final core syntax compatibility
+### Phase 24 — Final core syntax compatibility (completed 2026-08-12)
 
 Finish the remaining `op/threads.t` postfix create/join expression without a
 thread-specific parser shortcut that changes ordinary anonymous-sub precedence.
+
+Implemented by keeping an unknown print-filehandle candidate as an expression
+when it is followed by a known indirect-object package. This fixes the general
+`print method Package LIST` ambiguity rather than recognizing `threads` or the
+specific postfix chain. A system-Perl-validated regression test covers the
+generic form.
 
 Acceptance: `op/threads.t` reaches 30/30 on JVM and interpreter backends while
 `class/threads.t` remains 4/4 and `threads-dirh.t` continues to exit cleanly.
@@ -590,7 +596,7 @@ has a measured benefit over a fresh snapshot.
 
 ## 7. Progress Tracking
 
-### Current Status: Phase 23 implemented; compatibility hardening begins next
+### Current Status: Phase 24 complete; Phase 25 is next
 
 Hints, warnings, filters, and source maps are runtime-owned while compiler-only
 scratch remains protected by the global compile lock. The Phase 11 inventory is
@@ -735,11 +741,11 @@ request history.
 
 ### Next Steps
 
-1. After PR 939 merges, implement Phases 24–28 as independent, always-green PRs:
-   final core syntax, snapshot graph integrity, scalar operator parity, regex
-   concurrency/debug state, and then general regex parity. For every `_thr.t`
-   result, record the direct companion suite in the same run and require zero
-   thread-induced delta rather than comparing aggregate TAP counts alone.
+1. Implement Phases 25–28 as independent, always-green PRs: snapshot graph
+   integrity, scalar operator parity, regex concurrency/debug state, and then
+   general regex parity. For every `_thr.t` result, record the direct companion
+   suite in the same run and require zero thread-induced delta rather than
+   comparing aggregate TAP counts alone.
 2. Implement Phases 29–32 independently: truthful API behavior, resource
    inheritance and Test2 stress, native callback/handle ownership, and only then
    additional shared value categories. Preserve the green anchors after every

--- a/src/main/java/org/perlonjava/frontend/parser/FileHandle.java
+++ b/src/main/java/org/perlonjava/frontend/parser/FileHandle.java
@@ -363,6 +363,33 @@ public class FileHandle {
         return idx < parser.tokens.size() && "->".equals(parser.tokens.get(idx).text);
     }
 
+    /**
+     * An unknown bareword followed by a known package can be Perl's indirect
+     * object syntax ({@code method Package LIST}).  In print's ambiguous
+     * filehandle position it must remain an expression; autovivifying the
+     * method name as an IO glob makes the package and arguments look like a
+     * malformed print list.
+     */
+    private static boolean isFollowedByIndirectObjectPackage(Parser parser) {
+        int idx = parser.tokenIndex;
+        while (idx < parser.tokens.size()
+                && parser.tokens.get(idx).type == LexerTokenType.WHITESPACE) {
+            idx++;
+        }
+        if (idx >= parser.tokens.size()
+                || parser.tokens.get(idx).type != LexerTokenType.IDENTIFIER) {
+            return false;
+        }
+
+        String packageName = parser.tokens.get(idx).text;
+        Boolean packageExists = GlobalVariable.packageExistsCache.get(packageName);
+        if (packageExists == null && !packageName.contains("::")) {
+            packageExists = GlobalVariable.packageExistsCache.get(
+                    parser.ctx.symbolTable.getCurrentPackage() + "::" + packageName);
+        }
+        return Boolean.TRUE.equals(packageExists);
+    }
+
     private static boolean shouldAutovivifyBarewordHandle(Parser parser, String name, boolean autovivifyUnknownBareword) {
         // Do not treat compile-time magic like __PACKAGE__ as print filehandles:
         // they match ^[A-Z_][A-Z0-9_]*$ but must fall through to the expression list
@@ -382,6 +409,10 @@ public class FileHandle {
         }
 
         if (isFollowedByMethodDereference(parser)) {
+            return false;
+        }
+
+        if (isFollowedByIndirectObjectPackage(parser)) {
             return false;
         }
 

--- a/src/test/resources/unit/print_indirect_method_postfix.t
+++ b/src/test/resources/unit/print_indirect_method_postfix.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+
+{
+    package PrintIndirectFactory;
+
+    sub create {
+        my ($class, $code) = @_;
+        return bless { code => $code }, $class;
+    }
+
+    sub join { return $_[0]->{code}->() }
+}
+
+print "1..1\n";
+print create PrintIndirectFactory sub {
+    return sub { return sub { return "ok 1 - print preserves an indirect postfix call chain\n" } };
+}=>->join->()();


### PR DESCRIPTION
## Summary

- disambiguate `print method Package LIST` as an indirect-object expression when the package is known
- allow the remaining postfix create/join call chain in Perl core `op/threads.t` without a threads-specific parser rule
- add a generic system-Perl-validated regression test
- mark Phase 24 complete and advance the threads plan to snapshot graph integrity

## Validation

- `make` — passed, 962 Java/unit tests with 2 skips
- system Perl: `print_indirect_method_postfix.t` — 1/1
- JVM: `print_indirect_method_postfix.t` — 1/1
- interpreter: `print_indirect_method_postfix.t` — 1/1
- JVM core runner: `op/threads.t` — 30/30
- interpreter core: `op/threads.t` — 30 passing TAP assertions, exit 0
- JVM anchors: `class/threads.t` — 4/4; `threads-dirh.t` — clean
- interpreter anchors: `class/threads.t` — clean; `threads-dirh.t` — clean

Generated with [Codex](https://openai.com/codex)
