### PR TITLE
Fix WWW::Mechanize compiler tooling

### DIFF
--- a/src/main/java/org/perlonjava/runtime/ForkOpenState.java
+++ b/src/main/java/org/perlonjava/runtime/ForkOpenState.java
@@ -3,6 +3,15 @@ package org.perlonjava.runtime;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 import org.perlonjava.runtime.runtimetypes.RuntimeCode;
 import org.perlonjava.runtime.runtimetypes.PerlRuntime;
+import org.perlonjava.runtime.runtimetypes.GlobalVariable;
+import org.perlonjava.runtime.runtimetypes.RuntimeBase;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalarType;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Thread-local state for fork-open emulation.
@@ -18,13 +27,15 @@ import org.perlonjava.runtime.runtimetypes.PerlRuntime;
  *   <li>Child gets 0, typically calls exec to run a command</li>
  * </ul>
  * 
- * <p>Since JVM can't fork, we emulate this pattern:
+ * <p>Since the JVM can't fork, we emulate this pattern by replaying the
+ * current invocation in a child JVM:
  * <ol>
- *   <li>When {@code open FH, "-|"} is called without a command, we store a
- *       pending state and return 0 (pretending to be the "child")</li>
- *   <li>When {@code exec @cmd} is called, we detect the pending state,
- *       create the pipe using 3-arg semantics, and signal to return to
- *       the "parent" code path with the pipe ready</li>
+ *   <li>The parent starts the same Perl program with a marker identifying the
+ *       no-command open occurrence and returns the child PID.</li>
+ *   <li>The child suppresses output while replaying statements that happened
+ *       before the fork point.</li>
+ *   <li>At the marked open, the child restores stdout, updates {@code $$}, and
+ *       returns 0 so arbitrary child-side Perl code can continue.</li>
  * </ol>
  * 
  * <h2>Supported Patterns</h2>
@@ -33,7 +44,7 @@ import org.perlonjava.runtime.runtimetypes.PerlRuntime;
  * my $pid = open FH, "-|";
  * if ($pid) { ... } else { exec @cmd }
  * 
- * # or-exec idiom
+ * # The child may exec, or may continue running Perl code.
  * open FH, "-|" or exec @cmd;
  * }</pre>
  * 
@@ -44,6 +55,99 @@ import org.perlonjava.runtime.runtimetypes.PerlRuntime;
  * @see org.perlonjava.runtime.operators.SystemOperator#exec
  */
 public class ForkOpenState {
+    public static final String REPLAY_ENV = "PERLONJAVA_FORK_OPEN_REPLAY";
+
+    /** Whether this JVM is replaying the program up to a no-command pipe open. */
+    public static boolean isReplayProcess() {
+        return System.getenv(REPLAY_ENV) != null;
+    }
+
+    /** Return the next no-command pipe-open occurrence in this interpreter. */
+    public static int nextOccurrence() {
+        return ++PerlRuntime.current().forkOpenOccurrence;
+    }
+
+    /** Whether this occurrence is the fork point selected for the replay child. */
+    public static boolean isReplayChildOccurrence(int occurrence) {
+        String target = System.getenv(REPLAY_ENV);
+        if (target == null) return false;
+        try {
+            return Integer.parseInt(target.split(":", 2)[0]) == occurrence;
+        } catch (NumberFormatException ignored) {
+            return false;
+        }
+    }
+
+    /**
+     * During replay, expose the parent's PID until the fork point. Libraries
+     * such as Test2 then observe the same PID transition they see after fork.
+     */
+    public static long initialProcessId() {
+        String marker = System.getenv(REPLAY_ENV);
+        if (marker != null) {
+            String[] parts = marker.split(":", 2);
+            if (parts.length == 2) {
+                try {
+                    return Long.parseLong(parts[1]);
+                } catch (NumberFormatException ignored) {
+                    // Fall through to the real process ID.
+                }
+            }
+        }
+        return ProcessHandle.current().pid();
+    }
+
+    /** Reconstruct the current JVM invocation so a fork-open child can replay it. */
+    public static List<String> currentInvocation() {
+        ProcessHandle.Info info = ProcessHandle.current().info();
+        String[] arguments = info.arguments().orElse(new String[0]);
+        if (Arrays.asList(arguments).contains("org.perlonjava.app.cli.Main")) {
+            String command = info.command().orElseThrow(
+                    () -> new IllegalStateException("Cannot determine current Java executable"));
+            List<String> invocation = new ArrayList<>(arguments.length + 1);
+            invocation.add(command);
+            invocation.addAll(Arrays.asList(arguments));
+            return invocation;
+        }
+
+        // Unit tests and other embedders run PerlOnJava inside their own JVM.
+        // Reconstruct a CLI invocation from the active Perl program instead of
+        // accidentally re-executing the host (for example, a Gradle worker).
+        String javaName = System.getProperty("os.name", "").toLowerCase().contains("win")
+                ? "java.exe" : "java";
+        List<String> invocation = new ArrayList<>();
+        invocation.add(new File(new File(System.getProperty("java.home"), "bin"), javaName).getPath());
+        invocation.add("--enable-native-access=ALL-UNNAMED");
+        invocation.add("-cp");
+        invocation.add(System.getProperty("java.class.path"));
+        invocation.add("org.perlonjava.app.cli.Main");
+        for (RuntimeBase include : GlobalVariable.getGlobalArray("main::INC").elements) {
+            if (include instanceof RuntimeScalar scalar
+                    && !RuntimeScalarType.isReference(scalar)) {
+                invocation.add("-I" + include.toString());
+            }
+        }
+        String program = GlobalVariable.getGlobalVariable("main::0").toString();
+        if (program == null || program.isEmpty() || "-e".equals(program)) {
+            throw new IllegalStateException("no-command fork-open replay requires a script file");
+        }
+        File programFile = new File(program);
+        if (!programFile.isFile()) {
+            URL resource = ForkOpenState.class.getClassLoader().getResource(program);
+            if (resource != null && "file".equals(resource.getProtocol())) {
+                try {
+                    program = new File(resource.toURI()).getPath();
+                } catch (Exception ignored) {
+                    // Keep the original name so the child reports the useful error.
+                }
+            }
+        }
+        invocation.add(program);
+        for (RuntimeBase argument : GlobalVariable.getGlobalArray("main::ARGV").elements) {
+            invocation.add(argument.toString());
+        }
+        return invocation;
+    }
     
     /**
      * Thread-local storage for pending fork-open state.

--- a/src/main/java/org/perlonjava/runtime/io/PipeInputChannel.java
+++ b/src/main/java/org/perlonjava/runtime/io/PipeInputChannel.java
@@ -12,6 +12,7 @@ import java.io.*;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalVariable;
@@ -90,6 +91,13 @@ public class PipeInputChannel implements IOHandle {
         startProcessDirect(commandArgs);
     }
 
+    public PipeInputChannel(List<String> commandArgs, Map<String, String> environmentOverrides)
+            throws IOException {
+        this.isEOF = false;
+        ProcessBuilder processBuilder = new ProcessBuilder(commandArgs);
+        setupProcess(processBuilder, environmentOverrides);
+    }
+
     /**
      * Common setup for the process builder.
      *
@@ -97,12 +105,18 @@ public class PipeInputChannel implements IOHandle {
      * @throws IOException if an I/O error occurs starting the process
      */
     private void setupProcess(ProcessBuilder processBuilder) throws IOException {
+        setupProcess(processBuilder, Map.of());
+    }
+
+    private void setupProcess(ProcessBuilder processBuilder, Map<String, String> environmentOverrides)
+            throws IOException {
         // Set working directory to current directory
         String userDir = org.perlonjava.runtime.runtimetypes.RuntimeEnvironment.currentDirectory();
         processBuilder.directory(new File(userDir));
 
         // Copy %ENV to the subprocess environment
         copyPerlEnvToProcessBuilder(processBuilder);
+        processBuilder.environment().putAll(environmentOverrides);
 
         // Start the process
         process = processBuilder.start();

--- a/src/main/java/org/perlonjava/runtime/io/PipeOutputChannel.java
+++ b/src/main/java/org/perlonjava/runtime/io/PipeOutputChannel.java
@@ -12,6 +12,7 @@ import java.io.*;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalVariable;
@@ -112,6 +113,13 @@ public class PipeOutputChannel implements IOHandle {
         startProcessDirect(commandArgs);
     }
 
+    public PipeOutputChannel(List<String> commandArgs, Map<String, String> environmentOverrides)
+            throws IOException {
+        this.isClosed = false;
+        ProcessBuilder processBuilder = new ProcessBuilder(commandArgs);
+        setupProcess(processBuilder, environmentOverrides);
+    }
+
     /**
      * Starts the external process using shell interpretation.
      *
@@ -167,12 +175,18 @@ public class PipeOutputChannel implements IOHandle {
      * @throws IOException if an I/O error occurs starting the process
      */
     private void setupProcess(ProcessBuilder processBuilder) throws IOException {
+        setupProcess(processBuilder, Map.of());
+    }
+
+    private void setupProcess(ProcessBuilder processBuilder, Map<String, String> environmentOverrides)
+            throws IOException {
         // Set working directory to current directory
         String userDir = org.perlonjava.runtime.runtimetypes.RuntimeEnvironment.currentDirectory();
         processBuilder.directory(new File(userDir));
 
         // Copy %ENV to the subprocess environment
         copyPerlEnvToProcessBuilder(processBuilder);
+        processBuilder.environment().putAll(environmentOverrides);
 
         // Start the process
         process = processBuilder.start();

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -706,17 +706,16 @@ public class IOOperator {
             // Check for fork-open pattern: open FH, "-|" or open FH, "|-" with no command
             // This is the 2-arg piped open that normally forks in Perl
             if (args.length == 2 && (mode.equals("-|") || mode.equals("|-"))) {
-                // Fork-open emulation: set pending state and return 0 (child PID)
-                // The actual pipe will be created when exec() is called
-                ForkOpenState.setPending(fileHandle, 0, "");
-                if (ioDebug) {
-                    System.err.println("[JPERL_IO_DEBUG] Fork-open emulation: pending state set for " + mode);
-                    System.err.flush();
+                int occurrence = ForkOpenState.nextOccurrence();
+                if (ForkOpenState.isReplayChildOccurrence(occurrence)) {
+                    PerlRuntime.current().activateForkOpenChildStdout();
+                    return new RuntimeScalar(0);
                 }
-                return new RuntimeScalar(0);  // Return 0 = "child" branch
+                fh = RuntimeIO.openForkPipe(mode, occurrence);
+            } else {
+                // Pipe open with command (3+ arg form)
+                fh = RuntimeIO.openPipe(runtimeList);
             }
-            // Pipe open with command (3+ arg form)
-            fh = RuntimeIO.openPipe(runtimeList);
         } else if (args.length > 2) {
             // 3-argument open
             RuntimeScalar secondArg = args[2].scalar();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
@@ -1,5 +1,7 @@
 package org.perlonjava.runtime.runtimetypes;
 
+import org.perlonjava.runtime.ForkOpenState;
+
 import org.perlonjava.app.cli.CompilerOptions;
 import org.perlonjava.core.Configuration;
 import org.perlonjava.frontend.semantic.ScopedSymbolTable;
@@ -126,7 +128,7 @@ public class GlobalContext {
             ors.set(compilerOptions.outputRecordSeparator);    // initialize $\
             GlobalVariable.globalVariables.put("main::\\", ors);
         }
-        GlobalVariable.getGlobalVariable("main::$").set(RuntimeEnvironment.pid()); // initialize `$$` to runtime process id
+        GlobalVariable.getGlobalVariable("main::$").set(ForkOpenState.initialProcessId());
         GlobalVariable.getGlobalVariable("main::?");
         // Only set $0 if it hasn't been set yet - prevents overwriting during re-entrant calls
         // (e.g., when require() is called during module initialization)

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -89,6 +89,7 @@ public final class PerlRuntime implements AutoCloseable {
     public final Deque<Long> netSslErrorQueue = new ArrayDeque<>();
     public NetSSLeay.State netSslState = new NetSSLeay.State();
     public ForkOpenState.PendingForkOpen pendingForkOpen;
+    public int forkOpenOccurrence;
     public RuntimeArray libOriginalInc;
     public boolean storableLastOpInNetorder;
     public final Set<String> xsShimLoadingInProgress = new HashSet<>();
@@ -128,7 +129,11 @@ public final class PerlRuntime implements AutoCloseable {
     private PerlRuntime(PerlThreadRegistry threadRegistry, long perlThreadId) {
         this.threadRegistry = Objects.requireNonNull(threadRegistry, "threadRegistry");
         this.perlThreadId = perlThreadId;
-        ioStdout = new RuntimeIO(new StandardIO(System.out, true));
+        ioStdout = new RuntimeIO(new StandardIO(
+                ForkOpenState.isReplayProcess()
+                        ? java.io.OutputStream.nullOutputStream()
+                        : System.out,
+                true));
         ioStderr = new RuntimeIO(new StandardIO(System.err, false));
         ioStderr.autoFlush = true;
         ioStdin = new RuntimeIO(new StandardIO(System.in));
@@ -144,6 +149,18 @@ public final class PerlRuntime implements AutoCloseable {
         ioStdout.globName = "main::STDOUT";
         ioStderr.globName = "main::STDERR";
         ioStdin.globName = "main::STDIN";
+    }
+
+    /** Make replay-child output visible once execution reaches its fork point. */
+    public void activateForkOpenChildStdout() {
+        RuntimeIO muted = ioStdout;
+        RuntimeIO stdout = new RuntimeIO(new StandardIO(System.out, true));
+        replaceStandardHandle("main::STDOUT", stdout);
+        replaceStandardHandle("main::stdout", stdout);
+        if (ioSelectedHandle == muted) ioSelectedHandle = stdout;
+        if (ioLastWrittenHandle == muted) ioLastWrittenHandle = stdout;
+        GlobalVariable.getGlobalVariable("main::$").set(pid);
+        GlobalVariable.getGlobalHash("main::ENV").elements.remove(ForkOpenState.REPLAY_ENV);
     }
 
     /** Return the runtime bound to this thread, failing clearly when absent. */

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
@@ -984,6 +984,31 @@ public class RuntimeIO extends RuntimeScalar {
     }
 
     /**
+     * Re-executes the current PerlOnJava invocation to emulate a no-command
+     * {@code open FH, "-|"} or {@code open FH, "|-"}. The child suppresses
+     * replayed output until it reaches the selected open occurrence.
+     */
+    public static RuntimeIO openForkPipe(String mode, int occurrence) {
+        RuntimeIO fh = new RuntimeIO();
+        try {
+            Map<String, String> marker = Map.of(
+                    org.perlonjava.runtime.ForkOpenState.REPLAY_ENV,
+                    occurrence + ":" + ProcessHandle.current().pid());
+            List<String> invocation = org.perlonjava.runtime.ForkOpenState.currentInvocation();
+            if ("-|".equals(mode)) {
+                fh.ioHandle = new PipeInputChannel(invocation, marker);
+            } else {
+                fh.ioHandle = new PipeOutputChannel(invocation, marker);
+            }
+            addHandle(fh.ioHandle);
+            return fh;
+        } catch (IOException | RuntimeException e) {
+            handleIOError("fork-open failed: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
      * Converts a filename to a Path object relative to the current directory.
      *
      * @param fileName the filename to convert

--- a/src/main/perl/lib/HTTP/Cookies.pm
+++ b/src/main/perl/lib/HTTP/Cookies.pm
@@ -2,6 +2,7 @@ package HTTP::Cookies;
 
 use strict;
 use warnings;
+use HTTP::Date ();
 
 our $VERSION = '6.11';
 our $EPOCH_OFFSET = 0;
@@ -117,6 +118,52 @@ sub scan {
         }
     }
     return 1;
+}
+
+sub _join_header_words {
+    my @cur = @{ $_[0] };
+    my @attributes;
+    while (@cur) {
+        my $key = shift @cur;
+        my $value = shift @cur;
+        if (defined $value) {
+            if (!length($value)
+                || $value =~ /[\x00-\x20()<>@,;:\\"\/\[\]?={}\x7f-\xff]/) {
+                $value =~ s/(["\\])/\\$1/g;
+                $key .= qq(="$value");
+            }
+            else {
+                $key .= "=$value";
+            }
+        }
+        push @attributes, $key;
+    }
+    return join '; ', @attributes;
+}
+
+sub as_string {
+    my ($self, $skip_discard) = @_;
+    my @result;
+
+    $self->scan(sub {
+        my ($version, $key, $value, $path, $domain, $port,
+            $path_spec, $secure, $expires, $discard, $rest) = @_;
+        return if $discard && $skip_discard;
+
+        my @header = ($key, $value, path => $path, domain => $domain);
+        push @header, port => $port if defined $port;
+        push @header, path_spec => undef if $path_spec;
+        push @header, secure => undef if $secure;
+        push @header, expires => HTTP::Date::time2isoz($expires) if $expires;
+        push @header, discard => undef if $discard;
+        for my $attribute (sort keys %{ $rest || {} }) {
+            push @header, $attribute => $rest->{$attribute};
+        }
+        push @header, version => $version;
+        push @result, 'Set-Cookie3: ' . _join_header_words(\@header);
+    });
+
+    return join "\n", @result, '';
 }
 
 sub extract_cookies {

--- a/src/test/resources/unit/fork_open_no_command.t
+++ b/src/test/resources/unit/fork_open_no_command.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+my $pid = open my $child, '-|';
+if (!defined $pid) {
+    fail('no-command fork-open starts a child');
+    fail('parent can read child output');
+    fail('child exits successfully');
+}
+elsif (!$pid) {
+    print "fork-open child output\n";
+    exit 0;
+}
+else {
+    ok($pid > 0, 'no-command fork-open starts a child');
+    is(<$child>, "fork-open child output\n", 'parent can read child output');
+    ok(close($child), 'child exits successfully');
+}

--- a/src/test/resources/unit/http_cookies_as_string.t
+++ b/src/test/resources/unit/http_cookies_as_string.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More tests => 6;
+
+use HTTP::Cookies;
+
+my $jar = HTTP::Cookies->new;
+$jar->set_cookie(1, 'session', 'value with spaces', '/private', 'example.test',
+    '443', 1, 1, undef, 1);
+
+my $serialized = $jar->as_string;
+like($serialized, qr/^Set-Cookie3: session="value with spaces";/,
+    'quotes cookie values containing spaces');
+like($serialized, qr/; path="\/private";/, 'serializes the cookie path');
+like($serialized, qr/; domain=example\.test;/, 'serializes the cookie domain');
+like($serialized, qr/; port=443; path_spec; secure; discard; version=1\n\z/,
+    'serializes cookie attributes in HTTP::Cookies order');
+is($jar->as_string(1), '', 'can omit discard cookies');
+
+$jar->set_cookie(0, 'plain', 'value', '/', 'example.test');
+like($jar->as_string, qr/^Set-Cookie3: plain=value; path="\/"; domain=example\.test; version=0$/m,
+    'serializes a plain version zero cookie');


### PR DESCRIPTION
## Summary

- emulate no-command `open FH, "-|"` / `"|-"` by replaying the active Perl program in a marked child JVM
- preserve fork-visible stdout and `$$` behavior while supporting both CLI and embedded runners
- implement `HTTP::Cookies::as_string` in the bundled provider used by `WWW::Mechanize::clone`
- add system-Perl-validated regression coverage for both fixes

## Validation

- `make` — passes all five unit-test shards
- system Perl: `fork_open_no_command.t` — passes 3/3
- system Perl: `http_cookies_as_string.t` — passes 6/6
- `WWW::Mechanize` `t/clone.t` — passes 6/6
- `WWW::Mechanize` `t/cookies.t` — passes 14/14
- `./jcpan --jobs 8 -t WWW::Mechanize` — 64/65 programs and 913/914 assertions pass; the sole remaining `t/local/overload.t` failure is ignored because the distribution's corresponding localhost test also fails under system Perl in this environment

Generated with [Codex](https://openai.com/codex)
