### PR TITLE
Fix CPAN compiler and DATA handling issues

### DIFF
--- a/dev/modules/cpan_compiler_tooling_batch_20260814.md
+++ b/dev/modules/cpan_compiler_tooling_batch_20260814.md
@@ -1,0 +1,59 @@
+# CPAN compiler/tooling batch (2026-08-14)
+
+## Scope
+
+Investigate `Test::XML::Compare`, `Heap::Simple::Any`,
+`Lingua::StanfordCoreNLP`, `CPAN::Index::API::Object::Author`,
+`Chart::Sequence`, `Padre::Plugin::FormBuilder`, and
+`Lingua::EN::Keywords`, preferring reusable compiler and tooling fixes over
+distribution-specific preferences.
+
+## Progress Tracking
+
+### Current Status: implementation and local validation complete; PR in progress
+
+### Completed Phases
+
+- [x] Phase 1: baseline and system-Perl comparison (2026-08-14)
+  - Confirmed portable PerlOnJava failures in `Test::XML::Compare`,
+    `CPAN::Index::API`, and the `Lingua::EN::Keywords` dependency chain.
+  - Excluded `Heap::Simple::Perl` and `Chart::Sequence` because their own test
+    suites or module load fail with system Perl.
+  - Classified `Lingua::StanfordCoreNLP` (Inline::Java) and
+    `Padre::Plugin::FormBuilder` (Wx/native XS) as unavailable native stacks.
+- [x] Phase 2: reduce initial root causes (2026-08-14)
+  - Reduced `Lingua::EN::Tagger` to unverifiable bytecode generated for the
+    closure installed by `Memoize`.
+  - Reduced `CPAN::Index::API` to zero-based virtual DATA positions preventing
+    `File::Slurp` from restoring a DATA handle after reading it.
+  - Preserved absolute DATA offsets both when updating the early placeholder
+    handle and when a module declares DATA under a later package name.
+- [x] Phase 3: compiler/runtime implementation (2026-08-14)
+  - Made JVM list construction use the common `RuntimeBase` overload, avoiding
+    invalid bytecode when context conversion changes a statically inferred type.
+  - Made scalar-backed DATA handles expose source-absolute `tell`/`seek`
+    positions, including module package handles without an early placeholder.
+  - Matched Perl's caller line for a standalone first call in an `if`/`unless`
+    body in both backends.
+- [x] Phase 4: CPAN verification (2026-08-14)
+  - `Test::XML::Compare`: PASS, 13 files / 67 tests.
+  - `CPAN::Index::API`: PASS, 7 files / 74 tests.
+  - `Lingua::EN::Keywords`: PASS, 2 tests; its Tagger, Memoize, and stemming
+    dependency chain built successfully.
+- [x] Phase 5: regression validation (2026-08-14)
+  - New focused tests pass with system Perl and with both PerlOnJava backends.
+  - Full `make` suite passes.
+
+### Next Steps
+
+1. Commit, push, open a PR, and monitor CI.
+
+### Open Questions
+
+- None. No additional portable failure appeared after the Tagger verifier
+  boundary was fixed.
+
+## Related References
+
+- `.agents/skills/debug-perlonjava/SKILL.md`
+- `dev/modules/cpan_compiler_tooling_suite.md`

--- a/dev/modules/cpan_compiler_tooling_batch_20260814.md
+++ b/dev/modules/cpan_compiler_tooling_batch_20260814.md
@@ -75,6 +75,16 @@ distribution-specific preferences.
   - Rechecked the reported regression files: `op/do.t` 94/99,
     `op/caller.t` 93/115, `op/lexsub.t` 110/160, keys benchmark 5/6,
     `re/speed.t` 26/59, and `re/speed_thr.t` 26/59.
+- [x] Phase 9: latest-master regex regression repair (2026-08-15)
+  - Rebased PR #955 onto newly fetched `origin/master` at `d22f54d24`.
+  - Moved the recursive lexical-declaration scan behind the cheap branch-shape
+    checks, avoiding compiler work for conditionals that cannot need a caller
+    line override.
+  - Restored `re/pat_advanced.t` and `re/pat_advanced_thr.t` to 1376/1687,
+    matching a clean latest-master build.
+  - Confirmed `japh/abigail.t` is 109/130 on both PR #955 and latest master, so
+    the reported one-test difference is not caused by this PR.
+  - Full `make` suite passes after the latest rebase and fast-path change.
 
 ### Next Steps
 

--- a/dev/modules/cpan_compiler_tooling_batch_20260814.md
+++ b/dev/modules/cpan_compiler_tooling_batch_20260814.md
@@ -10,7 +10,7 @@ distribution-specific preferences.
 
 ## Progress Tracking
 
-### Current Status: implementation and local validation complete; PR in progress
+### Current Status: complete; PR #955 open with CI passing
 
 ### Completed Phases
 
@@ -43,10 +43,13 @@ distribution-specific preferences.
 - [x] Phase 5: regression validation (2026-08-14)
   - New focused tests pass with system Perl and with both PerlOnJava backends.
   - Full `make` suite passes.
+- [x] Phase 6: pull request and CI (2026-08-14)
+  - Opened PR #955 from `fix/cpan-compiler-tooling-20260814`.
+  - Ubuntu and Windows CI jobs passed.
 
 ### Next Steps
 
-1. Commit, push, open a PR, and monitor CI.
+1. Review and merge PR #955.
 
 ### Open Questions
 

--- a/dev/modules/cpan_compiler_tooling_batch_20260814.md
+++ b/dev/modules/cpan_compiler_tooling_batch_20260814.md
@@ -10,7 +10,7 @@ distribution-specific preferences.
 
 ## Progress Tracking
 
-### Current Status: complete; PR #955 open with CI passing
+### Current Status: PR #955 regression fixes validated locally; CI pending
 
 ### Completed Phases
 
@@ -46,10 +46,31 @@ distribution-specific preferences.
 - [x] Phase 6: pull request and CI (2026-08-14)
   - Opened PR #955 from `fix/cpan-compiler-tooling-20260814`.
   - Ubuntu and Windows CI jobs passed.
+- [x] Phase 7: post-PR regression repair (2026-08-14)
+  - Rebased PR #955 onto `origin/master` at `4de2934e4`.
+  - Replaced the broad `RuntimeBase` list-add fallback with a verifier-safe
+    `RuntimeList.addList(RuntimeBase)` entry point for statically list-valued
+    expressions, retaining specialized overloads and existing control-flow-list
+    flattening semantics.
+  - Limited conditional caller-line overrides to conditions containing lexical
+    declarations, matching Perl without changing ordinary `if`/`elsif` calls.
+  - Restored the rebased-master counts for `op/do.t` (94/99), `op/caller.t`
+    (92/115 locally), and `op/lexsub.t` (110/160); the additional caller failure
+    reported by the comparison also reproduces on current master.
+  - Confirmed the keys benchmark is load-sensitive (branch results varied from
+    5/6 to 6/6; paired current master scored 4/6 while the branch scored 5/6).
+  - Restored watchdog-limited regex progress to 26/59 for `re/speed.t` and
+    20/59 for `re/speed_thr.t`, meeting or exceeding the reported baselines.
+  - Full `make` suite passes; focused caller-line behavior passes with system
+    Perl and with both PerlOnJava backends.
+  - Revalidated the affected CPAN paths: `Test::XML::Compare` (13 files / 67
+    tests), `Lingua::EN::Keywords` (2 tests), and `CPAN::Index::API` (7 files /
+    74 tests) all pass.
 
 ### Next Steps
 
-1. Review and merge PR #955.
+1. Push the rebased regression fix and wait for PR #955 CI.
+2. Review and merge PR #955 after CI passes.
 
 ### Open Questions
 

--- a/dev/modules/cpan_compiler_tooling_batch_20260814.md
+++ b/dev/modules/cpan_compiler_tooling_batch_20260814.md
@@ -10,7 +10,7 @@ distribution-specific preferences.
 
 ## Progress Tracking
 
-### Current Status: PR #955 regression fixes validated locally; CI pending
+### Current Status: PR #955 rebased and validated locally; CI pending
 
 ### Completed Phases
 
@@ -66,10 +66,19 @@ distribution-specific preferences.
   - Revalidated the affected CPAN paths: `Test::XML::Compare` (13 files / 67
     tests), `Lingua::EN::Keywords` (2 tests), and `CPAN::Index::API` (7 files /
     74 tests) all pass.
+- [x] Phase 8: rebase onto current master (2026-08-15)
+  - Rebased PR #955 onto `origin/master` at `1be14c00b`.
+  - Kept master's newer full-source DATA handle implementation and dropped the
+    superseded scalar-handle base-offset shim while retaining the absolute
+    DATA-position regression test.
+  - Full `make` suite passes after the rebase.
+  - Rechecked the reported regression files: `op/do.t` 94/99,
+    `op/caller.t` 93/115, `op/lexsub.t` 110/160, keys benchmark 5/6,
+    `re/speed.t` 26/59, and `re/speed_thr.t` 26/59.
 
 ### Next Steps
 
-1. Push the rebased regression fix and wait for PR #955 CI.
+1. Push the current-master rebase and wait for PR #955 CI.
 2. Review and merge PR #955 after CI passes.
 
 ### Open Questions

--- a/src/main/java/org/perlonjava/backend/jvm/EmitLiteral.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitLiteral.java
@@ -524,7 +524,7 @@ public class EmitLiteral {
             emitterVisitor.ctx.javaClassInfo.releaseSpillRef(elementRef);
 
             // Add the element to the list
-            addElementToList(mv, element, contextType);
+            addElementToList(mv);
             // Stack: []
         }
 
@@ -701,44 +701,27 @@ public class EmitLiteral {
     }
 
     /**
-     * Adds an element to a RuntimeList with type-specific optimizations.
+     * Adds an element to a RuntimeList through its verifier-safe base overload.
      *
-     * <p>This method uses compile-time type information to generate optimized
-     * bytecode that calls the specific addToList method for known types, avoiding
-     * the overhead of interface dispatch when possible.</p>
+     * <p>AST return-type guesses are not reliable after context conversion, so
+     * list construction deliberately uses the common RuntimeBase contract.</p>
      *
      * <p>Stack transformation: [RuntimeList] [element] → [RuntimeList]</p>
      *
      * @param mv          The method visitor for bytecode generation
-     * @param element     The AST node representing the element being added
-     * @param contextType The context type (used for scalar context optimization)
      */
-    private static void addElementToList(MethodVisitor mv, Node element, int contextType) {
-        String returnType;
+    private static void addElementToList(MethodVisitor mv) {
         // Stack: [RuntimeList] [element]
 
-        // Determine the element's return type for optimization
-        if (contextType == RuntimeContextType.SCALAR) {
-            // In scalar context, all elements are treated as scalars
-            returnType = RuntimeDescriptorConstants.SCALAR_TYPE;
-        } else if (contextType == RuntimeContextType.RUNTIME) {
-            // In RUNTIME context, array/hash elements may have been converted to RuntimeBase
-            // via emitRuntimeContextConversion(), so we must use the generic add(RuntimeBase)
-            returnType = RuntimeDescriptorConstants.BASE_TYPE;
-        } else {
-            // Use static analysis to determine the element's return type
-            returnType = ReturnTypeVisitor.getReturnType(element);
-        }
-
-        // Generate type-specific method call for better performance
-        if (RuntimeDescriptorConstants.isKnownRuntimeType(returnType)) {
-            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, RuntimeDescriptorConstants.LIST_CLASS,
-                    "add", "(" + returnType + ")V", false);
-        } else {
-            // Fall back for unknown types
-            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, RuntimeDescriptorConstants.LIST_CLASS,
-                    "add", "(" + RuntimeDescriptorConstants.BASE_TYPE + ")V", false);
-        }
+        // List elements can cross context boundaries while they are emitted.  In
+        // particular, a subroutine call is statically described as RuntimeList but
+        // is converted to RuntimeBase when it appears in a runtime-context closure.
+        // Selecting an overload from the AST return-type guess therefore produced
+        // unverifiable bytecode for Memoize::_wrap.  Every runtime value derives
+        // from RuntimeBase, so use the type-safe overload here.  The JVM still
+        // dispatches this monomorphic call efficiently after warm-up.
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, RuntimeDescriptorConstants.LIST_CLASS,
+                "add", "(" + RuntimeDescriptorConstants.BASE_TYPE + ")V", false);
     }
 
     /**

--- a/src/main/java/org/perlonjava/backend/jvm/EmitLiteral.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitLiteral.java
@@ -524,7 +524,7 @@ public class EmitLiteral {
             emitterVisitor.ctx.javaClassInfo.releaseSpillRef(elementRef);
 
             // Add the element to the list
-            addElementToList(mv);
+            addElementToList(mv, element, contextType);
             // Stack: []
         }
 
@@ -701,27 +701,40 @@ public class EmitLiteral {
     }
 
     /**
-     * Adds an element to a RuntimeList through its verifier-safe base overload.
+     * Adds an element to a RuntimeList with verifier-safe specialization.
      *
-     * <p>AST return-type guesses are not reliable after context conversion, so
-     * list construction deliberately uses the common RuntimeBase contract.</p>
+     * <p>List-valued expressions can cross control-flow/context boundaries that
+     * widen their verifier type to RuntimeBase. Other statically known values
+     * retain the specialized overloads used by hot list-construction paths.</p>
      *
      * <p>Stack transformation: [RuntimeList] [element] → [RuntimeList]</p>
      *
      * @param mv          The method visitor for bytecode generation
+     * @param element     The AST node representing the element being added
+     * @param contextType The context in which the list element was emitted
      */
-    private static void addElementToList(MethodVisitor mv) {
+    private static void addElementToList(MethodVisitor mv, Node element, int contextType) {
         // Stack: [RuntimeList] [element]
 
-        // List elements can cross context boundaries while they are emitted.  In
-        // particular, a subroutine call is statically described as RuntimeList but
-        // is converted to RuntimeBase when it appears in a runtime-context closure.
-        // Selecting an overload from the AST return-type guess therefore produced
-        // unverifiable bytecode for Memoize::_wrap.  Every runtime value derives
-        // from RuntimeBase, so use the type-safe overload here.  The JVM still
-        // dispatches this monomorphic call efficiently after warm-up.
+        String returnType = ReturnTypeVisitor.getReturnType(element);
+        String methodName = "add";
+        // Memoize::_wrap exposed a list-valued expression whose verifier type had
+        // been widened while control-flow branches were merged. The addList base
+        // entry point keeps the bytecode verifier-safe while preserving the old
+        // list-flattening semantics inside RuntimeList.
+        if (RuntimeDescriptorConstants.LIST_TYPE.equals(returnType)
+                && contextType != RuntimeContextType.RUNTIME) {
+            methodName = "addList";
+            returnType = RuntimeDescriptorConstants.BASE_TYPE;
+        } else if (contextType == RuntimeContextType.RUNTIME) {
+            returnType = RuntimeDescriptorConstants.BASE_TYPE;
+        }
+
+        if (!RuntimeDescriptorConstants.isKnownRuntimeType(returnType)) {
+            returnType = RuntimeDescriptorConstants.BASE_TYPE;
+        }
         mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, RuntimeDescriptorConstants.LIST_CLASS,
-                "add", "(" + RuntimeDescriptorConstants.BASE_TYPE + ")V", false);
+                methodName, "(" + returnType + ")V", false);
     }
 
     /**

--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -379,10 +379,10 @@ public class StatementParser {
         // A lexical declaration in the condition owns the next COP in Perl, so
         // the first standalone call reports the conditional's source line.
         // Ordinary conditions keep the call's own line (see op/caller.t).
-        if (conditionContainsLexicalDeclaration(condition)
-                && !thenBranch.elements.isEmpty()
+        if (!thenBranch.elements.isEmpty()
                 && thenBranch.elements.get(0) instanceof BinaryOperatorNode first
-                && "(".equals(first.operator)) {
+                && "(".equals(first.operator)
+                && conditionContainsLexicalDeclaration(condition)) {
             first.setAnnotation("callerLineTokenOverride", statementStartIndex);
         }
         if (enterNewScope) {

--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -338,6 +338,7 @@ public class StatementParser {
      * @return An IfNode representing the if/unless/elsif statement
      */
     private static Node parseIfStatementInternal(Parser parser, boolean enterNewScope) {
+        int statementStartIndex = parser.tokenIndex;
         LexerToken operator = TokenUtils.consume(parser, LexerTokenType.IDENTIFIER); // "if", "unless", "elsif"
 
         // Enter a new scope for 'if' and 'unless' (but not for 'elsif' which is part of the same chain)
@@ -375,6 +376,16 @@ public class StatementParser {
         TestMoreHelper.handleSkipTest(parser, thenBranch);
 
         IfNode result = new IfNode(operator.text, condition, thenBranch, elseBranch, parser.tokenIndex);
+        // Perl associates a standalone call that is the first statement of an
+        // if/unless body with the conditional's source line.  Test::Builder::Tester
+        // relies on this when test_fail() is the first statement in a conditional.
+        // Preserve that call-site quirk for both execution backends without
+        // changing the source location of later statements in the block.
+        if (!thenBranch.elements.isEmpty()
+                && thenBranch.elements.get(0) instanceof BinaryOperatorNode first
+                && "(".equals(first.operator)) {
+            first.setAnnotation("callerLineTokenOverride", statementStartIndex);
+        }
         if (enterNewScope) {
             result.setAnnotation("postBlockHintHashId", HintHashRegistry.snapshotCurrentHintHash());
         }

--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -376,12 +376,11 @@ public class StatementParser {
         TestMoreHelper.handleSkipTest(parser, thenBranch);
 
         IfNode result = new IfNode(operator.text, condition, thenBranch, elseBranch, parser.tokenIndex);
-        // Perl associates a standalone call that is the first statement of an
-        // if/unless body with the conditional's source line.  Test::Builder::Tester
-        // relies on this when test_fail() is the first statement in a conditional.
-        // Preserve that call-site quirk for both execution backends without
-        // changing the source location of later statements in the block.
-        if (!thenBranch.elements.isEmpty()
+        // A lexical declaration in the condition owns the next COP in Perl, so
+        // the first standalone call reports the conditional's source line.
+        // Ordinary conditions keep the call's own line (see op/caller.t).
+        if (conditionContainsLexicalDeclaration(condition)
+                && !thenBranch.elements.isEmpty()
                 && thenBranch.elements.get(0) instanceof BinaryOperatorNode first
                 && "(".equals(first.operator)) {
             first.setAnnotation("callerLineTokenOverride", statementStartIndex);
@@ -390,6 +389,27 @@ public class StatementParser {
             result.setAnnotation("postBlockHintHashId", HintHashRegistry.snapshotCurrentHintHash());
         }
         return result;
+    }
+
+    private static boolean conditionContainsLexicalDeclaration(Node node) {
+        if (node instanceof OperatorNode operatorNode) {
+            if ("my".equals(operatorNode.operator) || "state".equals(operatorNode.operator)) {
+                return true;
+            }
+            return conditionContainsLexicalDeclaration(operatorNode.operand);
+        }
+        if (node instanceof BinaryOperatorNode binaryNode) {
+            return conditionContainsLexicalDeclaration(binaryNode.left)
+                    || conditionContainsLexicalDeclaration(binaryNode.right);
+        }
+        if (node instanceof ListNode listNode) {
+            for (Node element : listNode.elements) {
+                if (conditionContainsLexicalDeclaration(element)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeList.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeList.java
@@ -199,6 +199,15 @@ public class RuntimeList extends RuntimeBase {
     }
 
     /**
+     * Verifier-safe entry point for values statically known to be RuntimeList.
+     * Control-flow merges may widen the JVM stack type to RuntimeBase even though
+     * the Perl expression contract still guarantees a list result.
+     */
+    public void addList(RuntimeBase value) {
+        add((RuntimeList) value);
+    }
+
+    /**
      * Gets the size of the list.
      *
      * @return The number of elements in the list.

--- a/src/test/resources/unit/caller_exported_first_statement_in_if.t
+++ b/src/test/resources/unit/caller_exported_first_statement_in_if.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use Test::Builder::Tester tests => 1;
+
+sub failing_test($$;$) {
+    return Test::Builder->new->ok(0, $_[2]);
+}
+
+test_out('not ok 1 - captured failure');
+if (my $fail = 1) {
+    test_fail(6);
+}
+if (my $error = 0) {
+    test_err('unused');
+}
+failing_test('left', 'right', 'captured failure');
+test_test('exported first statement retains Perl caller line');

--- a/src/test/resources/unit/caller_if_condition_line.t
+++ b/src/test/resources/unit/caller_if_condition_line.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+no warnings 'syntax';
+use Test::More tests => 2;
+
+my @caller_lines;
+sub capture_caller_line { push @caller_lines, (caller)[2] }
+
+my $ordinary_call_line = __LINE__ + 2;
+if (1) {
+    capture_caller_line();
+}
+is($caller_lines[0], $ordinary_call_line,
+    'ordinary if body call keeps its own source line');
+
+my $declaration_condition_line = __LINE__ + 1;
+if (my $enabled = 1) {
+    capture_caller_line();
+}
+is($caller_lines[1], $declaration_condition_line,
+    'lexical declaration condition owns the first call source line');

--- a/src/test/resources/unit/data_handle_absolute_position.t
+++ b/src/test/resources/unit/data_handle_absolute_position.t
@@ -1,0 +1,19 @@
+package DataHandleAbsolutePosition;
+use strict;
+use warnings;
+use Test::More;
+use Fcntl qw(SEEK_SET);
+
+my $start = tell(DATA);
+ok($start > 0, 'DATA tell is the absolute source-file position');
+
+my $first = do { local $/; <DATA> };
+ok(seek(DATA, $start, SEEK_SET), 'DATA seeks back to its absolute start');
+my $second = do { local $/; <DATA> };
+
+is($second, $first, 'DATA content can be read again after restoring tell');
+
+done_testing;
+
+__DATA__
+payload

--- a/src/test/resources/unit/memoize_runtime_list_bytecode.t
+++ b/src/test/resources/unit/memoize_runtime_list_bytecode.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use Test::More;
+use Memoize;
+
+my $calls = 0;
+sub doubled {
+    $calls++;
+    return $_[0] * 2;
+}
+
+my $memoized = memoize(\&doubled, INSTALL => undef);
+
+is($memoized->(21), 42, 'memoized closure returns its value');
+is($memoized->(21), 42, 'memoized closure returns its cached value');
+is($calls, 1, 'memoized wrapper called the original once');
+
+done_testing;


### PR DESCRIPTION
## Summary

- make runtime list construction verifier-safe when emitted values cross context boundaries
- preserve source-absolute `tell`/`seek` positions for virtual DATA handles, including package DATA handles without an early placeholder
- match Perl's caller line for a standalone first call in an `if`/`unless` body
- add system-Perl-validated focused regressions and a progress document for the CPAN batch

## CPAN results

- `./jcpan -t Test::XML::Compare`: PASS (13 files, 67 tests)
- `./jcpan -t CPAN::Index::API::Object::Author`: PASS (7 files, 74 tests)
- `./jcpan -t Lingua::EN::Keywords`: PASS (2 tests), including the portable Lingua::EN::Tagger, Memoize, and stemming dependency chain

The remaining requested distributions were excluded after the system-Perl baseline:

- `Heap::Simple::Any` resolves to `Heap::Simple::Perl`, whose own test suite fails under system Perl
- `Chart::Sequence` fails to load under system Perl because its accessor generator derives invalid types
- `Lingua::StanfordCoreNLP` requires the unavailable Inline::Java native integration stack
- `Padre::Plugin::FormBuilder` requires the unavailable Wx/native XS GUI stack

No distribution preference was added. No new cryptographic provider was needed; existing Java providers such as BouncyCastle remain reused by the runtime where applicable.

## Validation

- focused regressions pass with system Perl
- focused regressions pass with both PerlOnJava JVM and interpreter backends
- `make` passes all unit-test shards

Generated with [Codex](https://openai.com/codex)
