### PR TITLE
Fix compiler and runtime issues in CPAN module workflows

### DIFF
--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -2735,7 +2735,7 @@ public class BytecodeInterpreter {
                                 int reg = bytecode[pc++];
                                 RuntimeBase val = registers[reg];
                                 if (val instanceof RuntimeScalar rs) {
-                                    rs.vivifyLvalue();
+                                    rs.vivifyLogicalAssignmentLvalue();
                                 }
                             }
 

--- a/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
@@ -1282,7 +1282,11 @@ public class InlineOpcodeHandler {
             registers[rd] = ensureMutableScalar(registers[rd]);
         }
         // Note: += does NOT warn for uninitialized values in Perl
-        MathOperators.addAssign((RuntimeScalar) registers[rd], (RuntimeScalar) registers[rs]);
+        RuntimeBase right = registers[rs];
+        RuntimeScalar rightScalar = right instanceof RuntimeScalar
+                ? (RuntimeScalar) right
+                : right.scalar();
+        MathOperators.addAssign((RuntimeScalar) registers[rd], rightScalar);
         return pc;
     }
 

--- a/src/main/java/org/perlonjava/backend/jvm/EmitLogicalOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitLogicalOperator.java
@@ -115,7 +115,7 @@ public class EmitLogicalOperator {
         // (with undef value) during lvalue resolution, before evaluating the boolean condition.
         mv.visitInsn(Opcodes.DUP);
         mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/runtimetypes/RuntimeScalar",
-                "vivifyLvalue", "()V", false);
+                "vivifyLogicalAssignmentLvalue", "()V", false);
 
         int leftSlot = emitterVisitor.ctx.javaClassInfo.acquireSpillSlot();
         boolean pooledLeft = leftSlot >= 0;

--- a/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
@@ -406,8 +406,17 @@ public class IdentifierParser {
                 if (isFirstToken && token.type == LexerTokenType.NUMBER) {
                     // Numeric variables like $0, $1, and @0 are never package-qualified.
                     // In strings, "$0::Foo" is $0 followed by literal "::Foo".
-                    variableName.append(token.text);
-                    parser.tokenIndex++;
+                    // The number lexer also accepts underscores for numeric literals, but
+                    // captures stop before an underscore: "$1_000" means $1 followed by
+                    // the literal "_000", not a variable named $1_000.
+                    int underscore = token.text.indexOf('_');
+                    if (underscore >= 0) {
+                        variableName.append(token.text, 0, underscore);
+                        token.text = token.text.substring(underscore);
+                    } else {
+                        variableName.append(token.text);
+                        parser.tokenIndex++;
+                    }
                     return variableName.toString();
                 }
                 if (token.text.equals("$") && (nextToken.text.equals("$")

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Internals.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Internals.java
@@ -68,6 +68,7 @@ public class Internals extends PerlModuleBase {
             internals.registerMethod("jperl_cv_deparse_info", "jperlCvDeparseInfo", "$");
             internals.registerMethod("jperl_cv_is_constant", "jperlCvIsConstant", "$");
             internals.registerMethod("jperl_end_av_ref", "jperlEndAvRef", "");
+            internals.registerMethod("jperl_b_object_2svref", "jperlBObject2svref", "$");
             internals.registerMethod("jperl_set_closed_over", "jperlSetClosedOver", null);
             internals.registerMethod("jperl_closed_over", "jperlClosedOver", null);
             internals.registerMethod("jperl_peek_sub", "jperlPeekSub", null);
@@ -82,6 +83,14 @@ public class Internals extends PerlModuleBase {
      */
     public static RuntimeList jperlEndAvRef(RuntimeArray args, int ctx) {
         return SpecialBlock.getEndBlocks().createReference().getList();
+    }
+
+    /** Resolve a reference pseudo-address previously exposed by stringification. */
+    public static RuntimeList jperlBObject2svref(RuntimeArray args, int ctx) {
+        if (args.size() != 1) {
+            throw new IllegalArgumentException("Usage: Internals::jperl_b_object_2svref(ADDRESS)");
+        }
+        return BObjectRegistry.resolve(args.get(0).getLong()).getList();
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/perlmodule/ScalarUtil.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/ScalarUtil.java
@@ -110,6 +110,9 @@ public class ScalarUtil extends PerlModuleBase {
             throw new IllegalStateException("Bad number of arguments for refaddr() method");
         }
         RuntimeScalar scalar = magicallyDeref(args.get(0));
+        if (scalar.value instanceof RuntimeBase referent) {
+            BObjectRegistry.register(referent);
+        }
         // refaddr returns undef for non-references
         // For references, return the identity hash code of the underlying referenced object
         switch (scalar.type) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/BObjectRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/BObjectRegistry.java
@@ -1,0 +1,34 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import java.lang.ref.WeakReference;
+import java.util.Map;
+
+/**
+ * Resolves the pseudo-addresses exposed by reference stringification back to
+ * live Perl referents for {@code B::SV::object_2svref()}.
+ *
+ * <p>The registry is scoped to a {@link PerlRuntime} and holds weak values, so
+ * exposing an address does not extend the referent's lifetime.</p>
+ */
+public final class BObjectRegistry {
+    private BObjectRegistry() {}
+
+    private static Map<Integer, WeakReference<RuntimeBase>> state() {
+        return PerlRuntime.current().bObjectState;
+    }
+
+    public static void register(RuntimeBase referent) {
+        if (referent == null) return;
+        state().put(referent.hashCode(), new WeakReference<>(referent));
+    }
+
+    public static RuntimeScalar resolve(long address) {
+        WeakReference<RuntimeBase> reference = state().get((int) address);
+        RuntimeBase referent = reference == null ? null : reference.get();
+        if (referent == null) {
+            state().remove((int) address);
+            return new RuntimeScalar();
+        }
+        return referent.createReference();
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/Overload.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/Overload.java
@@ -64,6 +64,9 @@ public class Overload {
         if (runtimeScalar.value == null) {
             return scalarUndef;
         }
+        if (runtimeScalar.value instanceof RuntimeBase referent) {
+            BObjectRegistry.register(referent);
+        }
         // Recursion guard — see STRINGIFY_MAX_DEPTH javadoc.
         ExecutionRuntimeState state = PerlRuntime.current().executionState();
         int depth = state.overloadStringifyDepth;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -18,17 +18,18 @@ import org.perlonjava.runtime.perlmodule.FilterRuntimeState;
 import org.perlonjava.runtime.perlmodule.NetSSLeay;
 import org.perlonjava.runtime.nativ.ExtendedNativeUtils;
 
+import java.lang.ref.WeakReference;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.ArrayDeque;
-import java.util.Deque;
+import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.TreeSet;
 
 /**
  * Identity and scoped thread binding for one Perl interpreter instance.
@@ -68,6 +69,7 @@ public final class PerlRuntime implements AutoCloseable {
     public final Map<Integer, ScalarFlipFlopOperator> flipFlopState = new HashMap<>();
     public final Map<Integer, ScalarGlobOperator> scalarGlobState = new HashMap<>();
     public final Map<Integer, String> pointerPackState = new HashMap<>();
+    final Map<Integer, WeakReference<RuntimeBase>> bObjectState = new HashMap<>();
     public final IORuntimeRegistryState ioRegistryState = new IORuntimeRegistryState();
     public final FileTestOperator.State fileTestState = new FileTestOperator.State();
     public final DebugRuntimeState debugState = new DebugRuntimeState();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -1367,6 +1367,17 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         // No-op for plain scalars
     }
 
+    /**
+     * Vivify an lvalue before testing a logical compound assignment. Read-only
+     * argument aliases must be testable without raising; a later assignment
+     * still reaches set()/vivify() and reports the canonical read-only error.
+     */
+    public void vivifyLogicalAssignmentLvalue() {
+        if (!(this instanceof RuntimeScalarReadOnly)) {
+            vivifyLvalue();
+        }
+    }
+
     // Setters
 
     /**
@@ -2267,6 +2278,9 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
     }
 
     public String toStringRef() {
+        if (value instanceof RuntimeBase referent) {
+            BObjectRegistry.register(referent);
+        }
         String ref = switch (type) {
             case UNDEF -> "SCALAR(0x" + scalarUndef.hashCode() + ")";
             case CODE -> {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/TieScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/TieScalar.java
@@ -101,6 +101,13 @@ public class TieScalar extends TiedVariableBase {
         }
         inMagic = true;
         try {
+            // Perl updates the SV's backing value before invoking STORE.  Magic
+            // is suppressed while STORE runs, so a recursive read of the same
+            // scalar sees the value being assigned.  Old tie classes use this
+            // to keep a tied hash element and its owner object in sync.
+            RuntimeScalar backingValue = new RuntimeScalar(v);
+            previousValue.type = backingValue.type;
+            previousValue.value = backingValue.value;
             return tieCall("STORE", v);
         } finally {
             inMagic = false;

--- a/src/main/perl/lib/B.pm
+++ b/src/main/perl/lib/B.pm
@@ -88,6 +88,15 @@ package B::SV {
         Internals::SvREFCNT($_[0]->{ref});
     }
 
+    sub object_2svref {
+        require Scalar::Util;
+        return $_[0]->{ref}
+            if Scalar::Util::reftype($_[0]) eq 'HASH';
+
+        require Internals;
+        return Internals::jperl_b_object_2svref(${$_[0]});
+    }
+
     sub RV {
         my $self = shift;
         my $r = $self->{ref};

--- a/src/test/resources/unit/b_object_2svref_roundtrip.t
+++ b/src/test/resources/unit/b_object_2svref_roundtrip.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+
+use B ();
+use Scalar::Util qw(refaddr reftype);
+use Test::More tests => 5;
+
+my $object = bless {}, 'Local::B::RoundTrip';
+my $string = "$object";
+
+like($string, qr/=HASH\(0x([0-9a-fA-F]+)\)\z/, 'object string exposes a reference address');
+my ($address) = $string =~ /0x([0-9a-fA-F]+)/;
+my $numeric_address = do { no warnings 'portable'; hex $address };
+my $b_object = bless \$numeric_address, 'B::SV';
+my $round_trip = $b_object->object_2svref;
+
+is(reftype($round_trip), 'HASH', 'object_2svref restores the referent type');
+is(ref($round_trip), 'Local::B::RoundTrip', 'object_2svref restores the blessing');
+is(refaddr($round_trip), refaddr($object), 'object_2svref restores the same referent');
+
+my $refaddr_value = refaddr($object);
+my $refaddr_b_object = bless \$refaddr_value, 'B::SV';
+is(refaddr($refaddr_b_object->object_2svref), refaddr($object), 'object_2svref resolves a Scalar::Util::refaddr value');

--- a/src/test/resources/unit/interpreter_compound_assign_list_rhs.t
+++ b/src/test/resources/unit/interpreter_compound_assign_list_rhs.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+my %values = (first => 1, second => 2);
+my $count = grep { $_ eq 'first' } keys %values;
+$count += grep { $_ eq 'second' } keys %values;
+
+is($count, 2, 'compound addition scalarizes a list-producing right operand');
+
+my $empty_count = 7;
+$empty_count += grep { 0 } keys %values;
+is($empty_count, 7, 'compound addition scalarizes an empty list to undef/zero');

--- a/src/test/resources/unit/regex_capture_underscore_interpolation.t
+++ b/src/test/resources/unit/regex_capture_underscore_interpolation.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+
+my $value = 'fooBar';
+$value =~ s{(\w)([A-Z])}{$1_\L$2}g;
+is($value, 'foo_bar', 'underscore after a capture is literal in a replacement');
+
+'abc' =~ /(a)/;
+is("$1_", 'a_', 'underscore after a capture is literal in a string');
+is("$1_000", 'a_000', 'underscore and digits remain literal after a capture');
+is("${1}_", 'a_', 'braced capture interpolation remains supported');

--- a/src/test/resources/unit/tied_scalar_self_backing_value.t
+++ b/src/test/resources/unit/tied_scalar_self_backing_value.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+
+{
+    package Local::SelfBackingTie;
+
+    sub TIESCALAR {
+        my ($class, $owner) = @_;
+        return bless \$owner, $class;
+    }
+
+    sub STORE {
+        $_[1] ||= '';
+        ${$_[0]}->{store_seen} = $_[1];
+    }
+
+    sub FETCH {
+        return ${$_[0]}->{value};
+    }
+}
+
+my $owner = {};
+tie $owner->{value}, 'Local::SelfBackingTie', $owner;
+$owner->{value} = 'current value';
+
+is($owner->{store_seen}, 'current value', 'STORE sees the assigned value');
+is($owner->{value}, 'current value', 'FETCH can read the tied scalar backing value recursively');
+my $tie_object = tied($owner->{value});
+is($$tie_object->{store_seen}, 'current value', 'tie object retains the owner identity');
+
+$owner->{value} = 'replacement value';
+is($owner->{value}, 'replacement value', 'repeated STORE can short-circuit ||= on a true readonly argument');


### PR DESCRIPTION
## Summary

- implement runtime-scoped `B::SV::object_2svref` round trips used by Type::Tiny/Moo
- preserve tied scalar backing values during `STORE` and defer readonly lvalue errors until a short-circuit assignment writes
- parse numeric captures before literal underscores in interpolated strings and regex replacements
- scalarize list-valued interpreter operands for compound addition

## CPAN validation

- `./jcpan -t Map::Tube::Leipzig`: PASS (2 files, 7 tests)
- `./jcpan -t Net::UploadMirror`: PASS (1 file, 93 tests; builds Net::MirrorDir)
- Telegram::JsonAPI ignored: system Perl cannot build without TDLib headers
- C3000 ignored: system Perl reports the OS is unsupported
- Audio::XMMSClient ignored: system Perl cannot configure without ExtUtils::PkgConfig/XMMS development tooling
- Tie::Array::Atomic ignored: its Devel::Malloc dependency fails to build with system Perl on this platform

The optional strict dependency run reaches additional upstream dependency suites, but currently fails in unrelated XML::Twig split/merge tooling and missing optional Text::LineFold. The requested default `jcpan -t` dependency build chains pass.

## Tests

- `make`
- all four new regression tests validated with stock Perl before PerlOnJava
- interpreter-specific compound-assignment regression test

Generated with [Codex](https://openai.com/codex)
