### PR TITLE
Complete Perl threads phases 26-30

### DIFF
--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -797,6 +797,17 @@ not a reset, and representative package, regex, and execution state deliberately
 remains observable on the closed object. The complete fresh-runtime equivalence
 contract and state inventory live in `runtime-pooling-reset-contract.md`.
 
+The 2026-08-14 post-activation compatibility pass also resolved several direct
+language defects exposed by the broader thread test surface. Reference
+stringification and numeric coercion now use one Perl identity, typeglob pseudo
+constants survive stash reconstruction and symbolic CODE lookup, tied-array
+localization no longer corrupts sparse storage, `do NAME(...)` follows modern
+syntax while `do BLOCK` copies its result, and `.=` preserves Perl's undef-warning
+rules. Interpreter compiler-flag opcodes now activate lexical warning masks at
+the same boundaries as generated JVM code. These are general Perl compatibility
+fixes rather than changes to ithread ownership. The detailed investigation and
+validation history is retained in the corresponding commit messages.
+
 ### Implementation History
 
 Completed phase history is intentionally kept out of this living design
@@ -824,6 +835,11 @@ request history.
 5. Keep virtual threads experimental until native callback diagnostics and
    repeated benchmarks justify promotion. Keep runtime pooling disabled until
    the separate Phase 34 reset contract proves fresh-runtime equivalence.
+6. Continue the direct-language differential exposed by the thread gate. Preserve
+   the recovered `gv.t`, `assignwarn.t`, `local.t`, and `do.t` behavior while
+   addressing the remaining regex-parser/diagnostic gaps in `pat_advanced.t` and
+   `speed.t`; compare serialized same-base runs because their historical totals
+   vary under concurrent machine load.
 
 ### Open Questions
 

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -815,6 +815,19 @@ document. The implementation record, validation details, regressions, and
 review decisions can be recovered from the phase commit messages and pull-
 request history.
 
+The core differential runner now reserves an exclusive serial lane for the
+resource-sensitive `gv.t`, advanced-regex, regex-speed, GH7094 benchmark, and
+Abigail JAPH tests. These tests have internal watchdogs or timing assertions
+whose TAP totals changed when they competed with the normal parallel corpus;
+they retain stable original indices, a 600-second minimum outer deadline, and
+`gv.t` receives the upstream timeout factor. This is test scheduling policy,
+not a relaxation of expected Perl behavior. The parser also accepts Perl's
+adjacent quoted import form (`use overload'""' => ...`) without weakening the
+old-style `Foo'Bar` package separator. Identical serialized runs with
+`--jobs 8` and `--jobs 1` produced `gv.t` 255/304, both advanced-regex tests
+1376/1687, `speed.t` 26/59, GH7094 6/6, and Abigail 109/130; the latter gains
+three assertions from the adjacent-import parser fix.
+
 ### Next Steps
 
 1. Complete lexical `re 'debug'` as a direct regex feature with parser/CV
@@ -840,6 +853,10 @@ request history.
    addressing the remaining regex-parser/diagnostic gaps in `pat_advanced.t` and
    `speed.t`; compare serialized same-base runs because their historical totals
    vary under concurrent machine load.
+7. Keep resource-sensitive core tests in the runner's exclusive lane when new
+   full-corpus evidence proves load-dependent watchdog or timing behavior. Do
+   not classify high-water TAP fluctuations as semantic regressions without a
+   serialized same-commit reproduction.
 
 ### Open Questions
 

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -495,23 +495,24 @@ Acceptance: `pat_psycho_thr.t`, `pat_rt_report_thr.t`, `pat_thr.t`,
 `regexp_unicode_prop_thr.t`, and `speed_thr.t` reach their direct, unthreaded
 suite baselines without clone exceptions on either backend.
 
-### Phase 26 — Scalar lvalue and magic parity (in progress)
+### Phase 26 — Scalar lvalue and magic parity (completed 2026-08-13)
 
 Fix the ordinary `index`/`substr` lvalue, warning, overload, reference-
 stringification, and lexical-magic behavior exposed by their thread wrappers.
 Treat failures present in the direct suite as language/operator gaps rather than
 thread-cloning failures.
 
-Implemented substantial shared JVM/interpreter lvalue context, negative offset/length
+Implemented shared JVM/interpreter lvalue context, negative offset/length
 clipping, warning/die behavior, live substring extent modes, one-time overload
-stringification, and loose refalias lvalue handling.
+stringification, loose refalias lvalue handling, graph-safe constant and lazy-CV
+capture identity, and an interpreter `$#array` lvalue opcode. Lazy named
+subroutines now preserve both their declaration attributes and lvalue compile
+context.
 
-The `index` gate is complete on the JVM backend; interpreter lazy-capture
-identity and the remaining direct `substr` assertions are still under
-validation. Acceptance: direct and threaded forms both reach `index_thr.t` 415/415 and
-`substr_thr.t` 400/400 on JVM and interpreter backends.
+Acceptance is complete: direct and threaded forms reach `index_thr.t` 415/415
+and `substr_thr.t` 400/400 on JVM and interpreter backends.
 
-### Phase 27 — Regex runtime concurrency (implemented 2026-08-12) and debug state
+### Phase 27 — Regex runtime concurrency (runtime portion completed 2026-08-13)
 
 Runtime-local user-defined Unicode-property results are inherited at snapshot,
 and simultaneous sibling resolution is coordinated per property name without
@@ -523,13 +524,24 @@ environment flag written to `System.err`. Correct support requires lexical
 parser/CV metadata, both backends, and a runtime diagnostic sink before thread
 trace equivalence can be claimed.
 
-Acceptance: `user_prop_race_thr.t` reaches 3/3 within its bounded deadlines and
-`stclass_threads.t` reaches 6/6 with parent/child trace equivalence.
+The runtime-concurrency acceptance gate is complete: repeated bounded runs of
+`user_prop_race_thr.t` reach 3/3. Static CV validation deliberately defers
+user-defined properties because resolving them executes arbitrary Perl in the
+owning runtime. Lexical-debug acceptance remains open: `stclass_threads.t`
+cannot reach 6/6 until the direct `re 'debug'` feature exists.
 
 ### Phase 28 — General regex parity exposed by thread wrappers (in progress)
 
 The recursive regex backend now supports `(?(DEFINE)...)`, named subroutine
 calls in that container, and extended bracket classes within definitions.
+Literal `qr//` syntax is now validated when a thread entry CV is materialized,
+so malformed entry code fails in the parent and does not create a child.
+User-defined Unicode properties remain runtime-resolved.
+
+The direct/thread `regexp_qr_embed` differential has narrowed from 45
+assertions to one while both paths execute the same 2207 of 2210 planned
+assertions. The remaining one-assertion delta and three blocked direct tests are
+still Phase 28 language work; this phase is not marked complete.
 
 Implement the remaining parser/runtime features in `pat_re_eval`,
 `regexp_qr_embed`, Unicode-property, conditional, control-verb, and lookbehind
@@ -539,13 +551,13 @@ the `_thr.t` harness.
 Acceptance: every applicable regex `_thr.t` wrapper has zero assertion delta
 from its direct companion suite and neither path terminates early.
 
-### Phase 29 — Complete and truthful `threads` API (implemented tranche 2026-08-12)
+### Phase 29 — Complete and truthful `threads` API (completed tranche 2026-08-13)
 
 Implemented current-thread/class-form `detach`, targeted thread signals,
 `object`, persisted creation context and `wantarray`, exit/context options,
 main-thread state, terminal alias records, and truthful platform/virtual
-stack-size behavior. Shutdown warnings and process retention for detached
-platform threads remain explicit follow-up work.
+stack-size behavior. CLI shutdown now reports exact running/finished unjoined
+counts, while detached children remain silent and do not retain the process.
 
 Complete remaining compatibility details for
 `wantarray`, exit/context options, exit status, and the stack-size API where the
@@ -566,6 +578,11 @@ conservative undef/rejection policy.
 Continue to define descriptor and filehandle behavior for thread snapshots.
 Preserve the already-green default Test2 thread/IPC suites, then enable the
 applicable timeout and opt-in thread stress paths without changing Test2.
+
+The current compatibility gate also proves that CPAN configuration can safely
+scalarize list-valued regex operands. Test::Simple's bundled-module install
+path completes, and the full DBIx::Class suite passes with 325 files and 42,671
+tests under `--jobs 8`.
 
 Acceptance: `ipc_wait_timeout.t` observes Perl-compatible inherited-pipe
 behavior; default Test2 remains green; `AUTHOR_TESTING` and
@@ -789,27 +806,22 @@ request history.
 
 ### Next Steps
 
-1. Finish the remaining Phase 26 interpreter lazy-lexical identity case and the
-   thirteen direct `substr.t` assertions. Keep direct and `_thr.t` companions in
-   the same run; a wrapper may not be called fixed merely because it no longer
-   terminates early.
-2. Complete lexical `re 'debug'` as a direct regex feature with parser/CV
+1. Complete lexical `re 'debug'` as a direct regex feature with parser/CV
    metadata, JVM and interpreter propagation, and runtime-owned diagnostic
    routing. Then finish the remaining Phase 28 `pat_re_eval` and
    `regexp_qr_embed` direct-language gaps before asserting thread equivalence.
-3. Finish Phase 29 shutdown warnings and detached platform-thread process
-   lifecycle. Continue Phase 30 resource classification beyond explicitly
+2. Continue Phase 30 resource classification beyond explicitly
    inherited internal pipes. Preserve the green anchors:
    `class/threads.t`, `threads-dirh.t`, Storable threads, and default Test2 IPC.
-4. Keep the complete platform-thread matrix green on both backends and retain
+3. Keep the complete platform-thread matrix green on both backends and retain
    virtual-mode parity. The new `examples/threads/dynamic_map_reduce.pl`
    demonstrates a small shared scheduler, isolated worker-local hashes, and
    deterministic join aggregation; it deliberately makes no performance claim.
-5. Keep the DBIx::Class regression gate green with captured output from
+4. Keep the DBIx::Class regression gate green with captured output from
    `timeout 3600 ./jcpan --jobs 8 -t DBIx::Class`. Investigate every future
    failure against the merged baseline; partial distribution results are not
    sufficient for release.
-6. Keep virtual threads experimental until native callback diagnostics and
+5. Keep virtual threads experimental until native callback diagnostics and
    repeated benchmarks justify promotion. Keep runtime pooling disabled until
    the separate Phase 34 reset contract proves fresh-runtime equivalence.
 

--- a/dev/tools/perl_test_runner.pl
+++ b/dev/tools/perl_test_runner.pl
@@ -84,13 +84,25 @@ my %feature_patterns = (
 );
 
 my $total_files = @test_files;
+my @indexed_tests = map {
+    +{ test_file => $test_files[$_], test_index => $_ + 1 }
+} 0 .. $#test_files;
+my (@parallel_tests, @exclusive_tests);
+for my $test (@indexed_tests) {
+    push @{ requires_exclusive_slot($test->{test_file})
+        ? \@exclusive_tests : \@parallel_tests }, $test;
+}
 
 print "Found $total_files test files\n";
-print "Running tests with $jperl_path (${jobs} parallel jobs, ${timeout}s base timeout)\n";
+print "Running tests with $jperl_path (${jobs} parallel jobs, ${timeout}s base timeout; "
+    . scalar(@exclusive_tests) . " resource-sensitive tests run serially)\n";
 print "-" x 60, "\n";
 
-# Run tests in parallel
-run_tests_parallel(\@test_files, $test_dir);
+# Run the normal corpus in parallel, then give known CPU-heavy tests an
+# exclusive slot. Their upstream watchdogs and TAP totals are load-sensitive,
+# so merely increasing the outer timeout is not sufficient under contention.
+run_tests_parallel(\@parallel_tests, $test_dir, $jobs, $total_files);
+run_tests_parallel(\@exclusive_tests, $test_dir, 1, $total_files);
 
 print "-" x 60, "\n";
 print_summary();
@@ -114,8 +126,7 @@ sub find_test_files {
 }
 
 sub run_tests_parallel {
-    my ($test_files, $test_dir) = @_;
-    my $total_files = @$test_files;
+    my ($test_files, $test_dir, $max_jobs, $total_files) = @_;
     my $completed = 0;
     my %children;
     my @test_queue = @$test_files;
@@ -124,7 +135,7 @@ sub run_tests_parallel {
     local $SIG{CHLD} = 'DEFAULT';
 
     # Start initial batch of jobs
-    while (@test_queue && keys(%children) < $jobs) {
+    while (@test_queue && keys(%children) < $max_jobs) {
         start_test_job(\@test_queue, \%children, $total_files, $completed);
     }
 
@@ -141,7 +152,7 @@ sub run_tests_parallel {
                 $completed++;
 
                 # Start a new job if queue has items
-                if (@test_queue && keys(%children) < $jobs) {
+                if (@test_queue && keys(%children) < $max_jobs) {
                     start_test_job(\@test_queue, \%children, $total_files, $completed);
                 }
             } elsif ($res < 0) {
@@ -238,6 +249,16 @@ sub run_single_test {
     # Give those known outliers a stable minimum wall-clock allowance while
     # preserving any larger timeout requested by the caller.
     my $test_timeout = timeout_for_test($test_file);
+
+    # gv.t has its own watchdog and scales it through this upstream variable.
+    # Keep a caller's larger value, but do not let the internal deadline expire
+    # before the resource-aware runner's outer deadline.
+    local $ENV{PERL_TEST_TIMEOUT_FACTOR} = $ENV{PERL_TEST_TIMEOUT_FACTOR};
+    if ($test_file =~ m{(?:^|/)perl5_t/t/op/gv\.t$}
+            && (!defined($ENV{PERL_TEST_TIMEOUT_FACTOR})
+                || $ENV{PERL_TEST_TIMEOUT_FACTOR} < 2)) {
+        $ENV{PERL_TEST_TIMEOUT_FACTOR} = 2;
+    }
 
     # Temporarily disable fatal unimplemented errors
     # so we can run tests that mix implemented and unimplemented features
@@ -426,8 +447,24 @@ sub timeout_for_test {
     return 600 if $test_file =~ m{
           (?:^|/)perl5_t/t/lib/croak\.t$
         | (?:^|/)perl5_t/t/re/pat\.t$
+        | (?:^|/)perl5_t/t/op/gv\.t$
+        | (?:^|/)perl5_t/t/re/pat_advanced(?:_thr)?\.t$
+        | (?:^|/)perl5_t/t/re/speed\.t$
+        | (?:^|/)perl5_t/t/benchmark/gh7094-speed-up-keys-on-empty-hash\.t$
+        | (?:^|/)perl5_t/t/japh/abigail\.t$
     }x && $timeout < 600;
     return $timeout;
+}
+
+sub requires_exclusive_slot {
+    my ($test_file) = @_;
+    return $test_file =~ m{
+          (?:^|/)perl5_t/t/op/gv\.t$
+        | (?:^|/)perl5_t/t/re/pat_advanced(?:_thr)?\.t$
+        | (?:^|/)perl5_t/t/re/speed\.t$
+        | (?:^|/)perl5_t/t/benchmark/gh7094-speed-up-keys-on-empty-hash\.t$
+        | (?:^|/)perl5_t/t/japh/abigail\.t$
+    }x;
 }
 
 sub start_test_job {
@@ -435,8 +472,9 @@ sub start_test_job {
 
     return unless @$test_queue;
 
-    my $test_file = shift @$test_queue;
-    my $test_index = $total_files - @$test_queue;
+    my $test = shift @$test_queue;
+    my $test_file = $test->{test_file};
+    my $test_index = $test->{test_index};
 
     my $pid = fork();
     if (!defined $pid) {
@@ -732,7 +770,7 @@ Options:
   --jperl PATH     Path to jperl executable (default: ./jperl)
   --timeout SEC    Base timeout per test in seconds (default: 300; selected
                    subprocess-heavy tests have a documented minimum)
-  --jobs|-j NUM    Number of parallel jobs (default: 4)
+  --jobs|-j NUM    Number of parallel jobs (default: 5)
   --output FILE    Save detailed results to JSON file
   --help           Show this help message
 

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -864,10 +864,10 @@ storage as their parent counterparts. Values explicitly shared through
 |---|---|
 | Thread signals | `threads->kill` targets live attached children and resolves the handler inside the child runtime. Completed and detached targets are not signalable. |
 | Effective stack sizing | Platform-backed children honor supported `stack_size` create/import requests. Virtual threads reject nonzero stack sizes because their stacks are JVM-managed. |
-| Additional introspection | `threads->object` and creation-context `wantarray` are implemented; process-shutdown warning parity remains incomplete. |
+| Additional introspection | `threads->object` and creation-context `wantarray` are implemented. CLI shutdown reports running and finished unjoined threads; detached children are silent. |
 | Shared object classes | Blessed and tied values are rejected by the supported `share`/`shared_clone` tranche. |
 | Native resources and callbacks | Internal pipes have an inherited lease policy. Net::SSLeay handles are runtime-owned and stored callbacks bind their registering runtime. Ordinary files, sockets, and other native handles are still rejected rather than silently shared. |
-| Upstream suite coverage | Core compatibility remains partial: measured results include `op/threads.t` 29/30, `op/substr_thr.t` 368/400, and `re/stclass_threads.t` 2/6; `class/threads.t`, Storable's thread test, `threads-dirh.t`, and Test2's thread IPC acceptance test complete. The regex suite now executes its child and exposes unsupported thread-local `re 'debug'` trace parity. |
+| Upstream suite coverage | Core thread/lvalue coverage includes `op/index_thr.t` 415/415 and `op/substr_thr.t` 400/400 on both backends. `class/threads.t`, Storable's thread test, `threads-dirh.t`, Test2's default thread IPC acceptance, and `user_prop_race_thr.t` complete. General regex-language parity remains partial; `re/stclass_threads.t` is blocked by unsupported lexical `re 'debug'`. |
 | PSGI | Availability of ithreads does not make one captured PSGI application runtime concurrently callable. `Plack::Handler::Netty` advertises `psgi.multithread => \0`. |
 
 The complete design and measured validation record is in

--- a/src/main/java/org/perlonjava/app/cli/Main.java
+++ b/src/main/java/org/perlonjava/app/cli/Main.java
@@ -86,9 +86,20 @@ public class Main {
      * @param args Command-line arguments.
      */
     public static void main(String[] args) {
-        try (PerlRuntime.Binding runtimeBinding = new PerlRuntime().bind()) {
+        PerlRuntime runtime = new PerlRuntime();
+        installThreadExitDiagnostic(runtime);
+        try (PerlRuntime.Binding runtimeBinding = runtime.bind()) {
             run(args);
         }
+    }
+
+    private static void installThreadExitDiagnostic(PerlRuntime runtime) {
+        Thread hook = Thread.ofPlatform().name("perlonjava-thread-exit-diagnostic")
+                .unstarted(() -> {
+                    String warning = runtime.threadRegistry().activeThreadExitWarning();
+                    if (!warning.isEmpty()) System.err.print(warning);
+                });
+        Runtime.getRuntime().addShutdownHook(hook);
     }
 
     private static void run(String[] args) {

--- a/src/main/java/org/perlonjava/app/cli/Main.java
+++ b/src/main/java/org/perlonjava/app/cli/Main.java
@@ -1,6 +1,7 @@
 package org.perlonjava.app.cli;
 
 import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+import org.perlonjava.runtime.operators.WarnDie;
 import org.perlonjava.runtime.runtimetypes.ErrorMessageUtil;
 import org.perlonjava.runtime.runtimetypes.GlobalVariable;
 import org.perlonjava.runtime.runtimetypes.PerlExitException;
@@ -97,7 +98,19 @@ public class Main {
         Thread hook = Thread.ofPlatform().name("perlonjava-thread-exit-diagnostic")
                 .unstarted(() -> {
                     String warning = runtime.threadRegistry().activeThreadExitWarning();
-                    if (!warning.isEmpty()) System.err.print(warning);
+                    if (warning.isEmpty()) return;
+                    try (PerlRuntime.Binding ignored = runtime.bind()) {
+                        // This is a Perl warning, so honor $SIG{__WARN__}
+                        // exactly like an ordinary warn() call. Core tests use
+                        // an empty handler while deliberately leaving a child
+                        // unjoined; printing directly to Java stderr made that
+                        // otherwise successful subprocess fail comparison.
+                        WarnDie.warn(new RuntimeScalar(warning), new RuntimeScalar());
+                    } catch (RuntimeException unavailableRuntime) {
+                        // Shutdown must still report an attached child if the
+                        // runtime has already become unusable.
+                        System.err.print(warning);
+                    }
                 });
         Runtime.getRuntime().addShutdownHook(hook);
     }

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -1344,7 +1344,8 @@ public class BytecodeCompiler implements Visitor {
             if (!isLastStatement && !(stmt instanceof BinaryOperatorNode && ((BinaryOperatorNode) stmt).operator.equals("="))) {
                 stmtContext = RuntimeContextType.VOID;
             } else {
-                stmtContext = currentCallContext;
+                stmtContext = isLastStatement && node.getBooleanAnnotation("subroutineIsLvalue")
+                        ? RuntimeContextType.LVALUE : currentCallContext;
             }
 
             compileNode(stmt, stmtTarget, stmtContext);

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -1376,7 +1376,13 @@ public class BytecodeCompiler implements Visitor {
 
         // Save the last statement's result to the outer register BEFORE exiting scope
         if (outerResultReg >= 0 && lastResultReg >= 0) {
-            emitAliasWithTarget(outerResultReg, lastResultReg);
+            if (node.getBooleanAnnotation("blockIsDoBlock")) {
+                emit(Opcodes.COPY_DO_BLOCK_RESULT);
+                emitReg(outerResultReg);
+                emitReg(lastResultReg);
+            } else {
+                emitAliasWithTarget(outerResultReg, lastResultReg);
+            }
         } else if (outerResultReg >= 0 && lastResultReg < 0) {
             // Last statement didn't produce a result (e.g., for loop), initialize to undef
             emit(Opcodes.LOAD_UNDEF);
@@ -4960,6 +4966,11 @@ public class BytecodeCompiler implements Visitor {
                 RuntimeScalar codeRef = GlobalVariable.createPseudoConstantCodeRef(globalName);
                 if (codeRef == null) {
                     codeRef = GlobalVariable.getGlobalCodeRefForFreshLookup(globalName);
+                }
+                if (codeRef.type == RuntimeScalarType.CODE
+                        && codeRef.value instanceof RuntimeCode rc) {
+                    rc.isSymbolicReference = true;
+                    rc.referenceOriginFqn = globalName;
                 }
                 int rd = allocateOutputRegister();
                 int constIdx = addToConstantPool(codeRef);

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -1390,6 +1390,10 @@ public class BytecodeInterpreter {
                                 pc = InlineOpcodeHandler.executeSetArrayLastIndex(bytecode, pc, registers);
                             }
 
+                            case Opcodes.ARRAY_LAST_INDEX_LVALUE -> {
+                                pc = InlineOpcodeHandler.executeArrayLastIndexLvalue(bytecode, pc, registers);
+                            }
+
                             case Opcodes.CREATE_ARRAY -> {
                                 pc = InlineOpcodeHandler.executeCreateArray(bytecode, pc, registers);
                             }
@@ -1551,7 +1555,8 @@ public class BytecodeInterpreter {
                                 // Convert to scalar if called in scalar or lvalue context
                                 if (context == RuntimeContextType.SCALAR || context == RuntimeContextType.LVALUE) {
                                     RuntimeBase scalarResult = result.scalar();
-                                    registers[rd] = (isImmutableProxy(scalarResult)) ? ensureMutableScalar(scalarResult) : scalarResult;
+                                    registers[rd] = context == RuntimeContextType.SCALAR && isImmutableProxy(scalarResult)
+                                            ? ensureMutableScalar(scalarResult) : scalarResult;
                                 } else {
                                     registers[rd] = result;
                                 }
@@ -1672,7 +1677,8 @@ public class BytecodeInterpreter {
                                 // Convert to scalar if called in scalar or lvalue context
                                 if (context == RuntimeContextType.SCALAR || context == RuntimeContextType.LVALUE) {
                                     RuntimeBase scalarResult = result.scalar();
-                                    registers[rd] = (isImmutableProxy(scalarResult)) ? ensureMutableScalar(scalarResult) : scalarResult;
+                                    registers[rd] = context == RuntimeContextType.SCALAR && isImmutableProxy(scalarResult)
+                                            ? ensureMutableScalar(scalarResult) : scalarResult;
                                 } else {
                                     registers[rd] = result;
                                 }

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -1030,6 +1030,12 @@ public class BytecodeInterpreter {
                                 registers[rs].addToScalar(rdScalar);
                             }
 
+                            case Opcodes.COPY_DO_BLOCK_RESULT -> {
+                                int rd = bytecode[pc++];
+                                int rs = bytecode[pc++];
+                                registers[rd] = RuntimeCode.copyDoBlockListResult(registers[rs]);
+                            }
+
                             case Opcodes.ASSIGN_LEXICAL_SCALAR -> {
                                 int rd = bytecode[pc++];
                                 int rs = bytecode[pc++];
@@ -2526,20 +2532,17 @@ public class BytecodeInterpreter {
                                 int hintHashId = bytecode[pc++];
                                 int warningScopeId = bytecode[pc++];
                                 WarningBitsRegistry.setCallSiteBits(code.stringPool[warningBitsIdx]);
-                                // A lexical `no warnings` node carries a runtime
-                                // warningScopeId whose localized suppression is
-                                // unwound at block exit. Do not overwrite the
-                                // enclosing enabled bits with its temporary mask.
-                                if (warningScopeId == 0) {
-                                    WarningBitsRegistry.setRuntimeWarningBits(code.stringPool[warningBitsIdx]);
-                                }
                                 WarningBitsRegistry.setCallSiteHints(hints);
                                 HintHashRegistry.setCallSiteHintHashId(hintHashId);
                                 if (warningScopeId > 0) {
+                                    // Localize the scope before installing its
+                                    // warning mask so dynamic unwind can restore
+                                    // the enclosing interpreter mask.
                                     RuntimeScalar warningScope = GlobalRuntimeScalar.makeLocal(
                                             GlobalContext.WARNING_SCOPE);
                                     warningScope.set(new RuntimeScalar(warningScopeId));
                                 }
+                                WarningBitsRegistry.setRuntimeWarningBits(code.stringPool[warningBitsIdx]);
                             }
 
                             case Opcodes.SET_CALL_SITE_HINTS ->

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
@@ -433,6 +433,14 @@ public class CompileAssignment {
      * Handles all forms of assignment including my/our/local, scalars, arrays, hashes, and slices.
      */
     public static void compileAssignmentOperator(BytecodeCompiler bytecodeCompiler, BinaryOperatorNode node) {
+        if (node.left instanceof OperatorNode leftOperator
+                && leftOperator.operator.equals("substr")
+                && leftOperator.operand instanceof ListNode arguments
+                && arguments.elements.size() > 3) {
+            bytecodeCompiler.throwCompilerException(
+                    "Can't modify substr in scalar assignment");
+            return;
+        }
         // Determine the calling context for the RHS based on LHS type
         // Use LValueVisitor to properly determine context for all LHS patterns
         // including $array[index], $hash{key}, etc.

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -1073,7 +1073,7 @@ public class CompileOperator {
                             && !modifiers.contains("u")) {
                         modifiers += "u";
                     }
-                    RuntimeRegex.compile(literalPattern.value, modifiers);
+                    RuntimeRegex.validateLiteralSyntax(literalPattern.value, modifiers);
                 }
                 boolean hasOModifier = false;
                 Node flagsNode = operand.elements.get(1);

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -2,6 +2,7 @@ package org.perlonjava.backend.bytecode;
 
 import org.perlonjava.frontend.astnode.*;
 import org.perlonjava.runtime.operators.ScalarGlobOperator;
+import org.perlonjava.runtime.regex.RuntimeRegex;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import java.util.ArrayList;
@@ -357,7 +358,10 @@ public class CompileOperator {
         bc.emit(bc.isBytesEnabled() ? 1 : 0);
         int stringReg;
         if (args.elements.size() > 3) {
-            bc.compileNode(args.elements.get(3), -1, RuntimeContextType.SCALAR);
+            boolean nonDestructive = args.elements.get(2) instanceof StringNode flags
+                    && flags.value.contains("r");
+            bc.compileNode(args.elements.get(3), -1,
+                    nonDestructive ? RuntimeContextType.SCALAR : RuntimeContextType.LVALUE);
             stringReg = bc.lastResultReg;
         } else {
             stringReg = loadDefaultUnderscore(bc);
@@ -418,8 +422,13 @@ public class CompileOperator {
             return;
         }
         java.util.List<Integer> argRegs = new java.util.ArrayList<>();
-        for (Node arg : args.elements) {
-            arg.accept(bc);
+        for (int i = 0; i < args.elements.size(); i++) {
+            Node arg = args.elements.get(i);
+            int argContext = i == 0
+                    && (args.elements.size() > 3
+                    || bc.currentCallContext == RuntimeContextType.LVALUE)
+                    ? RuntimeContextType.LVALUE : RuntimeContextType.SCALAR;
+            bc.compileNode(arg, -1, argContext);
             argRegs.add(bc.lastResultReg);
         }
         int argsListReg = bc.allocateRegister();
@@ -1056,6 +1065,16 @@ public class CompileOperator {
                 if (operand.elements.size() < 2) {
                     bytecodeCompiler.throwCompilerException("quoteRegex requires pattern and flags");
                 }
+                if (operand.elements.get(0) instanceof StringNode literalPattern
+                        && operand.elements.get(1) instanceof StringNode literalFlags
+                        && !RuntimeRegex.requiresRuntimeUnicodePropertyResolution(literalPattern.value)) {
+                    String modifiers = literalFlags.value;
+                    if (unicodeStringsImplicitUFlag(bytecodeCompiler) != 0
+                            && !modifiers.contains("u")) {
+                        modifiers += "u";
+                    }
+                    RuntimeRegex.compile(literalPattern.value, modifiers);
+                }
                 boolean hasOModifier = false;
                 Node flagsNode = operand.elements.get(1);
                 if (flagsNode instanceof StringNode) {
@@ -1520,6 +1539,12 @@ public class CompileOperator {
             if (bc.isStrictRefsEnabled()) { bc.emitWithToken(Opcodes.DEREF_ARRAY, node.getIndex()); bc.emitReg(arrayReg); bc.emitReg(refReg); }
             else { int pkgIdx = bc.addToStringPool(bc.getCurrentPackage()); bc.emitWithToken(Opcodes.DEREF_ARRAY_NONSTRICT, node.getIndex()); bc.emitReg(arrayReg); bc.emitReg(refReg); bc.emit(pkgIdx); }
         } else bc.throwCompilerException("$# requires array variable");
+        if (bc.currentCallContext == RuntimeContextType.LVALUE) {
+            int rd = bc.allocateOutputRegister();
+            bc.emit(Opcodes.ARRAY_LAST_INDEX_LVALUE); bc.emitReg(rd); bc.emitReg(arrayReg);
+            bc.lastResultReg = rd;
+            return;
+        }
         int sizeReg = bc.allocateRegister(); bc.emit(Opcodes.ARRAY_SIZE); bc.emitReg(sizeReg); bc.emitReg(arrayReg);
         int oneReg = bc.allocateRegister(); bc.emit(Opcodes.LOAD_INT); bc.emitReg(oneReg); bc.emitInt(1);
         int rd = bc.allocateOutputRegister(); bc.emit(Opcodes.SUB_SCALAR); bc.emitReg(rd); bc.emitReg(sizeReg); bc.emitReg(oneReg);

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -963,6 +963,11 @@ public class Disassemble {
                         arrayReg = interpretedCode.bytecode[pc++];
                         sb.append("ARRAY_SIZE r").append(rd).append(" = size(r").append(arrayReg).append(")\n");
                         break;
+                    case Opcodes.ARRAY_LAST_INDEX_LVALUE:
+                        rd = interpretedCode.bytecode[pc++];
+                        arrayReg = interpretedCode.bytecode[pc++];
+                        sb.append("ARRAY_LAST_INDEX_LVALUE r").append(rd).append(" = $#r").append(arrayReg).append("\n");
+                        break;
                     case Opcodes.CREATE_ARRAY:
                         rd = interpretedCode.bytecode[pc++];
                         int listSourceReg = interpretedCode.bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -1207,6 +1207,12 @@ public class Disassemble {
                         rs = interpretedCode.bytecode[pc++];
                         sb.append("SET_SCALAR r").append(rd).append(".set(r").append(rs).append(")\n");
                         break;
+                    case Opcodes.COPY_DO_BLOCK_RESULT:
+                        rd = interpretedCode.bytecode[pc++];
+                        rs = interpretedCode.bytecode[pc++];
+                        sb.append("COPY_DO_BLOCK_RESULT r").append(rd)
+                                .append(" = copy_do(r").append(rs).append(")\n");
+                        break;
                     case Opcodes.NOT:
                         rd = interpretedCode.bytecode[pc++];
                         rs = interpretedCode.bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
@@ -667,6 +667,17 @@ public class InlineOpcodeHandler {
         return pc;
     }
 
+    /**
+     * Return the mutable array-last-index cell used by lvalue expressions.
+     * Format: ARRAY_LAST_INDEX_LVALUE rd arrayReg
+     */
+    public static int executeArrayLastIndexLvalue(int[] bytecode, int pc, RuntimeBase[] registers) {
+        int rd = bytecode[pc++];
+        int arrayReg = bytecode[pc++];
+        registers[rd] = RuntimeArray.indexLastElem((RuntimeArray) registers[arrayReg]);
+        return pc;
+    }
+
 
     /**
      * Create array reference from list: rd = new RuntimeArray(rs_list).createReference()

--- a/src/main/java/org/perlonjava/backend/bytecode/OpcodeHandlerExtended.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/OpcodeHandlerExtended.java
@@ -918,15 +918,17 @@ public class OpcodeHandlerExtended {
         boolean bytesMode = bytecode[pc++] != 0;
 
         if (ctx == RuntimeContextType.RUNTIME) ctx = ((RuntimeScalar) registers[2]).getInt();
+        RuntimeScalar regex = registers[regexReg].scalar();
+        RuntimeScalar string = registers[stringReg].scalar();
         if (bytesMode) {
             registers[rd] = RuntimeRegex.matchRegexBytes(
-                    (RuntimeScalar) registers[regexReg],
-                    (RuntimeScalar) registers[stringReg],
+                    regex,
+                    string,
                     ctx);
         } else {
             registers[rd] = RuntimeRegex.matchRegex(
-                    (RuntimeScalar) registers[regexReg],
-                    (RuntimeScalar) registers[stringReg],
+                    regex,
+                    string,
                     ctx);
         }
         return pc;

--- a/src/main/java/org/perlonjava/backend/bytecode/OpcodeHandlerExtended.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/OpcodeHandlerExtended.java
@@ -338,7 +338,7 @@ public class OpcodeHandlerExtended {
         // (both operands were non-UTF-8). When concat produces STRING (at least
         // one operand was UTF-8), preserve the UTF-8 flag per Perl semantics.
         boolean wasByteString = (target.type == RuntimeScalarType.BYTE_STRING);
-        RuntimeScalar result = StringOperators.stringConcat(
+        RuntimeScalar result = StringOperators.stringConcatAssign(
                 target,
                 (RuntimeScalar) registers[rs]
         );

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -2458,6 +2458,9 @@ public class Opcodes {
     /** Refalias an lvalue proxy to a scalar reference. Format: ALIAS_LVALUE_REFERENCE targetReg refReg. */
     public static final short ALIAS_LVALUE_REFERENCE = 517;
 
+    /** Return the mutable {@code $#array} cell. Format: ARRAY_LAST_INDEX_LVALUE rd arrayReg. */
+    public static final short ARRAY_LAST_INDEX_LVALUE = 518;
+
     private Opcodes() {
     } // Utility class - no instantiation
 }

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -2458,6 +2458,9 @@ public class Opcodes {
     /** Refalias an lvalue proxy to a scalar reference. Format: ALIAS_LVALUE_REFERENCE targetReg refReg. */
     public static final short ALIAS_LVALUE_REFERENCE = 517;
 
+    /** Copy a do-block scalar/list result so loose lvalues do not escape. Format: rd, rs. */
+    public static final short COPY_DO_BLOCK_RESULT = 519;
+
     /** Return the mutable {@code $#array} cell. Format: ARRAY_LAST_INDEX_LVALUE rd arrayReg. */
     public static final short ARRAY_LAST_INDEX_LVALUE = 518;
 

--- a/src/main/java/org/perlonjava/backend/jvm/EmitBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitBinaryOperator.java
@@ -399,12 +399,21 @@ public class EmitBinaryOperator {
                 baseOpHandler = OperatorHandler.get(baseOperator);
             }
             if (baseOpHandler != null) {
-                mv.visitMethodInsn(
-                        baseOpHandler.methodType(),
-                        baseOpHandler.className(),
-                        baseOpHandler.methodName(),
-                        baseOpHandler.descriptor(),
-                        false);
+                if (node.operator.equals(".=")) {
+                    mv.visitMethodInsn(
+                            Opcodes.INVOKESTATIC,
+                            "org/perlonjava/runtime/operators/StringOperators",
+                            "stringConcatAssign",
+                            "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;",
+                            false);
+                } else {
+                    mv.visitMethodInsn(
+                            baseOpHandler.methodType(),
+                            baseOpHandler.className(),
+                            baseOpHandler.methodName(),
+                            baseOpHandler.descriptor(),
+                            false);
+                }
             } else {
                 throw new RuntimeException("No operator handler found for base operator: " + baseOperator);
             }

--- a/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
@@ -439,6 +439,22 @@ public class EmitBlock {
                     false);
         }
 
+        if (node.getBooleanAnnotation("blockIsDoBlock")) {
+            if (emitterVisitor.ctx.contextType == RuntimeContextType.SCALAR) {
+                mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                        "org/perlonjava/runtime/runtimetypes/RuntimeCode",
+                        "copyDoBlockResult",
+                        "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;",
+                        false);
+            } else if (emitterVisitor.ctx.contextType == RuntimeContextType.LIST) {
+                mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                        "org/perlonjava/runtime/runtimetypes/RuntimeCode",
+                        "copyDoBlockListResult",
+                        "(Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;",
+                        false);
+            }
+        }
+
         Local.localTeardown(localRecord, mv);
 
         if (regexStateLocal >= 0) {

--- a/src/main/java/org/perlonjava/backend/jvm/EmitRegex.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitRegex.java
@@ -4,6 +4,7 @@ import org.objectweb.asm.Opcodes;
 import org.perlonjava.frontend.analysis.EmitterVisitor;
 import org.perlonjava.frontend.astnode.*;
 import org.perlonjava.runtime.perlmodule.Strict;
+import org.perlonjava.runtime.regex.RuntimeRegex;
 import org.perlonjava.runtime.runtimetypes.PerlCompilerException;
 import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
 
@@ -274,6 +275,7 @@ public class EmitRegex {
         ListNode operand = (node.operand instanceof ListNode) 
             ? (ListNode) node.operand 
             : ListNode.makeList(node.operand);
+        validateLiteralRegex(emitterVisitor, operand);
         EmitterVisitor scalarVisitor = emitterVisitor.with(RuntimeContextType.SCALAR);
 
         // Process pattern and flags
@@ -290,6 +292,21 @@ public class EmitRegex {
         if (emitterVisitor.ctx.contextType == RuntimeContextType.VOID) {
             emitterVisitor.ctx.mv.visitInsn(Opcodes.POP);
         }
+    }
+
+    /** Validate non-interpolated qr// at CV compilation, as Perl does. */
+    private static void validateLiteralRegex(EmitterVisitor emitterVisitor, ListNode operand) {
+        if (operand.elements.size() < 2
+                || !(operand.elements.get(0) instanceof StringNode pattern)
+                || !(operand.elements.get(1) instanceof StringNode flags)
+                || RuntimeRegex.requiresRuntimeUnicodePropertyResolution(pattern.value)) {
+            return;
+        }
+        String modifiers = flags.value;
+        if (unicodeStringsEnabled(emitterVisitor) && !modifiers.contains("u")) {
+            modifiers += "u";
+        }
+        RuntimeRegex.compile(pattern.value, modifiers);
     }
 
     /**

--- a/src/main/java/org/perlonjava/backend/jvm/EmitRegex.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitRegex.java
@@ -306,7 +306,7 @@ public class EmitRegex {
         if (unicodeStringsEnabled(emitterVisitor) && !modifiers.contains("u")) {
             modifiers += "u";
         }
-        RuntimeRegex.compile(pattern.value, modifiers);
+        RuntimeRegex.validateLiteralSyntax(pattern.value, modifiers);
     }
 
     /**

--- a/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
@@ -774,6 +774,14 @@ public class EmitVariable {
     static void handleAssignOperator(EmitterVisitor emitterVisitor, BinaryOperatorNode node) {
         EmitterContext ctx = emitterVisitor.ctx;
 
+        if (node.left instanceof OperatorNode leftOperator
+                && leftOperator.operator.equals("substr")
+                && leftOperator.operand instanceof ListNode arguments
+                && arguments.elements.size() > 3) {
+            throw new PerlCompilerException(node.tokenIndex,
+                    "Can't modify substr in scalar assignment", ctx.errorUtil);
+        }
+
         if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("SET " + node);
         MethodVisitor mv = ctx.mv;
         // Determine the assign type based on the left side.

--- a/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
@@ -595,6 +595,22 @@ public class IdentifierParser {
      * @return The parsed subroutine identifier as a String, or null if there is no valid identifier.
      */
     public static String parseSubroutineIdentifier(Parser parser) {
+        return parseSubroutineIdentifier(parser, false);
+    }
+
+    /**
+     * Parses a subroutine identifier, optionally leaving a trailing quote for
+     * the caller to interpret as the start of an adjacent quoted argument.
+     * Perl permits declarations such as {@code use overload'""' => ...}, while
+     * the same quote remains an old-style package separator in names such as
+     * {@code Foo'Bar}.
+     *
+     * @param parser The parser object containing the tokens and current parsing state.
+     * @param allowTrailingQuoteDelimiter whether a quote not followed by an
+     *                                    identifier may delimit the identifier
+     * @return The parsed subroutine identifier as a String, or null if there is no valid identifier.
+     */
+    public static String parseSubroutineIdentifier(Parser parser, boolean allowTrailingQuoteDelimiter) {
         // Skip any leading whitespace to find the start of the identifier
         parser.tokenIndex = Whitespace.skipWhitespace(parser, parser.tokenIndex, parser.tokens);
         StringBuilder variableName = new StringBuilder();
@@ -690,6 +706,11 @@ public class IdentifierParser {
                         token = parser.tokens.get(parser.tokenIndex);
                         nextToken = parser.tokens.get(parser.tokenIndex + 1);
                         continue;
+                    } else if (allowTrailingQuoteDelimiter) {
+                        // The caller owns the adjacent quote as the beginning
+                        // of a quoted argument (for example overload'""').
+                        parser.tokenIndex++;
+                        return variableName.toString();
                     } else {
                         // Bad name after '
                         parser.throwCleanError("Bad name after " + variableName + "'");

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -53,6 +53,18 @@ public class OperatorParser {
             block.setAnnotation("blockIsDoBlock", true);
             return block;
         }
+        // Since Perl 5.42, `do NAME(...)` is a syntax error rather than an
+        // ambiguous do-file expression. CORE() retains its historical special
+        // case and `do NAME` without parentheses is still parsed as do-file.
+        if (token.type == IDENTIFIER && !token.text.equals("CORE")) {
+            int nextIndex = Whitespace.skipWhitespace(
+                    parser, parser.tokenIndex + 1, parser.tokens);
+            if (nextIndex < parser.tokens.size()
+                    && parser.tokens.get(nextIndex).type == OPERATOR
+                    && parser.tokens.get(nextIndex).text.equals("(")) {
+                parser.throwError("syntax error");
+            }
+        }
         // `do` file
         Node operand = ListParser.parseZeroOrOneList(parser, 1);
         return new OperatorNode("doFile", operand, parser.tokenIndex);

--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -739,7 +739,7 @@ public class StatementParser {
                 throw new PerlCompilerException(parser.tokenIndex, "syntax error", parser.ctx.errorUtil);
             }
             if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("use module: " + token);
-            packageName = IdentifierParser.parseSubroutineIdentifier(parser);
+            packageName = IdentifierParser.parseSubroutineIdentifier(parser, true);
             if (packageName == null) {
                 throw new PerlCompilerException(parser.tokenIndex, "syntax error", parser.ctx.errorUtil);
             }

--- a/src/main/java/org/perlonjava/runtime/operators/Operator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Operator.java
@@ -437,11 +437,12 @@ public class Operator {
             // Example: substr("a", -2, 2) -> offset=-1, adjustedLen=1, returns "a" (no warning)
             if (offset < 0) {
                 // Adjust length by the overshoot (negative offset value)
-                int adjustedLength = hasExplicitLength && length < 0
-                        ? strLength + length : length + offset;
+                int adjustedLength = !hasExplicitLength
+                        ? strLength
+                        : length < 0 ? strLength + length : length + offset;
                 if (adjustedLength < 0) {
                     // Adjusted length is negative - warn and return undef
-                    if (warnEnabled && ctx != RuntimeContextType.LVALUE) {
+                    if (warnEnabled && ctx != RuntimeContextType.LVALUE && !hasReplacement) {
                         WarnDie.warn(new RuntimeScalar("substr outside of string"),
                                 RuntimeScalarCache.scalarEmptyString);
                     }
@@ -471,7 +472,7 @@ public class Operator {
 
         // Only warn/error for positive offsets that exceed string length
         if (offset > strLength) {
-            if (warnEnabled && ctx != RuntimeContextType.LVALUE) {
+            if (warnEnabled && ctx != RuntimeContextType.LVALUE && !hasReplacement) {
                 WarnDie.warn(new RuntimeScalar("substr outside of string"),
                         RuntimeScalarCache.scalarEmptyString);
             }

--- a/src/main/java/org/perlonjava/runtime/operators/StringOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/StringOperators.java
@@ -508,6 +508,21 @@ public class StringOperators {
     }
 
     public static RuntimeScalar stringConcat(RuntimeScalar runtimeScalar, RuntimeScalar b) {
+        return stringConcat(runtimeScalar, b, true);
+    }
+
+    /**
+     * Implements {@code .=}. Perl treats an undefined left operand as the empty
+     * string without issuing the uninitialized warning that ordinary {@code .}
+     * emits. Keep this as a distinct entry point so eval-time warning changes do
+     * not turn concat-assignment into warning-aware concatenation.
+     */
+    public static RuntimeScalar stringConcatAssign(RuntimeScalar runtimeScalar, RuntimeScalar b) {
+        return stringConcat(runtimeScalar, b, false);
+    }
+
+    private static RuntimeScalar stringConcat(RuntimeScalar runtimeScalar, RuntimeScalar b,
+                                              boolean warnUninitialized) {
         RuntimeScalar overloaded = tryStringConcatOverload(runtimeScalar, b);
         if (overloaded != null) return overloaded;
 
@@ -518,7 +533,8 @@ public class StringOperators {
         // enclosing call site was compiled, so retain a cheap undef-only
         // runtime guard here as well. WarnDie performs the lexical category
         // check and dispatches a localized __WARN__ handler when applicable.
-        if (!aResolved.getDefinedBoolean() || !bResolved.getDefinedBoolean()) {
+        if (warnUninitialized
+                && (!aResolved.getDefinedBoolean() || !bResolved.getDefinedBoolean())) {
             WarnDie.warnWithCategory(
                     new RuntimeScalar("Use of uninitialized value in concatenation (.)"),
                     RuntimeScalarCache.scalarEmptyString, "uninitialized");

--- a/src/main/java/org/perlonjava/runtime/operators/sprintf/SprintfValueFormatter.java
+++ b/src/main/java/org/perlonjava/runtime/operators/sprintf/SprintfValueFormatter.java
@@ -2,6 +2,9 @@ package org.perlonjava.runtime.operators.sprintf;
 
 import org.perlonjava.runtime.runtimetypes.PerlCompilerException;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalarCache;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalarType;
+import org.perlonjava.runtime.operators.WarnDie;
 
 /**
  * Main formatter for sprintf operations.
@@ -64,6 +67,18 @@ public class SprintfValueFormatter {
         }
         if (conversion == 'n') {
             throw new PerlCompilerException("%n specifier not supported");
+        }
+
+        // A bare typeglob is a string-like symbol, not a glob reference. Perl
+        // warns and converts it to numeric zero for every numeric sprintf
+        // conversion. Handling this once here also avoids duplicate warnings
+        // from the preliminary Inf/NaN check and the actual formatter.
+        if (value.type == RuntimeScalarType.GLOB) {
+            WarnDie.warnWithCategory(
+                    new RuntimeScalar("Argument \"" + value + "\" isn't numeric in sprintf"),
+                    RuntimeScalarCache.scalarEmptyString,
+                    "numeric");
+            value = RuntimeScalarCache.scalarZero;
         }
 
         // Check for special floating-point values for numeric conversions

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
@@ -75,6 +75,16 @@ public final class Threads extends PerlModuleBase {
             stub.put("state", new RuntimeScalar("detached"));
             return ReferenceOperators.bless(stub.createReference(), new RuntimeScalar(CLASS)).getList();
         }
+        // Perl compiles an anonymous thread entry in the parent. In
+        // particular, a malformed qr// inside that CODE must fail in the
+        // surrounding eval before an ithread exists. Deferring the entry CV
+        // until child execution lost $@ and created a large direct-vs-thread
+        // diagnostic delta in regexp_qr_embed_thr.t.
+        if (code.type == RuntimeScalarType.CODE
+                && code.value instanceof RuntimeCode runtimeCode
+                && runtimeCode.compilerSupplier != null) {
+            runtimeCode.compilerSupplier.get();
+        }
         RuntimeArray threadArgs = new RuntimeArray();
         for (int i = codeIndex + 1; i < args.size(); i++) threadArgs.push(args.get(i));
         PerlRuntime parent = PerlRuntime.current();

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -354,6 +354,29 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 .matcher(patternString).find();
     }
 
+    /**
+     * Validate literal syntax without executing user-property callbacks.
+     *
+     * <p>CV compilation must reject malformed literals, but it must not turn a
+     * valid Perl feature that this backend cannot yet execute into an early
+     * compile-time fatal. Runtime compilation retains the existing
+     * JPERL_UNIMPLEMENTED policy for those patterns.</p>
+     */
+    public static void validateLiteralSyntax(String patternString, String modifiers) {
+        try {
+            compileSynchronized(patternString, modifiers);
+        } catch (PerlJavaUnimplementedException unsupported) {
+            String message = unsupported.getMessage();
+            if (message != null && (message.contains("Unclosed character class")
+                    || message.contains("Unclosed group")
+                    || message.contains("Dangling meta character")
+                    || message.contains("Unmatched closing")
+                    || message.contains("Illegal repetition"))) {
+                throw new PerlCompilerException(message);
+            }
+        }
+    }
+
     private static synchronized RuntimeRegex compileSynchronized(
             String patternString, String modifiers) {
         // Debug logging

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -346,6 +346,14 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         return compileSynchronized(patternString, modifiers);
     }
 
+    /** User properties execute Perl code and therefore cannot be validated while compiling a CV. */
+    public static boolean requiresRuntimeUnicodePropertyResolution(String patternString) {
+        if (patternString == null) return false;
+        return java.util.regex.Pattern.compile(
+                "\\\\[pP]\\{\\^?\\s*(?:[^}]*::)?[Ii][sSnN][^}]+}")
+                .matcher(patternString).find();
+    }
+
     private static synchronized RuntimeRegex compileSynchronized(
             String patternString, String modifiers) {
         // Debug logging

--- a/src/main/java/org/perlonjava/runtime/regex/UnicodeResolver.java
+++ b/src/main/java/org/perlonjava/runtime/regex/UnicodeResolver.java
@@ -165,17 +165,21 @@ public class UnicodeResolver {
             // Handle property references
             if (line.startsWith("+")) {
                 // Add another property
-                String propName = line.substring(1).trim();
+                String propName = stripDefinitionComment(line.substring(1));
                 UnicodeSet propSet = resolvePropertyReferenceAsSet(propName, recursionSet, propertyName);
                 resultSet.addAll(propSet);
             } else if (line.startsWith("-") || line.startsWith("!")) {
                 // Remove a property
-                String propName = line.substring(1).trim();
-                UnicodeSet propSet = resolvePropertyReferenceAsSet(propName, recursionSet, propertyName);
-                resultSet.removeAll(propSet);
+                String propName = stripDefinitionComment(line.substring(1));
+                // A leading minus may subtract a literal code point/range,
+                // e.g. "-61" in a consonant property definition.
+                if (!(line.startsWith("-") && removeHexRange(resultSet, propName))) {
+                    UnicodeSet propSet = resolvePropertyReferenceAsSet(propName, recursionSet, propertyName);
+                    resultSet.removeAll(propSet);
+                }
             } else if (line.startsWith("&")) {
                 // Intersection with a property
-                String propName = line.substring(1).trim();
+                String propName = stripDefinitionComment(line.substring(1));
                 UnicodeSet propSet = resolvePropertyReferenceAsSet(propName, recursionSet, propertyName);
                 if (!hasIntersection) {
                     intersectionSet = propSet;
@@ -247,6 +251,30 @@ public class UnicodeResolver {
         }
 
         return unicodeSetToJavaPattern(resultSet);
+    }
+
+    private static String stripDefinitionComment(String propertyReference) {
+        int comment = propertyReference.indexOf('#');
+        return (comment >= 0 ? propertyReference.substring(0, comment) : propertyReference).trim();
+    }
+
+    private static boolean removeHexRange(UnicodeSet target, String definition) {
+        String[] endpoints = definition.split("\\t+|\\s+");
+        if (endpoints.length < 1 || endpoints.length > 2) return false;
+        for (String endpoint : endpoints) {
+            if (!endpoint.matches("[0-9A-Fa-f]+")) return false;
+        }
+        try {
+            long start = Long.parseLong(endpoints[0], 16);
+            long end = endpoints.length == 1 ? start : Long.parseLong(endpoints[1], 16);
+            if (start > end) return false;
+            if (start <= 0x10FFFF) {
+                target.remove((int) start, (int) Math.min(end, 0x10FFFF));
+            }
+            return true;
+        } catch (NumberFormatException invalidHex) {
+            return false;
+        }
     }
 
     /**
@@ -445,16 +473,31 @@ public class UnicodeResolver {
      */
     private static String tryUserDefinedProperty(
             String property, Set<String> recursionSet, boolean caseInsensitive) {
-        // Add to recursion set
-        Set<String> newRecursionSet = new HashSet<>(recursionSet);
-        newRecursionSet.add(property);
-
         // Build the full subroutine name
         String subName = property;
         if (!subName.contains("::")) {
             // Try in main package
             subName = "main::" + subName;
         }
+
+        // The runtime-family coordinator also keys properties by their fully
+        // qualified sub name. Keep recursion tracking in that same canonical
+        // namespace; otherwise InFoo -> main::InFoo can wait on its own active
+        // future instead of reporting recursive expansion.
+        if (recursionSet.contains(subName)) {
+            StringBuilder chain = new StringBuilder();
+            for (String recursiveProperty : recursionSet) {
+                if (chain.length() > 0) chain.append(" in expansion of ");
+                chain.append(recursiveProperty);
+            }
+            if (chain.length() > 0) chain.append(" in expansion of ");
+            chain.append(subName);
+            throw new IllegalArgumentException(
+                    "Infinite recursion in user-defined property \"" + subName
+                            + "\" in expansion of " + chain);
+        }
+        Set<String> newRecursionSet = new HashSet<>(recursionSet);
+        newRecursionSet.add(subName);
 
         // Check cache first — Perl only calls user-defined property subs once
         String cacheKey = userPropertyCacheKey(subName, caseInsensitive);
@@ -562,8 +605,14 @@ public class UnicodeResolver {
             String property = pattern.substring(slash + 3, end).trim();
             if (property.startsWith("^")) property = property.substring(1).trim();
             if (property.matches("^(.*::)?([Ii][sSNn]).+")) {
-                translateUnicodeProperty(property, marker == 'P', new HashSet<>(),
-                        caseInsensitive);
+                // Preloading is an optimization for callbacks that are already
+                // available. Perl permits qr// to contain a forward reference
+                // to a user property; RegexPreprocessor represents that with a
+                // placeholder and recompiles on first use. Calling the complete
+                // translator here would turn that intentional forward reference
+                // into an early "unsupported property" fatal before the
+                // placeholder path can run.
+                tryUserDefinedProperty(property, new HashSet<>(), caseInsensitive);
             }
             slash = end;
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeScalar.java
@@ -1,6 +1,7 @@
 package org.perlonjava.runtime.runtimetypes;
 
 import java.util.Stack;
+import org.perlonjava.runtime.WarningBitsRegistry;
 
 /**
  * A RuntimeScalar subclass for global variables that knows its fully qualified name.
@@ -75,7 +76,7 @@ public class GlobalRuntimeScalar extends RuntimeScalar {
             // is intentionally read-only and therefore is not suitable here.
             originalVariable.tiedStore(new RuntimeScalar());
             localizedStack.push(
-                    new SavedGlobalState(fullName, originalVariable, savedValue, null));
+                    new SavedGlobalState(fullName, originalVariable, savedValue, null, null));
             // Do NOT replace the slot — the tied scalar stays in place so
             // that the subsequent `= value` assignment dispatches STORE.
             return;
@@ -101,7 +102,10 @@ public class GlobalRuntimeScalar extends RuntimeScalar {
             newLocal = new GlobalRuntimeScalar(fullName);
         }
 
-        localizedStack.push(new SavedGlobalState(fullName, originalVariable, null, newLocal));
+        String savedRuntimeWarningBits = fullName.equals(GlobalContext.WARNING_SCOPE)
+                ? WarningBitsRegistry.getRuntimeWarningBits() : null;
+        localizedStack.push(new SavedGlobalState(
+                fullName, originalVariable, null, newLocal, savedRuntimeWarningBits));
 
         // Replace this variable in the global symbol table with the new one
         GlobalVariable.globalVariables.put(fullName, newLocal);
@@ -177,6 +181,10 @@ public class GlobalRuntimeScalar extends RuntimeScalar {
 
                 // Restore the original variable in the global symbol table
                 GlobalVariable.globalVariables.put(saved.fullName, saved.originalVariable);
+
+                if (saved.fullName.equals(GlobalContext.WARNING_SCOPE)) {
+                    WarningBitsRegistry.setRuntimeWarningBits(saved.savedRuntimeWarningBits);
+                }
 
                 // Also restore all glob aliases to the original shared variable
                 java.util.List<String> aliasGroup = GlobalVariable.getGlobAliasGroup(saved.fullName);
@@ -266,6 +274,7 @@ public class GlobalRuntimeScalar extends RuntimeScalar {
             String fullName,
             RuntimeScalar originalVariable,
             RuntimeScalar savedTiedValue,
-            RuntimeScalar localizedVariable) {
+            RuntimeScalar localizedVariable,
+            String savedRuntimeWarningBits) {
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadRegistry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlThreadRegistry.java
@@ -57,6 +57,22 @@ public final class PerlThreadRegistry {
         return threads.size();
     }
 
+    /** Format Perl's process-exit diagnostic for attached, unjoined children. */
+    public String activeThreadExitWarning() {
+        int running = 0;
+        int finished = 0;
+        for (PerlThreadControlBlock thread : threads.values()) {
+            if (thread.isDetached()) continue;
+            if (thread.isRunning()) running++;
+            else finished++;
+        }
+        if (running == 0 && finished == 0) return "";
+        return "Perl exited with active threads:\n"
+                + "\t" + running + " running and unjoined\n"
+                + "\t" + finished + " finished and unjoined\n"
+                + "\t0 running and detached\n";
+    }
+
     /**
      * Serialize only simultaneous definitions of the same user Unicode property.
      * Different property names remain independent, matching Perl's regex lock

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArray.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArray.java
@@ -715,7 +715,14 @@ public class RuntimeArray extends RuntimeBase implements RuntimeScalarReference,
                     yield scalarUndef;
                 }
                 if (index == elements.size() - 1) {
-                    yield pop(this);
+                    RuntimeScalar previous = pop(this);
+                    // Perl arrays do not retain trailing nonexistent slots after
+                    // deleting the last existing element. This matters for sparse
+                    // arrays and for restoring a localized high tied index.
+                    while (!elements.isEmpty() && elements.getLast() == null) {
+                        elements.removeLast();
+                    }
+                    yield previous;
                 }
                 RuntimeScalar previous = this.get(index);
                 this.elements.set(index, null);
@@ -821,6 +828,35 @@ public class RuntimeArray extends RuntimeBase implements RuntimeScalarReference,
 
     public RuntimeScalar deleteLocal(RuntimeScalar indexScalar) {
         int index = indexScalar.getInt();
+        if (type == TIED_ARRAY) {
+            if (index < 0 && !TieArray.negativeIndicesAllowed(this)) {
+                index = TieArray.tiedFetchSize(this).getInt() + index;
+            }
+            final RuntimeScalar tiedIndex = new RuntimeScalar(index);
+            final boolean tiedExisted = TieArray.tiedExists(this, tiedIndex).getBoolean();
+            final RuntimeScalar tiedSavedValue = tiedExisted
+                    ? new RuntimeScalar(TieArray.tiedFetch(this, tiedIndex)) : null;
+            final RuntimeScalar tiedReturnValue = tiedExisted
+                    ? new RuntimeScalar(tiedSavedValue) : new RuntimeScalar();
+            RuntimeArray self = this;
+
+            DynamicVariableManager.pushLocalVariable(new DynamicState() {
+                @Override
+                public void dynamicSaveState() {
+                    TieArray.tiedDelete(self, tiedIndex);
+                }
+
+                @Override
+                public void dynamicRestoreState() {
+                    if (tiedExisted) {
+                        TieArray.tiedStore(self, tiedIndex, tiedSavedValue);
+                    } else {
+                        TieArray.tiedDelete(self, tiedIndex);
+                    }
+                }
+            });
+            return tiedReturnValue;
+        }
         if (index < 0) {
             index = elements.size() + index;
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -730,6 +730,21 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         return code != null && code.attributes != null && code.attributes.contains("lvalue");
     }
 
+    private static void restoreLazyAttributes(RuntimeCode code, java.util.List<String> savedAttributes) {
+        if (savedAttributes == null || savedAttributes.isEmpty()) {
+            return;
+        }
+        if (code.attributes == null) {
+            code.attributes = new java.util.ArrayList<>(savedAttributes);
+            return;
+        }
+        for (String attribute : savedAttributes) {
+            if (!code.attributes.contains(attribute)) {
+                code.attributes.add(attribute);
+            }
+        }
+    }
+
     public static void requireLvalueCallable(RuntimeCode code, int callContext, String subroutineName) {
         if ((callContext != RuntimeContextType.LVALUE && callContext != RuntimeContextType.LVALUE_LIST)
                 || isLvalueCode(code)
@@ -1427,9 +1442,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     if (savedConstantValue != null && code.constantValue == null) {
                         code.constantValue = savedConstantValue;
                     }
-                    if (savedAttributes != null && code.attributes == null) {
-                        code.attributes = savedAttributes;
-                    }
+                    restoreLazyAttributes(code, savedAttributes);
                 }
 
                 if (!code.defined() && "CORE".equals(code.packageName) && code.subName != null) {
@@ -4327,9 +4340,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 if (savedConstantValue != null && code.constantValue == null) {
                     code.constantValue = savedConstantValue;
                 }
-                if (savedAttributes != null && code.attributes == null) {
-                    code.attributes = savedAttributes;
-                }
+                restoreLazyAttributes(code, savedAttributes);
             }
 
             // Check if it's an unfilled forward declaration (not defined)
@@ -4717,9 +4728,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 if (savedConstantValue != null && code.constantValue == null) {
                     code.constantValue = savedConstantValue;
                 }
-                if (savedAttributes != null && code.attributes == null) {
-                    code.attributes = savedAttributes;
-                }
+                restoreLazyAttributes(code, savedAttributes);
             }
 
             // Lazily generate CORE:: subroutine wrappers on first call
@@ -4984,9 +4993,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 if (savedConstantValue != null && code.constantValue == null) {
                     code.constantValue = savedConstantValue;
                 }
-                if (savedAttributes != null && code.attributes == null) {
-                    code.attributes = savedAttributes;
-                }
+                restoreLazyAttributes(code, savedAttributes);
             }
 
             // Lazily generate CORE:: subroutine wrappers on first call

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -5393,6 +5393,31 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         return result;
     }
 
+    /**
+     * A do-block returns a mortal copy of its last scalar expression, not the
+     * underlying lvalue. In particular, a deleted hash element must stop
+     * aliasing its former storage when it crosses the do-block boundary.
+     */
+    public static RuntimeScalar copyDoBlockResult(RuntimeScalar result) {
+        return new RuntimeScalar(result);
+    }
+
+    /** Copy a do-block result used in list context without collapsing the list. */
+    public static RuntimeBase copyDoBlockListResult(RuntimeBase result) {
+        if (result instanceof RuntimeScalar scalar) {
+            return new RuntimeScalar(scalar);
+        }
+        if (result instanceof RuntimeList list) {
+            RuntimeList copy = new RuntimeList();
+            for (RuntimeBase element : list.elements) {
+                copy.elements.add(element instanceof RuntimeScalar scalar
+                        ? new RuntimeScalar(scalar) : element);
+            }
+            return copy;
+        }
+        return result;
+    }
+
     public boolean defined() {
         // Built-in operators are always considered "defined"
         if (this.isBuiltin) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
@@ -625,8 +625,10 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
                 }
                 return value;
             case UNDEF:
-                // TODO: Add "Undefined value assigned to typeglob" warning with proper guards
-                // to avoid false positives during module loading
+                WarnDie.warnWithCategory(
+                        new RuntimeScalar("Undefined value assigned to typeglob"),
+                        RuntimeScalarCache.scalarEmptyString,
+                        "misc");
                 return value;
             case INTEGER:
             case DOUBLE:

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
@@ -79,8 +79,12 @@ public class RuntimeGraphCloner {
         Object existing = clones.get(value);
         if (existing != null) return (RuntimeBase) existing;
 
-        if (value instanceof RuntimeScalarReadOnly) {
-            // Constants are immutable and may safely retain process identity.
+        if (value instanceof RuntimeScalarReadOnly scalar
+                && !RuntimeScalarType.isReference(scalar)) {
+            // Plain immutable values may safely retain process identity. A
+            // readonly reference is only an immutable reference *slot*; its
+            // referent is still part of the ithread snapshot and must pass
+            // through this cloner's identity map.
             clones.put(value, value);
             return value;
         }
@@ -100,6 +104,17 @@ public class RuntimeGraphCloner {
         RuntimeCode target;
         if (source instanceof InterpretedCode interpreted) {
             target = cloneInterpretedCode(interpreted);
+        } else if (source.subroutine instanceof InterpretedCode interpreted) {
+            // Lazy named subs keep their stable RuntimeCode placeholder and
+            // install the materialized interpreter body into subroutine/codeObject.
+            // Cloning the wrapper as an opaque Java PerlSubroutine would retain
+            // the parent's capturedVars array even though the placeholder's
+            // metadata had been cloned correctly.
+            target = new RuntimeCode((PerlSubroutine) null, source.prototype);
+            clones.put(source, target);
+            InterpretedCode clonedBody = cloneInterpretedCode(interpreted);
+            target.subroutine = clonedBody;
+            target.codeObject = clonedBody;
         } else {
             target = new RuntimeCode((PerlSubroutine) null, source.prototype);
             clones.put(source, target);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -3088,7 +3088,8 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             default -> {
                 // Symbolic reference: treat the scalar's string value as a subroutine name
                 String varName = NameNormalizer.normalizeVariableName(this.toString(), packageName);
-                yield GlobalVariable.getGlobalCodeRef(varName);
+                RuntimeScalar pseudoCode = GlobalVariable.createPseudoConstantCodeRef(varName);
+                yield pseudoCode != null ? pseudoCode : GlobalVariable.getGlobalCodeRef(varName);
             }
         };
     }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStashEntry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStashEntry.java
@@ -22,6 +22,12 @@ public class RuntimeStashEntry extends RuntimeGlob {
         super(globName);
         if (!isDefined) {
             type = RuntimeScalarType.UNDEF;
+        } else if (GlobalVariable.hasGlobalPseudoConstant(globName)) {
+            // The stash hash exposes a scalar-reference proxy constant as the
+            // assigned reference even though globDeref() still provides the
+            // symbol's complete typeglob.
+            type = REFERENCE;
+            value = GlobalVariable.getGlobalVariable(globName);
         }
         // System.out.println("Stash Entry create: " + globName + " " + isDefined);
     }
@@ -88,6 +94,20 @@ public class RuntimeStashEntry extends RuntimeGlob {
                 && sourceEntry.globName.endsWith("::")) {
             return super.set((RuntimeGlob) sourceEntry);
         }
+        // A symbolic \&name can be compiled before an earlier runtime stash
+        // assignment has installed name's pseudo-constant. Resolve that
+        // placeholder at the typeglob assignment point, after the preceding
+        // statement has run but before clearing the destination metadata.
+        if (value.type == CODE
+                && value.value instanceof RuntimeCode code
+                && !code.defined()
+                && code.referenceOriginFqn != null) {
+            RuntimeScalar pseudoCode = GlobalVariable.createPseudoConstantCodeRef(
+                    code.referenceOriginFqn);
+            if (pseudoCode != null) {
+                value = pseudoCode;
+            }
+        }
         type = RuntimeScalarType.GLOB;
         GlobalVariable.clearGlobalPseudoConstant(this.globName);
         if (value.type == READONLY_SCALAR) {
@@ -116,6 +136,10 @@ public class RuntimeStashEntry extends RuntimeGlob {
                     // lookup without installing an actual CODE slot.
                     super.set(value);
                     GlobalVariable.setGlobalPseudoConstant(this.globName, targetScalar);
+                    // The hash-view value remains the assigned scalar reference;
+                    // globDeref() still exposes this symbol's live typeglob slots.
+                    this.type = REFERENCE;
+                    this.value = targetScalar;
                     notifyCodeSlotChanged();
                 }
             }
@@ -222,8 +246,8 @@ public class RuntimeStashEntry extends RuntimeGlob {
                 }
                 return value;
             case UNDEF:
-                // TODO: Add "Undefined value assigned to typeglob" warning with proper guards
-                // to avoid false positives during module loading
+                // Direct `$stash{name} = undef` does not carry the warning
+                // emitted by the distinct `*name = undef` typeglob operation.
                 return value;
             case INTEGER:
             case DOUBLE:

--- a/src/test/java/org/perlonjava/runtime/runtimetypes/PerlThreadShutdownWarningTest.java
+++ b/src/test/java/org/perlonjava/runtime/runtimetypes/PerlThreadShutdownWarningTest.java
@@ -1,0 +1,50 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("unit")
+class PerlThreadShutdownWarningTest {
+
+    @Test
+    void reportsOnlyAttachedUnjoinedChildrenAtProcessExit() throws Exception {
+        PerlRuntime runtime = new PerlRuntime();
+        CountDownLatch entered = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        PerlThreadControlBlock child;
+        try (PerlRuntime.Binding ignored = runtime.bind()) {
+            child = PerlThreadControlBlock.create(runtime, childRuntime -> {
+                entered.countDown();
+                if (!release.await(5, TimeUnit.SECONDS)) {
+                    throw new AssertionError("child release timed out");
+                }
+                return new RuntimeScalar(1);
+            }).start();
+        }
+
+        try {
+            assertTrue(entered.await(5, TimeUnit.SECONDS));
+            assertEquals("Perl exited with active threads:\n"
+                            + "\t1 running and unjoined\n"
+                            + "\t0 finished and unjoined\n"
+                            + "\t0 running and detached\n",
+                    runtime.threadRegistry().activeThreadExitWarning());
+
+            child.detach();
+            assertEquals("", runtime.threadRegistry().activeThreadExitWarning());
+        } finally {
+            release.countDown();
+            Thread javaThread = child.platformThread();
+            if (javaThread != null) javaThread.join(5_000);
+            assertFalse(javaThread != null && javaThread.isAlive());
+            runtime.close();
+        }
+    }
+}

--- a/src/test/resources/unit/concat_assign_undef_warning.t
+++ b/src/test/resources/unit/concat_assign_undef_warning.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+
+print "1..2\n";
+
+sub TIESCALAR { my $value; bless \$value, shift }
+sub FETCH { ${$_[0]} }
+sub STORE { ${$_[0]} = $_[1] }
+
+for my $tied (0, 1) {
+    my $warning = '';
+    local $SIG{__WARN__} = sub { $warning .= $_[0] };
+    my $value;
+    tie $value, __PACKAGE__ if $tied;
+    $value .= 'x';
+    my $number = $tied + 1;
+    print $value eq 'x' && $warning eq ''
+        ? "ok $number - undef concat assignment does not warn\n"
+        : "not ok $number - undef concat assignment does not warn ($warning)\n";
+}

--- a/src/test/resources/unit/do_modern_syntax_and_copy.t
+++ b/src/test/resources/unit/do_modern_syntax_and_copy.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+
+print "1..3\n";
+
+sub named { die "named sub must not be called" }
+for my $source ('do named()', 'do named(1)') {
+    my $result = eval $source;
+    my $number = $source eq 'do named()' ? 1 : 2;
+    print !defined($result) && $@ =~ /^syntax error/
+        ? "ok $number - $source is a syntax error\n"
+        : "not ok $number - $source is a syntax error ($@)\n";
+}
+
+my %value = (key => 7);
+my $alias = \$value{key};
+my $copied = sub {
+    ${$alias}++;
+    return $_[0] != ${$alias};
+}->(do { 1; delete $value{key} });
+print $copied
+    ? "ok 3 - do block copies a deleted hash element\n"
+    : "not ok 3 - do block copies a deleted hash element\n";

--- a/src/test/resources/unit/glob_numeric_warning.t
+++ b/src/test/resources/unit/glob_numeric_warning.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+no warnings 'once';
+
+print "1..6\n";
+
+my $warning = '';
+local $SIG{__WARN__} = sub { $warning .= $_[0] };
+*target = undef;
+print $warning =~ /Undefined value assigned to typeglob/
+    ? "ok 1 - assigning undef to a typeglob warns\n"
+    : "not ok 1 - assigning undef to a typeglob warns ($warning)\n";
+
+my $glob = *TARGET;
+for my $case ([d => 0], [u => 0], [e => qr/^0\.0+e\+?00$/i]) {
+    $warning = '';
+    my ($format, $expected) = @$case;
+    my $got = sprintf "%$format", $glob;
+    my $value_ok = ref($expected) ? $got =~ $expected : $got eq $expected;
+    my $number = $format eq 'd' ? 2 : $format eq 'u' ? 3 : 4;
+    print $value_ok && $warning =~ /isn't numeric in sprintf/
+        ? "ok $number - bare glob warns and numifies to zero for %$format\n"
+        : "not ok $number - bare glob warns and numifies to zero for %$format ($got; $warning)\n";
+}
+
+{
+    no warnings 'numeric';
+    $warning = '';
+    my $got = sprintf '%d', $glob;
+    print $got eq '0' && $warning eq ''
+        ? "ok 5 - no warnings suppresses the numeric glob warning\n"
+        : "not ok 5 - no warnings suppresses the numeric glob warning ($got; $warning)\n";
+}
+
+$warning = '';
+my $got = sprintf '%d', $glob;
+print $got eq '0' && $warning =~ /isn't numeric in sprintf/
+    ? "ok 6 - numeric glob warning is restored after lexical scope\n"
+    : "not ok 6 - numeric glob warning is restored after lexical scope ($got; $warning)\n";

--- a/src/test/resources/unit/glob_pseudo_constant_export.t
+++ b/src/test/resources/unit/glob_pseudo_constant_export.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+no warnings 'once';
+
+print "1..4\n";
+
+no strict 'refs';
+$::{source} = \"value";
+*{'target'} = \&{'source'};
+print eval('target') eq 'value'
+    ? "ok 1 - proxy constant exports through a typeglob\n"
+    : "not ok 1 - proxy constant exports through a typeglob\n";
+print eval('source') eq 'value'
+    ? "ok 2 - exporting leaves source constant intact\n"
+    : "not ok 2 - exporting leaves source constant intact\n";
+
+$::{self_export} = \"self";
+*{'self_export'} = \&{'self_export'};
+print eval('self_export()') eq 'self'
+    ? "ok 3 - self-assigned proxy constant remains callable\n"
+    : "not ok 3 - self-assigned proxy constant remains callable\n";
+print ref($::{source}) eq 'SCALAR'
+    ? "ok 4 - source stash representation remains a scalar reference\n"
+    : "not ok 4 - source stash representation remains a scalar reference\n";

--- a/src/test/resources/unit/threads_entry_compile_error.t
+++ b/src/test/resources/unit/threads_entry_compile_error.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use threads;
+
+print "1..3\n";
+
+my $thread;
+eval q{$thread = threads->create(sub { qr/[ / })};
+print($@ =~ /Unmatched \[/ ? "ok 1" : "not ok 1",
+    " - malformed regex in entry CODE fails in the parent\n");
+print(!defined($thread) ? "ok 2" : "not ok 2",
+    " - failed entry compilation does not create a thread\n");
+
+my $valid = threads->create(sub { qr/[a]/; return 42 });
+print($valid->join == 42 ? "ok 3" : "not ok 3",
+    " - a valid compiled entry still runs in the child\n");

--- a/src/test/resources/unit/tied_array_delete_local.t
+++ b/src/test/resources/unit/tied_array_delete_local.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+
+print "1..4\n";
+
+{
+    package LocalArray;
+    sub TIEARRAY { bless [], shift }
+    sub STORE { $_[0]->[$_[1]] = $_[2] }
+    sub FETCH { $_[0]->[$_[1]] }
+    sub FETCHSIZE { scalar @{$_[0]} }
+    sub EXISTS { exists $_[0]->[$_[1]] }
+    sub DELETE { delete $_[0]->[$_[1]] }
+    sub CLEAR { @{$_[0]} = () }
+    sub EXTEND { }
+}
+
+tie my @values, 'LocalArray';
+@values = qw(a b c);
+{
+    my $deleted = delete local $values[1];
+    print $deleted eq 'b' && !exists $values[1]
+        ? "ok 1 - delete local returns and removes tied element\n"
+        : "not ok 1 - delete local returns and removes tied element\n";
+
+    delete local $values[888];
+    $values[888] = 'temporary';
+    print $values[888] eq 'temporary'
+        ? "ok 2 - localized missing high element can be assigned\n"
+        : "not ok 2 - localized missing high element can be assigned\n";
+}
+
+print $values[1] eq 'b'
+    ? "ok 3 - existing tied element is restored\n"
+    : "not ok 3 - existing tied element is restored\n";
+print @values == 3 && !exists $values[888]
+    ? "ok 4 - missing high tied element and size are restored\n"
+    : "not ok 4 - missing high tied element and size are restored\n";

--- a/src/test/resources/unit/use_adjacent_import_quote.t
+++ b/src/test/resources/unit/use_adjacent_import_quote.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+
+print "1..3\n";
+
+{
+    package Adjacent::FatComma;
+    use overload'""' => sub { 'fat-comma' }, fallback => 1;
+    sub new { bless {}, shift }
+}
+
+{
+    package Adjacent::Comma;
+    use overload'""', sub { 'comma' }, fallback => 1;
+    sub new { bless {}, shift }
+}
+
+{
+    package Legacy'Package;
+    sub value { 42 }
+}
+
+print "" . Adjacent::FatComma->new eq 'fat-comma'
+    ? "ok 1 - adjacent quoted import after module name\n"
+    : "not ok 1 - adjacent quoted import after module name\n";
+print "" . Adjacent::Comma->new eq 'comma'
+    ? "ok 2 - adjacent comma import form\n"
+    : "not ok 2 - adjacent comma import form\n";
+print Legacy::Package::value() == 42
+    ? "ok 3 - old-style package separator remains supported\n"
+    : "not ok 3 - old-style package separator remains supported\n";


### PR DESCRIPTION
## Summary

- complete Phase 26 scalar lvalue and snapshot identity parity on both backends
- preserve runtime Unicode-property resolution while validating malformed thread-entry regex literals in the parent
- add Perl-compatible active-thread shutdown diagnostics
- harden interpreter regex matching for list-valued operands
- update the concurrency plan and public feature matrix with measured Phase 27–30 status

## Validation

- `make`
- `make check-links`
- system Perl: `threads_entry_compile_error.t` (3/3)
- JVM and interpreter: `threads_entry_compile_error.t` (3/3 each)
- interpreter: `op/index_thr.t` (415/415)
- interpreter: `op/substr_thr.t` (400/400)
- JVM runner: `op/index_thr.t` (415/415), `op/substr.t` and `op/substr_thr.t` (400/400 each), `class/threads.t` (4/4), `user_prop_race_thr.t` (3/3)
- JVM and interpreter: `threads_inherited_pipe.t` (3/3 each)
- `./jcpan --jobs 8 -t Test::Simple` (bundled distribution gate passes)
- `./jcpan --jobs 8 -t DBIx::Class` (325 files, 42,671 tests, PASS)

## Remaining planned work

- lexical `re 'debug'` support and `stclass_threads.t` trace parity
- the final one-assertion direct/thread `regexp_qr_embed` differential and three direct blocked assertions
- continued resource inheritance classification; runtime pooling remains disabled pending its reset contract
