### PR TITLE
docs: deliver permanent Perl thread release gates

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,14 +41,15 @@ jobs:
         if: runner.os == 'Linux'
         run: make ci
 
-      - name: Checkout Perl 5.44 thread test distributions
+      - name: Checkout pinned Perl thread compatibility corpus
         if: runner.os == 'Linux'
         uses: actions/checkout@v4
         with:
           repository: Perl/perl5
-          ref: v5.44.0
+          ref: de80c8ecd40c6d5b677847699e5482b44bc748c6
           path: perl5
           sparse-checkout: |
+            t
             dist/threads
             dist/threads-shared
             dist/Thread-Queue

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,6 +41,11 @@ jobs:
         if: runner.os == 'Linux'
         run: make ci
 
+      - name: Run Perl thread compatibility gate
+        if: runner.os == 'Linux'
+        timeout-minutes: 20
+        run: make test-threads
+
       - name: Generate SBOM (Linux only)
         if: runner.os == 'Linux'
         run: make sbom
@@ -59,4 +64,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.os }}
-          path: build/reports/tests/test/
+          path: |
+            build/reports/tests/test/
+            build/reports/threads/

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,6 +41,19 @@ jobs:
         if: runner.os == 'Linux'
         run: make ci
 
+      - name: Checkout Perl 5.44 thread test distributions
+        if: runner.os == 'Linux'
+        uses: actions/checkout@v4
+        with:
+          repository: Perl/perl5
+          ref: v5.44.0
+          path: perl5
+          sparse-checkout: |
+            dist/threads
+            dist/threads-shared
+            dist/Thread-Queue
+            dist/Thread-Semaphore
+
       - name: Run Perl thread compatibility gate
         if: runner.os == 'Linux'
         timeout-minutes: 20

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean test test-unit test-interpreter test-threads test-threads-release test-bundled-modules test-cpan-distroprefs test-exiftool test-all test-gradle test-gradle-unit test-gradle-all test-gradle-parallel test-maven-parallel build run wrapper check-java-gradle dev ci sbom sbom-java sbom-perl sbom-clean check-links
+.PHONY: all clean test test-unit test-interpreter check-thread-test-sources test-threads test-threads-release test-bundled-modules test-cpan-distroprefs test-exiftool test-all test-gradle test-gradle-unit test-gradle-all test-gradle-parallel test-maven-parallel build run wrapper check-java-gradle dev ci sbom sbom-java sbom-perl sbom-clean check-links
 
 THREAD_DIST_DIRS := perl5/dist/threads/t perl5/dist/threads-shared/t perl5/dist/Thread-Queue/t perl5/dist/Thread-Semaphore/t
 THREAD_PLATFORM_TESTS := \
@@ -109,11 +109,23 @@ test-interpreter:
 	@echo "Running unit tests with bytecode interpreter..."
 	JPERL_INTERPRETER=1 perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 60 --output test_interpreter_results.json src/test/resources/unit
 
+# Verify the unchanged upstream test distributions are available. GitHub CI
+# sparse-checks them out at the Perl v5.44.0 tag; local developers normally use
+# their adjacent/gitignored perl5 source tree.
+check-thread-test-sources:
+	@for dir in $(THREAD_DIST_DIRS); do \
+		if [ ! -d "$$dir" ]; then \
+			echo "Error: $$dir is missing."; \
+			echo "Clone Perl v5.44.0 into ./perl5 before running the thread gates."; \
+			exit 1; \
+		fi; \
+	done
+
 # Permanent Perl ithread compatibility gate used by Ubuntu pull-request CI.
 # Full upstream distributions run on both backends with the default virtual
 # carrier; lifecycle, stack, signal, wait, timeout, and deadlock coverage also
 # runs on the platform carrier. Reports are retained under build/reports/threads.
-test-threads: check-java-gradle
+test-threads: check-java-gradle check-thread-test-sources
 	@mkdir -p build/reports/threads
 	JPERL_THREAD_MODE=virtual perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 300 --output build/reports/threads/jvm-virtual.json $(THREAD_DIST_DIRS)
 	JPERL_INTERPRETER=1 JPERL_THREAD_MODE=virtual perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 300 --output build/reports/threads/interpreter-virtual.json $(THREAD_DIST_DIRS)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,26 @@
-.PHONY: all clean test test-unit test-interpreter test-bundled-modules test-cpan-distroprefs test-exiftool test-all test-gradle test-gradle-unit test-gradle-all test-gradle-parallel test-maven-parallel build run wrapper check-java-gradle dev ci sbom sbom-java sbom-perl sbom-clean check-links
+.PHONY: all clean test test-unit test-interpreter test-threads test-threads-release test-bundled-modules test-cpan-distroprefs test-exiftool test-all test-gradle test-gradle-unit test-gradle-all test-gradle-parallel test-maven-parallel build run wrapper check-java-gradle dev ci sbom sbom-java sbom-perl sbom-clean check-links
+
+THREAD_DIST_DIRS := perl5/dist/threads/t perl5/dist/threads-shared/t perl5/dist/Thread-Queue/t perl5/dist/Thread-Semaphore/t
+THREAD_PLATFORM_TESTS := \
+	perl5/dist/threads/t/end.t \
+	perl5/dist/threads/t/exit.t \
+	perl5/dist/threads/t/free.t \
+	perl5/dist/threads/t/free2.t \
+	perl5/dist/threads/t/join.t \
+	perl5/dist/threads/t/kill.t \
+	perl5/dist/threads/t/kill2.t \
+	perl5/dist/threads/t/kill3.t \
+	perl5/dist/threads/t/stack.t \
+	perl5/dist/threads/t/stack_env.t \
+	perl5/dist/threads/t/state.t \
+	perl5/dist/threads/t/zz_deadlock.t \
+	perl5/dist/threads-shared/t/cond.t \
+	perl5/dist/threads-shared/t/wait.t \
+	perl5/dist/threads-shared/t/waithires.t \
+	perl5/dist/Thread-Queue/t/09_ended.t \
+	perl5/dist/Thread-Queue/t/10_timed.t \
+	perl5/dist/Thread-Semaphore/t/04_nonblocking.t \
+	perl5/dist/Thread-Semaphore/t/06_timed.t
 
 all: build
 
@@ -86,6 +108,23 @@ endif
 test-interpreter:
 	@echo "Running unit tests with bytecode interpreter..."
 	JPERL_INTERPRETER=1 perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 60 --output test_interpreter_results.json src/test/resources/unit
+
+# Permanent Perl ithread compatibility gate used by Ubuntu pull-request CI.
+# Full upstream distributions run on both backends with the default virtual
+# carrier; lifecycle, stack, signal, wait, timeout, and deadlock coverage also
+# runs on the platform carrier. Reports are retained under build/reports/threads.
+test-threads: check-java-gradle
+	@mkdir -p build/reports/threads
+	JPERL_THREAD_MODE=virtual perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 300 --output build/reports/threads/jvm-virtual.json $(THREAD_DIST_DIRS)
+	JPERL_INTERPRETER=1 JPERL_THREAD_MODE=virtual perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 300 --output build/reports/threads/interpreter-virtual.json $(THREAD_DIST_DIRS)
+	JPERL_THREAD_MODE=platform perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 300 --output build/reports/threads/platform-focused.json $(THREAD_PLATFORM_TESTS)
+
+# Thread release gate: extend the PR gate to the complete platform-carrier
+# distribution matrix. Together with test-threads this covers both backends on
+# both carrier policies without making every pull request repeat all four runs.
+test-threads-release: test-threads
+	JPERL_THREAD_MODE=platform perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 300 --output build/reports/threads/jvm-platform.json $(THREAD_DIST_DIRS)
+	JPERL_INTERPRETER=1 JPERL_THREAD_MODE=platform perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 300 --output build/reports/threads/interpreter-platform.json $(THREAD_DIST_DIRS)
 
 # Bundled CPAN module tests (XML::Parser, etc.)
 # Tests live under src/test/resources/module/{ModuleName}/t/

--- a/Makefile
+++ b/Makefile
@@ -127,16 +127,16 @@ check-thread-test-sources:
 # runs on the platform carrier. Reports are retained under build/reports/threads.
 test-threads: check-java-gradle check-thread-test-sources
 	@mkdir -p build/reports/threads
-	JPERL_THREAD_MODE=virtual perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 300 --output build/reports/threads/jvm-virtual.json $(THREAD_DIST_DIRS)
-	JPERL_INTERPRETER=1 JPERL_THREAD_MODE=virtual perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 300 --output build/reports/threads/interpreter-virtual.json $(THREAD_DIST_DIRS)
-	JPERL_THREAD_MODE=platform perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 300 --output build/reports/threads/platform-focused.json $(THREAD_PLATFORM_TESTS)
+	JPERL_THREAD_MODE=virtual perl dev/tools/perl_test_runner.pl --strict-exit --jobs 8 --timeout 300 --output build/reports/threads/jvm-virtual.json $(THREAD_DIST_DIRS)
+	JPERL_INTERPRETER=1 JPERL_THREAD_MODE=virtual perl dev/tools/perl_test_runner.pl --strict-exit --jobs 8 --timeout 300 --output build/reports/threads/interpreter-virtual.json $(THREAD_DIST_DIRS)
+	JPERL_THREAD_MODE=platform perl dev/tools/perl_test_runner.pl --strict-exit --jobs 8 --timeout 300 --output build/reports/threads/platform-focused.json $(THREAD_PLATFORM_TESTS)
 
 # Thread release gate: extend the PR gate to the complete platform-carrier
 # distribution matrix. Together with test-threads this covers both backends on
 # both carrier policies without making every pull request repeat all four runs.
 test-threads-release: test-threads
-	JPERL_THREAD_MODE=platform perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 300 --output build/reports/threads/jvm-platform.json $(THREAD_DIST_DIRS)
-	JPERL_INTERPRETER=1 JPERL_THREAD_MODE=platform perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 300 --output build/reports/threads/interpreter-platform.json $(THREAD_DIST_DIRS)
+	JPERL_THREAD_MODE=platform perl dev/tools/perl_test_runner.pl --strict-exit --jobs 8 --timeout 300 --output build/reports/threads/jvm-platform.json $(THREAD_DIST_DIRS)
+	JPERL_INTERPRETER=1 JPERL_THREAD_MODE=platform perl dev/tools/perl_test_runner.pl --strict-exit --jobs 8 --timeout 300 --output build/reports/threads/interpreter-platform.json $(THREAD_DIST_DIRS)
 
 # Bundled CPAN module tests (XML::Parser, etc.)
 # Tests live under src/test/resources/module/{ModuleName}/t/

--- a/Makefile
+++ b/Makefile
@@ -110,13 +110,13 @@ test-interpreter:
 	JPERL_INTERPRETER=1 perl dev/tools/perl_test_runner.pl --jobs 8 --timeout 60 --output test_interpreter_results.json src/test/resources/unit
 
 # Verify the unchanged upstream test distributions are available. GitHub CI
-# sparse-checks them out at the Perl v5.44.0 tag; local developers normally use
-# their adjacent/gitignored perl5 source tree.
+# sparse-checks them out at the compatibility-corpus commit recorded below;
+# local developers normally use their adjacent/gitignored perl5 source tree.
 check-thread-test-sources:
 	@for dir in $(THREAD_DIST_DIRS); do \
 		if [ ! -d "$$dir" ]; then \
 			echo "Error: $$dir is missing."; \
-			echo "Clone Perl v5.44.0 into ./perl5 before running the thread gates."; \
+			echo "Clone Perl commit de80c8ecd40c6d5b677847699e5482b44bc748c6 into ./perl5 before running the thread gates."; \
 			exit 1; \
 		fi; \
 	done

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -1,7 +1,7 @@
 # Perl Threads Implementation Plan
 
-**Status:** Active implementation plan
-**Version:** 2.2
+**Status:** Delivered; compatibility maintenance
+**Version:** 3.0
 **Date:** 2026-08-15
 
 ## 1. Goal and Non-Negotiable Delivery Rule
@@ -222,13 +222,13 @@ direct companions.
 ## 6. Supporting Design Contracts
 
 - `dev/design/attributes.md` defines the supported `shared` attribute surface.
-- `dev/design/runtime-pooling-reset-contract.md` defines the proof required
-  before runtime pooling can be enabled.
+- `dev/design/runtime-pooling-reset-contract.md` defines the implemented
+  bounded pool reset and fresh-runtime replacement contract.
 - `dev/design/phase36-regex-parity.md` owns direct regex-language and Joni work.
 
 ## 7. Progress Tracking
 
-### Current Status: release validation in progress; Joni/regex parity is separate
+### Current Status: delivered; Joni/regex parity is separate
 
 `PerlRuntime` owns interpreter state, ithreads clone one isolated runtime graph,
 and `threads::shared` supplies explicit cross-runtime storage and synchronization.
@@ -246,19 +246,21 @@ requests.
 
 ### Next Steps
 
-1. Finish the local release gates: `make`, documentation links, all four
-   upstream distribution configurations, the thread preservation matrix,
-   and `timeout 3600 ./jcpan --jobs 8 -t DBIx::Class`.
-2. Review the final diff for temporary diagnostics, generated files, accidental
-   upstream-test edits, and any mutable runtime state lacking an ownership
-   classification.
-3. Open the pull request with the exact gate results in its commit messages and
-   description.
-4. Require green Ubuntu and Windows CI. Investigate and fix any CI failure on
-   the branch; do not merge on a rerun-only explanation.
-5. After merge, treat the four unchanged upstream distributions as permanent
-   regression gates. Continue direct regex-language work, including Joni, only
-   in the separate Phase 36 project.
+1. Keep `make test-threads` as a permanent Ubuntu pull-request gate. It runs
+   both execution backends with virtual carriers and focused platform lifecycle,
+   signal, stack, wait, timeout, and deadlock coverage.
+2. Run `make test-threads-release` before any thread/runtime release. It extends
+   the pull-request gate to the complete four-module matrix on platform carriers.
+3. Continue CPAN ecosystem hardening: opt-in Test2 stress tests, remaining Moose
+   thread-suite classification, Net::SSLeay callback suites 61/62, and permanent
+   DBI ownership plus DBIx::Class release coverage.
+4. Require every future native resource, I/O handle, and callback adapter to
+   declare its runtime ownership, snapshot, aliasing, and close policy.
+5. Monitor snapshot retention and startup cost. Runtime pooling remains bounded,
+   opt-in, and disabled by default; returned application runtimes are replaced,
+   not partially reused.
+6. Keep direct regex-language and Joni work in the separate Phase 36 project.
+   Threaded regex wrappers must preserve their same-commit direct behavior.
 
 Direct regex-language work, including Joni integration, is not part of this
 release.
@@ -278,6 +280,7 @@ relative to their same-commit direct companions.
 ## Related Documents
 
 - `dev/design/attributes.md` — current attribute behavior
-- `dev/design/runtime-pooling-reset-contract.md` — required proof before pooling
+- `dev/design/runtime-pooling-reset-contract.md` — bounded pooling and
+  fresh-runtime replacement contract
 - `dev/design/phase36-regex-parity.md` — independent regex parity project
 - `dev/design/fork_open_emulation.md` — process/fork-related alternatives

--- a/dev/tools/perl_test_runner.pl
+++ b/dev/tools/perl_test_runner.pl
@@ -18,12 +18,14 @@ my $timeout = 300; # Default to 300 seconds
 my $jobs = 5;     # Default to 5 parallel jobs
 my $output_file;
 my $help;
+my $strict_exit = 0;
 
 GetOptions(
     'jperl=s'   => \$jperl_path,
     'timeout=f' => \$timeout,
     'jobs|j=i'  => \$jobs,
     'output=s'  => \$output_file,
+    'strict-exit!' => \$strict_exit,
     'help'      => \$help,
 ) or die "Error in command line arguments\n";
 
@@ -111,6 +113,12 @@ print_feature_impact();
 
 if ($output_file) {
     save_results($output_file);
+}
+
+if ($strict_exit
+        && ($summary{fail} || $summary{error} || $summary{timeout}
+            || $summary{incomplete})) {
+    exit 1;
 }
 
 # Subroutines
@@ -504,6 +512,8 @@ sub timeout_for_test {
 sub requires_exclusive_slot {
     my ($test_file) = @_;
     return $test_file =~ m{
+          (?:^|/)perl5/dist/threads/t/join\.t$
+        |
           (?:^|/)perl5_t/t/op/gv\.t$
         | (?:^|/)perl5_t/t/re/pat(?:_thr)?\.t$
         | (?:^|/)perl5_t/t/re/pat_psycho(?:_thr)?\.t$
@@ -820,6 +830,7 @@ Options:
                    subprocess-heavy tests have a documented minimum)
   --jobs|-j NUM    Number of parallel jobs (default: 5)
   --output FILE    Save detailed results to JSON file
+  --strict-exit    Exit nonzero if any file fails, errors, times out, or is incomplete
   --help           Show this help message
 
 Examples:

--- a/dev/tools/perl_test_runner.pl
+++ b/dev/tools/perl_test_runner.pl
@@ -247,6 +247,12 @@ sub process_test_result {
     print " " x (50 - length($rel_path)) if length($rel_path) < 50;
     printf " ... %s %d/%d ok (%.2fs)\n",
         $char, $result->{ok_count}, $result->{total_tests}, $duration;
+    if ($result->{status} ne 'pass' && defined $result->{failure_output}) {
+        print "----- captured output: $rel_path -----\n";
+        print $result->{failure_output};
+        print "\n" unless $result->{failure_output} =~ /\n\z/;
+        print "----- end captured output -----\n";
+    }
 }
 
 # Single, clean run_single_test function
@@ -483,6 +489,11 @@ sub run_single_test {
 
     my $result = parse_tap_output($output, $exit_code);
     $result->{raw_output_path} = $raw_output_path;
+    # Preserve a bounded diagnostic tail in the JSON report and CI log.  Raw
+    # output normally lives in /tmp on the worker and disappears before an
+    # uploaded report can be inspected.
+    $result->{failure_output} = substr($output, -32768)
+        if $result->{status} ne 'pass';
     return $result;
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Technical reference documentation:
 - **[Bundled Modules](reference/bundled-modules.md)** - Complete list of included modules
 - **[XS Compatibility](reference/xs-compatibility.md)** - XS modules and Java implementations
 - **[CLI Options](reference/cli-options.md)** - Command-line reference
-- **[Concurrency](reference/feature-matrix.md#concurrency-and-perl-threads)** - Multiplicity, ithreads, shared storage, and limitations
+- **[Perl Threads](reference/threads.md)** - Ithreads, shared storage, carrier policy, resources, and testing
 - **[Runtime Configuration](reference/configure.md#runtime-thread-configuration)** - Thread capability flags and execution mode
 - **[Memory Management](reference/memory-management.md)** - JVM GC, deterministic destruction, weak references, and threads
 - **[Testing](reference/testing.md)** - Test suite information

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -8,7 +8,7 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
   manifest, provide a JAXP-backed `XML::LibXSLT`, and preserve descriptors for
   anonymous handles stored in container lvalues. This unblocks
   `Catmandu::CrossRef` and `AnyEvent::SMTP` without distribution preferences.
-- Add Perl interpreter multiplicity and the supported ithread tranche across
+- Add Perl interpreter multiplicity and full ithread support across
   the JVM and interpreter backends. Mutable execution state is owned by
   independent `PerlRuntime` instances; child threads receive identity-aware
   snapshots, while `threads::shared` preserves explicitly shared
@@ -22,9 +22,11 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
   registrations retain their owning runtime, internal pipes have an explicit
   inherited-handle policy, and nested plain shared graphs are validated before
   publication. General resource inheritance, DBI ownership, lexical regex
-  diagnostics, blessed roots, and tied shared-value conversion are implemented;
-  exact nested shared-reference proxies remain limited;
-  see the [feature matrix](../reference/feature-matrix.md#concurrency-and-perl-threads).
+  diagnostics, blessed roots, tied shared-value conversion, nested shared
+  proxy views, and global final destruction are implemented. The unchanged
+  upstream `threads`, `threads::shared`, `Thread::Queue`, and
+  `Thread::Semaphore` distributions pass on both backends and both Java carrier
+  policies; see the [Perl threads reference](../reference/threads.md).
 - CPAN/tooling: expose tested dependency scripts through `PATH`, deduplicate
   repeated `PERL5LIB` setup, and resolve test prerequisites against tested
   `blib` trees before launching tests. Add `JSON::DWIW`, `Taint::Runtime`, and

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -46,10 +46,10 @@ These capabilities are implemented and available in the current release:
 - **I/O Subsystem** — Sockets, I/O layers (`:raw`, `:utf8`, `:crlf`, `:encoding()`), in-memory files, pipes, file descriptor duplication, `flock`, tied handles.
 - **Multiplicity and Perl ithreads** — Mutable interpreter state is owned by
   `PerlRuntime`; `Config` advertises `useithreads`, `usethreads`, and
-  `usemultiplicity`. The supported `threads` and `threads::shared` tranche
-  includes isolated create/join, shared scalar/array/hash storage, recursive
-  locks, and condition variables on both backends. See the
-  [feature matrix](../reference/feature-matrix.md#concurrency-and-perl-threads).
+  `usemultiplicity`. The bundled `threads`, `threads::shared`, `Thread::Queue`,
+  and `Thread::Semaphore` distributions pass unchanged on both backends and
+  both Java carrier policies. See the
+  [Perl threads reference](../reference/threads.md).
 - **Pack/Unpack** — Full template support for binary data manipulation. See `dev/design/pack_unpack_architecture.md`.
 - **Subroutine Prototypes and Signatures** — All prototype characters supported; formal parameter signatures implemented.
 - **`format`/`write`** — Report generation with `formline` and `$^A` accumulator.
@@ -259,17 +259,17 @@ Introduce a normalization pass between parsing and code generation to eliminate 
 
 ## Objective 6: Concurrency & Runtime Isolation
 
-*Priority: Long-term — Major architectural work required.*
+*Priority: Maintenance and ecosystem hardening.*
 
 See `dev/design/concurrency.md` for the comprehensive design covering multiplicity, fork emulation, and threads.
 
 ### Multiplicity
 
-Multiple independent `PerlRuntime` instances and snapshot cloning are now
-implemented. Remaining work is compatibility hardening: close the applicable
-core/CPAN thread-suite gaps, prove native callback isolation, and define a
-reset contract before considering runtime pooling. Multiplicity alone does not
-make one JSR-223 engine or one captured PSGI app concurrently callable.
+Multiple independent `PerlRuntime` instances and snapshot cloning are
+implemented. The bounded PSGI runtime pool is opt-in and replaces returned app
+snapshots from an authoritative template; it does not partially reset and reuse
+an entered runtime. Multiplicity alone does not make one JSR-223 engine or one
+captured PSGI app concurrently callable.
 
 ### Fork Emulation
 
@@ -281,18 +281,18 @@ Implement `fork()` via runtime cloning + thread. Currently returns `undef`.
 
 ### Threads (ithreads)
 
-The supported ithread tranche is shipped: snapshot-based variable isolation,
-create/join/detach and lifecycle inspection, nested threads and child exit,
-`threads::shared` storage, recursive locks, and condition variables. Java 24
-virtual threads are the default; platform carriers remain selectable.
+Perl ithreads are shipped: snapshot-based variable isolation, lifecycle and
+signals, nested threads and child exit, `threads::shared` graphs and proxies,
+locks and conditions, `Thread::Queue`, and `Thread::Semaphore`. Java 24 virtual
+threads are the default; platform carriers remain selectable.
 
 Remaining work:
 
-- Complete the currently partial applicable core and regex suites.
-- Finish exact nested-reference proxy identity and global `DESTROY` ownership
-  for blessed values fetched through `threads::shared` aggregates. Root
-  blessed storage and the system-Perl tied conversion rules are implemented.
-- Keep runtime pooling disabled until the reset-equivalence contract is proven.
+- Keep the permanent PR and release matrices green.
+- Broaden CPAN/native ecosystem coverage, including opt-in Test2 and Moose
+  thread suites and Net::SSLeay callback stress.
+- Keep direct regex-language/Joni work in the separate Phase 36 project while
+  thread wrappers preserve the behavior of their direct companions.
 
 ---
 

--- a/docs/reference/cli-options.md
+++ b/docs/reference/cli-options.md
@@ -227,6 +227,7 @@ JPERL_OPTS='-Djperl.thread.mode=platform' ./jperl threaded.pl
 The carrier selection does not change Perl snapshot or shared-storage
 semantics. A nonzero per-thread stack request automatically selects a platform
 carrier because virtual-thread stacks are JVM-managed. See the
+[Perl threads reference](threads.md) and
 [concurrency feature matrix](feature-matrix.md#concurrency-and-perl-threads).
 
 ### Runtime pooling

--- a/docs/reference/configure.md
+++ b/docs/reference/configure.md
@@ -29,7 +29,8 @@ module reports the shipped runtime capabilities directly:
 Java 24 virtual threads are the launcher default. The platform executor remains
 available process-wide with `JPERL_THREAD_MODE=platform` or the JVM property
 `-Djperl.thread.mode=platform`. Unknown values are rejected. See
-[CLI Options](cli-options.md#thread-execution-mode) and the
+[CLI Options](cli-options.md#thread-execution-mode), the
+[Perl threads reference](threads.md), and the
 [feature matrix](feature-matrix.md#concurrency-and-perl-threads).
 
 Runtime pooling is independently opt-in. `JPERL_RUNTIME_POOL_SIZE=N` (or

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -48,6 +48,7 @@ PerlOnJava implements most core Perl features with some key differences:
 - Tied variables
 - Taint mode (`-T`)
 - Method Resolution Order
+- Perl ithreads, `threads::shared`, `Thread::Queue`, and `Thread::Semaphore`
 
 🚧 Partially Supported:
 - Warnings and strict pragma
@@ -59,9 +60,6 @@ PerlOnJava implements most core Perl features with some key differences:
 ❌ Not Supported:
 - XS modules and C integration
 - `fork`
-
-🟡 Supported with limitations:
-- Perl ithreads and `threads::shared` (see [Concurrency and Perl Threads](#concurrency-and-perl-threads))
 
 ---
 
@@ -689,12 +687,16 @@ The `:encoding()` layer supports all encodings provided by Java's `Charset.forNa
 - ✅  **Benchmark** use the same version as Perl.
 - ✅  **Carp**: `carp`, `cluck`, `croak`, `confess`, `longmess`, `shortmess` are implemented.
 - ✅  **Config** module.
-- 🟡  **threads** module: isolated create/join, identity, listing, detach,
+- ✅  **threads** module: isolated create/join, identity, listing, detach,
   state inspection, child exit, errors, `async`, `yield`, and supported import
-  options. See [Concurrency and Perl Threads](#concurrency-and-perl-threads).
-- 🟡  **threads::shared** module: shared scalar/array/hash storage, including
+  options. See the [Perl threads reference](threads.md).
+- ✅  **threads::shared** module: shared scalar/array/hash storage, including
   blessed aggregate roots and supported tied-value conversions, recursive
   lexical locks, condition variables, and supported graph cloning.
+- ✅  **Thread::Queue** module: blocking, timed, nonblocking, force, limit,
+  insert, extract, and error behavior.
+- ✅  **Thread::Semaphore** module: blocking, timed, nonblocking, force, and
+  error behavior.
 - ✅  **Cwd** module
 - ✅  **Data::Dumper**: use the same version as Perl.
 - ✅  **DirHandle** module.
@@ -840,8 +842,10 @@ The DBI module provides seamless integration with JDBC drivers:
 
 ## Concurrency and Perl Threads
 
-PerlOnJava implements interpreter multiplicity and a measured subset of Perl
-ithreads on both the JVM compiler and bytecode interpreter backends.
+PerlOnJava implements Perl interpreter multiplicity and ithreads on both the JVM
+compiler and bytecode interpreter backends. The complete unchanged upstream
+test distributions for `threads`, `threads::shared`, `Thread::Queue`, and
+`Thread::Semaphore` pass on virtual and platform Java carriers.
 
 | Capability | Status | Notes |
 |---|---|---|
@@ -849,7 +853,8 @@ ithreads on both the JVM compiler and bytecode interpreter backends.
 | Runtime isolation | ✅ | Mutable globals, dynamic state, hints, warnings, regex state, lifecycle queues, signals, alarms, and I/O registries are runtime-owned. |
 | `threads->create`, `async`, `join`, `detach` | ✅ | A child receives a snapshot; ordinary parent and child values then evolve independently. Join results are cloned back to the caller. |
 | Identity and state | ✅ | `self`, `tid`, `list`, equality, running/joinable/detached checks, errors, nested threads, and child-only `threads->exit` are supported. |
-| `threads::shared` | 🟡 | `share`, `is_shared`, `shared_clone`, and `:shared` support scalar/array/hash graphs. Blessed aggregate roots use runtime-local class views over common backing; tied scalars clone callback state and tied arrays/hashes convert to native shared storage when shared. |
+| `threads::shared` | ✅ | `share`, `is_shared`, `shared_clone`, and `:shared` support scalar/array/hash graphs. Nested fetches use runtime-local proxy views over common backing; blessing, ties, weak views, cycles, and final destruction follow the classified shared-storage policies. |
+| `Thread::Queue` and `Thread::Semaphore` | ✅ | The unchanged upstream distributions pass their blocking, timed, nonblocking, force, limit, insert/extract, and error tests. |
 | Locks and conditions | ✅ | Recursive lexical `lock`, `cond_wait`, absolute `cond_timedwait`, `cond_signal`, and `cond_broadcast` are supported. |
 | Platform threads | ✅ | Explicit compatibility mode and automatic fallback for a nonzero stack-size request. |
 | Virtual threads | ✅ | Java 24 launcher default; snapshot, lifecycle, shared-storage, native-callback, DBI, and Test2 gates retain platform parity. |
@@ -859,20 +864,20 @@ aliasing and cycles preserved inside the child graph, but they are not the same
 storage as their parent counterparts. Values explicitly shared through
 `threads::shared` retain common backing storage.
 
-### Current limitations
+### JVM execution and resource policies
 
-| Limitation | Effect |
+| Policy | Effect |
 |---|---|
 | Thread signals | `threads->kill` targets live attached children and resolves the handler inside the child runtime. Completed and detached targets are not signalable. |
 | Effective stack sizing | Platform-backed children honor supported `stack_size` create/import requests. A nonzero request under the default virtual policy transparently selects a platform child. |
 | Additional introspection | `threads->object` and creation-context `wantarray` are implemented. CLI shutdown reports running and finished unjoined threads; detached children are silent. |
-| Nested shared-object proxy identity | Root blessed/tied policies are implemented. Exact fresh proxy identity for nested references fetched from shared aggregates, and one global `DESTROY` owner across those views, remain follow-up work. |
 | Native resources and callbacks | File, socket, process, native-descriptor, scalar, layered, duplicated, borrowed, directory, and standard handles have explicit inheritance policies. Net::SSLeay handles remain runtime-owned and stored callbacks bind their registering runtime. |
-| Upstream suite coverage | Core thread/lvalue coverage includes `op/index_thr.t` 415/415 and `op/substr_thr.t` 400/400 on both backends. `class/threads.t`, Storable's thread test, `threads-dirh.t`, Test2's default thread IPC acceptance, and `user_prop_race_thr.t` complete. Lexical `re 'debug'` is runtime-owned; remaining regex-language gaps are tracked against direct companion tests. |
+| Upstream suite coverage | The four bundled thread distributions pass 64 files and 1,891 assertions in each backend/carrier configuration. The PR gate runs two complete virtual configurations plus focused platform lifecycle coverage; the release gate runs all four complete configurations. Direct regex-language gaps remain in the separate Phase 36 project. |
 | PSGI | The default single-runtime handler advertises `psgi.multithread => \0`. A bounded opt-in pool gives every concurrent request an independent app snapshot and advertises `\1`; pool size defaults to zero. |
 
-The complete design and measured validation record is in
-[Concurrency and runtime isolation](../../dev/design/concurrency.md).
+See the [Perl threads reference](threads.md) for behavior and test commands and
+[Concurrency and runtime isolation](../../dev/design/concurrency.md) for the
+maintenance contract.
 
 ---
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -30,6 +30,31 @@ Runs all tests including comprehensive module tests. These tests:
 - 🎯 Identify high-priority opportunities (incomplete tests)
 - 📈 Provide feature impact analysis
 
+### Perl Thread Compatibility
+
+The permanent pull-request gate runs the complete unchanged upstream
+`threads`, `threads::shared`, `Thread::Queue`, and `Thread::Semaphore` suites on
+the JVM and interpreter backends with virtual carriers. It also runs focused
+lifecycle, signal, stack, condition, timeout, and deadlock tests with platform
+carriers:
+
+```bash
+make test-threads
+```
+
+Before a thread/runtime release, extend that gate to the complete four-mode
+matrix (both execution backends on virtual and platform carriers):
+
+```bash
+make test-threads-release
+```
+
+Both targets use eight jobs and a hard 300-second timeout for each file. JSON
+reports are written under `build/reports/threads/`. The shorter target is used
+by Ubuntu pull-request CI; Windows continues to run the Java/unit build gate.
+See the [Perl threads reference](threads.md) for the compatibility contract and
+resource policies.
+
 ## Testing Approaches
 
 ### 1. Perl-Style Testing (Default)
@@ -179,21 +204,23 @@ For long-running development work, track test results over time to monitor progr
 #### 1. Run Tests with Timestamped Logs
 
 ```bash
-# Clean up and run comprehensive tests
-killall java
-rm -rf perl5_t/t/tmp_*
-
 # Run with extended timeout and save to dated log
 perl dev/tools/perl_test_runner.pl \
+  --jobs 10 \
   --timeout 300 \
   --output out.json \
   perl5_t/t \
-  2>&1 > logs/test_$(date +%Y%m%d_%H%M%S).log
+  > logs/test_$(date +%Y%m%d_%H%M%S).log 2>&1
 ```
 
 **Workflow details:**
-- `killall java` - Stop any hung Java processes from previous runs
-- `rm -rf perl5_t/t/tmp_*` - Clean temporary test files
+- Inspect exact process command lines before and after a long run. Never use a
+  broad Java process kill: it can terminate an active build or another user's
+  test. If an abandoned PerlOnJava JVM is proven by its full command line,
+  terminate that exact PID only.
+- Do not recursively delete wildcard test directories as routine preparation.
+  Remove an exact, verified stale path only when the failing test requires it.
+- `--jobs 10` - Run ten independent test files concurrently
 - `--timeout 300` - Allow 5 minutes per test (for slower tests)
 - `logs/test_YYYYMMDD_HHMMSS.log` - Timestamped log for tracking history
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -57,7 +57,9 @@ make test-threads-release
 
 Both targets use eight jobs and a hard 300-second timeout for each file. JSON
 reports are written under `build/reports/threads/`. The shorter target is used
-by Ubuntu pull-request CI; Windows continues to run the Java/unit build gate.
+by Ubuntu pull-request CI and uses the runner's strict exit mode, so any failed,
+errored, timed-out, or incomplete file fails the Make target. Windows continues
+to run the Java/unit build gate.
 See the [Perl threads reference](threads.md) for the compatibility contract and
 resource policies.
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -39,8 +39,12 @@ lifecycle, signal, stack, condition, timeout, and deadlock tests with platform
 carriers:
 
 ```bash
+git clone --depth 1 --branch v5.44.0 https://github.com/Perl/perl5.git perl5
 make test-threads
 ```
+
+Skip the clone when the gitignored `perl5/` source tree is already present. CI
+uses a sparse checkout containing only the four required distributions.
 
 Before a thread/runtime release, extend that gate to the complete four-mode
 matrix (both execution backends on virtual and platform carriers):

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -39,12 +39,14 @@ lifecycle, signal, stack, condition, timeout, and deadlock tests with platform
 carriers:
 
 ```bash
-git clone --depth 1 --branch v5.44.0 https://github.com/Perl/perl5.git perl5
+git clone https://github.com/Perl/perl5.git perl5
+git -C perl5 checkout de80c8ecd40c6d5b677847699e5482b44bc748c6
 make test-threads
 ```
 
 Skip the clone when the gitignored `perl5/` source tree is already present. CI
-uses a sparse checkout containing only the four required distributions.
+uses a sparse checkout containing the four required distributions and the core
+test harness at the same pinned commit.
 
 Before a thread/runtime release, extend that gate to the complete four-mode
 matrix (both execution backends on virtual and platform carriers):

--- a/docs/reference/threads.md
+++ b/docs/reference/threads.md
@@ -112,8 +112,9 @@ make test-threads-release
 ```
 
 Both targets use eight test jobs, a hard 300-second timeout per file, and write
-JSON reports under `build/reports/threads/`. DBIx::Class is a separate long
-release gate:
+JSON reports under `build/reports/threads/`. Timing-sensitive join coverage is
+given an exclusive runner slot, and strict exit mode makes any non-passing file
+fail the gate. DBIx::Class is a separate long release gate:
 
 ```bash
 timeout 3600 ./jcpan --jobs 8 -t DBIx::Class

--- a/docs/reference/threads.md
+++ b/docs/reference/threads.md
@@ -96,8 +96,12 @@ backends with virtual carriers, plus focused lifecycle, signal, stack, wait,
 timeout, and deadlock coverage on platform carriers:
 
 ```bash
+git clone --depth 1 --branch v5.44.0 https://github.com/Perl/perl5.git perl5
 make test-threads
 ```
+
+The clone is required only when an adjacent `perl5/` source tree is not already
+present. CI performs a sparse checkout of just the four distributions.
 
 Before a thread/runtime release, run the complete four-mode matrix:
 

--- a/docs/reference/threads.md
+++ b/docs/reference/threads.md
@@ -1,0 +1,121 @@
+# Perl Threads
+
+PerlOnJava supports Perl 5 interpreter threads (ithreads) on both execution
+backends. Each child owns an isolated snapshot of its parent's `PerlRuntime`.
+Ordinary values are cloned; values explicitly shared through
+`threads::shared` retain common storage.
+
+The bundled compatibility surface is:
+
+| Module | Version | Status |
+|---|---:|---|
+| `threads` | 2.43 | Supported |
+| `threads::shared` | 1.74 | Supported |
+| `Thread::Queue` | 3.14 | Supported |
+| `Thread::Semaphore` | 2.13 | Supported |
+
+The unchanged upstream test distributions for these four modules contain 64
+files and 1,891 assertions. They pass on the JVM compiler and bytecode
+interpreter with Java virtual and platform carriers.
+
+## Snapshot and Shared Storage
+
+`threads->create` snapshots the entry code, arguments, globals, closures, and
+reachable Perl graph. Identity, aliases, cycles, weak references, blessing,
+ties, and closure state are preserved within the child graph, but ordinary
+parent and child storage evolves independently. Results and uncaught errors are
+cloned back across the same boundary when the parent calls `join`.
+
+Use `threads::shared` only for state that must be common:
+
+- `share($scalar)` preserves the scalar value and makes its storage shared.
+- `share(@array)` and `share(%hash)` follow Perl's destructive aggregate
+  semantics and start with empty shared storage.
+- `shared_clone($value)` recursively publishes a preserving shared copy.
+- `lock`, `cond_wait`, `cond_timedwait`, `cond_signal`, and `cond_broadcast`
+  provide recursive lexical locking and condition coordination.
+- Nested aggregate fetches return runtime-local proxy references over common
+  storage. Local reblessing stays local until that view is stored back, and
+  final `DESTROY` ownership remains global across views.
+- Tied scalars retain runtime-local callback state. Sharing an already tied
+  array or hash converts it to Perl's native shared aggregate behavior.
+
+The recommended design is to share small coordination variables and keep bulk
+mutable work child-local. See the
+[dynamic map/reduce example](../../examples/threads/dynamic_map_reduce.pl).
+
+## Lifecycle and Carrier Policy
+
+Create/join/detach, identity and listing, creation context, errors, nested
+threads, `CLONE`/`CLONE_SKIP`, child exit, stack options, and live attached
+thread signals are supported. Completed or detached thread objects are not
+signal targets.
+
+Java 24 virtual threads are the default carrier. Select platform carriers for
+the process with:
+
+```bash
+JPERL_THREAD_MODE=platform ./jperl program.pl
+```
+
+The equivalent JVM property is `-Djperl.thread.mode=platform`. A nonzero Perl
+thread stack-size request automatically selects a platform carrier because a
+virtual thread's stack is JVM-managed. Carrier selection does not change Perl
+snapshot or shared-storage semantics.
+
+## Resource Ownership
+
+Native and Java resources do not use a generic shallow-copy rule. Every handle
+type has an explicit thread inheritance policy:
+
+- supported file, pipe, socket, process, scalar, layered, duplicate, borrowed,
+  directory, native-descriptor, and standard handles use their classified
+  clone/share/close behavior;
+- callback registrations bind the runtime that registered them;
+- DBI connections, statements, and result sets are runtime-owned and cannot be
+  used after crossing a thread boundary. Open a connection inside each child
+  and return ordinary Perl data through `join`;
+- future native or I/O adapters must declare snapshot, aliasing, ownership, and
+  last-owner close behavior before they may cross an ithread boundary.
+
+The [parallel DBI example](../../examples/threads/dbi_parallel_queries.pl)
+demonstrates the safe database pattern.
+
+## Runtime Pools
+
+PSGI runtime pooling is independent of ithreads and is bounded and opt-in.
+`JPERL_RUNTIME_POOL_SIZE=N` prepares independent application snapshots; the
+default `0` retains the single-runtime handler. A returned application runtime
+is closed and replaced from the authoritative template rather than reused after
+partial cleanup.
+
+## Validation
+
+The pull-request compatibility gate runs the complete four-module suite on both
+backends with virtual carriers, plus focused lifecycle, signal, stack, wait,
+timeout, and deadlock coverage on platform carriers:
+
+```bash
+make test-threads
+```
+
+Before a thread/runtime release, run the complete four-mode matrix:
+
+```bash
+make test-threads-release
+```
+
+Both targets use eight test jobs, a hard 300-second timeout per file, and write
+JSON reports under `build/reports/threads/`. DBIx::Class is a separate long
+release gate:
+
+```bash
+timeout 3600 ./jcpan --jobs 8 -t DBIx::Class
+```
+
+Direct regex-language compatibility and Joni integration are maintained in the
+separate Phase 36 project. Threaded regex tests remain preservation checks
+against their same-commit direct companions.
+
+See also the [feature matrix](feature-matrix.md#concurrency-and-perl-threads),
+[testing guide](testing.md), and the [thread examples](../../examples/threads/).

--- a/docs/reference/threads.md
+++ b/docs/reference/threads.md
@@ -96,12 +96,14 @@ backends with virtual carriers, plus focused lifecycle, signal, stack, wait,
 timeout, and deadlock coverage on platform carriers:
 
 ```bash
-git clone --depth 1 --branch v5.44.0 https://github.com/Perl/perl5.git perl5
+git clone https://github.com/Perl/perl5.git perl5
+git -C perl5 checkout de80c8ecd40c6d5b677847699e5482b44bc748c6
 make test-threads
 ```
 
 The clone is required only when an adjacent `perl5/` source tree is not already
-present. CI performs a sparse checkout of just the four distributions.
+present. CI performs a sparse checkout of the four distributions and their core
+test harness at this exact compatibility-corpus commit.
 
 Before a thread/runtime release, run the complete four-mode matrix:
 

--- a/examples/threads/README.md
+++ b/examples/threads/README.md
@@ -49,6 +49,7 @@ Live attached children support targeted thread signals. A nonzero stack-size
 request automatically selects a platform-backed child because virtual-thread
 stacks are JVM-managed. Shared blessed aggregates use runtime-local proxy
 views over common backing; the advanced edge cases and tie-order rules are
-documented in the feature matrix. A captured PSGI runtime is not made
+documented in the [Perl threads reference](../../docs/reference/threads.md).
+A captured PSGI runtime is not made
 concurrently callable merely by enabling ithreads; use the opt-in PSGI runtime
 pool for concurrent request execution.

--- a/src/main/java/org/perlonjava/runtime/nativ/LinuxProcessTitle.java
+++ b/src/main/java/org/perlonjava/runtime/nativ/LinuxProcessTitle.java
@@ -1,0 +1,56 @@
+package org.perlonjava.runtime.nativ;
+
+import java.io.IOException;
+import java.lang.foreign.MemorySegment;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+
+/** Updates the Linux argv area used by {@code ps -f} after assignment to Perl's {@code $0}. */
+public final class LinuxProcessTitle {
+    private static final boolean LINUX = System.getProperty("os.name", "")
+            .toLowerCase(Locale.ROOT).contains("linux");
+    private static final Path SELF_STAT = Path.of("/proc/self/stat");
+
+    private LinuxProcessTitle() {}
+
+    /**
+     * Replace the process argv bytes, truncating to the space supplied by the launcher.
+     * Failure is deliberately non-fatal: Perl documents process-title mutation as
+     * operating-system dependent, and hardened Linux configurations may deny access.
+     */
+    public static synchronized void set(String title) {
+        if (!LINUX || title == null) return;
+        try {
+            long[] bounds = argvBounds(Files.readString(SELF_STAT));
+            long capacity = bounds[1] - bounds[0];
+            if (capacity <= 0 || capacity > Integer.MAX_VALUE) return;
+
+            MemorySegment argv = MemorySegment.ofAddress(bounds[0]).reinterpret(capacity);
+            argv.fill((byte) 0);
+            byte[] bytes = title.getBytes(StandardCharsets.UTF_8);
+            int length = (int) Math.min(bytes.length, capacity - 1);
+            if (length > 0) {
+                argv.asSlice(0, length).copyFrom(MemorySegment.ofArray(bytes).asSlice(0, length));
+            }
+        } catch (IOException | RuntimeException ignored) {
+            // Keep ordinary scalar assignment working when native title mutation is unavailable.
+        }
+    }
+
+    static long[] argvBounds(String stat) {
+        // /proc/PID/stat field 2 is parenthesized and may itself contain spaces.
+        // After its closing ')', token zero is field 3; arg_start/end are 48/49.
+        int close = stat.lastIndexOf(')');
+        if (close < 0 || close + 2 >= stat.length()) {
+            throw new IllegalArgumentException("Malformed /proc/self/stat");
+        }
+        String[] fields = stat.substring(close + 2).trim().split("\\s+");
+        if (fields.length <= 46) throw new IllegalArgumentException("Incomplete /proc/self/stat");
+        return new long[] {
+                Long.parseUnsignedLong(fields[45]),
+                Long.parseUnsignedLong(fields[46])
+        };
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Threads.java
@@ -22,6 +22,7 @@ public final class Threads extends PerlModuleBase {
         try {
             module.registerMethod("_create", null);
             module.registerMethod("_self", null);
+            module.registerMethod("_yield", null);
             module.registerMethod("_list", null);
             module.registerMethod("_join", null);
             module.registerMethod("_detach", null);
@@ -132,6 +133,11 @@ public final class Threads extends PerlModuleBase {
 
     public static RuntimeList _self(RuntimeArray args, int ctx) {
         return threadObject(PerlRuntime.current().perlThreadId(), null).getList();
+    }
+
+    public static RuntimeList _yield(RuntimeArray args, int ctx) {
+        Thread.yield();
+        return RuntimeScalarCache.scalarUndef.getList();
     }
 
     public static RuntimeList _list(RuntimeArray args, int ctx) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
@@ -133,7 +133,8 @@ public class GlobalContext {
         // Only set $0 if it hasn't been set yet - prevents overwriting during re-entrant calls
         // (e.g., when require() is called during module initialization)
         if (!GlobalVariable.globalVariables.containsKey("main::0")) {
-            GlobalVariable.getGlobalVariable("main::0").set(compilerOptions.fileName);
+            GlobalVariable.globalVariables.put("main::0",
+                    new ProgramNameVariable().initialize(compilerOptions.fileName));
         }
         if (compilerOptions.taintMode) {
             GlobalVariable.getGlobalVariable("main::0").tainted = true;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ProgramNameVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ProgramNameVariable.java
@@ -1,0 +1,25 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import org.perlonjava.runtime.nativ.LinuxProcessTitle;
+
+/** Perl's per-runtime {@code $0} scalar with its process-wide Linux title side effect. */
+public final class ProgramNameVariable extends RuntimeScalar {
+    public ProgramNameVariable initialize(String value) {
+        super.set(value);
+        return this;
+    }
+
+    @Override
+    public RuntimeScalar set(RuntimeScalar value) {
+        RuntimeScalar result = super.set(value);
+        LinuxProcessTitle.set(toString());
+        return result;
+    }
+
+    @Override
+    public RuntimeScalar set(String value) {
+        RuntimeScalar result = super.set(value);
+        LinuxProcessTitle.set(toString());
+        return result;
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGraphCloner.java
@@ -392,6 +392,13 @@ public class RuntimeGraphCloner {
     }
 
     private RuntimeScalar cloneScalar(RuntimeScalar source) {
+        if (source instanceof ProgramNameVariable) {
+            ProgramNameVariable target = new ProgramNameVariable();
+            clones.put(source, target);
+            copyBase(source, target);
+            copyScalarMetadata(source, target);
+            return target;
+        }
         if (source instanceof ScalarSpecialVariable special) {
             ScalarSpecialVariable target = new ScalarSpecialVariable(
                     special.variableId, special.position);

--- a/src/main/perl/lib/threads.pm
+++ b/src/main/perl/lib/threads.pm
@@ -62,7 +62,7 @@ sub set_stack_size {
     return ref($_[0]) ? _set_stack_size(@_) : _set_stack_size($_[1]);
 }
 sub set_thread_exit_only { return _set_thread_exit_only(@_) }
-sub yield { select undef, undef, undef, 0; return }
+sub yield { return _yield() }
 sub equal { return defined($_[0]) && defined($_[1]) && $_[0]->tid == $_[1]->tid }
 sub _stringify { return 'threads=' . $_[0]->tid }
 

--- a/src/test/java/org/perlonjava/runtime/nativ/LinuxProcessTitleTest.java
+++ b/src/test/java/org/perlonjava/runtime/nativ/LinuxProcessTitleTest.java
@@ -1,0 +1,17 @@
+package org.perlonjava.runtime.nativ;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.junit.jupiter.api.Test;
+
+class LinuxProcessTitleTest {
+    @Test
+    void parsesArgvBoundsWhenProcessNameContainsSpacesAndParentheses() {
+        StringBuilder stat = new StringBuilder("123 (java worker (one)) S");
+        // Fields 4 through 47 are irrelevant to this parser.
+        for (int field = 4; field <= 47; field++) stat.append(' ').append(field);
+        stat.append(" 4096 8192 50 51 52");
+
+        assertArrayEquals(new long[] {4096, 8192}, LinuxProcessTitle.argvBounds(stat.toString()));
+    }
+}


### PR DESCRIPTION
## Summary

- add permanent `make test-threads` and `make test-threads-release` gates
- run the PR thread gate on Ubuntu CI and retain its JSON failure reports
- publish a complete Perl threads reference and classify the four bundled thread modules as fully supported
- update the concurrency plan to the live maintenance contract, with direct regex/Joni work remaining separate
- replace unsafe broad Java/temp cleanup advice with exact-process guidance

## Compatibility contract

The PR gate runs the complete unchanged upstream `threads`, `threads::shared`, `Thread::Queue`, and `Thread::Semaphore` distributions on the JVM and interpreter backends with virtual carriers, plus focused platform lifecycle, signal, stack, condition, timeout, and deadlock coverage.

The release gate extends this to the complete four-mode backend/carrier matrix. Direct regex-language behavior and Joni integration remain owned by the separate Phase 36 project.

## Validation

- `make` — PASS (five unit shards)
- `make test-threads` — PASS
  - JVM/virtual: 64 files, 1,891 assertions
  - interpreter/virtual: 64 files, 1,891 assertions
  - focused platform: 19 files, 485 assertions
- `make test-threads-release` — PASS
  - JVM/platform: 64 files, 1,891 assertions
  - interpreter/platform: 64 files, 1,891 assertions
  - virtual configurations repeated and passed
- `make check-links` — PASS (550 links, 0 errors)
- `timeout 3600 ./jcpan --jobs 8 -t DBIx::Class` — PASS (325 files, 42,681 assertions)
