### PR TITLE
Fix HTML parser tooling for TagRescue

### DIFF
--- a/src/main/java/org/perlonjava/runtime/perlmodule/HTMLParser.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/HTMLParser.java
@@ -137,6 +137,7 @@ public class HTMLParser extends PerlModuleBase {
         // State tracking
         pstate.put("_parsing", scalarFalse);
         pstate.put("_eof", scalarFalse);
+        pstate.put("_started", scalarFalse);
         pstate.put("_buf", new RuntimeScalar(""));
         pstate.put("_bool_attr_val", scalarUndef);
         pstate.put("_in_cdata", scalarFalse);
@@ -166,6 +167,10 @@ public class HTMLParser extends PerlModuleBase {
             if (args.size() > 1) {
                 RuntimeScalar chunk = args.get(1);
                 if (chunk.getDefinedBoolean()) {
+                    if (!pstate.get("_started").getBoolean()) {
+                        pstate.put("_started", scalarTrue);
+                        fireEvent(self, selfHash, pstate, "start_document");
+                    }
                     String chunkStr = chunk.toString();
 
                     // When utf8_mode is set and the input is a BYTE_STRING, try to
@@ -218,6 +223,10 @@ public class HTMLParser extends PerlModuleBase {
         } else {
             pstate.put("_parsing", scalarTrue);
             try {
+                if (!pstate.get("_started").getBoolean()) {
+                    pstate.put("_started", scalarTrue);
+                    fireEvent(self, selfHash, pstate, "start_document");
+                }
                 // Flush any remaining buffered text
                 String remaining = pstate.get("_buf").toString();
                 if (!remaining.isEmpty()) {
@@ -226,6 +235,7 @@ public class HTMLParser extends PerlModuleBase {
                 }
                 // Fire end_document event
                 fireEvent(self, selfHash, pstate, "end_document");
+                pstate.put("_started", scalarFalse);
             } finally {
                 pstate.put("_parsing", scalarFalse);
             }
@@ -440,13 +450,22 @@ public class HTMLParser extends PerlModuleBase {
     private static void fireEvent(RuntimeScalar self, RuntimeHash selfHash, RuntimeHash pstate, String eventName, RuntimeScalar... eventArgs) {
         RuntimeHash handlers = pstate.get("_handlers").hashDeref();
         RuntimeScalar cb = handlers.get(eventName + "_cb");
+        String handlerName = eventName;
 
         if (cb == null || !cb.getDefinedBoolean()) {
-            return;
+            // HTML::Parser's default handler receives every event which does
+            // not have its own handler.  Plugins commonly use this to process
+            // a complete document with one callback (TagRescue is one such
+            // consumer), so silently dropping these events loses all output.
+            cb = handlers.get("default_cb");
+            handlerName = "default";
+            if (cb == null || !cb.getDefinedBoolean()) {
+                return;
+            }
         }
 
         // Parse argspec to determine what arguments to pass
-        RuntimeScalar argspecSv = handlers.get(eventName + "_argspec");
+        RuntimeScalar argspecSv = handlers.get(handlerName + "_argspec");
         String argspec = (argspecSv != null && argspecSv.getDefinedBoolean()) ?
                 argspecSv.toString() : "";
 
@@ -557,8 +576,11 @@ public class HTMLParser extends PerlModuleBase {
             switch (token) {
                 case "tagname":
                 case "tag":
-                    // First arg for start/end events is tagname
-                    if (eventArgs.length > 0) {
+                    // Only tag events have a tag name. Text and document
+                    // events also carry a first internal argument, but it is
+                    // not a tag and Perl's HTML::Parser returns undef here.
+                    if (("start".equals(eventName) || "end".equals(eventName))
+                            && eventArgs.length > 0) {
                         RuntimeArray.push(result, eventArgs[0]);
                     } else {
                         RuntimeArray.push(result, scalarUndef);

--- a/src/test/resources/unit/html_parser_default_handler.t
+++ b/src/test/resources/unit/html_parser_default_handler.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+
+use HTML::Parser;
+use Test::More;
+
+my @events;
+my $parser = HTML::Parser->new(api_version => 3);
+$parser->handler(
+    default => sub { push @events, [@_] },
+    'event,text,tagname',
+);
+$parser->parse('<B>Bold!</B> &amp; text');
+$parser->eof;
+
+is($events[0][0], 'start_document', 'default handler receives start_document');
+is($events[-1][0], 'end_document', 'default handler receives end_document');
+is(join('', map { $_->[1] } @events), '<B>Bold!</B> &amp; text',
+    'default handler receives the complete original document text');
+ok(!scalar(grep { $_->[0] eq 'text' && defined $_->[2] } @events),
+    'text events do not report their text as a tag name');
+is_deeply(
+    [map { [$_->[0], $_->[2]] } grep { $_->[0] eq 'start' || $_->[0] eq 'end' } @events],
+    [[start => 'b'], [end => 'b']],
+    'default handler receives tag names for tag events',
+);
+
+done_testing;


### PR DESCRIPTION
## Summary

- dispatch unhandled `HTML::Parser` events through the configured default handler
- emit `start_document` and `end_document` around parse cycles
- preserve undefined tag names for non-tag events
- add a system-Perl-validated regression test for default-handler semantics

This fixes `Template::Plugin::TagRescue` at the shared Java-backed HTML parser layer, without a distribution preference.

## Requested module results

- `Template::Plugin::TagRescue`: passes after the fix (18 tests)
- `Cikl`: passes its normal jcpan workflow; its release contains no runnable top-level test files
- `Python`: ignored because CPAN resolves it to `pyperl-1.0.3`, which has no Perl build file and fails identically under system Perl
- `Data::Dumper::EasyOO`: ignored because its upstream suite fails under system Perl with the same re-import/POD-coverage failures
- `GuiBuilder`: ignored because its Tk dependency fails to configure under system Perl on this platform, after which GuiBuilder cannot load

## Verification

- `prove src/test/resources/unit/html_parser_default_handler.t` with system Perl
- `make`
- `./jcpan -t Template::Plugin::TagRescue`
- `./jcpan --strict-dependency-tests -t Template::Plugin::TagRescue`
- `./jcpan -t Cikl`

The strict Cikl dependency audit also exercised dependency suites. Its remaining dependency failures reproduce under system Perl (for example Net::DNS's distribution test cannot locate its adjacent `t/TestToolkit.pm`) and are outside this PerlOnJava fix.

Generated with [Codex](https://openai.com/codex)
