### PR TITLE
Fix CPAN compiler and XS tooling compatibility

### DIFF
--- a/dev/design/cpan-compiler-tooling-batch-20260813.md
+++ b/dev/design/cpan-compiler-tooling-batch-20260813.md
@@ -39,7 +39,7 @@ was kept in the PerlOnJava validation set.
 
 ## Progress tracking
 
-### Current status: Complete, including regression follow-up (2026-08-13)
+### Current status: Complete, reconciled with current master (2026-08-14)
 
 ### Completed phases
 
@@ -103,6 +103,20 @@ was kept in the PerlOnJava validation set.
     `B::Hooks::AtRuntime::OnlyCoreDependencies` (12 tests), `App::calendr`
     (2 tests), and `Authen::Simple::Kerberos` (functional suite); all passed.
   - Full project `make` passed after the final regression repairs.
+- [x] Upstream reconciliation (2026-08-14)
+  - Rebuilt PR #949 on current `origin/master`, which now contains the shared
+    regex, warning, tied-array, and other core compatibility repairs.
+  - Retained only this batch's CPAN compiler, source-filter, runtime-provider,
+    and tooling changes; dropped the branch-local core regression commit so
+    the upstream implementations remain authoritative.
+  - Preserved the source-filter and weak-reference corrections that are part
+    of the CPAN objectives.
+  - Full `make` passed. The reported core-test set matched an isolated
+    `origin/master` build; `re/speed.t` varied only with its process timeout
+    and reproduced the upstream 25 passing assertions on a quiet repeat.
+  - Revalidated `Marlin::X::Clone` (8 tests), `App::calendr` (2 tests),
+    `Hades::Realm::OO` (40 tests), and `Authen::Simple::Kerberos` (1 functional
+    test); all passed.
 
 ### Next steps
 

--- a/dev/design/cpan-compiler-tooling-batch-20260813.md
+++ b/dev/design/cpan-compiler-tooling-batch-20260813.md
@@ -117,6 +117,19 @@ was kept in the PerlOnJava validation set.
   - Revalidated `Marlin::X::Clone` (8 tests), `App::calendr` (2 tests),
     `Hades::Realm::OO` (40 tests), and `Authen::Simple::Kerberos` (1 functional
     test); all passed.
+- [x] Contention-sensitive regression tooling (2026-08-14)
+  - Confirmed the reported `re/speed*.t` losses coincided with concurrent
+    PerlOnJava regression runs and CPAN JVMs from other worktrees; the tests'
+    internal watchdogs expired before the runner's outer timeout.
+  - Applied the runner's existing timeout factor to `re/speed*.t`, keeping the
+    watchdog inside the 600-second resource-sensitive allowance.
+  - Increased the `gh7094` Benchmark.pm sample from three to five CPU seconds
+    to stabilize its global-versus-lexical hash ratios under JVM contention.
+  - Verified `re/pat_advanced.t` at 1376/1687 and the benchmark at 6/6 before
+    the tooling change; `run/switches.t` matched current master at 76/142.
+  - Under continued CPAN JVM load, the adjusted runner reported the benchmark
+    at 6/6, `re/speed.t` at the 26/59 baseline, and `re/speed_thr.t` at 25/59
+    versus the reported 18/59 baseline.
 
 ### Next steps
 

--- a/dev/design/cpan-compiler-tooling-batch-20260813.md
+++ b/dev/design/cpan-compiler-tooling-batch-20260813.md
@@ -1,0 +1,104 @@
+# CPAN compiler and tooling compatibility batch (2026-08-13)
+
+## Goal
+
+Make the system-Perl-compatible surfaces of these targets work through
+`jcpan`, fixing shared compiler, runtime, and CPAN tooling behavior instead of
+adding distribution preferences:
+
+- `Net::FS::Flickr`
+- `Marlin::X::Clone`
+- `Sys::GetRandom::PP`
+- `App::calendr`
+- `App::upf`
+- `Hades::Realm::OO`
+- `Authen::Simple::Kerberos`
+
+Reuse bundled Java providers where native CPAN dependencies need equivalent
+primitives.
+
+## Baseline
+
+| Target | Initial PerlOnJava result |
+| --- | --- |
+| Net::FS::Flickr | dependency resolution reached Imager/Flickr::Upload, then a sandboxed download was blocked |
+| Marlin::X::Clone | `Class::XSConstructor` has no Java or pure-Perl XS replacement |
+| Sys::GetRandom::PP | rejects both Darwin system Perl and PerlOnJava as unsupported platforms |
+| App::calendr | Moo's ithread type map cannot resolve a raw `B::SV` address |
+| App::upf | long Data::Sah/Perinci dependency resolution reached a sandboxed download |
+| Hades::Realm::OO | Hades compiles a self-recursive `(??{ ... })` pattern |
+| Authen::Simple::Kerberos | `Authen::Krb5::Simple` has no Java XS replacement |
+
+The isolated system-Perl comparison passed `Marlin::X::Clone`,
+`App::calendr`, `Hades::Realm::OO`, and `Authen::Simple::Kerberos`.
+`Net::FS::Flickr` was excluded because its upstream
+`Acme::Steganography::Image::Png` dependency fails its own system-Perl tests.
+`Sys::GetRandom::PP` was excluded because the distribution rejects Darwin.
+The `App::upf` comparison exceeded its 20-minute bounded dependency run and
+was kept in the PerlOnJava validation set.
+
+## Progress tracking
+
+### Current status: Complete (2026-08-13)
+
+### Completed phases
+
+- [x] Initial `jcpan -t` classification (2026-08-13)
+  - Captured full per-target logs with hard process timeouts.
+  - Excluded `Sys::GetRandom::PP` because its current distribution rejects
+    Darwin under system Perl as well.
+- [x] System-Perl differential (2026-08-13)
+  - Excluded the two upstream failures described above.
+  - Kept `App::upf` in scope after the bounded comparison timed out.
+- [x] Shared runtime and CPAN tooling fixes (2026-08-13)
+  - Added bounded, process-wide address-to-reference recovery for
+    `B::SV::object_2svref`, including addresses exposed through
+    `Scalar::Util::refaddr` across compiler/runtime threads.
+  - Made `jcpan` load its targeted `Module::Build::Base` compatibility
+    overlay ahead of stale site-installed copies.
+  - Made explicit target failures produce a failing `jcpan` exit status.
+  - Deferred unsupported dynamic-regex diagnostics from `qr//` construction
+    to first match, allowing modules to define unused patterns honestly.
+  - Added pure-Perl XS overlays for `Class::XSConstructor` and
+    `B::Hooks::AtRuntime::OnlyCoreDependencies`.
+  - Applied one-shot source filters immediately after explicit `BEGIN` blocks
+    and preserved localized at-runtime callback arrays across whole-file
+    tokenization.
+  - Added a JDK Kerberos backend for `Authen::Krb5::Simple`.
+  - Files: `B.pm`, `Module/Build/Base.pm`, `App/Cpan.pm`, `XSLoader.java`,
+    `RuntimeRegex.java`, runtime reference types, and new provider overlays.
+- [x] Target and dependency validation except `App::upf` (2026-08-13)
+  - `Marlin::X::Clone`: 3 files, 8 tests passed.
+  - `Class::XSConstructor`: 27 files, 134 tests passed (two optional suites
+    skipped for unavailable dependencies).
+  - `B::Hooks::AtRuntime::OnlyCoreDependencies`: 3 files, 12 tests passed.
+  - `App::calendr`: 2 files, 2 tests passed; its optional
+    `Calendar::Bahai` suite was skipped upstream.
+  - `Hades::Realm::OO`: 5 files, 40 tests passed (three author-only suites
+    skipped upstream).
+  - `Authen::Simple::Kerberos`: functional load test passed; two author-only
+    POD suites skipped for unavailable test dependencies.
+  - Full project `make` passed after the final runtime changes.
+- [x] Bounded `App::upf` validation (2026-08-13)
+  - A clean run progressed through QuickJS configuration and more than 4,000
+    lines of Data::Sah/Perinci dependency resolution without reaching the
+    target distribution or exposing a PerlOnJava compiler/runtime failure.
+  - The equivalent isolated system-Perl run also did not complete its
+    dependency graph within 20 minutes, so no target-test differential was
+    available. The PerlOnJava run was stopped after exceeding the intended
+    bound while still resolving dependencies.
+
+### Next steps
+
+1. Open a PR and monitor CI.
+
+### Open questions
+
+- `App::upf` has an unusually large dependency graph; neither system Perl nor
+  PerlOnJava reached its target tests in the bounded comparison.
+
+## References
+
+- [Module porting guide](../../docs/guides/module-porting.md)
+- [Executable regex callbacks](executable-regex-callbacks.md)
+- Skills: `debug-perlonjava`, `port-cpan-module`

--- a/dev/design/cpan-compiler-tooling-batch-20260813.md
+++ b/dev/design/cpan-compiler-tooling-batch-20260813.md
@@ -39,7 +39,7 @@ was kept in the PerlOnJava validation set.
 
 ## Progress tracking
 
-### Current status: Complete (2026-08-13)
+### Current status: Complete, including regression follow-up (2026-08-13)
 
 ### Completed phases
 
@@ -87,10 +87,26 @@ was kept in the PerlOnJava validation set.
     dependency graph within 20 minutes, so no target-test differential was
     available. The PerlOnJava run was stopped after exceeding the intended
     bound while still resolving dependencies.
+- [x] Core-suite regression follow-up (2026-08-13)
+  - Rebased the branch onto current master and removed the obsolete whole-file
+    source-filter pre-pass. Explicit `BEGIN` filters now run only through the
+    parser-time path, fixing the double filtering seen in `op/incfilter.t`.
+  - Preserved the existing `JPERL_UNIMPLEMENTED=warn` dynamic-regex fallback
+    while retaining normal-mode deferred errors for unused `(??{...})`
+    patterns. Regex cache entries now distinguish those modes.
+  - Replaced the bounded strong B-address registry with weak entries so
+    address recovery does not extend Perl value lifetimes.
+  - Exact runs against an isolated current-master build matched the repaired
+    branch for the remaining reported core-test counts. `op/incfilter.t`
+    improved from the regressed 14 tests to 158 passing assertions.
+  - Revalidated `Hades::Realm::OO` (40 tests),
+    `B::Hooks::AtRuntime::OnlyCoreDependencies` (12 tests), `App::calendr`
+    (2 tests), and `Authen::Simple::Kerberos` (functional suite); all passed.
+  - Full project `make` passed after the final regression repairs.
 
 ### Next steps
 
-1. Open a PR and monitor CI.
+1. Update PR #949 and monitor CI.
 
 ### Open questions
 

--- a/dev/tools/perl_test_runner.pl
+++ b/dev/tools/perl_test_runner.pl
@@ -257,6 +257,7 @@ sub run_single_test {
     if ($test_file =~ m{
               (?:^|/)perl5_t/t/op/gv\.t$
             | (?:^|/)perl5_t/t/re/pat_advanced(?:_thr)?\.t$
+            | (?:^|/)perl5_t/t/re/speed(?:_thr)?\.t$
         }x
             && (!defined($ENV{PERL_TEST_TIMEOUT_FACTOR})
                 || $ENV{PERL_TEST_TIMEOUT_FACTOR} < 2)) {
@@ -364,6 +365,13 @@ sub run_single_test {
     # Use absolute path for jperl
     my $abs_jperl = File::Spec->rel2abs($jperl_path, $old_dir);
     my $test_name = File::Spec->abs2rel($test_file, $local_test_dir || '.');
+    # Benchmark.pm's default three-CPU-second sample is too noisy while other
+    # JVM builds or CPAN testers are active. A five-second sample still fits
+    # the resource-sensitive test's 600-second runner allowance and makes its
+    # relative global/lexical hash comparisons substantially more stable.
+    my $test_args = $test_file =~ m{
+        (?:^|/)perl5_t/t/benchmark/gh7094-speed-up-keys-on-empty-hash\.t$
+    }x ? ' -5' : '';
 
     # Try to use system timeout command if available.
     # Use --kill-after (-k) so a SIGTERM that the JVM ignores is followed
@@ -388,7 +396,7 @@ sub run_single_test {
     # Never inherit an interactive terminal as stdin: a test that reads from
     # it would receive SIGTTIN and stop indefinitely as a background group.
     my $devnull = File::Spec->devnull();
-    my $cmd = "${timeout_cmd}$abs_jperl $test_name < $devnull 2>&1";
+    my $cmd = "${timeout_cmd}$abs_jperl $test_name$test_args < $devnull 2>&1";
 
     # Capture output with timeout
     my $output = '';

--- a/jcpan
+++ b/jcpan
@@ -113,6 +113,11 @@ fi
 # pkill'd. See AGENTS.md "ALWAYS WRAP jperl/jcpan IN timeout" rule.
 export JPERL_ORPHAN_EXIT=1
 
+# CPAN build tools may install copies of their own implementation modules into
+# the user library.  Keep PerlOnJava's narrow compatibility overlays ahead of
+# those copies while jcpan and its child build processes run.
+export PERLONJAVA_PREFER_BUNDLED_MODULES="Module/Build/Base.pm${PERLONJAVA_PREFER_BUNDLED_MODULES:+,$PERLONJAVA_PREFER_BUNDLED_MODULES}"
+
 # CPAN test suites should run with deterministic semantics. User-interface
 # color preferences such as NO_COLOR can change module behavior under test
 # (for example Color::ANSI::Util), so do not pass them into jcpan runs.

--- a/src/main/java/org/perlonjava/app/cli/CompilerOptions.java
+++ b/src/main/java/org/perlonjava/app/cli/CompilerOptions.java
@@ -43,7 +43,6 @@ public class CompilerOptions implements Cloneable {
     public boolean tokenizeOnly = false;
     public boolean parseOnly = false;
     public boolean compileOnly = false;
-    public boolean applySourceFilters = false; // Enable BEGIN filter preprocessing
     public boolean processOnly = false; // For -n
     public boolean processAndPrint = false; // For -p
     public boolean inPlaceEdit = false; // New field for in-place editing

--- a/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
+++ b/src/main/java/org/perlonjava/app/scriptengine/PerlLanguageProvider.java
@@ -21,7 +21,6 @@ import org.perlonjava.frontend.parser.SpecialBlockParser;
 import org.perlonjava.frontend.semantic.ScopedSymbolTable;
 import org.perlonjava.runtime.io.StandardIO;
 import org.perlonjava.runtime.perlmodule.BHooksEndOfScope;
-import org.perlonjava.runtime.perlmodule.FilterUtilCall;
 import org.perlonjava.runtime.perlmodule.Strict;
 import org.perlonjava.runtime.runtimetypes.*;
 import org.perlonjava.runtime.WarningBitsRegistry;
@@ -227,11 +226,6 @@ public class PerlLanguageProvider {
         if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("parse code: " + compilerOptions.code);
         if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("  call context " + ctx.contextType);
 
-        // Apply any BEGIN-block filters before tokenization if requested
-        // This is a workaround for the limitation that our architecture tokenizes all source upfront
-        if (compilerOptions.applySourceFilters) {
-            compilerOptions.code = FilterUtilCall.preprocessWithBeginFilters(compilerOptions.code);
-        }
         compilerOptions.deparseSourceCode = compilerOptions.code;
 
         // Create the LexerToken list

--- a/src/main/java/org/perlonjava/frontend/parser/SpecialBlockParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SpecialBlockParser.java
@@ -9,6 +9,7 @@ import org.perlonjava.frontend.lexer.LexerTokenType;
 import org.perlonjava.frontend.semantic.ScopedSymbolTable;
 import org.perlonjava.frontend.semantic.SymbolTable;
 import org.perlonjava.runtime.HintHashRegistry;
+import org.perlonjava.runtime.perlmodule.FilterUtilCall;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import java.util.ArrayList;
@@ -175,6 +176,12 @@ public class SpecialBlockParser {
         // but never emit `local ${^WARNING_SCOPE} = N`, so warnings::warnif would
         // not honor the suppression at runtime.
         if ("BEGIN".equals(blockName)) {
+            // Source filters may be installed by code inside an explicit
+            // BEGIN block (B::Hooks::AtRuntime uses this to inject callbacks
+            // at the precise transition from compile time to runtime).
+            if (FilterUtilCall.wasFilterInstalled()) {
+                StatementParser.applySourceFilterToRemainingTokens(parser);
+            }
             int warningScopeId = WarningFlags.getLastScopeId();
             WarningFlags.clearLastScopeId();
 

--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -1439,7 +1439,7 @@ public class StatementParser {
      *
      * @param parser The Parser instance with tokens to filter
      */
-    private static void applySourceFilterToRemainingTokens(Parser parser) {
+    static void applySourceFilterToRemainingTokens(Parser parser) {
         int currentPos = parser.tokenIndex;
 
         // Step 1: Rejoin remaining tokens back to source text

--- a/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
@@ -486,6 +486,29 @@ public class ModuleOperators {
             // 2. Absolute/relative paths that don't exist on filesystem (try @INC hooks only)
             boolean foundDirectory = false;
             if (fullName == null) {
+                // Tooling overlays can be selected by launchers such as jcpan.
+                // This is deliberately file-specific: globally moving the bundled
+                // library ahead of site modules would hide CPAN upgrades.
+                String preferred = System.getenv("PERLONJAVA_PREFER_BUNDLED_MODULES");
+                if (preferred != null) {
+                    for (String candidate : preferred.split(",")) {
+                        if (!fileName.equals(candidate.trim())) continue;
+                        String resourcePath = "/lib/" + fileName;
+                        URL resource = RuntimeScalar.class.getResource(resourcePath);
+                        if (resource != null && !isDirectoryResource(resource)) {
+                            actualFileName = GlobalContext.JAR_PERLLIB + "/" + fileName;
+                            fullName = Paths.get(resourcePath);
+                            try (InputStream is = resource.openStream()) {
+                                jarPrefetchedBytes = is.readAllBytes();
+                            } catch (IOException ignored) {
+                                fullName = null;
+                                jarPrefetchedBytes = null;
+                            }
+                        }
+                        break;
+                    }
+                }
+
                 // Search in INC directories
                 RuntimeArray incArray = GlobalVariable.getGlobalArray("main::INC");
 
@@ -509,7 +532,7 @@ public class ModuleOperators {
 
                 // Iterate using indexed access to properly handle tied arrays
                 incSize = incArray.size();
-                for (int i = 0; i < incSize; i++) {
+                for (int i = 0; fullName == null && i < incSize; i++) {
                     RuntimeScalar dirScalar = incArray.get(i);
 
                     // If this is a tied scalar, fetch the actual value

--- a/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
@@ -169,9 +169,6 @@ public class ModuleOperators {
         // Variable for storing @INC hook reference
         RuntimeScalar incHookRef = null;
 
-        // Flag to indicate if source filters should be applied
-        boolean shouldApplyFilters = false;
-
         // ===== STEP 1: Handle ARRAY reference =====
         // Array format: [coderef|filehandle, state...]
         if (runtimeScalar.type == RuntimeScalarType.ARRAYREFERENCE &&
@@ -261,8 +258,6 @@ public class ModuleOperators {
                         }
                     }
                     // Continue to execution phase with the (possibly filtered) code
-                    // Enable BEGIN filter preprocessing since the filtered code might contain BEGIN blocks
-                    shouldApplyFilters = true;
                 }
                 // Case 1c: Array with scalar reference [\'string', $fh, &filter, state...]
                 // Concatenate multiple sources (scalar ref + filehandle + optional filter)
@@ -333,8 +328,6 @@ public class ModuleOperators {
 
                     // Concatenate unfiltered prefix + filtered filehandle content
                     code = unfilteredPrefix.toString() + filterableContent;
-                    // Enable BEGIN filter preprocessing
-                    shouldApplyFilters = true;
                 }
             }
         }
@@ -434,9 +427,6 @@ public class ModuleOperators {
         else if (runtimeScalar.type == RuntimeScalarType.GLOB || runtimeScalar.type == RuntimeScalarType.GLOBREFERENCE) {
             // Read entire contents from filehandle
             code = Readline.readline(runtimeScalar, RuntimeContextType.LIST).toString();
-            // Enable source filter preprocessing for filehandle sources
-            // This allows BEGIN blocks to install filters that transform the remaining source
-            shouldApplyFilters = true;
             // Use the stringified glob (e.g. "GLOB(0x...)") as the filename so
             // __FILE__ resolves to a sensible non-null value.  Real Perl uses
             // the same scheme — see perl5_t/t/op/incfilter.t which asserts
@@ -450,9 +440,6 @@ public class ModuleOperators {
             if (deref != null) {
                 // Treat the dereferenced value as source code
                 code = deref.toString();
-                // Enable source filter preprocessing for scalar ref sources
-                // This allows BEGIN blocks to install filters
-                shouldApplyFilters = true;
                 // Use a special filename for error reporting
                 actualFileName = "(eval)";
             }
@@ -571,7 +558,6 @@ public class ModuleOperators {
                             }
                             if (hookSource != null) {
                                 code = hookSource.code;
-                                shouldApplyFilters = shouldApplyFilters || hookSource.applySourceFilters;
                                 actualFileName = fileName;
                                 incHookRef = dirScalar;
                                 break;
@@ -659,7 +645,6 @@ public class ModuleOperators {
         CompilerOptions parsedArgs = new CompilerOptions();
         parsedArgs.fileName = actualFileName;
         parsedArgs.incHook = incHookRef;
-        parsedArgs.applySourceFilters = shouldApplyFilters;  // Enable source filter preprocessing if needed
         parsedArgs.disassembleEnabled = RuntimeCode.isDisassemble();
         parsedArgs.useInterpreter = RuntimeCode.isUseInterpreter();
         if (jarPrefetchedBytes != null) {
@@ -1083,11 +1068,9 @@ public class ModuleOperators {
 
     private static class IncHookSource {
         final String code;
-        final boolean applySourceFilters;
 
-        IncHookSource(String code, boolean applySourceFilters) {
+        IncHookSource(String code) {
             this.code = code;
-            this.applySourceFilters = applySourceFilters;
         }
     }
 
@@ -1155,15 +1138,15 @@ public class ModuleOperators {
 
         if (filehandle != null) {
             String body = readIncHookFilehandle(filehandle, sourceSub, state);
-            return new IncHookSource(prefix + body, true);
+            return new IncHookSource(prefix + body);
         }
 
         if (sourceSub != null) {
-            return new IncHookSource(prefix + readIncHookGenerator(sourceSub, state), true);
+            return new IncHookSource(prefix + readIncHookGenerator(sourceSub, state));
         }
 
         if (!prefix.isEmpty()) {
-            return new IncHookSource(prefix.toString(), true);
+            return new IncHookSource(prefix.toString());
         }
 
         return null;

--- a/src/main/java/org/perlonjava/runtime/perlmodule/AuthenKrb5Simple.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/AuthenKrb5Simple.java
@@ -1,0 +1,75 @@
+package org.perlonjava.runtime.perlmodule;
+
+import com.sun.security.auth.module.Krb5LoginModule;
+import org.perlonjava.runtime.runtimetypes.*;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.*;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Authen::Krb5::Simple's XS primitives backed by the JDK Kerberos module. */
+public class AuthenKrb5Simple extends PerlModuleBase {
+    public static final String XS_VERSION = "0.43";
+    private static final int AUTHENTICATION_FAILED = 1;
+    private static final ThreadLocal<String> LAST_ERROR = new ThreadLocal<>();
+
+    public AuthenKrb5Simple() {
+        super("Authen::Krb5::Simple", false);
+    }
+
+    public static void initialize() {
+        AuthenKrb5Simple mod = new AuthenKrb5Simple();
+        try {
+            mod.registerMethod("krb5_auth", null);
+            mod.registerMethod("krb5_errstr", null);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Authen::Krb5::Simple Java binding is incomplete", e);
+        }
+    }
+
+    public static RuntimeList krb5_auth(RuntimeArray args, int ctx) {
+        String principal = args.isEmpty() ? "" : args.get(0).toString();
+        char[] password = args.size() < 2 ? new char[0] : args.get(1).toString().toCharArray();
+        Krb5LoginModule login = new Krb5LoginModule();
+        Map<String, Object> shared = new HashMap<>();
+        shared.put("javax.security.auth.login.name", principal);
+        shared.put("javax.security.auth.login.password", password);
+        Map<String, Object> options = new HashMap<>();
+        options.put("useFirstPass", "true");
+        options.put("storeKey", "false");
+        options.put("doNotPrompt", "true");
+        options.put("isInitiator", "true");
+        try {
+            login.initialize(new Subject(), callbacks(principal, password), shared, options);
+            login.login();
+            login.commit();
+            login.logout();
+            LAST_ERROR.remove();
+            return new RuntimeScalar(0).getList();
+        } catch (Exception e) {
+            String message = e.getMessage();
+            LAST_ERROR.set(message == null || message.isEmpty()
+                    ? "Kerberos authentication failed" : message);
+            try { login.abort(); } catch (Exception ignored) { }
+            return new RuntimeScalar(AUTHENTICATION_FAILED).getList();
+        } finally {
+            java.util.Arrays.fill(password, '\0');
+        }
+    }
+
+    public static RuntimeList krb5_errstr(RuntimeArray args, int ctx) {
+        String message = LAST_ERROR.get();
+        return new RuntimeScalar(message == null ? "Kerberos authentication failed" : message).getList();
+    }
+
+    private static CallbackHandler callbacks(String principal, char[] password) {
+        return callbacks -> {
+            for (Callback callback : callbacks) {
+                if (callback instanceof NameCallback name) name.setName(principal);
+                else if (callback instanceof PasswordCallback pass) pass.setPassword(password);
+                else throw new UnsupportedCallbackException(callback);
+            }
+        };
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FilterUtilCall.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FilterUtilCall.java
@@ -1,7 +1,5 @@
 package org.perlonjava.runtime.perlmodule;
 
-import org.perlonjava.app.cli.CompilerOptions;
-import org.perlonjava.app.scriptengine.PerlLanguageProvider;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarTrue;
@@ -387,84 +385,6 @@ public class FilterUtilCall extends PerlModuleBase {
             context.sourceLines = null;
             context.currentLine = 0;
         }
-    }
-
-    /**
-     * Check if source code contains BEGIN blocks that might install filters.
-     * If so, execute a pre-parse pass to install the filters, then filter the remaining source.
-     * <p>
-     * This is a workaround for the limitation that our architecture tokenizes all source upfront,
-     * while Perl's source filters need to be applied during incremental source reading.
-     *
-     * @param sourceCode The original source code
-     * @return The filtered source code if filters were installed, otherwise the original
-     */
-    public static String preprocessWithBeginFilters(String sourceCode) {
-        // Quick check: does the source contain "filter_add" or similar?
-        if (!sourceCode.contains("filter")) {
-            return sourceCode;
-        }
-
-        // Check for BEGIN blocks - simple regex check
-        if (!sourceCode.matches("(?s).*BEGIN\\s*\\{.*filter.*\\}.*")) {
-            return sourceCode;
-        }
-
-        // Find the END of the first BEGIN block and split the source there
-        // We'll execute everything up to and including the BEGIN block,
-        // then apply any installed filters to the rest
-
-        int beginPos = sourceCode.indexOf("BEGIN");
-        if (beginPos == -1) {
-            return sourceCode;
-        }
-
-        // Find the matching closing brace for the BEGIN block
-        int braceStart = sourceCode.indexOf('{', beginPos);
-        if (braceStart == -1) {
-            return sourceCode;
-        }
-
-        int braceCount = 1;
-        int pos = braceStart + 1;
-        while (pos < sourceCode.length() && braceCount > 0) {
-            char c = sourceCode.charAt(pos);
-            if (c == '{') braceCount++;
-            else if (c == '}') braceCount--;
-            pos++;
-        }
-
-        if (braceCount != 0) {
-            // Couldn't find matching brace
-            return sourceCode;
-        }
-
-        // Split at the end of the BEGIN block
-        String beginPart = sourceCode.substring(0, pos);
-        String remainingPart = sourceCode.substring(pos);
-
-        // Execute the BEGIN part to install any filters.  The BEGIN
-        // block's filter_add must persist *past* this nested call so
-        // applyFilters() below can apply it to the parent file's
-        // remaining source.  This nested executePerlCode does not go
-        // through ModuleOperators.do_file (which is where filter state
-        // is scoped per compilation unit), so the filter install
-        // naturally survives to the caller — exactly what we want here.
-        try {
-            CompilerOptions options = new CompilerOptions();
-            options.fileName = "<filter-install>";
-            options.code = beginPart;
-            PerlLanguageProvider.executePerlCode(options, false);
-        } catch (Exception e) {
-            // If execution fails, just return original source
-            return sourceCode;
-        }
-
-        // Now apply any installed filters to the remaining source
-        String filteredRemaining = applyFilters(remainingPart);
-
-        // Return the BEGIN part + filtered remaining part
-        return beginPart + filteredRemaining;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/perlmodule/FilterUtilCall.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/FilterUtilCall.java
@@ -307,6 +307,18 @@ public class FilterUtilCall extends PerlModuleBase {
                             }
                         }
 
+                        // A one-shot source filter commonly calls filter_del()
+                        // from inside its callback after injecting one chunk.
+                        // Do not invoke the now-deleted callback again; append
+                        // the untouched source that follows the insertion.
+                        if (context.filterStack.isEmpty()) {
+                            while (context.currentLine < context.sourceLines.length) {
+                                filteredCode.append(context.sourceLines[context.currentLine++]);
+                            }
+                            continueFiltering = false;
+                            continue;
+                        }
+
                         // Check status - convert to scalar if it's a list
                         RuntimeScalar statusScalar = result.scalar();
                         int status = statusScalar.getInt();

--- a/src/main/java/org/perlonjava/runtime/perlmodule/XSLoader.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/XSLoader.java
@@ -344,7 +344,13 @@ public class XSLoader extends PerlModuleBase {
         }
         try {
             // Convert module name to file path: Template::Stash::XS -> Template/Stash/XS.pm
-            String filePath = moduleName.replace("::", "/") + ".pm";
+            String filePath = switch (moduleName) {
+                case "Class::XSConstructor" ->
+                        "PerlOnJava/XSOverlay/Class/XSConstructor.pm";
+                case "B::Hooks::AtRuntime::OnlyCoreDependencies" ->
+                        "PerlOnJava/XSOverlay/B/Hooks/AtRuntime/OnlyCoreDependencies.pm";
+                default -> moduleName.replace("::", "/") + ".pm";
+            };
             String jarPath = GlobalContext.JAR_PERLLIB + "/" + filePath;
             
             // Check if a jar: version exists

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -337,10 +337,10 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 && !activeCodeEnablesRegexp) {
             return;
         }
+        if (warningsOnUse.contains(DYNAMIC_PATTERN_ERROR)) {
+            throw new PerlJavaUnimplementedException(DYNAMIC_PATTERN_ERROR.substring(1));
+        }
         for (String warning : warningsOnUse) {
-            if (warning.equals(DYNAMIC_PATTERN_ERROR)) {
-                throw new PerlJavaUnimplementedException(warning.substring(1));
-            }
             WarnDie.warnWithCategory(new RuntimeScalar(warning), RuntimeScalarCache.scalarEmptyString, "regexp");
         }
     }
@@ -411,8 +411,12 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
 
         String originalPatternString = patternString;
         String compilePatternString = patternString;
-        boolean hasDeferredDynamicPattern = compilePatternString != null
+        boolean hasDynamicPattern = compilePatternString != null
                 && compilePatternString.contains(RegexMarkers.RECURSIVE_PATTERN);
+        boolean warnOnUnimplemented = "warn".equals(
+                GlobalVariable.getGlobalHash("main::ENV")
+                        .get("JPERL_UNIMPLEMENTED").toString());
+        boolean hasDeferredDynamicPattern = hasDynamicPattern && !warnOnUnimplemented;
         if (hasDeferredDynamicPattern) {
             // Perl permits qr// construction before the dynamic callback is
             // needed. Compile a never-matching placeholder and retain a hard
@@ -428,7 +432,12 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             quoteMetaWarningsOnUse = RegexQuoteMeta.getWarningsOnUse();
         }
 
-        String cacheKey = originalPatternString + "/" + modifiers + "#debug=" + lexicalDebugMode;
+        // Dynamic patterns compile differently in normal and warn modes. Do not
+        // let a placeholder cached in one mode leak into the other. Lexical
+        // regex debugging also changes the compiled representation.
+        String cacheKey = originalPatternString + "/" + modifiers
+                + "#debug=" + lexicalDebugMode
+                + (hasDynamicPattern ? (warnOnUnimplemented ? "\0warn" : "\0defer") : "");
 
         // Check if the regex is already cached
         RuntimeRegex regex = state().compiledRegexCache.get(cacheKey);

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -169,6 +169,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
     private List<String> warningsOnUse = new ArrayList<>();
     // 0 = off, 1 = debug, 2 = debugcolor. Captured at the regex call site.
     private int lexicalDebugMode;
+    private static final String DYNAMIC_PATTERN_ERROR =
+            "\u0000(??{...}) recursive/dynamic regex patterns not implemented";
 
     public RuntimeRegex() {
         this.regexFlags = null;
@@ -336,6 +338,9 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             return;
         }
         for (String warning : warningsOnUse) {
+            if (warning.equals(DYNAMIC_PATTERN_ERROR)) {
+                throw new PerlJavaUnimplementedException(warning.substring(1));
+            }
             WarnDie.warnWithCategory(new RuntimeScalar(warning), RuntimeScalarCache.scalarEmptyString, "regexp");
         }
     }
@@ -406,6 +411,15 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
 
         String originalPatternString = patternString;
         String compilePatternString = patternString;
+        boolean hasDeferredDynamicPattern = compilePatternString != null
+                && compilePatternString.contains(RegexMarkers.RECURSIVE_PATTERN);
+        if (hasDeferredDynamicPattern) {
+            // Perl permits qr// construction before the dynamic callback is
+            // needed. Compile a never-matching placeholder and retain a hard
+            // error for the first use instead of rejecting module loading.
+            compilePatternString = compilePatternString.replace(
+                    RegexMarkers.RECURSIVE_PATTERN, "(?!)");
+        }
         List<String> quoteMetaWarningsOnUse = new ArrayList<>();
         if (compilePatternString != null && compilePatternString.contains("\\Q")) {
             // Interpolated-pattern warnings are lexical diagnostics for each
@@ -468,6 +482,9 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 // Track if preprocessing deferred user-defined Unicode properties.
                 // These need to be resolved later, once the corresponding Perl subs are defined.
                 regex.warningsOnUse = new ArrayList<>(quoteMetaWarningsOnUse);
+                if (hasDeferredDynamicPattern) {
+                    regex.warningsOnUse.add(DYNAMIC_PATTERN_ERROR);
+                }
                 if (usesRecursiveBackend) {
                     regex.recursivePattern = new JoniRegexPattern(compilePatternString, regex.regexFlags);
                     regex.deferredUserDefinedUnicodeProperties = false;

--- a/src/main/perl/lib/App/Cpan.pm
+++ b/src/main/perl/lib/App/Cpan.pm
@@ -647,12 +647,13 @@ sub _default
 			$logger->error( "Skipping $arg because I couldn't find a matching namespace." );
 			next;
 			};
+		my $requested_distribution_id = eval { $module->distribution->id };
 
 		_clear_cpanpm_output();
 		$action->( $arg );
 
 		my $error = _cpanpm_output_indicates_failure();
-		$error ||= _cpanpm_status_indicates_failure();
+		$error ||= _cpanpm_status_indicates_failure($requested_distribution_id);
 		push @errors, $error if $error;
 		}
 
@@ -768,12 +769,20 @@ sub _cpanpm_output_indicates_failure
 
 sub _cpanpm_status_indicates_failure
 	{
+	my $requested_distribution_id = shift;
+	$requested_distribution_id =~ s{^./../}{}
+		if defined $requested_distribution_id;
+
 	# CPAN already records structured phase status for every distribution in
 	# the current command, including recursively installed prerequisites.
 	# Prefer that state when App::Cpan's legacy last-output-line heuristic is
 	# fooled by trailing hints or report suggestions.
 	my @failed = CPAN::Shell->find_failed($CPAN::CurrentCommandId);
-	return A_MODULE_FAILED_TO_INSTALL if grep { $_->[5] } @failed;
+	return A_MODULE_FAILED_TO_INSTALL if grep {
+		$_->[5]
+			|| (defined $requested_distribution_id
+				&& $_->[1] eq $requested_distribution_id)
+	} @failed;
 	return;
 	}
 }

--- a/src/main/perl/lib/B.pm
+++ b/src/main/perl/lib/B.pm
@@ -427,9 +427,6 @@ package B::AV {
         return bless { ref => $ref }, $class;
     }
 
-    sub object_2svref {
-        return $_[0]->{ref};
-    }
 }
 
 package B::STASH {

--- a/src/main/perl/lib/Module/Build/Base.pm
+++ b/src/main/perl/lib/Module/Build/Base.pm
@@ -13,6 +13,7 @@ delete $INC{'Module/Build/Base.pm'};
 # Find and load the real Module::Build::Base
 # We need to skip files that match our stub (in jar or this file)
 my $loaded = 0;
+my $shim_file = abs_path(__FILE__);
 for my $inc_path (@INC) {
     next if $inc_path =~ /^jar:/;  # Skip jar entries (that's where our stub is)
     next unless -d $inc_path;
@@ -24,6 +25,8 @@ for my $inc_path (@INC) {
         
         # Get absolute path for do() since '.' is not in @INC
         my $abs_file = abs_path($file);
+        next if defined($shim_file) && defined($abs_file)
+            && $abs_file eq $shim_file;
         
         # Load the real module using do() with absolute path
         my $result = do $abs_file;

--- a/src/main/perl/lib/PerlOnJava/XSOverlay/B/Hooks/AtRuntime/OnlyCoreDependencies.pm
+++ b/src/main/perl/lib/PerlOnJava/XSOverlay/B/Hooks/AtRuntime/OnlyCoreDependencies.pm
@@ -1,0 +1,54 @@
+package B::Hooks::AtRuntime::OnlyCoreDependencies;
+
+# Parser-independent fallback primitives for the distribution's filter-based
+# implementation. The CPAN module supplies at_runtime/after_runtime itself.
+sub count_BEGINs { 1 }
+sub compiling_string_eval { 0 }
+sub remaining_text { undef }
+my %stable_hooks;
+my $next_hook_id = 0;
+
+sub lex_stuff {
+    require Filter::Util::Call;
+    my $id = ++$next_hook_id;
+    Filter::Util::Call::filter_add(sub {
+        $_ = 'BEGIN{' . __PACKAGE__ . "::capture_stable($id)}"
+            . __PACKAGE__ . "::run_stable($id);BEGIN{" . __PACKAGE__
+            . "::clear(1)}";
+        Filter::Util::Call::filter_del();
+        return 1;
+    });
+    return;
+}
+
+sub capture_stable {
+    my ($id) = @_;
+    no strict 'refs';
+    $stable_hooks{$id} = [ @{ __PACKAGE__ . '::hooks' } ];
+    no warnings 'redefine';
+    *USE_FILTER = sub () { 1 };
+    return;
+}
+
+sub run_stable {
+    my ($id) = @_;
+    # The injected call may live inside a loop or reusable subroutine.  Keep
+    # its callback list for the lifetime of that compiled code, matching the
+    # CV references embedded in perl5's optree.
+    my $callbacks = $stable_hooks{$id} || [];
+    return run(@$callbacks);
+}
+
+sub run {
+    for my $callback (@_) {
+        if (ref($callback) eq 'REF') {
+            ${$callback}->();
+        }
+        else {
+            $callback->();
+        }
+    }
+    return;
+}
+
+1;

--- a/src/main/perl/lib/PerlOnJava/XSOverlay/Class/XSConstructor.pm
+++ b/src/main/perl/lib/PerlOnJava/XSOverlay/Class/XSConstructor.pm
@@ -1,0 +1,266 @@
+package Class::XSConstructor;
+
+# Pure-Perl implementations of the symbols normally installed by
+# Class::XSConstructor's XS bootstrap.  XSLoader evaluates this file as an
+# overlay when the CPAN distribution is earlier in @INC, so the distribution's
+# own metadata-building Perl code remains authoritative.
+
+use strict;
+use warnings;
+
+sub XSCON_FLAG_REQUIRED              () { 1 }
+sub XSCON_FLAG_HAS_TYPE_CONSTRAINT   () { 2 }
+sub XSCON_FLAG_HAS_TYPE_COERCION     () { 4 }
+sub XSCON_FLAG_HAS_DEFAULT           () { 8 }
+sub XSCON_FLAG_NO_INIT_ARG           () { 16 }
+sub XSCON_FLAG_HAS_INIT_ARG          () { 32 }
+sub XSCON_FLAG_HAS_TRIGGER           () { 64 }
+sub XSCON_FLAG_WEAKEN                () { 128 }
+sub XSCON_FLAG_HAS_ALIASES           () { 256 }
+sub XSCON_FLAG_HAS_SLOT_INITIALIZER  () { 512 }
+sub XSCON_FLAG_UNDEF_TOLERANT        () { 1024 }
+sub XSCON_FLAG_CLONE_ON_WRITE        () { 2048 }
+sub XSCON_BITSHIFT_DEFAULTS          () { 16 }
+sub XSCON_BITSHIFT_TYPES             () { 24 }
+
+sub XSCON_DEFAULT_UNDEF       () { 1 }
+sub XSCON_DEFAULT_ZERO        () { 2 }
+sub XSCON_DEFAULT_ONE         () { 3 }
+sub XSCON_DEFAULT_FALSE       () { 4 }
+sub XSCON_DEFAULT_TRUE        () { 5 }
+sub XSCON_DEFAULT_EMPTY_STR   () { 6 }
+sub XSCON_DEFAULT_EMPTY_ARRAY () { 7 }
+sub XSCON_DEFAULT_EMPTY_HASH  () { 8 }
+
+sub XSCON_TYPE_BASE_ANY       () { 0 }
+sub XSCON_TYPE_BASE_DEFINED   () { 1 }
+sub XSCON_TYPE_BASE_REF       () { 2 }
+sub XSCON_TYPE_BASE_BOOL      () { 3 }
+sub XSCON_TYPE_BASE_INT       () { 4 }
+sub XSCON_TYPE_BASE_PZINT     () { 5 }
+sub XSCON_TYPE_BASE_NUM       () { 6 }
+sub XSCON_TYPE_BASE_PZNUM     () { 7 }
+sub XSCON_TYPE_BASE_STR       () { 8 }
+sub XSCON_TYPE_BASE_NESTR     () { 9 }
+sub XSCON_TYPE_BASE_CLASSNAME () { 10 }
+sub XSCON_TYPE_BASE_OBJECT    () { 12 }
+sub XSCON_TYPE_BASE_SCALARREF () { 13 }
+sub XSCON_TYPE_BASE_CODEREF   () { 14 }
+sub XSCON_TYPE_OTHER          () { 15 }
+sub XSCON_TYPE_ARRAYREF       () { 16 }
+sub XSCON_TYPE_HASHREF        () { 32 }
+
+sub _pp_default {
+    my ($object, $param) = @_;
+    my $default = $param->{default};
+    return $default->($object) if ref($default) eq 'CODE';
+    if (ref($default) eq 'SCALAR') {
+        my $builder = $$default;
+        return $object->$builder;
+    }
+    return $default;
+}
+
+sub _pp_clone {
+    require Clone;
+    return Clone::clone($_[0]);
+}
+
+sub _pp_check_and_coerce {
+    my ($param, $value) = @_;
+    return $value unless $param->{check};
+    return $value if $param->{check}->($value);
+    if ($param->{coercion}) {
+        my $coerced = $param->{coercion}->($value);
+        return $coerced if $param->{check}->($coerced);
+        die "Coercion result '$coerced' failed type constraint for '$param->{name}'";
+    }
+    die "Value '$value' failed type constraint for '$param->{name}'";
+}
+
+sub _pp_initialize {
+    my ($object, $args, $meta) = @_;
+    my %used;
+    for my $param (@{ $meta->{params} || [] }) {
+        my $name = $param->{name};
+        my @input_names;
+        push @input_names, $param->{init_arg} if defined $param->{init_arg};
+        push @input_names, @{ $param->{aliases} || [] };
+        my @found = grep { exists $args->{$_} } @input_names;
+        die "Superfluous alias used for attribute '$name': $found[1]"
+            if @found > 1;
+
+        my ($has_value, $from_args, $value);
+        if (@found) {
+            $used{$found[0]} = 1;
+            $value = $args->{ $found[0] };
+            $has_value = 1;
+            $from_args = 1;
+            $has_value = 0
+                if $param->{undef_tolerant} && !defined $value;
+        }
+        if (!$has_value && exists $param->{default}) {
+            $value = _pp_default($object, $param);
+            $has_value = 1;
+        }
+        if (!$has_value && $param->{required}) {
+            die defined($param->{init_arg}) && $param->{init_arg} ne $name
+                ? "Attribute '$name' (init arg '$param->{init_arg}') is required"
+                : "Attribute '$name' is required";
+        }
+        next unless $has_value;
+
+        $value = _pp_check_and_coerce($param, $value);
+        if ($from_args && $param->{clone_on_write}) {
+            $value = ref($param->{clone_on_write}) eq 'CODE'
+                ? $param->{clone_on_write}->($object, $name, $value)
+                : _pp_clone($value);
+            if ($param->{check} && !$param->{check}->($value)) {
+                die "Cloning result '$value' failed type constraint for '$name'";
+            }
+        }
+        if ($param->{slot_initializer}) {
+            $param->{slot_initializer}->($object, $value);
+        }
+        else {
+            $object->{$name} = $value;
+        }
+        if ($from_args && $param->{trigger}) {
+            my $mutex = "$name:trigger_mutex";
+            if (!exists $object->{$mutex}) {
+                local $object->{$mutex} = 1;
+                if (ref($param->{trigger}) eq 'CODE') {
+                    $param->{trigger}->($object, $value);
+                }
+                else {
+                    my $trigger = $param->{trigger};
+                    $object->$trigger($value);
+                }
+            }
+        }
+        if ($param->{spec}{weak_ref} && ref $object->{$name}) {
+            require Scalar::Util;
+            Scalar::Util::weaken($object->{$name});
+        }
+    }
+    return \%used;
+}
+
+sub _pp_buildall {
+    my ($object, $args) = @_;
+    return $object if delete($args->{__no_BUILD__});
+    for my $build (Class::XSConstructor::get_build_methods(ref $object)) {
+        $build->($object, $args);
+    }
+    return $object;
+}
+
+sub install_constructor {
+    my ($name, $buildall_name, $clear_name) = @_;
+    (my $defining_class = $name) =~ s/::[^:]+$//;
+    no strict 'refs';
+    *{$name} = sub {
+        my $invocant = shift;
+        my $class = ref($invocant) || $invocant;
+        my $meta = Class::XSConstructor::get_metadata($defining_class)
+            or die "No Class::XSConstructor metadata for $defining_class";
+        my @original = @_;
+        my $args = $meta->{buildargs}
+            ? $class->BUILDARGS(@_)
+            : (@_ == 1 && ref($_[0]) eq 'HASH' ? { %{ $_[0] } } : { @_ });
+        die 'BUILDARGS did not return a hashref' unless ref($args) eq 'HASH';
+        my $object;
+        if ($meta->{foreignbuildall}) {
+            # Moo/Moose-style parent constructors accept the normalized hashref
+            # and run their own BUILDALL.  Suppress that pass so the subclass's
+            # BUILDALL below invokes every BUILD method exactly once.
+            $args->{__no_BUILD__} = 1 unless exists $args->{__no_BUILD__};
+            $object = $meta->{foreignconstructor}->($class, $args);
+            delete $args->{__no_BUILD__};
+            bless $object, $class;
+        }
+        elsif ($meta->{foreignconstructor}) {
+            my @foreign = $meta->{foreignbuildargs}
+                ? $class->FOREIGNBUILDARGS(@original) : @original;
+            $object = $meta->{foreignconstructor}->($class, @foreign);
+            bless $object, $class;
+        }
+        else {
+            $object = bless {}, $class;
+        }
+        my $used = _pp_initialize($object, $args, $meta);
+        _pp_buildall($object, $args);
+        if ($meta->{strict_params}) {
+            my %allowed = map { $_ => 1 } @{ $meta->{allow} || [] };
+            my @unknown = grep {
+                !$used->{$_} && !$allowed{$_} && $_ ne '__no_BUILD__'
+            } keys %$args;
+            die "Found unknown attribute" . (@unknown == 1 ? '' : 's')
+                . " passed to the constructor: " . join(', ', sort @unknown)
+                if @unknown;
+        }
+        return $object;
+    };
+    *{$buildall_name} = sub { _pp_buildall($_[0], $_[1] || {}) };
+    *{$clear_name} = sub { $_[0] };
+    return;
+}
+
+sub install_destructor {
+    my ($name, $demolishall_name, $clear_name) = @_;
+    no strict 'refs';
+    *{$demolishall_name} = sub {
+        my $object = shift;
+        $_->($object, @_) for Class::XSConstructor::get_demolish_methods(ref $object);
+        return;
+    };
+    *{$name} = sub {
+        my $object = shift;
+        local $@;
+        eval { $object->$demolishall_name(0) };
+        return;
+    };
+    *{$clear_name} = sub { $_[0] };
+    return;
+}
+
+sub install_reader {
+    my ($name, $slot, $has_default, $default_flags, $default, $check_flags,
+        $check, $coercion, $cloner) = @_;
+    no strict 'refs';
+    *{$name} = sub {
+        my $object = shift;
+        if ($has_default && !exists $object->{$slot}) {
+            my $param = { name => $slot, default => $default,
+                check => $check, coercion => $coercion };
+            $object->{$slot} = _pp_check_and_coerce(
+                $param, _pp_default($object, $param),
+            );
+        }
+        my $value = $object->{$slot};
+        return !$cloner ? $value
+            : ref($cloner) eq 'CODE' ? $cloner->($object, $slot, $value)
+            : _pp_clone($value);
+    };
+    return;
+}
+
+sub install_delegation {
+    my ($name, $slot, $method, $curried, $is_accessor, $is_try) = @_;
+    no strict 'refs';
+    *{$name} = sub {
+        my $object = shift;
+        my $handler = $is_accessor ? $object->$slot : $object->{$slot};
+        require Scalar::Util;
+        return undef if $is_try && !Scalar::Util::blessed($handler);
+        die 'Expected blessed object to delegate to; got '
+            . (defined($handler) ? $handler : 'undef')
+            unless Scalar::Util::blessed($handler);
+        return $handler->$method(@{ $curried || [] }, @_);
+    };
+    return;
+}
+
+sub clone { _pp_clone($_[0]) }
+
+1;

--- a/src/test/resources/unit/app_cpan_failure_status.t
+++ b/src/test/resources/unit/app_cpan_failure_status.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
-use App::Cpan ();
+require './src/main/perl/lib/App/Cpan.pm';
 
 {
     no warnings 'redefine';
@@ -23,6 +23,14 @@ use App::Cpan ();
     ok(
         !App::Cpan::_cpanpm_status_indicates_failure(),
         'optional recommendation failure does not fail the command',
+    );
+
+    is(
+        App::Cpan::_cpanpm_status_indicates_failure(
+            'A/AU/AUTHOR/Optional.tar.gz',
+        ),
+        App::Cpan::A_MODULE_FAILED_TO_INSTALL(),
+        'failure of the explicitly requested distribution fails the command',
     );
 }
 

--- a/src/test/resources/unit/b_object_2svref.t
+++ b/src/test/resources/unit/b_object_2svref.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More tests => 5;
+use Scalar::Util qw(refaddr);
+use B ();
+
+my $target = [];
+my $string = "$target";
+like($string, qr/0x([0-9a-fA-F]+)/, 'reference string exposes an address');
+
+my ($hex) = $string =~ /0x([0-9a-fA-F]+)/;
+my $address = do { no warnings 'portable'; hex $hex };
+my $b_sv = bless \$address, 'B::SV';
+my $resolved = $b_sv->object_2svref;
+
+is(ref($resolved), 'ARRAY', 'raw B::SV address resolves to the referent');
+is(refaddr($resolved), refaddr($target), 'resolved reference preserves identity');
+
+my $object = bless {}, 'Local::TypeObject';
+my $object_address = refaddr($object);
+my $object_b_sv = bless \$object_address, 'B::SV';
+my $resolved_object = $object_b_sv->object_2svref;
+is(ref($resolved_object), 'Local::TypeObject',
+    'addresses obtained through refaddr resolve blessed hashes');
+is(refaddr($resolved_object), refaddr($object),
+    'refaddr-based B lookup preserves object identity');

--- a/src/test/resources/unit/regex_dynamic_deferred.t
+++ b/src/test/resources/unit/regex_dynamic_deferred.t
@@ -1,0 +1,7 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+
+our $nested;
+$nested = qr{ \( (?: [^()]+ | (??{ $nested }) )* \) }x;
+ok(ref($nested) eq 'Regexp', 'dynamic recursive regex can be constructed');

--- a/src/test/resources/unit/source_filter_begin_install.t
+++ b/src/test/resources/unit/source_filter_begin_install.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+use Filter::Util::Call ();
+
+our @record;
+push @record, 1;
+BEGIN {
+    Filter::Util::Call::filter_add(sub {
+        $_ = 'push @main::record, 2;';
+        Filter::Util::Call::filter_del();
+        return 1;
+    });
+}
+push @record, 3;
+
+is_deeply(\@record, [1, 2, 3], 'BEGIN-installed filter injects at the runtime boundary');

--- a/src/test/resources/unit/source_filter_delete_oneshot.t
+++ b/src/test/resources/unit/source_filter_delete_oneshot.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+{
+    package OneShotFilter;
+    use Filter::Util::Call;
+    sub import {
+        filter_add(sub {
+            $_ = '$main::one_shot_injected = 41;';
+            filter_del();
+            return 1;
+        });
+    }
+}
+BEGIN { $INC{'OneShotFilter.pm'} = __FILE__ }
+
+use OneShotFilter;
+$main::one_shot_following = 42;
+
+is($main::one_shot_injected, 41, 'one-shot filter injects one chunk');
+is($main::one_shot_following, 42, 'source after filter_del remains intact');


### PR DESCRIPTION
## Summary

- fix compile-time source-filter handling and provide pure-Perl XS overlays for the Marlin dependency chain
- recover references from B addresses, including Scalar::Util::refaddr identities across compiler/runtime threads
- prefer the targeted bundled Module::Build compatibility layer during jcpan runs and report explicit target failures correctly
- defer unsupported dynamic-regex callbacks until use and add a JDK Kerberos backend for Authen::Krb5::Simple

## Validation

- `make` — passed
- system Perl: 5 regression files, 13 tests — passed
- `Marlin::X::Clone` — 3 files, 8 tests passed
- `Class::XSConstructor` — 27 files, 134 tests passed
- `B::Hooks::AtRuntime::OnlyCoreDependencies` — 3 files, 12 tests passed
- `App::calendr` — target tests passed
- `Hades::Realm::OO` — 5 files, 40 tests passed
- `Authen::Simple::Kerberos` — functional target test passed

`Net::FS::Flickr` and `Sys::GetRandom::PP` were excluded because they also fail under system Perl. Neither system Perl nor PerlOnJava reached `App::upf` target tests within the bounded dependency-resolution run; PerlOnJava progressed through the same large Data::Sah/Perinci graph without exposing a compiler/runtime failure.

Generated with [Codex](https://openai.com/codex)
