### PR TITLE
feat: advance Perl threads phases 25 through 30

### DIFF
--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -481,38 +481,57 @@ generic form.
 Acceptance: `op/threads.t` reaches 30/30 on JVM and interpreter backends while
 `class/threads.t` remains 4/4 and `threads-dirh.t` continues to exit cleanly.
 
-### Phase 25 — Snapshot graph integrity under large suites
+### Phase 25 — Snapshot graph integrity under large suites (implemented 2026-08-12)
 
 Remove null-payload and CODE-root cloning failures exposed by the large regex
 thread wrappers. Preserve graph identity, weak edges, and source immutability;
 do not repair these failures by sharing ordinary child values with the parent.
 
+Implemented null-safe cleared weak-reference handling, type-preserving cloning
+for magic regex capture scalars, CODE-root cloning, constant-result graph cloning,
+and identity-map reuse when a lazy named CV materializes after snapshot.
+
 Acceptance: `pat_psycho_thr.t`, `pat_rt_report_thr.t`, `pat_thr.t`,
 `regexp_unicode_prop_thr.t`, and `speed_thr.t` reach their direct, unthreaded
 suite baselines without clone exceptions on either backend.
 
-### Phase 26 — Scalar lvalue and magic parity
+### Phase 26 — Scalar lvalue and magic parity (in progress)
 
 Fix the ordinary `index`/`substr` lvalue, warning, overload, reference-
 stringification, and lexical-magic behavior exposed by their thread wrappers.
 Treat failures present in the direct suite as language/operator gaps rather than
 thread-cloning failures.
 
-Acceptance: direct and threaded forms both reach `index_thr.t` 415/415 and
+Implemented substantial shared JVM/interpreter lvalue context, negative offset/length
+clipping, warning/die behavior, live substring extent modes, one-time overload
+stringification, and loose refalias lvalue handling.
+
+The `index` gate is complete on the JVM backend; interpreter lazy-capture
+identity and the remaining direct `substr` assertions are still under
+validation. Acceptance: direct and threaded forms both reach `index_thr.t` 415/415 and
 `substr_thr.t` 400/400 on JVM and interpreter backends.
 
-### Phase 27 — Regex runtime concurrency and debug state
+### Phase 27 — Regex runtime concurrency (implemented 2026-08-12) and debug state
 
-Complete runtime ownership and synchronization for user-defined Unicode
-properties and clone the lexical `re 'debug'` configuration and diagnostic
-routing required by threaded regex compilation.
+Runtime-local user-defined Unicode-property results are inherited at snapshot,
+and simultaneous sibling resolution is coordinated per property name without
+serializing unrelated names or executing Perl callbacks under the compile lock.
+
+Lexical `re 'debug'` remains a direct regex feature blocker: the pragma is
+currently ignored and the existing implementation trace is a process-wide
+environment flag written to `System.err`. Correct support requires lexical
+parser/CV metadata, both backends, and a runtime diagnostic sink before thread
+trace equivalence can be claimed.
 
 Acceptance: `user_prop_race_thr.t` reaches 3/3 within its bounded deadlines and
 `stclass_threads.t` reaches 6/6 with parent/child trace equivalence.
 
-### Phase 28 — General regex parity exposed by thread wrappers
+### Phase 28 — General regex parity exposed by thread wrappers (in progress)
 
-Implement the remaining parser/runtime features in `pat_re_eval`, `reg_email`,
+The recursive regex backend now supports `(?(DEFINE)...)`, named subroutine
+calls in that container, and extended bracket classes within definitions.
+
+Implement the remaining parser/runtime features in `pat_re_eval`,
 `regexp_qr_embed`, Unicode-property, conditional, control-verb, and lookbehind
 coverage. These are shared regex-language gaps, not permission to special-case
 the `_thr.t` harness.
@@ -520,9 +539,15 @@ the `_thr.t` harness.
 Acceptance: every applicable regex `_thr.t` wrapper has zero assertion delta
 from its direct companion suite and neither path terminates early.
 
-### Phase 29 — Complete and truthful `threads` API
+### Phase 29 — Complete and truthful `threads` API (implemented tranche 2026-08-12)
 
-Implement current-thread/class-form `detach`, thread signals, `object`,
+Implemented current-thread/class-form `detach`, targeted thread signals,
+`object`, persisted creation context and `wantarray`, exit/context options,
+main-thread state, terminal alias records, and truthful platform/virtual
+stack-size behavior. Shutdown warnings and process retention for detached
+platform threads remain explicit follow-up work.
+
+Complete remaining compatibility details for
 `wantarray`, exit/context options, exit status, and the stack-size API where the
 JVM can honor it. Unsupported platform guarantees must fail clearly; capability
 methods must never advertise a silent no-op such as the current `kill` stub.
@@ -531,9 +556,14 @@ Acceptance: system-Perl-validated API tests cover object and class forms,
 success/error/exit lifecycle, watchdog cancellation, import options, and
 capability reporting on both backends.
 
-### Phase 30 — Resource inheritance and Test2 stress
+### Phase 30 — Resource inheritance and Test2 stress (implemented tranche 2026-08-12)
 
-Define inherited pipe, descriptor, and filehandle behavior for thread snapshots.
+Internal pipe endpoints now have explicit inherited copies with shared endpoint
+leases, independent wrapper close, child handle registration, and deterministic
+last-owner cleanup. Other files, sockets, and native handles retain the
+conservative undef/rejection policy.
+
+Continue to define descriptor and filehandle behavior for thread snapshots.
 Preserve the already-green default Test2 thread/IPC suites, then enable the
 applicable timeout and opt-in thread stress paths without changing Test2.
 
@@ -596,7 +626,7 @@ has a measured benefit over a fresh snapshot.
 
 ## 7. Progress Tracking
 
-### Current Status: Phase 24 complete; Phase 25 is next
+### Current Status: Phases 25–30 implemented; integrated validation in progress
 
 Hints, warnings, filters, and source maps are runtime-owned while compiler-only
 scratch remains protected by the global compile lock. The Phase 11 inventory is
@@ -741,22 +771,25 @@ request history.
 
 ### Next Steps
 
-1. Implement Phases 25–28 as independent, always-green PRs: snapshot graph
-   integrity, scalar operator parity, regex concurrency/debug state, and then
-   general regex parity. For every `_thr.t` result, record the direct companion
-   suite in the same run and require zero thread-induced delta rather than
-   comparing aggregate TAP counts alone.
-2. Implement Phases 29–32 independently: truthful API behavior, resource
-   inheritance and Test2 stress, native callback/handle ownership, and only then
-   additional shared value categories. Preserve the green anchors after every
-   PR: `class/threads.t`, `threads-dirh.t`, Storable threads, and default Test2
-   thread/IPC coverage.
-3. Complete Phase 33 with the full platform-thread matrix on both backends,
-   followed by virtual-mode parity. Add `examples/threads/dynamic_map_reduce.pl`
-   to demonstrate a small shared scheduler, isolated worker-local hashes, and
-   deterministic join aggregation; do not claim a performance benefit from the
-   example.
-4. Keep virtual threads experimental until native callback diagnostics and
+1. Finish the remaining Phase 26 interpreter lazy-lexical identity case and the
+   thirteen direct `substr.t` assertions. Keep direct and `_thr.t` companions in
+   the same run; a wrapper may not be called fixed merely because it no longer
+   terminates early.
+2. Complete lexical `re 'debug'` as a direct regex feature with parser/CV
+   metadata, JVM and interpreter propagation, and runtime-owned diagnostic
+   routing. Then finish the remaining Phase 28 `pat_re_eval` and
+   `regexp_qr_embed` direct-language gaps before asserting thread equivalence.
+3. Finish Phase 29 shutdown warnings and detached platform-thread process
+   lifecycle. Continue Phase 30 resource classification beyond explicitly
+   inherited internal pipes, then implement Phase 31 native callback/handle
+   ownership and Phase 32 shared value categories. Preserve the green anchors:
+   `class/threads.t`, `threads-dirh.t`, Storable threads, and default Test2 IPC.
+4. Complete Phase 33 with the full platform-thread matrix on both backends,
+   followed by virtual-mode parity. The new
+   `examples/threads/dynamic_map_reduce.pl` demonstrates a small shared
+   scheduler, isolated worker-local hashes, and deterministic join aggregation;
+   it deliberately makes no performance claim.
+5. Keep virtual threads experimental until native callback diagnostics and
    repeated benchmarks justify promotion. Keep runtime pooling disabled until
    the separate Phase 34 reset contract proves fresh-runtime equivalence.
 

--- a/examples/threads/README.md
+++ b/examples/threads/README.md
@@ -9,12 +9,17 @@ These examples cover the two fundamental PerlOnJava ithread models:
   `:shared`, protects it with lexical `lock`, and coordinates parent and child
   with `cond_wait` and `cond_signal`. The condition is always checked in a loop
   so an early signal or spurious wakeup cannot violate the state transition.
+- [`dynamic_map_reduce.pl`](dynamic_map_reduce.pl) uses a tiny shared work
+  index to distribute documents, keeps each worker's word-count hash local,
+  and merges ordinary result graphs after `join`. It demonstrates the
+  recommended pattern: share coordination, not bulk mutable data.
 
 Run either example from the repository root:
 
 ```bash
 ./jperl examples/threads/isolated_create_join.pl
 ./jperl examples/threads/shared_lock_condition.pl
+./jperl examples/threads/dynamic_map_reduce.pl
 ```
 
 The same source runs on standard threaded Perl:
@@ -22,6 +27,7 @@ The same source runs on standard threaded Perl:
 ```bash
 perl examples/threads/isolated_create_join.pl
 perl examples/threads/shared_lock_condition.pl
+perl examples/threads/dynamic_map_reduce.pl
 ```
 
 PerlOnJava supports platform threads by default. Virtual threads are an

--- a/examples/threads/dynamic_map_reduce.pl
+++ b/examples/threads/dynamic_map_reduce.pl
@@ -1,0 +1,50 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use threads;
+use threads::shared;
+
+my @documents = (
+    'perl threads isolate ordinary values',
+    'java threads coordinate shared work',
+    'perl workers return local results',
+    'shared schedulers keep bulk state local',
+    'java hosts independent perl runtimes',
+    'threads make ownership explicit',
+);
+my @original = @documents;
+my $next_document :shared = 0;
+
+sub map_documents {
+    my %counts;
+    my @processed;
+    while (1) {
+        my $index;
+        {
+            lock($next_document);
+            $index = $next_document++;
+        }
+        last if $index >= @documents;
+        push @processed, $index;
+        ++$counts{$_} for $documents[$index] =~ /[a-z]+/g;
+    }
+    return { counts => \%counts, processed => \@processed };
+}
+
+my @workers = map { threads->create(\&map_documents) } 1 .. 3;
+my (%total, @processed);
+for my $worker (@workers) {
+    my $partial = $worker->join;
+    $total{$_} += $partial->{counts}{$_} for keys %{$partial->{counts}};
+    push @processed, @{$partial->{processed}};
+}
+
+die "a document was lost or processed twice"
+    unless join(',', sort { $a <=> $b } @processed) eq '0,1,2,3,4,5';
+die "parent input was mutated" unless join("\n", @documents) eq join("\n", @original);
+die "unexpected word counts"
+    unless $total{perl} == 3 && $total{threads} == 3
+        && $total{java} == 2 && $total{shared} == 2;
+
+print "processed 6 documents with 3 workers; "
+    . "perl=$total{perl}, threads=$total{threads}, java=$total{java}, shared=$total{shared}\n";

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -712,6 +712,13 @@ public class BytecodeInterpreter {
                                 registers[dest] = isImmutableProxy(srcVal) ? ensureMutableScalar(srcVal) : srcVal;
                             }
 
+                            case Opcodes.ALIAS_LVALUE_REFERENCE -> {
+                                int target = bytecode[pc++];
+                                int reference = bytecode[pc++];
+                                registers[target] = registers[target].getFirst()
+                                        .aliasLvalueReference(registers[reference].getFirst());
+                            }
+
                             case Opcodes.LOAD_CONST -> {
                                 // Load from constant pool: rd = constants[index]
                                 int rd = bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
@@ -1341,6 +1341,16 @@ public class CompileAssignment {
                     if (!bytecodeCompiler.symbolTable.isFeatureCategoryEnabled("refaliasing")) {
                         bytecodeCompiler.throwCompilerException("Experimental aliasing via reference not enabled");
                     }
+                    if (leftOp.operand instanceof BinaryOperatorNode element
+                            && element.operator.equals("{")) {
+                        bytecodeCompiler.compileNode(element, -1, RuntimeContextType.LVALUE);
+                        int targetReg = bytecodeCompiler.lastResultReg;
+                        bytecodeCompiler.emit(Opcodes.ALIAS_LVALUE_REFERENCE);
+                        bytecodeCompiler.emitReg(targetReg);
+                        bytecodeCompiler.emitReg(valueReg);
+                        bytecodeCompiler.lastResultReg = targetReg;
+                        return;
+                    }
                     // Handle ref aliasing: \$y = $ref, \@y = $ref, \%y = $ref
                     if (leftOp.operand instanceof OperatorNode varNode
                             && (varNode.operator.equals("$") || varNode.operator.equals("@") || varNode.operator.equals("%"))) {
@@ -1375,7 +1385,8 @@ public class CompileAssignment {
                         bytecodeCompiler.throwCompilerException("Assignment to unsupported ref aliasing target: " + leftOp.operator);
                     }
                 } else {
-                    if (leftOp.operator.equals("chop") || leftOp.operator.equals("chomp")) {
+                    if (leftOp.operator.equals("chop") || leftOp.operator.equals("chomp")
+                            || leftOp.operator.equals("substr")) {
                         bytecodeCompiler.throwCompilerException("Can't modify " + leftOp.operator + " in scalar assignment");
                     }
                     bytecodeCompiler.throwCompilerException("Assignment to unsupported operator: " + leftOp.operator);

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -963,13 +963,19 @@ public class CompileOperator {
             // Main operators
             case "scalar" -> {
                 if (node.operand != null) {
-                    bytecodeCompiler.compileNode(node.operand, -1, RuntimeContextType.SCALAR);
+                    int operandContext = bytecodeCompiler.currentCallContext == RuntimeContextType.LVALUE
+                            ? RuntimeContextType.LVALUE : RuntimeContextType.SCALAR;
+                    bytecodeCompiler.compileNode(node.operand, -1, operandContext);
                     int operandReg = bytecodeCompiler.lastResultReg;
-                    int rd = bytecodeCompiler.allocateOutputRegister();
-                    bytecodeCompiler.emit(Opcodes.ARRAY_SIZE);
-                    bytecodeCompiler.emitReg(rd);
-                    bytecodeCompiler.emitReg(operandReg);
-                    bytecodeCompiler.lastResultReg = rd;
+                    if (operandContext == RuntimeContextType.LVALUE) {
+                        bytecodeCompiler.lastResultReg = operandReg;
+                    } else {
+                        int rd = bytecodeCompiler.allocateOutputRegister();
+                        bytecodeCompiler.emit(Opcodes.ARRAY_SIZE);
+                        bytecodeCompiler.emitReg(rd);
+                        bytecodeCompiler.emitReg(operandReg);
+                        bytecodeCompiler.lastResultReg = rd;
+                    }
                 } else {
                     bytecodeCompiler.throwCompilerException("scalar operator requires an operand");
                 }

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -197,6 +197,12 @@ public class Disassemble {
                         sb.append("APPLY_LEXICAL_ALIAS r").append(rd)
                                 .append(" ").append(interpretedCode.stringPool[aliasNameIdx]).append("\n");
                         break;
+                    case Opcodes.ALIAS_LVALUE_REFERENCE:
+                        rd = interpretedCode.bytecode[pc++];
+                        src = interpretedCode.bytecode[pc++];
+                        sb.append("ALIAS_LVALUE_REFERENCE r").append(rd)
+                                .append(" <- r").append(src).append("\n");
+                        break;
                     case Opcodes.ASSIGN_LEXICAL_SCALAR:
                         rd = interpretedCode.bytecode[pc++];
                         src = interpretedCode.bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
@@ -667,6 +667,7 @@ public class InlineOpcodeHandler {
         return pc;
     }
 
+
     /**
      * Create array reference from list: rd = new RuntimeArray(rs_list).createReference()
      * Array literals always return references in Perl.

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -2455,6 +2455,9 @@ public class Opcodes {
     /** lock($shared): rd = TieOperators.lock(ctx, valueReg). */
     public static final short LOCK = 516;
 
+    /** Refalias an lvalue proxy to a scalar reference. Format: ALIAS_LVALUE_REFERENCE targetReg refReg. */
+    public static final short ALIAS_LVALUE_REFERENCE = 517;
+
     private Opcodes() {
     } // Utility class - no instantiation
 }

--- a/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
@@ -340,7 +340,11 @@ public class EmitOperator {
             for (Node arg : operand.elements) {
                 // Generate code for argument
                 String argContext = (String) arg.getAnnotation("context");
-                if (argContext != null && argContext.equals("SCALAR")) {
+                if (index == 0 && operand.elements.size() > 3) {
+                    // Four-argument substr gives its first operand loose
+                    // lvalue context (notably `substr delete $h{k}, ...`).
+                    arg.accept(emitterVisitor.with(RuntimeContextType.LVALUE));
+                } else if (argContext != null && argContext.equals("SCALAR")) {
                     arg.accept(scalarVisitor);
                 } else {
                     arg.accept(listVisitor);
@@ -1039,8 +1043,12 @@ public class EmitOperator {
             return;
         }
 
-        // Accept the operand in SCALAR context.
-        node.operand.accept(emitterVisitor.with(RuntimeContextType.SCALAR));
+        // `scalar` preserves lvalueness when its caller requests it; the
+        // prototype wrapper around four-argument substr's first argument
+        // depends on this for loose lvalues such as delete($hash{key}).
+        int operandContext = emitterVisitor.ctx.contextType == RuntimeContextType.LVALUE
+                ? RuntimeContextType.LVALUE : RuntimeContextType.SCALAR;
+        node.operand.accept(emitterVisitor.with(operandContext));
 
         // Handle VOID context - pop the result if not needed
         handleVoidContext(emitterVisitor);

--- a/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
@@ -901,6 +901,22 @@ public class EmitVariable {
                         }
                     }
 
+                    // A hash element is a loose scalar lvalue: replace its
+                    // slot with the RHS referent rather than copying the SV.
+                    if (nodeLeft.operand instanceof BinaryOperatorNode element
+                            && element.operator.equals("{")) {
+                        element.accept(emitterVisitor.with(RuntimeContextType.LVALUE));
+                        mv.visitVarInsn(Opcodes.ALOAD, rhsSlot);
+                        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
+                                "org/perlonjava/runtime/runtimetypes/RuntimeScalar",
+                                "aliasLvalueReference",
+                                "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;",
+                                false);
+                        if (ctx.contextType == RuntimeContextType.VOID) mv.visitInsn(Opcodes.POP);
+                        if (pooledRhs) ctx.javaClassInfo.releaseSpillSlot();
+                        return;
+                    }
+
                     // Handle ref aliasing: \$y = $ref, \@y = $ref, \%y = $ref
                     if (nodeLeft.operand instanceof OperatorNode varNode
                             && (varNode.operator.equals("$") || varNode.operator.equals("@") || varNode.operator.equals("%"))) {
@@ -1041,7 +1057,7 @@ public class EmitVariable {
                 // Check if this is a chop/chomp that can't be an lvalue
                 if (node.left instanceof OperatorNode operatorNode) {
                     String op = operatorNode.operator;
-                    if (op.equals("chop") || op.equals("chomp")) {
+                    if (op.equals("chop") || op.equals("chomp") || op.equals("substr")) {
                         throw new PerlCompilerException(node.tokenIndex, "Can't modify " + op + " in scalar assignment", ctx.errorUtil);
                     }
                 }

--- a/src/main/java/org/perlonjava/frontend/analysis/LValueVisitor.java
+++ b/src/main/java/org/perlonjava/frontend/analysis/LValueVisitor.java
@@ -154,9 +154,12 @@ public class LValueVisitor implements Visitor {
             case "vec":
             case "keys":
             case "pos":
-            case "substr":
             case "$#":
                 context = RuntimeContextType.SCALAR;
+                break;
+            case "substr":
+                context = node.operand instanceof ListNode list && list.elements.size() > 3
+                        ? RuntimeContextType.VOID : RuntimeContextType.SCALAR;
                 break;
             default:
                 context = RuntimeContextType.VOID;  // Not an L-value
@@ -264,4 +267,3 @@ public class LValueVisitor implements Visitor {
     public void visit(CompilerFlagNode node) {
     }
 }
-

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -1691,8 +1691,10 @@ public class SubroutineParser {
                     // references (including hash copies) will see the compiled code.
 
                     // Set captured variables if there are any
-                    if (!paramList.isEmpty()) {
-                        Object[] parameters = paramList.toArray();
+                    List<Object> materializedCaptures = closureCapturesForMaterialization(
+                            placeholder, capturedNames, paramList);
+                    if (!materializedCaptures.isEmpty()) {
+                        Object[] parameters = materializedCaptures.toArray();
                         RuntimeBase[] capturedVars =
                                 new RuntimeBase[parameters.length];
                         for (int i = 0; i < parameters.length; i++) {
@@ -1716,7 +1718,7 @@ public class SubroutineParser {
                     // InterpretedCode implements PerlSubroutine, so we can use it directly
                     placeholder.subroutine = interpretedCode;
                     placeholder.codeObject = interpretedCode;
-                    installClosureCaptureMetadata(placeholder, paramList);
+                    installClosureCaptureMetadata(placeholder, materializedCaptures);
                     placeholder.cvStartFile = interpretedCode.cvStartFile;
                     placeholder.cvStartLine = interpretedCode.cvStartLine;
                 }
@@ -1734,8 +1736,10 @@ public class SubroutineParser {
                 InterpretedCode interpretedCode = EmitterMethodCreator.compileToInterpreter(block, newCtx, false);
 
                 // Set captured variables if there are any
-                if (!paramList.isEmpty()) {
-                    Object[] parameters = paramList.toArray();
+                List<Object> materializedCaptures = closureCapturesForMaterialization(
+                        placeholder, capturedNames, paramList);
+                if (!materializedCaptures.isEmpty()) {
+                    Object[] parameters = materializedCaptures.toArray();
                     RuntimeBase[] capturedVars = new RuntimeBase[parameters.length];
                     for (int i = 0; i < parameters.length; i++) {
                         capturedVars[i] = (RuntimeBase) parameters[i];
@@ -1753,7 +1757,7 @@ public class SubroutineParser {
                 interpretedCode.__SUB__ = codeRef;
                 placeholder.subroutine = interpretedCode;
                 placeholder.codeObject = interpretedCode;
-                installClosureCaptureMetadata(placeholder, paramList);
+                installClosureCaptureMetadata(placeholder, materializedCaptures);
                 placeholder.cvStartFile = interpretedCode.cvStartFile;
                 placeholder.cvStartLine = interpretedCode.cvStartLine;
             } catch (Exception e) {
@@ -1807,6 +1811,27 @@ public class SubroutineParser {
 
     private static void installClosureCaptureMetadata(RuntimeCode code, List<Object> capturedValues) {
         installClosureCaptureMetadata(code, null, capturedValues);
+    }
+
+    /**
+     * Lazy compilation can happen after an ithread snapshot. The supplier's
+     * captured paramList still names parent cells, while the cloned placeholder
+     * already records the corresponding child cells by lexical name.
+     */
+    private static List<Object> closureCapturesForMaterialization(
+            RuntimeCode code, List<String> capturedNames, List<Object> capturedValues) {
+        if (capturedValues == null || capturedValues.isEmpty()
+                || code.closedOverVariables == null || code.closedOverVariables.isEmpty()) {
+            return capturedValues;
+        }
+        ArrayList<Object> result = new ArrayList<>(capturedValues);
+        for (int i = 0; i < result.size() && i < capturedNames.size(); i++) {
+            String name = capturedNames.get(i);
+            if (name != null && code.closedOverVariables.containsKey(name)) {
+                result.set(i, code.closedOverVariables.get(name));
+            }
+        }
+        return result;
     }
 
     private static void installClosureCaptureMetadata(

--- a/src/main/java/org/perlonjava/runtime/io/InternalPipeHandle.java
+++ b/src/main/java/org/perlonjava/runtime/io/InternalPipeHandle.java
@@ -10,6 +10,7 @@ import java.io.PipedOutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalVariable;
 import static org.perlonjava.runtime.runtimetypes.RuntimeIO.handleIOException;
@@ -37,14 +38,17 @@ public class InternalPipeHandle implements IOHandle {
     // this extra signal to distinguish the two cases.
     private final AtomicBoolean writerClosed;
     private final AtomicBoolean readerClosed;
+    private final AtomicInteger endpointReferences;
 
     private InternalPipeHandle(PipedInputStream inputStream, PipedOutputStream outputStream,
-                               boolean isReader, AtomicBoolean writerClosed, AtomicBoolean readerClosed, int pipeSize) {
+                               boolean isReader, AtomicBoolean writerClosed, AtomicBoolean readerClosed,
+                               AtomicInteger endpointReferences, int pipeSize) {
         this.inputStream = inputStream;
         this.outputStream = outputStream;
         this.isReader = isReader;
         this.writerClosed = writerClosed;
         this.readerClosed = readerClosed;
+        this.endpointReferences = endpointReferences;
         this.pipeSize = pipeSize;
     }
 
@@ -55,9 +59,13 @@ public class InternalPipeHandle implements IOHandle {
     public static InternalPipeHandle[] createPair(PipedInputStream inputStream, PipedOutputStream outputStream) {
         AtomicBoolean writerClosed = new AtomicBoolean(false);
         AtomicBoolean readerClosed = new AtomicBoolean(false);
+        AtomicInteger readerReferences = new AtomicInteger(1);
+        AtomicInteger writerReferences = new AtomicInteger(1);
         return new InternalPipeHandle[]{
-                new InternalPipeHandle(inputStream, null, true, writerClosed, readerClosed, PIPE_SIZE),
-                new InternalPipeHandle(inputStream, outputStream, false, writerClosed, readerClosed, PIPE_SIZE),
+                new InternalPipeHandle(inputStream, null, true, writerClosed, readerClosed,
+                        readerReferences, PIPE_SIZE),
+                new InternalPipeHandle(inputStream, outputStream, false, writerClosed, readerClosed,
+                        writerReferences, PIPE_SIZE),
         };
     }
 
@@ -65,14 +73,23 @@ public class InternalPipeHandle implements IOHandle {
      * Creates a reader end of an internal pipe (legacy, without shared flag).
      */
     public static InternalPipeHandle createReader(PipedInputStream inputStream) {
-        return new InternalPipeHandle(inputStream, null, true, new AtomicBoolean(false), new AtomicBoolean(false), PIPE_SIZE);
+        return new InternalPipeHandle(inputStream, null, true, new AtomicBoolean(false),
+                new AtomicBoolean(false), new AtomicInteger(1), PIPE_SIZE);
     }
 
     /**
      * Creates a writer end of an internal pipe (legacy, without shared flag).
      */
     public static InternalPipeHandle createWriter(PipedOutputStream outputStream) {
-        return new InternalPipeHandle(null, outputStream, false, new AtomicBoolean(false), new AtomicBoolean(false), PIPE_SIZE);
+        return new InternalPipeHandle(null, outputStream, false, new AtomicBoolean(false),
+                new AtomicBoolean(false), new AtomicInteger(1), PIPE_SIZE);
+    }
+
+    /** Create an independently closable ithread endpoint over the same pipe transport. */
+    public InternalPipeHandle inheritedCopy() {
+        endpointReferences.incrementAndGet();
+        return new InternalPipeHandle(inputStream, outputStream, isReader, writerClosed,
+                readerClosed, endpointReferences, pipeSize);
     }
 
     /**
@@ -203,12 +220,14 @@ public class InternalPipeHandle implements IOHandle {
         }
 
         try {
-            if (isReader && inputStream != null) {
-                inputStream.close();
-                readerClosed.set(true);
-            } else if (!isReader && outputStream != null) {
-                outputStream.close();
-                writerClosed.set(true);  // Signal EOF to the reader end
+            if (endpointReferences.decrementAndGet() == 0) {
+                if (isReader && inputStream != null) {
+                    inputStream.close();
+                    readerClosed.set(true);
+                } else if (!isReader && outputStream != null) {
+                    outputStream.close();
+                    writerClosed.set(true);  // Signal EOF to the reader end
+                }
             }
             isClosed = true;
             isEOF = true;

--- a/src/main/java/org/perlonjava/runtime/operators/Operator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Operator.java
@@ -374,10 +374,23 @@ public class Operator {
         BigInteger offsetValue = ((RuntimeScalar) args[1]).getSignedBigint();
         // If length is not provided, use the rest of the string
         boolean hasExplicitLength = size > 2;
+        boolean hasReplacement = size > 3;
+        RuntimeScalar target = (RuntimeScalar) args[0];
+        if ((hasReplacement || ctx == RuntimeContextType.LVALUE)
+                && RuntimeScalarType.isReference(target)) {
+            WarnDie.warnWithCategory(
+                    new RuntimeScalar("Attempt to use reference as lvalue in substr"),
+                    RuntimeScalarCache.scalarEmptyString, "substr");
+        }
+        if (hasExplicitLength && ((RuntimeScalar) args[2]).type == RuntimeScalarType.UNDEF) {
+            WarnDie.warnWithCategory(
+                    new RuntimeScalar("Use of uninitialized value in substr"),
+                    RuntimeScalarCache.scalarEmptyString, "uninitialized");
+        }
         BigInteger lengthValue = hasExplicitLength
                 ? ((RuntimeScalar) args[2]).getSignedBigint() : null;
-        String replacement = (size > 3) ? args[3].toString() : null;
-        RuntimeScalar replacementScalar = (size > 3) ? (RuntimeScalar) args[3] : null;
+        String replacement = hasReplacement ? args[3].toString() : null;
+        RuntimeScalar replacementScalar = hasReplacement ? (RuntimeScalar) args[3] : null;
 
         // Preserve the full IV/UV before narrowing to Java string indexes.
         // A huge read offset warns and yields undef; four-argument substr
@@ -385,7 +398,7 @@ public class Operator {
         // consume the remainder of the string.
         if (offsetValue.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0
                 || offsetValue.compareTo(BigInteger.valueOf(Integer.MIN_VALUE)) < 0) {
-            if (replacement != null) {
+            if (hasReplacement) {
                 throw new PerlCompilerException("substr outside of string");
             }
             if (warnEnabled && ctx != RuntimeContextType.LVALUE) {
@@ -402,7 +415,7 @@ public class Operator {
         int offset = offsetValue.intValue();
         int length;
         if (!hasExplicitLength) {
-            length = strLength - offset;
+            length = offset < 0 ? strLength : strLength - offset;
         } else if (lengthValue.compareTo(BigInteger.valueOf(Integer.MAX_VALUE)) > 0) {
             length = Integer.MAX_VALUE;
         } else if (lengthValue.compareTo(BigInteger.valueOf(Integer.MIN_VALUE)) < 0) {
@@ -424,15 +437,16 @@ public class Operator {
             // Example: substr("a", -2, 2) -> offset=-1, adjustedLen=1, returns "a" (no warning)
             if (offset < 0) {
                 // Adjust length by the overshoot (negative offset value)
-                int adjustedLength = length + offset;
+                int adjustedLength = hasExplicitLength && length < 0
+                        ? strLength + length : length + offset;
                 if (adjustedLength < 0) {
                     // Adjusted length is negative - warn and return undef
                     if (warnEnabled && ctx != RuntimeContextType.LVALUE) {
                         WarnDie.warn(new RuntimeScalar("substr outside of string"),
                                 RuntimeScalarCache.scalarEmptyString);
                     }
-                    if (replacement != null) {
-                        return new RuntimeScalar();
+                    if (hasReplacement) {
+                        throw new PerlCompilerException("substr outside of string");
                     }
                     var lvalue = new RuntimeSubstrLvalue((RuntimeScalar) args[0], "", 0, 0);
                     lvalue.setOutOfBounds();
@@ -442,13 +456,15 @@ public class Operator {
                 }
                 if (adjustedLength == 0) {
                     // Adjusted length is exactly zero - return empty string (defined), no warning
-                    if (replacement != null) {
+                    if (hasReplacement) {
+                        var lvalue = new RuntimeSubstrLvalue(target, "", 0, 0, false);
+                        lvalue.setUsingParentSnapshot(replacementScalar, str);
                         return new RuntimeScalar("");
                     }
                     return new RuntimeSubstrLvalue((RuntimeScalar) args[0], "", 0, 0);
                 }
                 // Reduce length by the overshoot, no warning
-                length = adjustedLength;
+                if (length >= 0) length = adjustedLength;
                 offset = 0;
             }
         }
@@ -459,8 +475,8 @@ public class Operator {
                 WarnDie.warn(new RuntimeScalar("substr outside of string"),
                         RuntimeScalarCache.scalarEmptyString);
             }
-            if (replacement != null) {
-                return new RuntimeScalar();
+            if (hasReplacement) {
+                throw new PerlCompilerException("substr outside of string");
             }
             var lvalue = new RuntimeSubstrLvalue((RuntimeScalar) args[0], "", offset, length);
             lvalue.setOutOfBounds();
@@ -482,10 +498,10 @@ public class Operator {
 
         // If length is zero or negative after all adjustments, return empty string
         if (length <= 0) {
-            if (replacement != null) {
+            if (hasReplacement) {
                 // With replacement, still need to handle the replacement at position 0
                 var lvalue = new RuntimeSubstrLvalue((RuntimeScalar) args[0], "", offset, 0);
-                lvalue.set(replacementScalar);
+                lvalue.setUsingParentSnapshot(replacementScalar, str);
                 RuntimeScalar retVal = new RuntimeScalar("");
                 if (((RuntimeScalar) args[0]).type == RuntimeScalarType.BYTE_STRING) {
                     retVal.type = RuntimeScalarType.BYTE_STRING;
@@ -507,12 +523,12 @@ public class Operator {
         // alias remains live: a negative offset is re-evaluated if the parent
         // scalar is replaced while the alias is still in scope.
         var lvalue = new RuntimeSubstrLvalue(
-                (RuntimeScalar) args[0], result, lvalueOffset, lvalueLength);
+                target, result, lvalueOffset, lvalueLength, !hasExplicitLength);
 
-        if (replacement != null) {
+        if (hasReplacement) {
             // When replacement is provided, save the extracted substring before modifying
             String extractedSubstring = result;
-            lvalue.set(replacementScalar);
+            lvalue.setUsingParentSnapshot(replacementScalar, str);
             // Return the extracted substring, not the lvalue (which now contains the replacement)
             RuntimeScalar retVal = new RuntimeScalar(extractedSubstring);
             // Preserve BYTE_STRING type from parent

--- a/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
+++ b/src/main/java/org/perlonjava/runtime/operators/WarnDie.java
@@ -663,6 +663,10 @@ public class WarnDie {
      */
     public static RuntimeScalar exit(RuntimeScalar runtimeScalar) {
         int exitCode = runtimeScalar.getInt();
+        PerlRuntime runtime = PerlRuntime.current();
+        if (runtime.perlThreadId() != 0 && runtime.perlThreadExitOnly()) {
+            throw new PerlThreadExitException(new RuntimeArray(RuntimeScalarCache.scalarUndef));
+        }
         // Set $? to the exit code before running END blocks (Perl 5 semantics).
         // From perlvar: "Inside an END subroutine $? contains the value that
         // is going to be given to exit(). You can modify $? in an END

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
@@ -2,9 +2,12 @@ package org.perlonjava.runtime.perlmodule;
 
 import org.perlonjava.app.scriptengine.PerlLanguageProvider;
 import org.perlonjava.runtime.operators.ReferenceOperators;
+import org.perlonjava.runtime.operators.WarnDie;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 /** Java backend for the first, deliberately unadvertised Perl threads API tranche. */
 public final class Threads extends PerlModuleBase {
@@ -27,6 +30,13 @@ public final class Threads extends PerlModuleBase {
             module.registerMethod("_is_detached", null);
             module.registerMethod("_error", null);
             module.registerMethod("_exit", null);
+            module.registerMethod("_object", null);
+            module.registerMethod("_wantarray", null);
+            module.registerMethod("_kill", null);
+            module.registerMethod("_get_stack_size", null);
+            module.registerMethod("_set_stack_size", null);
+            module.registerMethod("_set_thread_exit_only", null);
+            module.registerMethod("_set_default_exit_only", null);
         } catch (NoSuchMethodException e) {
             throw new IllegalStateException("Missing threads backend method", e);
         }
@@ -34,9 +44,9 @@ public final class Threads extends PerlModuleBase {
 
     public static RuntimeList _create(RuntimeArray args, int ctx) {
         int codeIndex = 0;
+        RuntimeHash options = null;
         if (!args.isEmpty() && args.get(0).type == RuntimeScalarType.HASHREFERENCE) {
-            // Perl's creation options (notably stack_size) are advisory here:
-            // JVM thread stack sizing is owned by PerlThreadExecutionPolicy.
+            options = (RuntimeHash) args.get(0).value;
             codeIndex = 1;
         }
         if (args.size() <= codeIndex) {
@@ -67,8 +77,12 @@ public final class Threads extends PerlModuleBase {
         }
         RuntimeArray threadArgs = new RuntimeArray();
         for (int i = codeIndex + 1; i < args.size(); i++) threadArgs.push(args.get(i));
+        PerlRuntime parent = PerlRuntime.current();
+        int threadContext = creationContext(options, ctx);
+        long stackSize = optionLong(options, "stack_size", parent.defaultPerlThreadStackSize());
+        boolean exitOnly = optionExitOnly(options, parent.defaultPerlThreadExitOnly());
         PerlThreadControlBlock thread = PerlThreadControlBlock.create(
-                PerlRuntime.current(), code, threadArgs, ctx).start();
+                parent, code, threadArgs, threadContext, stackSize, exitOnly).start();
         return threadObject(thread.id(), null).getList();
     }
 
@@ -95,7 +109,8 @@ public final class Threads extends PerlModuleBase {
             PerlThreadControlBlock.Completion completion = thread.join();
             object.put("state", new RuntimeScalar("joined"));
             String error = errorText(completion.error());
-            object.put("error", new RuntimeScalar(error));
+            object.put("error", error.isEmpty() ? RuntimeScalarCache.scalarUndef : new RuntimeScalar(error));
+            if (completion.error() instanceof PerlExitException processExit) throw processExit;
             if (!error.isEmpty()) {
                 RuntimeIO.getStderr().write(
                         "Thread " + thread.id() + " terminated abnormally: " + error + "\n");
@@ -103,6 +118,9 @@ public final class Threads extends PerlModuleBase {
             if (!(completion.value() instanceof RuntimeArray values)) return new RuntimeList();
             List<RuntimeBase> cloned = new RuntimeGraphCloner(
                     thread.childRuntime(), PerlRuntime.current()).cloneRoots(values.elements);
+            if (thread.context() == RuntimeContextType.VOID) {
+                return RuntimeScalarCache.scalarUndef.getList();
+            }
             if (ctx == RuntimeContextType.VOID) return new RuntimeList();
             if (ctx == RuntimeContextType.SCALAR) {
                 return cloned.isEmpty() ? RuntimeScalarCache.scalarUndef.getList()
@@ -121,22 +139,27 @@ public final class Threads extends PerlModuleBase {
         if (thread == null) throw new IllegalStateException("Thread is no longer detachable");
         thread.detach();
         object.put("state", new RuntimeScalar("detached"));
-        return threadObjectScalar(args).getList();
+        return RuntimeScalarCache.scalarUndef.getList();
     }
 
     public static RuntimeList _is_running(RuntimeArray args, int ctx) {
-        PerlThreadControlBlock thread = findThread(threadHash(args));
+        RuntimeHash object = threadHash(args);
+        RuntimeScalar tid = object.get("tid");
+        if (tid != null && tid.getLong() == 0) return new RuntimeScalar(1).getList();
+        PerlThreadControlBlock thread = findKnownThread(object);
         return new RuntimeScalar(thread != null && thread.isRunning() ? 1 : 0).getList();
     }
 
     public static RuntimeList _is_joinable(RuntimeArray args, int ctx) {
-        PerlThreadControlBlock thread = findThread(threadHash(args));
+        PerlThreadControlBlock thread = findKnownThread(threadHash(args));
         return new RuntimeScalar(thread != null && thread.isJoinable() ? 1 : 0).getList();
     }
 
     public static RuntimeList _is_detached(RuntimeArray args, int ctx) {
         RuntimeHash object = threadHash(args);
-        PerlThreadControlBlock thread = findThread(object);
+        RuntimeScalar tid = object.get("tid");
+        if (tid != null && tid.getLong() == 0) return new RuntimeScalar(1).getList();
+        PerlThreadControlBlock thread = findKnownThread(object);
         boolean detached = thread != null ? thread.isDetached()
                 : "detached".equals(object.get("state").toString());
         return new RuntimeScalar(detached ? 1 : 0).getList();
@@ -145,24 +168,157 @@ public final class Threads extends PerlModuleBase {
     public static RuntimeList _error(RuntimeArray args, int ctx) {
         RuntimeHash object = threadHash(args);
         RuntimeScalar saved = object.get("error");
-        PerlThreadControlBlock thread = findThread(object);
-        if (thread != null && thread.state() == PerlThreadControlBlock.State.FAILED) {
-            return new RuntimeScalar(errorText(thread.error())).getList();
+        PerlThreadControlBlock thread = findKnownThread(object);
+        if (thread != null) {
+            return thread.error() == null ? RuntimeScalarCache.scalarUndef.getList()
+                    : new RuntimeScalar(errorText(thread.error())).getList();
         }
-        return saved == null ? RuntimeScalarCache.scalarUndef.getList() : saved.getList();
+        return saved == null || !saved.getDefinedBoolean()
+                ? RuntimeScalarCache.scalarUndef.getList() : saved.getList();
     }
 
     public static RuntimeList _exit(RuntimeArray args, int ctx) {
         if (PerlRuntime.current().perlThreadId() == 0) {
-            throw new IllegalStateException("threads->exit may only be called from a child thread");
+            RuntimeScalar status = args.isEmpty() ? new RuntimeScalar(0) : args.get(0);
+            return WarnDie.exit(status).getList();
         }
         RuntimeArray values = new RuntimeArray(RuntimeScalarCache.scalarUndef);
         throw new PerlThreadExitException(values);
     }
 
+    public static RuntimeList _object(RuntimeArray args, int ctx) {
+        if (args.isEmpty() || !args.get(0).getDefinedBoolean()) return RuntimeScalarCache.scalarUndef.getList();
+        long id = args.get(0).getLong();
+        if (id == 0) return threadObject(0, null).getList();
+        PerlThreadControlBlock thread = PerlRuntime.current().threadRegistry().get(id);
+        return thread == null ? RuntimeScalarCache.scalarUndef.getList() : threadObject(id, thread).getList();
+    }
+
+    public static RuntimeList _wantarray(RuntimeArray args, int ctx) {
+        RuntimeHash object = threadHash(args);
+        RuntimeScalar tid = object.get("tid");
+        int context = RuntimeContextType.SCALAR;
+        if (tid != null && tid.getLong() != 0) {
+            PerlThreadControlBlock thread = findKnownThread(object);
+            if (thread == null) return RuntimeScalarCache.scalarUndef.getList();
+            context = thread.context();
+        }
+        if (context == RuntimeContextType.VOID) return RuntimeScalarCache.scalarUndef.getList();
+        return new RuntimeScalar(RuntimeContextType.isListLike(context) ? 1 : 0).getList();
+    }
+
+    public static RuntimeList _kill(RuntimeArray args, int ctx) {
+        RuntimeScalar object = threadObjectScalar(args);
+        RuntimeHash hash = threadHash(args);
+        if (args.size() < 2) throw new IllegalArgumentException("Usage: $thr->kill('SIG...')");
+        String signal = normalizeSignal(args.get(1));
+        PerlThreadControlBlock thread = findThread(hash);
+        if (thread == null || !thread.isRunning() || thread.isDetached()) {
+            return RuntimeScalarCache.scalarUndef.getList();
+        }
+        thread.signal(signal);
+        return object.getList();
+    }
+
+    public static RuntimeList _get_stack_size(RuntimeArray args, int ctx) {
+        if (args.isEmpty()) return new RuntimeScalar(PerlRuntime.current().defaultPerlThreadStackSize()).getList();
+        RuntimeHash object = threadHash(args);
+        RuntimeScalar tid = object.get("tid");
+        if (tid != null && tid.getLong() == 0) {
+            return new RuntimeScalar(PerlRuntime.current().perlThreadStackSize()).getList();
+        }
+        PerlThreadControlBlock thread = findKnownThread(object);
+        return new RuntimeScalar(thread == null ? 0 : thread.stackSize()).getList();
+    }
+
+    public static RuntimeList _set_stack_size(RuntimeArray args, int ctx) {
+        if (args.isEmpty()) throw new IllegalArgumentException("Missing stack size");
+        long size = args.get(args.size() - 1).getLong();
+        if (size < 0) throw new IllegalArgumentException("Stack size must not be negative");
+        if (args.size() > 1 && args.get(0).type == RuntimeScalarType.HASHREFERENCE) {
+            throw new IllegalStateException("Cannot change stack size of an existing thread");
+        }
+        PerlRuntime runtime = PerlRuntime.current();
+        long old = runtime.defaultPerlThreadStackSize();
+        runtime.setDefaultPerlThreadStackSize(size);
+        return new RuntimeScalar(old).getList();
+    }
+
+    public static RuntimeList _set_thread_exit_only(RuntimeArray args, int ctx) {
+        if (args.size() < 2) throw new IllegalArgumentException("Missing thread exit policy");
+        RuntimeScalar invocant = args.get(0);
+        boolean value = args.get(1).getBoolean();
+        if (invocant.type == RuntimeScalarType.HASHREFERENCE) {
+            PerlThreadControlBlock thread = findKnownThread(threadHash(args));
+            if (thread != null) thread.childRuntime().setPerlThreadExitOnly(value);
+        } else {
+            PerlRuntime.current().setPerlThreadExitOnly(value);
+        }
+        return invocant.getList();
+    }
+
+    public static RuntimeList _set_default_exit_only(RuntimeArray args, int ctx) {
+        boolean value = !args.isEmpty() && args.get(0).getBoolean();
+        PerlRuntime.current().setDefaultPerlThreadExitOnly(value);
+        return RuntimeScalarCache.scalarUndef.getList();
+    }
+
     private static PerlThreadControlBlock findThread(RuntimeHash object) {
         RuntimeScalar tid = object.get("tid");
         return tid == null ? null : PerlRuntime.current().threadRegistry().get(tid.getLong());
+    }
+
+    private static PerlThreadControlBlock findKnownThread(RuntimeHash object) {
+        RuntimeScalar tid = object.get("tid");
+        return tid == null ? null : PerlRuntime.current().threadRegistry().getKnown(tid.getLong());
+    }
+
+    private static int creationContext(RuntimeHash options, int implicit) {
+        if (options == null) return implicit;
+        RuntimeScalar named = options.get("context");
+        if (named != null && named.getDefinedBoolean()) return namedContext(named.toString());
+        if (truthy(options, "list") || truthy(options, "array")) return RuntimeContextType.LIST;
+        if (truthy(options, "scalar")) return RuntimeContextType.SCALAR;
+        if (truthy(options, "void")) return RuntimeContextType.VOID;
+        return implicit;
+    }
+
+    private static int namedContext(String value) {
+        return switch (value.toLowerCase(Locale.ROOT)) {
+            case "list", "array" -> RuntimeContextType.LIST;
+            case "scalar" -> RuntimeContextType.SCALAR;
+            case "void" -> RuntimeContextType.VOID;
+            default -> throw new IllegalArgumentException("Invalid context: " + value);
+        };
+    }
+
+    private static boolean truthy(RuntimeHash options, String key) {
+        RuntimeScalar value = options.get(key);
+        return value != null && value.getBoolean();
+    }
+
+    private static long optionLong(RuntimeHash options, String key, long fallback) {
+        if (options == null) return fallback;
+        RuntimeScalar value = options.get(key);
+        return value == null || !value.getDefinedBoolean() ? fallback : value.getLong();
+    }
+
+    private static boolean optionExitOnly(RuntimeHash options, boolean fallback) {
+        if (options == null) return fallback;
+        RuntimeScalar value = options.get("exit");
+        if (value == null || !value.getDefinedBoolean()) return fallback;
+        return value.toString().matches("threads?_only");
+    }
+
+    private static final Set<String> SIGNALS = Set.of(
+            "HUP", "INT", "QUIT", "ILL", "TRAP", "ABRT", "BUS", "FPE",
+            "KILL", "USR1", "SEGV", "USR2", "PIPE", "ALRM", "TERM", "CHLD");
+
+    private static String normalizeSignal(RuntimeScalar value) {
+        String signal = value.toString().toUpperCase(Locale.ROOT);
+        if (signal.startsWith("SIG")) signal = signal.substring(3);
+        if (!SIGNALS.contains(signal)) throw new IllegalArgumentException("Unrecognized signal name: " + value);
+        return signal;
     }
 
     private static RuntimeHash threadHash(RuntimeArray args) {

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -22,7 +22,7 @@ final class JoniRegexPattern {
     private final Map<String, Integer> namedGroups;
 
     JoniRegexPattern(String perlPattern, RegexFlags flags) {
-        sourcePattern = translatePattern(perlPattern);
+        sourcePattern = translatePattern(perlPattern, flags);
         byte[] bytes = sourcePattern.getBytes(StandardCharsets.UTF_8);
         regex = new Regex(bytes, 0, bytes.length, toJoniOptions(flags),
                 UTF8Encoding.INSTANCE, Syntax.RUBY);
@@ -61,6 +61,11 @@ final class JoniRegexPattern {
     }
 
     static String translatePattern(String pattern) {
+        return translatePattern(pattern, RegexFlags.fromModifiers("", pattern));
+    }
+
+    private static String translatePattern(String pattern, RegexFlags flags) {
+        pattern = translateDefineBlocks(pattern);
         StringBuilder out = new StringBuilder(pattern.length() + 16);
         boolean escaped = false;
         boolean inClass = false;
@@ -84,6 +89,10 @@ final class JoniRegexPattern {
             if (ch == ']' && inClass) {
                 inClass = false;
                 out.append(ch);
+                continue;
+            }
+            if (!inClass && pattern.startsWith("(?[", i)) {
+                i = ExtendedCharClass.handleExtendedCharacterClass(pattern, i, out, flags);
                 continue;
             }
             if (!inClass && pattern.startsWith("(?^", i)) {
@@ -133,6 +142,84 @@ final class JoniRegexPattern {
             out.append(ch);
         }
         return out.toString();
+    }
+
+    /**
+     * Ruby/Oniguruma syntax supports named subexpression calls but not PCRE's
+     * {@code (?(DEFINE) ...)} container. Keep the definitions in the compiled
+     * graph inside a negative lookahead whose body is forced to fail; the
+     * lookahead therefore always succeeds without consuming input, while the
+     * named groups remain available to later {@code (?&name)} calls.
+     */
+    private static String translateDefineBlocks(String pattern) {
+        StringBuilder out = new StringBuilder(pattern.length() + 16);
+        boolean escaped = false;
+        boolean inClass = false;
+        for (int i = 0; i < pattern.length(); i++) {
+            char ch = pattern.charAt(i);
+            if (escaped) {
+                out.append(ch);
+                escaped = false;
+                continue;
+            }
+            if (ch == '\\') {
+                out.append(ch);
+                escaped = true;
+                continue;
+            }
+            if (ch == '[') {
+                inClass = true;
+                out.append(ch);
+                continue;
+            }
+            if (ch == ']' && inClass) {
+                inClass = false;
+                out.append(ch);
+                continue;
+            }
+            if (!inClass && pattern.startsWith("(?(DEFINE)", i)) {
+                int end = findGroupEnd(pattern, i);
+                if (end > i) {
+                    String definitions = pattern.substring(i + 10, end);
+                    out.append("(?!(?:")
+                            .append(translateDefineBlocks(definitions))
+                            .append(")(?!))");
+                    i = end;
+                    continue;
+                }
+            }
+            out.append(ch);
+        }
+        return out.toString();
+    }
+
+    private static int findGroupEnd(String pattern, int start) {
+        int depth = 0;
+        boolean escaped = false;
+        boolean inClass = false;
+        for (int i = start; i < pattern.length(); i++) {
+            char ch = pattern.charAt(i);
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaped = true;
+                continue;
+            }
+            if (ch == '[') {
+                inClass = true;
+                continue;
+            }
+            if (ch == ']' && inClass) {
+                inClass = false;
+                continue;
+            }
+            if (inClass) continue;
+            if (ch == '(') depth++;
+            else if (ch == ')' && --depth == 0) return i;
+        }
+        return -1;
     }
 
     private static Map<String, Integer> collectNamedGroups(Regex regex) {

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -554,6 +554,10 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         String cacheKey = regex.patternString + "/" + (regex.regexFlags == null ? "" : regex.regexFlags.toFlagString());
         state().compiledRegexCache.remove(cacheKey);
 
+        // User property subs can execute arbitrary Perl and block. Resolve them
+        // before compile() takes its process-wide monitor; only simultaneous
+        // definitions of the same property coordinate in PerlThreadRegistry.
+        UnicodeResolver.preloadUserDefinedProperties(regex.patternString);
         RuntimeRegex recompiled = compile(regex.patternString, regex.regexFlags == null ? "" : regex.regexFlags.toFlagString());
         regex.pattern = recompiled.pattern;
         regex.patternUnicode = recompiled.patternUnicode;

--- a/src/main/java/org/perlonjava/runtime/regex/UnicodeResolver.java
+++ b/src/main/java/org/perlonjava/runtime/regex/UnicodeResolver.java
@@ -3,6 +3,7 @@ package org.perlonjava.runtime.regex;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
 import com.ibm.icu.text.UnicodeSet;
+import org.perlonjava.app.scriptengine.PerlLanguageProvider;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import java.util.HashSet;
@@ -455,29 +456,60 @@ public class UnicodeResolver {
             return userPropertyCache().get(subName);
         }
 
+        // A property sub is arbitrary Perl and may block. Regex parsing occurs
+        // under the process compile lock, so invoking it here would prevent an
+        // unrelated ithread from compiling a different property. Leave the
+        // existing placeholder marker for ensureCompiledForRuntime() to resolve
+        // after ordinary execution has released the compiler lock.
+        if (PerlLanguageProvider.COMPILE_LOCK.isHeldByCurrentThread()) {
+            return null;
+        }
+
         // Look up the subroutine without autovivifying an empty CODE slot.
         if (!GlobalVariable.isGlobalCodeRefDefined(subName)) {
             return null;
         }
         RuntimeScalar codeRef = GlobalVariable.getGlobalCodeRef(subName);
 
+        final String resolvedSubName = subName;
+        try {
+            String parsed = PerlRuntime.current().threadRegistry()
+                    .resolveUserUnicodeProperty(resolvedSubName,
+                            () -> resolveUserDefinedProperty(
+                                    codeRef, resolvedSubName, newRecursionSet));
+            userPropertyCache().put(subName, parsed);
+            return parsed;
+        } catch (PerlCompilerException e) {
+            // Re-throw Perl exceptions (like die in IsDeath)
+            String msg = e.getMessage();
+            if (msg != null && !msg.contains("in expansion of")) {
+                throw new IllegalArgumentException("Died" + (msg.isEmpty() ? "" : ": " + msg) + " in expansion of " + subName, e);
+            }
+            throw e;
+        } catch (IllegalArgumentException e) {
+            // Re-throw validation errors from parseUserDefinedProperty
+            throw e;
+        } catch (Exception e) {
+            // Wrap other errors
+            throw new IllegalArgumentException("Error in user-defined property " + subName + ": " + e.getMessage(), e);
+        }
+    }
+
+    private static String resolveUserDefinedProperty(RuntimeScalar codeRef, String subName,
+                                                     Set<String> recursionSet) {
         try {
             // Call the subroutine with an empty argument list
             RuntimeArray args = new RuntimeArray();
             RuntimeList result = RuntimeCode.apply(codeRef, args, RuntimeContextType.SCALAR);
 
             if (result.elements.isEmpty()) {
-                String parsed = "";
-                userPropertyCache().put(subName, parsed);
-                return parsed;
+                return "";
             }
 
             String definition = result.elements.getFirst().toString();
 
             // Parse and cache the property definition
-            String parsed = parseUserDefinedProperty(definition, newRecursionSet, subName);
-            userPropertyCache().put(subName, parsed);
-            return parsed;
+            return parseUserDefinedProperty(definition, recursionSet, subName);
 
         } catch (PerlCompilerException e) {
             // Re-throw Perl exceptions (like die in IsDeath)
@@ -492,6 +524,36 @@ public class UnicodeResolver {
         } catch (Exception e) {
             // Wrap other errors
             throw new IllegalArgumentException("Error in user-defined property " + subName + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Resolve deferred top-level user properties before entering the synchronized
+     * regex compiler. Property subs are arbitrary Perl and may block; keeping
+     * them outside that compiler monitor lets unrelated property names proceed.
+     */
+    static void preloadUserDefinedProperties(String pattern) {
+        if (pattern == null || pattern.isEmpty()) return;
+
+        for (int slash = pattern.indexOf('\\'); slash >= 0;
+             slash = pattern.indexOf('\\', slash + 1)) {
+            int precedingSlashes = 0;
+            for (int cursor = slash - 1; cursor >= 0 && pattern.charAt(cursor) == '\\'; cursor--) {
+                precedingSlashes++;
+            }
+            if ((precedingSlashes & 1) != 0 || slash + 3 >= pattern.length()) continue;
+
+            char marker = pattern.charAt(slash + 1);
+            if ((marker != 'p' && marker != 'P') || pattern.charAt(slash + 2) != '{') continue;
+            int end = pattern.indexOf('}', slash + 3);
+            if (end < 0) return;
+
+            String property = pattern.substring(slash + 3, end).trim();
+            if (property.startsWith("^")) property = property.substring(1).trim();
+            if (property.matches("^(.*::)?([Ii][sSNn]).+")) {
+                translateUnicodeProperty(property, marker == 'P');
+            }
+            slash = end;
         }
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ArraySpecialVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ArraySpecialVariable.java
@@ -27,6 +27,10 @@ public class ArraySpecialVariable extends AbstractList<RuntimeScalar> {
         this.mode = mode;
     }
 
+    ArraySpecialVariable snapshotView() {
+        return new ArraySpecialVariable(mode);
+    }
+
     /**
      * Returns the position of the capturing group at the specified index.
      * The position returned depends on the mode: end position for Id.LAST_MATCH_END,

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeState.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Runtime-owned Perl global state.
@@ -17,6 +18,9 @@ import java.util.Set;
  * services.</p>
  */
 public final class GlobalRuntimeState {
+    private static final int COMPILED_CODE_REF_RANGE_SIZE = 1_000_000;
+    private static final AtomicInteger NEXT_THREAD_COMPILED_CODE_REF_BASE =
+            new AtomicInteger(COMPILED_CODE_REF_RANGE_SIZE);
     private final Map<String, RuntimeScalar> scalarValues = new HashMap<>();
     private final Map<String, RuntimeArray> arrayValues = new HashMap<>();
     private final Map<String, RuntimeHash> hashValues = new HashMap<>();
@@ -298,7 +302,14 @@ public final class GlobalRuntimeState {
         classFields.forEach((name, fields) -> target.classFields.put(name, new HashSet<>(fields)));
         target.classParents.putAll(classParents);
         target.packageVersions.putAll(packageVersions);
-        target.nextCompiledCodeRefId = nextCompiledCodeRefId;
+        // Lazy named CVs may compile in the parent after this snapshot while
+        // the child also compiles new code. Give every snapshot runtime its
+        // own range so later parent metadata cannot collide with IDs already
+        // embedded in child-generated call sites. Fresh independent runtimes
+        // still begin at one and retain their isolated-ID contract.
+        target.nextCompiledCodeRefId = Math.max(nextCompiledCodeRefId,
+                NEXT_THREAD_COMPILED_CODE_REF_BASE.getAndAdd(
+                        COMPILED_CODE_REF_RANGE_SIZE));
         target.stashEnumerationVersion = stashEnumerationVersion;
         target.coreGlobalsInitialized = coreGlobalsInitialized;
         // Class loaders, caches, named IO and formats are child-owned/fresh.

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/Overload.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/Overload.java
@@ -58,6 +58,12 @@ public class Overload {
      * @return the string representation based on overloading rules
      */
     public static RuntimeScalar stringify(RuntimeScalar runtimeScalar) {
+        // A weak reference can be cleared between graph snapshot and use. Its
+        // scalar may briefly retain the old reference type while the referent
+        // payload is gone; Perl observes undef, not a reference to stringify.
+        if (runtimeScalar.value == null) {
+            return scalarUndef;
+        }
         // Recursion guard — see STRINGIFY_MAX_DEPTH javadoc.
         ExecutionRuntimeState state = PerlRuntime.current().executionState();
         int depth = state.overloadStringifyDepth;
@@ -111,6 +117,9 @@ public class Overload {
      * @return the numeric representation based on overloading rules
      */
     public static RuntimeScalar numify(RuntimeScalar runtimeScalar) {
+        if (runtimeScalar.value == null) {
+            return scalarUndef;
+        }
         // Prepare overload context and check if object is eligible for overloading
         int blessId = RuntimeScalarType.blessedId(runtimeScalar);
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -47,6 +47,11 @@ public final class PerlRuntime implements AutoCloseable {
     private volatile boolean closed;
     private final PerlThreadRegistry threadRegistry;
     private final long perlThreadId;
+    private volatile int perlThreadContext = RuntimeContextType.SCALAR;
+    private volatile long perlThreadStackSize;
+    private volatile long defaultPerlThreadStackSize;
+    private volatile boolean perlThreadExitOnly;
+    private volatile boolean defaultPerlThreadExitOnly;
 
     public final ExecutionRuntimeState executionState = new ExecutionRuntimeState();
     public final RuntimeRegexState regexState = new RuntimeRegexState();
@@ -196,6 +201,17 @@ public final class PerlRuntime implements AutoCloseable {
         return perlThreadId;
     }
 
+    public int perlThreadContext() { return perlThreadContext; }
+    public void setPerlThreadContext(int context) { perlThreadContext = context; }
+    public long perlThreadStackSize() { return perlThreadStackSize; }
+    public void setPerlThreadStackSize(long size) { perlThreadStackSize = size; }
+    public long defaultPerlThreadStackSize() { return defaultPerlThreadStackSize; }
+    public void setDefaultPerlThreadStackSize(long size) { defaultPerlThreadStackSize = size; }
+    public boolean perlThreadExitOnly() { return perlThreadExitOnly; }
+    public void setPerlThreadExitOnly(boolean value) { perlThreadExitOnly = value; }
+    public boolean defaultPerlThreadExitOnly() { return defaultPerlThreadExitOnly; }
+    public void setDefaultPerlThreadExitOnly(boolean value) { defaultPerlThreadExitOnly = value; }
+
     /** Initialize this independent interpreter's globals and runtime services. */
     public PerlRuntime initialize() {
         executionLock.lock();
@@ -291,10 +307,13 @@ public final class PerlRuntime implements AutoCloseable {
             }
 
             PerlRuntime child = new PerlRuntime(registry, threadId);
+            child.defaultPerlThreadStackSize = defaultPerlThreadStackSize;
+            child.defaultPerlThreadExitOnly = defaultPerlThreadExitOnly;
             RuntimeGraphCloner cloner = new RuntimeGraphCloner(this, child, skipped);
             try (Binding ignored = bind()) {
                 globalState.snapshotInto(child.globalState, cloner);
                 runtimeCodeState.snapshotCompiledMetadataInto(child.runtimeCodeState);
+                regexState.snapshotInto(child.regexState);
             }
             child.currentDirectory = currentDirectory;
             child.initialized = true;
@@ -327,10 +346,16 @@ public final class PerlRuntime implements AutoCloseable {
                 : new java.util.ArrayList<>(globalState.codeRefs().entrySet())) {
             String fqn = entry.getKey();
             boolean cloneHook = fqn.endsWith("::CLONE") || fqn.endsWith("::CLONE_SKIP");
-            if (!cloneHook && !fqn.startsWith("threads::")) continue;
             RuntimeScalar hook = entry.getValue();
-            if (hook != null && hook.value instanceof RuntimeCode code
-                    && code.compilerSupplier != null) {
+            if (hook == null || !(hook.value instanceof RuntimeCode code)) continue;
+            // A lazy named sub that closes over lexicals must be materialized
+            // while the parent capture cells are authoritative. Non-capturing
+            // subs stay lazy, avoiding the large test.pl eager-compilation
+            // regression that originally motivated this narrow preflight.
+            boolean capturesLexicals = code.closedOverVariables != null
+                    && !code.closedOverVariables.isEmpty();
+            if (!cloneHook && !fqn.startsWith("threads::") && !capturesLexicals) continue;
+            if (code.compilerSupplier != null) {
                 code.compilerSupplier.get();
             }
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlSignalQueue.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlSignalQueue.java
@@ -30,6 +30,12 @@ public class PerlSignalQueue {
         state.hasPendingSignal = true;  // Set flag for fast checking
     }
 
+    /** Queue a signal for another runtime; its handler is resolved when delivered. */
+    public static void enqueue(State state, String signal) {
+        state.signalQueue.offer(new SignalEvent(signal, null));
+        state.hasPendingSignal = true;
+    }
+
     /**
      * Lightweight signal check - called frequently at safe execution points.
      * If no signals are pending, this is just a volatile boolean read (~2 CPU cycles).
@@ -61,9 +67,19 @@ public class PerlSignalQueue {
         SignalEvent event;
         while ((event = state.signalQueue.poll()) != null) {
             state.hasPendingSignal = !state.signalQueue.isEmpty();
+            RuntimeScalar handler = event.handler;
+            if (handler == null) {
+                handler = GlobalVariable.getGlobalHash("main::SIG").get(event.signal);
+            }
+            String disposition = handler == null ? "" : handler.toString();
+            if ("IGNORE".equals(disposition)) continue;
+            if (handler == null || !handler.getDefinedBoolean()
+                    || disposition.isEmpty() || "DEFAULT".equals(disposition)) {
+                continue;
+            }
             RuntimeArray args = new RuntimeArray();
             args.push(new RuntimeScalar(event.signal));
-            RuntimeCode.apply(event.handler, args, RuntimeContextType.VOID);
+            RuntimeCode.apply(handler, args, RuntimeContextType.VOID);
         }
         state.hasPendingSignal = false;
     }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlock.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadControlBlock.java
@@ -22,6 +22,8 @@ public final class PerlThreadControlBlock {
     private final PerlThreadRegistry registry;
     private final PerlRuntime childRuntime;
     private final EntryPoint entryPoint;
+    private final int context;
+    private final long stackSize;
     private final CountDownLatch finished = new CountDownLatch(1);
     private final AtomicBoolean joinClaimed = new AtomicBoolean();
     private volatile State state = State.NEW;
@@ -37,16 +39,27 @@ public final class PerlThreadControlBlock {
         this.parentId = parent.perlThreadId();
         this.entryPoint = Objects.requireNonNull(entryPoint, "entryPoint");
         this.childRuntime = parent.snapshotCloneForThread(registry, id).runtime();
+        this.context = RuntimeContextType.SCALAR;
+        this.stackSize = parent.defaultPerlThreadStackSize();
+        childRuntime.setPerlThreadContext(context);
+        childRuntime.setPerlThreadStackSize(stackSize);
+        childRuntime.setPerlThreadExitOnly(parent.defaultPerlThreadExitOnly());
         registry.register(this);
     }
 
-    private PerlThreadControlBlock(PerlRuntime parent, RuntimeScalar code, RuntimeArray args, int context) {
+    private PerlThreadControlBlock(PerlRuntime parent, RuntimeScalar code, RuntimeArray args,
+                                   int context, long stackSize, boolean exitOnly) {
         Objects.requireNonNull(parent, "parent");
         this.registry = parent.threadRegistry();
         this.id = registry.allocateId();
         this.parentId = parent.perlThreadId();
         PerlRuntime.ThreadSnapshot snapshot = parent.snapshotCloneForThread(registry, id);
         this.childRuntime = snapshot.runtime();
+        this.context = context;
+        this.stackSize = stackSize;
+        childRuntime.setPerlThreadContext(context);
+        childRuntime.setPerlThreadStackSize(stackSize);
+        childRuntime.setPerlThreadExitOnly(exitOnly);
 
         List<RuntimeBase> roots = new ArrayList<>(args.size() + 1);
         roots.add(Objects.requireNonNull(code, "code"));
@@ -71,13 +84,20 @@ public final class PerlThreadControlBlock {
     /** Create a Perl thread, cloning its CODE and arguments with the runtime snapshot graph. */
     public static PerlThreadControlBlock create(
             PerlRuntime parent, RuntimeScalar code, RuntimeArray args, int context) {
-        return new PerlThreadControlBlock(parent, code, args, context);
+        return new PerlThreadControlBlock(parent, code, args, context,
+                parent.defaultPerlThreadStackSize(), parent.defaultPerlThreadExitOnly());
+    }
+
+    public static PerlThreadControlBlock create(
+            PerlRuntime parent, RuntimeScalar code, RuntimeArray args, int context,
+            long stackSize, boolean exitOnly) {
+        return new PerlThreadControlBlock(parent, code, args, context, stackSize, exitOnly);
     }
 
     public synchronized PerlThreadControlBlock start() {
         if (state != State.NEW) throw new IllegalStateException("Thread already started");
         state = State.RUNNING;
-        platformThread = PerlThreadExecutionPolicy.configured().unstarted(id, this::run);
+        platformThread = PerlThreadExecutionPolicy.configured().unstarted(id, stackSize, this::run);
         platformThread.start();
         return this;
     }
@@ -161,6 +181,16 @@ public final class PerlThreadControlBlock {
     public String javaThreadName() { return platformThread == null ? null : platformThread.getName(); }
     public boolean isVirtualThread() { return platformThread != null && platformThread.isVirtual(); }
     public Throwable error() { return error; }
+    public int context() { return context; }
+    public long stackSize() { return stackSize; }
+
+    /** Deliver a Perl signal in the target runtime at its next safe point. */
+    public void signal(String signal) {
+        if (!isRunning()) return;
+        PerlSignalQueue.enqueue(childRuntime.signalState, signal);
+        Thread javaThread = platformThread;
+        if (javaThread != null) javaThread.interrupt();
+    }
 
     private record Outcome(RuntimeBase value, Throwable error) {}
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadExecutionPolicy.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadExecutionPolicy.java
@@ -40,10 +40,22 @@ public final class PerlThreadExecutionPolicy {
     }
 
     public Thread unstarted(long id, Runnable task) {
+        return unstarted(id, 0, task);
+    }
+
+    public Thread unstarted(long id, long stackSize, Runnable task) {
         Objects.requireNonNull(task, "task");
+        if (stackSize < 0) throw new IllegalArgumentException("Thread stack size must not be negative");
         String name = "perl-ithread-" + id;
-        return mode == Mode.VIRTUAL
-                ? Thread.ofVirtual().name(name).unstarted(task)
-                : Thread.ofPlatform().name(name).unstarted(task);
+        if (mode == Mode.VIRTUAL) {
+            if (stackSize != 0) {
+                throw new IllegalArgumentException(
+                        "Per-thread stack sizing is not supported by Java virtual threads");
+            }
+            return Thread.ofVirtual().name(name).unstarted(task);
+        }
+        Thread.Builder.OfPlatform builder = Thread.ofPlatform().name(name);
+        if (stackSize != 0) builder = builder.stackSize(stackSize);
+        return builder.unstarted(task);
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadRegistry.java
@@ -4,12 +4,20 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 /** Runtime-family registry for platform threads created by Perl ithreads. */
 public final class PerlThreadRegistry {
     private final AtomicLong nextId = new AtomicLong(1);
     private final ConcurrentHashMap<Long, PerlThreadControlBlock> threads = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, CompletableFuture<String>> userUnicodeProperties =
+            new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, PerlThreadControlBlock> terminalThreads = new ConcurrentHashMap<>();
 
     long allocateId() {
         return nextId.getAndIncrement();
@@ -21,11 +29,17 @@ public final class PerlThreadRegistry {
     }
 
     void remove(PerlThreadControlBlock thread) {
-        threads.remove(thread.id(), thread);
+        if (threads.remove(thread.id(), thread)) terminalThreads.put(thread.id(), thread);
     }
 
     public PerlThreadControlBlock get(long id) {
         return threads.get(id);
+    }
+
+    /** Lookup including joined/detached records retained for existing object aliases. */
+    public PerlThreadControlBlock getKnown(long id) {
+        PerlThreadControlBlock active = threads.get(id);
+        return active != null ? active : terminalThreads.get(id);
     }
 
     public List<PerlThreadControlBlock> snapshot() {
@@ -36,5 +50,51 @@ public final class PerlThreadRegistry {
 
     public int size() {
         return threads.size();
+    }
+
+    /**
+     * Serialize only simultaneous definitions of the same user Unicode property.
+     * Different property names remain independent, matching Perl's regex lock
+     * granularity without sharing a child's mutable regex cache.
+     */
+    public String resolveUserUnicodeProperty(String name, Supplier<String> resolver) {
+        CompletableFuture<String> mine = new CompletableFuture<>();
+        CompletableFuture<String> active = userUnicodeProperties.putIfAbsent(name, mine);
+        if (active == null) {
+            try {
+                String result = resolver.get();
+                mine.complete(result);
+                return result;
+            } catch (RuntimeException | Error failure) {
+                mine.completeExceptionally(failure);
+                throw failure;
+            } finally {
+                userUnicodeProperties.remove(name, mine);
+            }
+        }
+
+        try {
+            return active.get(10, TimeUnit.SECONDS);
+        } catch (TimeoutException timeout) {
+            throw new IllegalArgumentException(
+                    "Timeout waiting for another thread to define \""
+                            + shortPropertyName(name) + "\" in regex", timeout);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                    "Interrupted waiting for user-defined Unicode property " + name,
+                    interrupted);
+        } catch (ExecutionException failed) {
+            Throwable cause = failed.getCause();
+            if (cause instanceof RuntimeException runtime) throw runtime;
+            if (cause instanceof Error error) throw error;
+            throw new IllegalStateException("User-defined Unicode property failed: " + name,
+                    cause);
+        }
+    }
+
+    private static String shortPropertyName(String name) {
+        int separator = name.lastIndexOf("::");
+        return separator >= 0 ? name.substring(separator + 2) : name;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
@@ -203,8 +203,15 @@ public class RuntimeGraphCloner {
                         targetRuntime.globalState(), this);
                 RuntimeCode completed;
                 try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
-                    completed = (RuntimeCode) new RuntimeGraphCloner(
-                            sourceRuntime, targetRuntime, skippedClasses).cloneCode(source);
+                    // Reuse this snapshot's identity map. A fresh cloner would
+                    // duplicate lexicals that were already copied as runtime
+                    // roots before this lazy CV was materialized.
+                    clones.remove(source);
+                    try {
+                        completed = (RuntimeCode) cloneCode(source);
+                    } finally {
+                        clones.put(source, target);
+                    }
                 }
                 target.adoptDefinitionFrom(completed);
                 target.compilerSupplier = null;
@@ -226,7 +233,14 @@ public class RuntimeGraphCloner {
         target.stateVariable = cloneScalarMap(source.stateVariable);
         target.stateArray = cloneArrayMap(source.stateArray);
         target.stateHash = cloneHashMap(source.stateHash);
-        target.constantValue = source.constantValue;
+        if (source.constantValue == null) {
+            target.constantValue = null;
+        } else {
+            target.constantValue = new RuntimeList();
+            for (RuntimeBase value : source.constantValue.elements) {
+                target.constantValue.elements.add(cloneValue(value));
+            }
+        }
 
         if (source.closedOverVariables != null) {
             target.closedOverVariables = new LinkedHashMap<>();
@@ -267,6 +281,17 @@ public class RuntimeGraphCloner {
     }
 
     private RuntimeScalar cloneScalar(RuntimeScalar source) {
+        if (source instanceof ScalarSpecialVariable special) {
+            ScalarSpecialVariable target = new ScalarSpecialVariable(
+                    special.variableId, special.position);
+            clones.put(source, target);
+            copyBase(source, target);
+            copyScalarMetadata(source, target);
+            if (special.lvalue != null) {
+                target.lvalue = (RuntimeScalar) cloneValue(special.lvalue);
+            }
+            return target;
+        }
         if (source instanceof TieScalar tied) {
             RuntimeScalar placeholder = new RuntimeScalar();
             clones.put(source, placeholder);
@@ -283,15 +308,28 @@ public class RuntimeGraphCloner {
         copyBase(source, target);
         copyScalarMetadata(source, target);
 
-        if (source.type == CODE && source.value instanceof RuntimeCode code) {
+        if (RuntimeScalarType.isReference(source) && source.value == null) {
+            // A cleared weak reference can temporarily retain its reference
+            // type while its payload has already disappeared.  It is Perl
+            // undef at a thread snapshot boundary; copying the stale type
+            // produces an impossible child SV that later crashes overload
+            // stringification/numification on a null referent.
+            target.type = UNDEF;
+            target.value = null;
+        } else if (source.type == CODE && source.value instanceof RuntimeCode code) {
             target.value = cloneCode(code);
         } else if (source.value instanceof RuntimeRegex regex) {
             target.value = regex.cloneTracked();
-        } else if (source.value instanceof RuntimeIO) {
-            // Java channels/descriptors have no portable ithread duplication
-            // semantics. Non-standard resource scalars become undef.
-            target.type = UNDEF;
-            target.value = null;
+        } else if (source.value instanceof RuntimeIO io) {
+            RuntimeIO inherited = cloneInheritedPipe(io);
+            if (inherited != null) {
+                target.value = inherited;
+            } else {
+                // Files, sockets and native descriptors have no portable
+                // ithread duplication semantics and remain unsupported.
+                target.type = UNDEF;
+                target.value = null;
+            }
         } else if (source.value instanceof RuntimeBase base) {
             if (shouldSkip(base)) {
                 target.type = UNDEF;
@@ -318,7 +356,8 @@ public class RuntimeGraphCloner {
     }
 
     private RuntimeArray cloneArray(RuntimeArray source) {
-        RuntimeArray target = new RuntimeArray(source.elements.size());
+        RuntimeArray target = new RuntimeArray(
+                source.elements instanceof ArraySpecialVariable ? 0 : source.elements.size());
         clones.put(source, target);
         copyBase(source, target);
         target.type = source.type;
@@ -327,7 +366,11 @@ public class RuntimeGraphCloner {
         target.elementsOwned = source.elementsOwned;
         target.elementsAliased = source.elementsAliased;
 
-        if (source.type == RuntimeArray.TIED_ARRAY && source.elements instanceof TieArray tie) {
+        if (source.elements instanceof ArraySpecialVariable special) {
+            // Regex capture arrays are dynamic views over the bound runtime's
+            // match state. Copy the view mode, never its current elements.
+            target.elements = special.snapshotView();
+        } else if (source.type == RuntimeArray.TIED_ARRAY && source.elements instanceof TieArray tie) {
             target.elements = new TieArray(tie.getTiedPackage(),
                     (RuntimeArray) cloneValue(tie.getPreviousValue()),
                     (RuntimeScalar) cloneValue(tie.getSelf()), target);
@@ -394,9 +437,25 @@ public class RuntimeGraphCloner {
         if (source.codeSlot != null) {
             target.codeSlot = (RuntimeScalar) cloneValue(source.codeSlot);
         }
-        // Filehandles are runtime resources. Standard handles are installed by
-        // PerlRuntime; detached/non-standard handles become an empty IO slot.
-        target.IO = new RuntimeScalar();
+        // Standard handles are installed by PerlRuntime. Internal pipe
+        // endpoints have an explicit inherited lease; other handles remain empty.
+        if (source.IO != null && source.IO.value instanceof RuntimeIO io
+                && io.ioHandle instanceof org.perlonjava.runtime.io.InternalPipeHandle) {
+            target.IO = (RuntimeScalar) cloneValue(source.IO);
+        } else {
+            target.IO = new RuntimeScalar();
+        }
+        return target;
+    }
+
+    private RuntimeIO cloneInheritedPipe(RuntimeIO source) {
+        Object existing = clones.get(source);
+        if (existing != null) return (RuntimeIO) existing;
+        RuntimeIO target;
+        try (PerlRuntime.Binding ignored = targetRuntime.bind()) {
+            target = source.inheritedPipeCopy();
+        }
+        if (target != null) clones.put(source, target);
         return target;
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
@@ -760,7 +760,10 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
                     // (setLarge or RuntimeCode.apply). This prevents premature DESTROY
                     // when the caller captures the return value.
                     MortalList.deferDecrementIfTracked(value);
-                    yield new RuntimeScalar(value);
+                    // The deleted SV is a loose lvalue. This is observable when
+                    // the slot aliases another scalar and is passed as the
+                    // first argument of four-argument substr.
+                    yield value;
                 }
                 yield new RuntimeScalar();
             }
@@ -782,7 +785,7 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
                 if (value != null) {
                     // Schedule deferred refCount decrement (see delete(RuntimeScalar) above)
                     MortalList.deferDecrementIfTracked(value);
-                    yield new RuntimeScalar(value);
+                    yield value;
                 }
                 yield new RuntimeScalar();
             }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHashProxyEntry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHashProxyEntry.java
@@ -96,6 +96,19 @@ public class RuntimeHashProxyEntry extends RuntimeBaseProxy {
         }
     }
 
+    /** Replace this hash slot with the scalar referenced by a refaliasing RHS. */
+    public RuntimeScalar aliasToReference(RuntimeScalar reference) {
+        RuntimeScalar referent = reference.scalarDeref();
+        parent.notePackageRootMutation();
+        parent.elements.put(key, referent);
+        parent.markKeyByte(key, byteKey);
+        parent.markPackageRootedValue(referent);
+        this.lvalue = referent;
+        this.type = referent.type;
+        this.value = referent.value;
+        return referent;
+    }
+
     /**
      * Saves the current state of the RuntimeScalar instance.
      *

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
@@ -404,6 +404,22 @@ public class RuntimeIO extends RuntimeScalar {
     }
 
     /**
+     * Clone the narrow resource class Perl ithreads can safely inherit.
+     * Ordinary files, sockets, subprocess handles and native resources retain
+     * the conservative unsupported policy in {@link RuntimeGraphCloner}.
+     */
+    RuntimeIO inheritedPipeCopy() {
+        if (!(ioHandle instanceof InternalPipeHandle pipe)) return null;
+        RuntimeIO copy = new RuntimeIO(pipe.inheritedCopy());
+        copy.currentLineNumber = currentLineNumber;
+        copy.globName = globName;
+        copy.needFlush = needFlush;
+        copy.autoFlush = autoFlush;
+        addHandle(copy.ioHandle);
+        return copy;
+    }
+
+    /**
      * Replace this handle's runtime state with another handle while preserving
      * object identity. Perl keeps the PVIO object stable across {@code open FH}
      * on an already-vivified bareword handle, so values captured by

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeRegexState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeRegexState.java
@@ -85,4 +85,9 @@ public final class RuntimeRegexState {
         manualCaptureStarts = null;
         manualCaptureEnds = null;
     }
+
+    /** Copy immutable regex metadata that Perl ithreads inherit at creation. */
+    void snapshotInto(RuntimeRegexState target) {
+        target.userUnicodePropertyCache.putAll(userUnicodePropertyCache);
+    }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -1523,6 +1523,14 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         return result;
     }
 
+    /** Compiler hook for experimental scalar refaliasing into an lvalue proxy. */
+    public RuntimeScalar aliasLvalueReference(RuntimeScalar reference) {
+        if (this instanceof RuntimeHashProxyEntry hashEntry) {
+            return hashEntry.aliasToReference(reference);
+        }
+        throw new PerlCompilerException("Assignment to unsupported ref aliasing target");
+    }
+
     RuntimeScalar setFromSubstrLvalue(RuntimeScalar value) {
         if (this != value) {
             RuntimeScalar result = setLarge(value);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeSubstrLvalue.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeSubstrLvalue.java
@@ -18,6 +18,9 @@ public class RuntimeSubstrLvalue extends RuntimeBaseProxy {
      */
     private int length;
 
+    /** True when the original two-argument substr extended to string end. */
+    private final boolean toEnd;
+
     /**
      * Flag indicating the substr offset was out of bounds.
      * When true, assignment to this lvalue should die.
@@ -33,9 +36,15 @@ public class RuntimeSubstrLvalue extends RuntimeBaseProxy {
      * @param length The length of the substring.
      */
     public RuntimeSubstrLvalue(RuntimeScalar parent, String str, int offset, int length) {
+        this(parent, str, offset, length, false);
+    }
+
+    public RuntimeSubstrLvalue(
+            RuntimeScalar parent, String str, int offset, int length, boolean toEnd) {
         this.lvalue = parent;
         this.offset = offset;
         this.length = length;
+        this.toEnd = toEnd;
         this.outOfBounds = false;
 
         // Preserve BYTE_STRING type from parent so substr() on byte strings stays byte
@@ -70,6 +79,15 @@ public class RuntimeSubstrLvalue extends RuntimeBaseProxy {
      */
     @Override
     public RuntimeScalar set(RuntimeScalar value) {
+        return setInternal(value, null);
+    }
+
+    /** Four-argument substr has already stringified its target once. */
+    public RuntimeScalar setUsingParentSnapshot(RuntimeScalar value, String parentSnapshot) {
+        return setInternal(value, parentSnapshot);
+    }
+
+    private RuntimeScalar setInternal(RuntimeScalar value, String parentSnapshot) {
         // Die on assignment if the original substr was out of bounds
         if (outOfBounds) {
             WarnDie.die(new RuntimeScalar("substr outside of string"),
@@ -78,7 +96,7 @@ public class RuntimeSubstrLvalue extends RuntimeBaseProxy {
         }
 
         // Update the local type and value
-        String parentValue = lvalue.toString();
+        String parentValue = parentSnapshot != null ? parentSnapshot : lvalue.toString();
         String newValue = value.toString();
         this.type = value.type;
         this.value = value.value;
@@ -99,8 +117,8 @@ public class RuntimeSubstrLvalue extends RuntimeBaseProxy {
         }
 
         // Calculate the actual length, handling negative lengths
-        int actualLength = length;
-        if (length < 0) {
+        int actualLength = toEnd ? strLength - actualOffset : length;
+        if (!toEnd && length < 0) {
             actualLength = strLength + length - actualOffset;
         }
 
@@ -171,9 +189,11 @@ public class RuntimeSubstrLvalue extends RuntimeBaseProxy {
             // Negative-offset aliases stay anchored to the same suffix of the
             // parent.  If the replacement changes width, shift the negative
             // start by the opposite delta so that suffix length remains fixed.
-            this.offset += this.length - replacementLength;
+            this.offset += actualLength - replacementLength;
         }
-        this.length = replacementLength;
+        if (!toEnd && this.length >= 0) {
+            this.length = replacementLength;
+        }
         this.type = value.type;
         this.value = newValue;
         this.tainted = updated.tainted;
@@ -208,9 +228,9 @@ public class RuntimeSubstrLvalue extends RuntimeBaseProxy {
         int actualOffset = offset < 0 ? strLength + offset : offset;
         actualOffset = Math.max(0, Math.min(actualOffset, strLength));
 
-        int actualLength = length < 0
-                ? strLength + length - actualOffset
-                : length;
+        int actualLength = toEnd
+                ? strLength - actualOffset
+                : length < 0 ? strLength + length - actualOffset : length;
         actualLength = Math.max(0, Math.min(actualLength, strLength - actualOffset));
 
         int startIndex = PerlUtfString.offsetByPerlCodePoints(parentValue, 0, actualOffset);

--- a/src/main/perl/lib/threads.pm
+++ b/src/main/perl/lib/threads.pm
@@ -3,6 +3,7 @@ package threads;
 use strict;
 use warnings;
 our $VERSION = '2.27';
+our $threads = 1;
 
 sub all ()      { 0 }
 sub running ()  { 1 }
@@ -10,7 +11,18 @@ sub joinable () { 2 }
 
 sub create {
     my $caller = caller;
-    shift;
+    my $invocant = shift;
+    if (ref($invocant)) {
+        my $inherited = $invocant->get_stack_size;
+        if (ref($_[0]) eq 'HASH') {
+            my %options = %{$_[0]};
+            $options{stack_size} = $inherited unless exists $options{stack_size};
+            $_[0] = \%options;
+        }
+        else {
+            unshift @_, { stack_size => $inherited };
+        }
+    }
     my $code_index = ref($_[0]) eq 'HASH' ? 1 : 0;
     if (defined($_[$code_index]) && !ref($_[$code_index])
             && $_[$code_index] !~ /::/) {
@@ -25,15 +37,24 @@ sub new { shift->create(@_) }
 sub async (&;@) { return __PACKAGE__->create(@_) }
 sub self { return _self() }
 sub tid { return ref($_[0]) ? $_[0]->{tid} : _self()->{tid} }
+sub object { shift; return _object(@_) }
 sub list { shift if @_ && !ref($_[0]) && $_[0] eq __PACKAGE__; return _list(@_) }
 sub join { return _join($_[0]) }
-sub detach { return _detach($_[0]) }
+sub detach { return _detach(ref($_[0]) ? $_[0] : _self()) }
 sub is_running { return _is_running($_[0]) }
 sub is_joinable { return _is_joinable($_[0]) }
-sub is_detached { return _is_detached($_[0]) }
+sub is_detached { return _is_detached(ref($_[0]) ? $_[0] : _self()) }
 sub error { return _error($_[0]) }
 sub exit { shift if @_ && !ref($_[0]) && $_[0] eq __PACKAGE__; return _exit(@_) }
-sub kill { return }
+sub kill { return _kill(@_) }
+sub wantarray { return _wantarray(ref($_[0]) ? $_[0] : _self()) }
+sub get_stack_size {
+    return ref($_[0]) ? _get_stack_size($_[0]) : _get_stack_size();
+}
+sub set_stack_size {
+    return ref($_[0]) ? _set_stack_size(@_) : _set_stack_size($_[1]);
+}
+sub set_thread_exit_only { return _set_thread_exit_only(@_) }
 sub yield { select undef, undef, undef, 0; return }
 sub equal { return defined($_[0]) && defined($_[1]) && $_[0]->tid == $_[1]->tid }
 sub _stringify { return 'threads=' . $_[0]->tid }
@@ -42,6 +63,7 @@ sub import {
     shift;
     my $caller = caller;
     my @exports = ('async');
+    my ($stack_size, $exit_only);
 
     while (my $option = shift) {
         if ($option eq 'yield' || $option eq ':all') {
@@ -55,15 +77,23 @@ sub import {
             require Carp;
             Carp::croak("threads: Missing argument for option: $option")
                 unless defined $value;
-            # PerlOnJava owns JVM stack sizing and threads->exit is always
-            # thread-only. Accept the standard import spellings so portable
-            # programs can declare their intent without changing semantics.
+            if ($option =~ /^stack/i) {
+                $stack_size = $value;
+            }
+            else {
+                $exit_only = $value =~ /^threads?_only$/ ? 1 : 0;
+            }
         }
         else {
             require Carp;
             Carp::croak("threads: Unknown import option: $option");
         }
     }
+
+    $stack_size = $ENV{PERL5_ITHREADS_STACK_SIZE}
+        if defined $ENV{PERL5_ITHREADS_STACK_SIZE};
+    _set_stack_size($stack_size) if defined $stack_size;
+    _set_default_exit_only($exit_only) if defined $exit_only;
 
     no strict 'refs';
     *{"${caller}::$_"} = \&{$_} for @exports;
@@ -89,15 +119,21 @@ C<async> is exported by default. C<yield> and C<:all> also export C<yield>.
 C<stringify> changes string conversion of a thread object from the stable
 C<threads=ID> form to its numeric thread ID.
 
-The standard C<stack_size> and C<exit> declarations are accepted for source
-compatibility. JVM stack sizing is runtime-managed, and C<threads-E<gt>exit>
-always exits only the calling child ithread. Missing values and unknown import
-options are errors.
+The standard C<stack_size> and C<exit> declarations configure subsequently
+created platform threads. Java virtual threads reject a non-zero stack-size
+request because their stack size cannot be selected by the application.
+Missing values and unknown import options are errors.
 
 =head1 COMPATIBILITY
 
 The supported lifecycle is C<create>/C<async>, C<self>, C<tid>, C<list>,
 C<join>, and C<detach>, together with state and error inspection. Thread
-signals (C<kill>), per-thread stack sizing, C<object>, and C<wantarray> are not
-yet implemented. Shared storage, locks, and condition variables are provided
-by L<threads::shared> for its documented scalar, array, and hash tranche.
+signals, C<object>, C<wantarray>, current-thread detach, creation context, and
+the stack-size metadata API are implemented. JVM platform stack sizes are
+requests to the JVM rather than portable native-stack guarantees. Shared
+storage, locks, and condition variables are provided by L<threads::shared> for
+its documented scalar, array, and hash tranche.
+
+C<kill> returns the thread object when a signal is queued to a live, joinable
+Java target. It returns undef for a completed, joined, or detached target,
+where no signal can be delivered.

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeRegexSnapshotTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlRuntimeRegexSnapshotTest.java
@@ -1,0 +1,27 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unit")
+class PerlRuntimeRegexSnapshotTest {
+    @Test
+    void snapshotInheritsUserPropertyResultsWithoutSharingTheCache() {
+        PerlRuntime parent = new PerlRuntime();
+        parent.regexState.userUnicodePropertyCache.put(
+                "main::IsPhaseTwentySeven", "\\x{41}");
+
+        PerlRuntime child = parent.snapshotClone();
+
+        assertNotSame(parent.regexState.userUnicodePropertyCache,
+                child.regexState.userUnicodePropertyCache);
+        assertEquals("\\x{41}", child.regexState.userUnicodePropertyCache.get(
+                "main::IsPhaseTwentySeven"));
+        child.regexState.userUnicodePropertyCache.put("main::IsChildOnly", "\\x{42}");
+        assertTrue(!parent.regexState.userUnicodePropertyCache.containsKey("main::IsChildOnly"));
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlThreadApiPhase29Test.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlThreadApiPhase29Test.java
@@ -1,0 +1,32 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("unit")
+class PerlThreadApiPhase29Test {
+    @Test
+    void terminalControlBlockRemainsAvailableToExistingObjectAliases() throws Exception {
+        PerlRuntime parent = new PerlRuntime().initialize();
+        try (PerlRuntime.Binding ignored = parent.bind()) {
+            PerlThreadControlBlock thread = PerlThreadControlBlock.create(parent,
+                    child -> new RuntimeScalar(7)).start();
+            assertEquals(7, ((RuntimeScalar) thread.join().value()).getInt());
+            assertNull(parent.threadRegistry().get(thread.id()));
+            assertSame(thread, parent.threadRegistry().getKnown(thread.id()));
+            assertEquals(PerlThreadControlBlock.State.JOINED, thread.state());
+        } finally {
+            parent.close();
+        }
+    }
+
+    @Test
+    void virtualThreadsRejectAnUnfulfillableStackSizeRequest() {
+        PerlThreadExecutionPolicy virtual = PerlThreadExecutionPolicy.resolve("virtual", null);
+        IllegalArgumentException failure = assertThrows(IllegalArgumentException.class,
+                () -> virtual.unstarted(1, 1024 * 1024, () -> {}));
+        assertTrue(failure.getMessage().contains("virtual threads"));
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlThreadRegistryUserPropertyTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlThreadRegistryUserPropertyTest.java
@@ -1,0 +1,72 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unit")
+class PerlThreadRegistryUserPropertyTest {
+    @Test
+    void samePropertyWaitsForOneDefinitionWhileDifferentNamesProceed() throws Exception {
+        PerlThreadRegistry registry = new PerlThreadRegistry();
+        CountDownLatch ownerStarted = new CountDownLatch(1);
+        CountDownLatch releaseOwner = new CountDownLatch(1);
+        AtomicInteger sameNameCalls = new AtomicInteger();
+
+        FutureTask<String> owner = new FutureTask<>(() -> registry.resolveUserUnicodeProperty(
+                "main::IsSlow", () -> {
+                    sameNameCalls.incrementAndGet();
+                    ownerStarted.countDown();
+                    try {
+                        assertTrue(releaseOwner.await(5, TimeUnit.SECONDS));
+                    } catch (InterruptedException interrupted) {
+                        Thread.currentThread().interrupt();
+                        throw new IllegalStateException(interrupted);
+                    }
+                    return "slow";
+                }));
+        Thread ownerThread = Thread.ofPlatform().start(owner);
+        assertTrue(ownerStarted.await(5, TimeUnit.SECONDS));
+
+        FutureTask<String> waiter = new FutureTask<>(() -> registry.resolveUserUnicodeProperty(
+                "main::IsSlow", () -> {
+                    sameNameCalls.incrementAndGet();
+                    return "wrong";
+                }));
+        Thread waiterThread = Thread.ofPlatform().start(waiter);
+
+        assertEquals("quick", registry.resolveUserUnicodeProperty(
+                "main::IsQuick", () -> "quick"));
+        waitUntilBlockedOnOwner(waiterThread, waiter);
+        assertFalse(waiter.isDone());
+        releaseOwner.countDown();
+
+        assertEquals("slow", owner.get(5, TimeUnit.SECONDS));
+        assertEquals("slow", waiter.get(5, TimeUnit.SECONDS));
+        assertEquals(1, sameNameCalls.get());
+        ownerThread.join(5_000);
+        waiterThread.join(5_000);
+        assertFalse(ownerThread.isAlive());
+        assertFalse(waiterThread.isAlive());
+    }
+
+    private static void waitUntilBlockedOnOwner(Thread waiterThread, FutureTask<?> waiter)
+            throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (!waiter.isDone()
+                && waiterThread.getState() != Thread.State.TIMED_WAITING
+                && System.nanoTime() < deadline) {
+            Thread.sleep(1);
+        }
+        assertEquals(Thread.State.TIMED_WAITING, waiterThread.getState(),
+                "waiter entered the existing property's timed future wait");
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/RuntimeCodeGraphClonerTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/RuntimeCodeGraphClonerTest.java
@@ -29,6 +29,22 @@ class RuntimeCodeGraphClonerTest {
         }
     }
 
+    @Test
+    void acceptsRuntimeCodeAsTheGraphRootOnBothBackends() throws Exception {
+        for (boolean interpreter : new boolean[]{false, true}) {
+            PerlRuntime sourceRuntime = new PerlRuntime();
+            PerlRuntime targetRuntime = new PerlRuntime();
+            RuntimeCode sourceCode = (RuntimeCode) compileClosure(
+                    sourceRuntime, interpreter).value;
+            RuntimeCode clonedCode = (RuntimeCode) new RuntimeGraphCloner(
+                    sourceRuntime, targetRuntime).cloneGraph(sourceCode);
+
+            assertNotSame(sourceCode, clonedCode);
+            assertEquals("41:2:2", invoke(targetRuntime, clonedCode.scalar()));
+            assertEquals("41:2:2", invoke(sourceRuntime, sourceCode.scalar()));
+        }
+    }
+
     private static RuntimeScalar compileClosure(PerlRuntime runtime, boolean interpreter)
             throws Exception {
         try (PerlRuntime.Binding ignored = runtime.bind()) {

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphClonerPipeInheritanceTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphClonerPipeInheritanceTest.java
@@ -1,0 +1,56 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.runtime.io.InternalPipeHandle;
+
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unit")
+class RuntimeGraphClonerPipeInheritanceTest {
+    @Test
+    void internalPipeEndpointsCrossSnapshotWithIndependentCloseLeases() throws Exception {
+        PerlRuntime parent = new PerlRuntime();
+        PerlRuntime child = new PerlRuntime();
+        PipedInputStream input = new PipedInputStream(InternalPipeHandle.PIPE_SIZE);
+        PipedOutputStream output = new PipedOutputStream(input);
+        InternalPipeHandle[] pair = InternalPipeHandle.createPair(input, output);
+        RuntimeIO parentReader = new RuntimeIO(pair[0]);
+        RuntimeIO parentWriter = new RuntimeIO(pair[1]);
+
+        RuntimeGraphCloner cloner = new RuntimeGraphCloner(parent, child);
+        List<RuntimeBase> roots = cloner.cloneRoots(List.of(
+                new RuntimeScalar(parentReader), new RuntimeScalar(parentWriter)));
+        RuntimeIO childReader = (RuntimeIO) ((RuntimeScalar) roots.get(0)).value;
+        RuntimeIO childWriter = (RuntimeIO) ((RuntimeScalar) roots.get(1)).value;
+
+        assertNotSame(parentReader, childReader);
+        assertNotSame(parentWriter, childWriter);
+        try (PerlRuntime.Binding ignored = child.bind()) {
+            assertTrue(childWriter.close().getBoolean());
+        }
+
+        try (PerlRuntime.Binding ignored = parent.bind()) {
+            assertTrue(parentWriter.write("from parent\n").getBoolean());
+        }
+        try (PerlRuntime.Binding ignored = child.bind()) {
+            assertEquals("from parent\n", childReader.ioHandle.doRead(64,
+                    java.nio.charset.StandardCharsets.UTF_8).toString());
+            assertTrue(childReader.close().getBoolean());
+        }
+
+        try (PerlRuntime.Binding ignored = parent.bind()) {
+            assertTrue(parentWriter.write("still open\n").getBoolean());
+            assertEquals("still open\n", parentReader.ioHandle.doRead(64,
+                    java.nio.charset.StandardCharsets.UTF_8).toString());
+            parentWriter.close();
+            parentReader.close();
+        }
+    }
+}

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphClonerTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphClonerTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -87,5 +88,57 @@ class RuntimeGraphClonerTest {
         assertNotSame(referent, ((RuntimeScalar) cloned.get(0)).value);
         assertEquals(42, ((RuntimeHash) ((RuntimeScalar) cloned.get(0)).value)
                 .elements.get("value").getInt());
+    }
+
+    @Test
+    void normalizesClearedReferencePayloadWithoutMutatingSource() {
+        PerlRuntime sourceRuntime = new PerlRuntime();
+        PerlRuntime targetRuntime = new PerlRuntime();
+        RuntimeScalar clearedReference = new RuntimeScalar();
+        clearedReference.type = RuntimeScalarType.HASHREFERENCE;
+        clearedReference.value = null;
+
+        RuntimeScalar cloned = (RuntimeScalar) new RuntimeGraphCloner(
+                sourceRuntime, targetRuntime).cloneGraph(clearedReference);
+
+        assertEquals(RuntimeScalarType.UNDEF, cloned.type);
+        assertNull(cloned.value);
+        assertEquals("", cloned.toString());
+        assertEquals(0.0, cloned.getDouble());
+        assertEquals(RuntimeScalarType.HASHREFERENCE, clearedReference.type);
+        assertNull(clearedReference.value);
+        assertEquals("", Overload.stringify(clearedReference).toString());
+        assertEquals(0.0, Overload.numify(clearedReference).getDouble());
+    }
+
+    @Test
+    void preservesRegexCaptureProxySemantics() {
+        PerlRuntime sourceRuntime = new PerlRuntime();
+        PerlRuntime targetRuntime = new PerlRuntime();
+        ScalarSpecialVariable source = new ScalarSpecialVariable(
+                ScalarSpecialVariable.Id.CAPTURE, 3);
+
+        RuntimeScalar cloned = (RuntimeScalar) new RuntimeGraphCloner(
+                sourceRuntime, targetRuntime).cloneGraph(source);
+
+        ScalarSpecialVariable proxy = assertInstanceOf(ScalarSpecialVariable.class, cloned);
+        assertEquals(ScalarSpecialVariable.Id.CAPTURE, proxy.variableId);
+        assertEquals(3, proxy.position);
+        assertNotSame(source, proxy);
+    }
+
+    @Test
+    void preservesDynamicRegexCaptureArrayViews() {
+        PerlRuntime sourceRuntime = new PerlRuntime();
+        PerlRuntime targetRuntime = new PerlRuntime();
+        RuntimeArray source = new RuntimeArray();
+        source.type = RuntimeArray.READONLY_ARRAY;
+        source.elements = new ArraySpecialVariable(ArraySpecialVariable.Id.LAST_MATCH_START);
+
+        RuntimeArray cloned = (RuntimeArray) new RuntimeGraphCloner(
+                sourceRuntime, targetRuntime).cloneGraph(source);
+
+        assertInstanceOf(ArraySpecialVariable.class, cloned.elements);
+        assertNotSame(source.elements, cloned.elements);
     }
 }

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/ThreadCompiledCodeIdRangeTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/ThreadCompiledCodeIdRangeTest.java
@@ -1,0 +1,41 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@Tag("unit")
+class ThreadCompiledCodeIdRangeTest {
+    @Test
+    void childCompilationCannotCollideWithLateParentLazyCode() {
+        PerlRuntime parent = new PerlRuntime();
+        PerlRuntime child;
+        try (PerlRuntime.Binding ignored = parent.bind()) {
+            parent.initialize();
+            child = parent.snapshotClone();
+        }
+
+        RuntimeScalar childCode = new RuntimeScalar("child");
+        int childId;
+        try (PerlRuntime.Binding ignored = child.bind()) {
+            childId = GlobalVariable.registerCompiledCodeRef(childCode);
+        }
+
+        RuntimeScalar lateParentCode = new RuntimeScalar("parent");
+        int parentId;
+        try (PerlRuntime.Binding ignored = parent.bind()) {
+            parentId = GlobalVariable.registerCompiledCodeRef(lateParentCode);
+        }
+
+        assertNotEquals(parentId, childId);
+        try (PerlRuntime.Binding ignored = child.bind()) {
+            parent.globalState().snapshotCompiledCodeRefsInto(
+                    child.globalState(), new RuntimeGraphCloner(parent, child));
+            assertSame(childCode, GlobalVariable.getCompiledCodeRef(childId));
+            assertSame(lateParentCode.value,
+                    GlobalVariable.getCompiledCodeRef(parentId).value);
+        }
+    }
+}

--- a/src/test/resources/unit/regex_define_subroutine_calls.t
+++ b/src/test/resources/unit/regex_define_subroutine_calls.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+
+print "1..4\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - $name\n");
+}
+
+my $pattern = qr{
+    (?(DEFINE)
+        (?<atom> [a-z]+)
+        (?<pair> (?&atom) = (?&atom))
+    )
+    (?&pair)
+}x;
+
+check(scalar('left=right' =~ /^$pattern$/), 'DEFINE group can be called');
+check(scalar('left=' !~ /^$pattern$/), 'subroutine call retains its body');
+check(scalar('one=two' =~ /(?&pair)(?(DEFINE)(?<atom>[a-z]+)(?<pair>(?&atom)=(?&atom)))/),
+    'DEFINE container may follow its call');
+check(scalar('1=two' !~ /^$pattern$/), 'nested named calls preserve character classes');

--- a/src/test/resources/unit/substr_core_edge_semantics.t
+++ b/src/test/resources/unit/substr_core_edge_semantics.t
@@ -1,0 +1,61 @@
+use strict;
+use warnings;
+
+print "1..10\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - $name\n");
+}
+
+my @warnings;
+local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+
+check(substr('54321', -7, -5) eq '', 'negative start clips to a zero endpoint');
+check(substr('54321', -7, -2) eq '543', 'negative start clips with end-relative length');
+check(!@warnings, 'valid clipped negative substrings do not warn');
+
+my $reference = [];
+substr($reference, 0, 1) = 'Foo';
+check(grep(/^Attempt to use reference as lvalue in substr/, @warnings),
+    'reference lvalue substr warns');
+
+@warnings = ();
+my $target = 'abc';
+substr($target, 3, undef, 'x');
+check(grep(/^Use of uninitialized value/, @warnings),
+    'undefined four-argument length warns');
+
+for my $offset (-99, 99) {
+    my $error = '';
+    eval { substr($target, $offset, 0, '') };
+    $error = $@;
+    check($error =~ /^substr outside of string/,
+        'out-of-range four-argument substr dies');
+}
+
+my $compile_error = '';
+eval 'substr($target, 0, 0, q()) = q(x)';
+$compile_error = $@;
+check($compile_error =~ /Can't modify substr/,
+    'four-argument substr cannot be an assignment target');
+
+{
+    package SubstrCounted {
+        use overload '""' => sub { ++$main::stringifications; 'abc' };
+    }
+}
+our $stringifications = 0;
+my $counted = bless [], 'SubstrCounted';
+substr($counted, 0, 0, '');
+check($stringifications == 1, 'four-argument substr stringifies target once');
+
+{
+    use feature 'refaliasing';
+    no warnings 'experimental::refaliasing';
+    my %hash;
+    \$hash{key} = \(my $aliased = 'baz');
+    substr delete $hash{key}, 1, 1, 'o';
+    check($aliased eq 'boz', 'four-argument substr accepts a loose lvalue');
+}

--- a/src/test/resources/unit/substr_live_extent_modes.t
+++ b/src/test/resources/unit/substr_live_extent_modes.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+
+print "1..4\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - $name\n");
+}
+
+for my $case (
+    [ 1,  undef, 'XXfrompswiggle',  'positive offset to end' ],
+    [ 1,  -1,    'XXffrompswiggl', 'positive offset to negative end' ],
+    [ -5, undef, 'le',             'negative offset to end' ],
+    [ -5, -1,    'gl',             'negative offset to negative end' ],
+) {
+    my ($offset, $length, $expected, $name) = @$case;
+    my $string = 'abcdef';
+    if (defined $length) {
+        for (substr($string, $offset, $length)) {
+            $_ = 'XX';
+            $string .= 'frompswiggle';
+            check($_ eq $expected, $name);
+        }
+    } else {
+        for (substr($string, $offset)) {
+            $_ = 'XX';
+            $string .= 'frompswiggle';
+            check($_ eq $expected, $name);
+        }
+    }
+}

--- a/src/test/resources/unit/threads_api_phase29.t
+++ b/src/test/resources/unit/threads_api_phase29.t
@@ -1,0 +1,72 @@
+use strict;
+use warnings;
+use threads;
+use threads::shared;
+
+print "1..23\n";
+my $n;
+sub ok_ { my ($v, $name) = @_; ++$n; print($v ? "ok " : "not ok ", "$n - $name\n") }
+
+my $self = threads->self;
+ok_($threads::threads, 'threads capability marker');
+ok_($self->tid == 0, 'main tid');
+ok_($self->is_running, 'main running');
+ok_(!$self->is_joinable, 'main not joinable');
+ok_($self->is_detached, 'main detached');
+ok_(threads->object(0) == $self, 'object finds main');
+ok_(!defined threads->object(999999), 'object rejects unknown tid');
+
+my $ready :shared = 0;
+my $active = threads->create(sub { $ready = 1; sleep 1; return 4 });
+1 until $ready;
+my $alias = threads->object($active->tid);
+ok_(defined($alias) && $alias == $active, 'object finds active child');
+ok_($active->join == 4, 'active child joins');
+ok_(!defined threads->object($active->tid), 'joined child is no longer active');
+
+my $list = threads->create({ context => 'list' }, sub {
+    return (threads->wantarray ? 'list' : 'wrong', 2, 3);
+});
+my @list_values = $list->join;
+ok_(@list_values == 3 && $list_values[0] eq 'list', 'explicit list context');
+ok_($list->wantarray, 'object reports list context');
+my $scalar = threads->create({ scalar => 1 }, sub {
+    return defined(threads->wantarray) && !threads->wantarray ? (5, 6) : 0;
+});
+ok_($scalar->join == 6, 'explicit scalar context');
+ok_(defined($scalar->wantarray) && !$scalar->wantarray, 'object reports scalar context');
+my $void = threads->create({ void => 1 }, sub { return 8 });
+ok_(!defined($void->join), 'void context joins as undef');
+ok_(!defined($void->wantarray), 'object reports void context');
+
+my $detach_result :shared = 1;
+my $detach_done :shared = 0;
+my $detached = threads->create(sub {
+    $detach_result = defined threads->detach;
+    $detach_done = 1;
+    return;
+});
+1 until $detach_done;
+ok_($detached->is_detached, 'class detach marks child detached');
+ok_(!$detach_result, 'class detach returns undef');
+
+my $signal_ready :shared = 0;
+my $seen :shared = 0;
+my $signalled = threads->create(sub {
+    $SIG{USR1} = sub { $seen = 1 };
+    $signal_ready = 1;
+    sleep 1 until $seen;
+    return $seen;
+});
+1 until $signal_ready;
+ok_($signalled->kill('USR1') == $signalled, 'kill returns thread object');
+ok_($signalled->join == 1, 'signal handler runs in child');
+
+my $old = threads->set_stack_size(1024 * 1024);
+my $stacked = threads->create({ stack_size => 2 * 1024 * 1024 }, sub { return 1 });
+ok_($stacked->get_stack_size >= 2 * 1024 * 1024, 'object reports requested stack size');
+ok_($stacked->join == 1, 'stack-sized child joins');
+threads->set_stack_size($old);
+
+my $exited = threads->create({ exit => 'thread_only' }, sub { exit 7 });
+ok_(!defined($exited->join) && !defined($exited->error), 'thread-only exit is normal');

--- a/src/test/resources/unit/threads_cleared_weak_snapshot.t
+++ b/src/test/resources/unit/threads_cleared_weak_snapshot.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use threads;
+use Scalar::Util qw(weaken);
+
+print "1..3\n";
+
+my $target = {};
+my $weak = $target;
+weaken($weak);
+undef $target;
+
+my $thread = threads->create(sub {
+    no warnings 'uninitialized';
+    print(!defined($weak) ? "ok 1" : "not ok 1",
+        " - cleared weak reference clones as undef\n");
+    print("$weak" eq "" ? "ok 2" : "not ok 2",
+        " - cloned undef stringifies safely\n");
+    print(0 + $weak == 0 ? "ok 3" : "not ok 3",
+        " - cloned undef numifies safely\n");
+});
+$thread->join;

--- a/src/test/resources/unit/threads_index_clone_identity.t
+++ b/src/test/resources/unit/threads_index_clone_identity.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+use threads;
+
+print "1..4\n";
+my $number = 0;
+sub check {
+    my ($condition, $name) = @_;
+    ++$number;
+    print($condition ? "ok " : "not ok ", $number, " - $name\n");
+}
+
+use constant mutable_ref => \our $referent;
+my $constant_thread = threads->create(sub {
+    my $was_scalar = ref(mutable_ref) eq 'SCALAR';
+    package ThreadIndexStringifier {
+        use overload '""' => sub { 'needle' };
+    }
+    bless \our $referent, 'ThreadIndexStringifier';
+    return [$was_scalar, index('needle', mutable_ref)];
+});
+my $constant_result = $constant_thread->join;
+check($constant_result->[0], 'reference constant remains a scalar reference');
+check($constant_result->[1] == 0,
+    'reference constant observes mutation of the cloned referent');
+
+my $stored = 100;
+{
+    package ThreadIndexTie {
+        require Tie::Scalar;
+        our @ISA = qw(Tie::StdScalar);
+        sub STORE { $stored = $_[1] }
+    }
+}
+my $tie_thread = threads->create(sub {
+    my $value;
+    tie $value, 'ThreadIndexTie';
+    $value = (index('foo', 'o') == -1);
+    return $stored;
+});
+check($tie_thread->join == 0, 'lazy tie method mutates its cloned lexical');
+check(($tie_thread->error || '') eq '', 'lazy tie method completes without error');

--- a/src/test/resources/unit/threads_inherited_pipe.t
+++ b/src/test/resources/unit/threads_inherited_pipe.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+
+use threads;
+
+print "1..3\n";
+my $test_number = 0;
+sub ok_ {
+    my ($condition, $name) = @_;
+    ++$test_number;
+    print($condition ? "ok " : "not ok ", "$test_number - $name\n");
+}
+
+pipe(my $reader, my $writer) or die "pipe: $!";
+
+my $worker = threads->create(sub {
+    close $writer;
+    my $line = <$reader>;
+    close $reader;
+    return defined($line) ? $line : '<eof>';
+});
+
+close $reader;
+ok_(print($writer "message from parent\n"),
+    'parent writes through its pipe endpoint');
+ok_(close($writer), 'parent closes its pipe endpoint independently');
+ok_($worker->join eq "message from parent\n",
+    'child inherits the reader endpoint and receives parent data');

--- a/src/test/resources/unit/threads_regex_capture_snapshot.t
+++ b/src/test/resources/unit/threads_regex_capture_snapshot.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use threads;
+
+print "1..2\n";
+
+sub capture_signature {
+    my $pattern = qr/^(a+)(b+)(c+)$/;
+    return 'aaabbbccc' =~ $pattern ? join(',', $1, $2, $3) : 'no match';
+}
+
+print capture_signature() eq 'aaa,bbb,ccc'
+    ? "ok 1 - parent capture variables remain dynamic\n"
+    : "not ok 1 - parent capture variables remain dynamic\n";
+print threads->create(\&capture_signature)->join() eq 'aaa,bbb,ccc'
+    ? "ok 2 - child capture variables retain magic after snapshot\n"
+    : "not ok 2 - child capture variables retain magic after snapshot\n";

--- a/src/test/resources/unit/threads_user_property_snapshot.t
+++ b/src/test/resources/unit/threads_user_property_snapshot.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+
+use threads;
+
+print "1..3\n";
+my $test_number = 0;
+sub ok_ {
+    my ($condition, $name) = @_;
+    ++$test_number;
+    print($condition ? "ok " : "not ok ", "$test_number - $name\n");
+}
+
+my $calls = 0;
+sub IsPhaseTwentySeven {
+    ++$calls;
+    return "0041";
+}
+
+ok_(eval(q{"A" =~ /\p{IsPhaseTwentySeven}/}) && !$@,
+    'parent resolves a user-defined Unicode property');
+ok_($calls == 1, 'parent caches the property definition');
+
+my $child = threads->create(sub {
+    my $matched = eval(q{"A" =~ /\p{IsPhaseTwentySeven}/});
+    return [$matched ? 1 : 0, $calls, "$@"];
+});
+my $result = $child->join;
+
+ok_(ref($result) eq 'ARRAY'
+        && $result->[0] == 1
+        && $result->[1] == 1
+        && $result->[2] eq '',
+    'ithread inherits the resolved property cache without calling its cloned sub');


### PR DESCRIPTION
## Summary

- preserve magic regex captures, cleared weak references, CODE roots, constants, and lazy compiled-code identity across ithread snapshots
- improve shared JVM/interpreter scalar lvalue behavior, user Unicode-property coordination, thread API lifecycle/context/signals/stack metadata, and inherited internal pipes
- add general recursive-regex `(?(DEFINE))` support, focused system-Perl-valid tests, a realistic dynamic map/reduce example, and updated design progress

## Validation

- `make` after rebasing onto `origin/master`: PASS (all unit shards)
- system Perl: 9 new files / 56 assertions PASS
- new Perl tests: JVM and interpreter focused coverage
- `pat_psycho_thr.t`: 17/17 after previously terminating before TAP
- `pat_rt_report_thr.t`: no clone/compiled-ID exception; matches the direct 2478-pass count
- map/reduce example: system Perl, JVM, and interpreter PASS with identical output

## Explicit follow-ups

- Phase 26 remains in progress for one interpreter lazy-lexical identity case and remaining direct `substr.t` assertions
- lexical `re 'debug'`, `pat_re_eval`, and the remaining `regexp_qr_embed` surface are direct regex-language work, not thread-wrapper special cases
- detached platform-thread shutdown warnings/process retention and non-pipe resource classes remain follow-up lifecycle work

Generated with [OpenAI Codex](https://openai.com/codex)
