### PR TITLE
test: extend post-Joni thread release gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean test test-unit test-interpreter check-thread-test-sources test-threads test-threads-release test-bundled-modules test-cpan-distroprefs test-exiftool test-all test-gradle test-gradle-unit test-gradle-all test-gradle-parallel test-maven-parallel build run wrapper check-java-gradle dev ci sbom sbom-java sbom-perl sbom-clean check-links
+.PHONY: all clean test test-unit test-interpreter check-thread-test-sources check-thread-regex-test-sources test-threads test-threads-regex test-threads-release test-threads-ecosystem test-bundled-modules test-cpan-distroprefs test-exiftool test-all test-gradle test-gradle-unit test-gradle-all test-gradle-parallel test-maven-parallel build run wrapper check-java-gradle dev ci sbom sbom-java sbom-perl sbom-clean check-links
 
 THREAD_DIST_DIRS := perl5/dist/threads/t perl5/dist/threads-shared/t perl5/dist/Thread-Queue/t perl5/dist/Thread-Semaphore/t
 THREAD_PLATFORM_TESTS := \
@@ -21,6 +21,12 @@ THREAD_PLATFORM_TESTS := \
 	perl5/dist/Thread-Queue/t/10_timed.t \
 	perl5/dist/Thread-Semaphore/t/04_nonblocking.t \
 	perl5/dist/Thread-Semaphore/t/06_timed.t
+THREAD_REGEX_ANCHOR_TESTS := \
+	perl5_t/t/re/pat_psycho_thr.t \
+	perl5_t/t/re/pat_special_cc_thr.t \
+	perl5_t/t/re/reg_email_thr.t \
+	perl5_t/t/re/stclass_threads.t \
+	perl5_t/t/re/user_prop_race_thr.t
 
 all: build
 
@@ -121,6 +127,15 @@ check-thread-test-sources:
 		fi; \
 	done
 
+check-thread-regex-test-sources:
+	@for file in $(THREAD_REGEX_ANCHOR_TESTS); do \
+		if [ ! -f "$$file" ]; then \
+			echo "Error: $$file is missing."; \
+			echo "Import the pinned Perl core tests into ./perl5_t before running the regex-thread gate."; \
+			exit 1; \
+		fi; \
+	done
+
 # Permanent Perl ithread compatibility gate used by Ubuntu pull-request CI.
 # Full upstream distributions run on both backends with the default virtual
 # carrier; lifecycle, stack, signal, wait, timeout, and deadlock coverage also
@@ -131,12 +146,31 @@ test-threads: check-java-gradle check-thread-test-sources
 	JPERL_INTERPRETER=1 JPERL_THREAD_MODE=virtual perl dev/tools/perl_test_runner.pl --strict-exit --jobs 8 --timeout 300 --output build/reports/threads/interpreter-virtual.json $(THREAD_DIST_DIRS)
 	JPERL_THREAD_MODE=platform perl dev/tools/perl_test_runner.pl --strict-exit --jobs 8 --timeout 300 --output build/reports/threads/platform-focused.json $(THREAD_PLATFORM_TESTS)
 
+# Post-Joni preservation anchors. These are unchanged Perl core tests whose
+# direct regex semantics are complete and whose threaded variants prove lexical
+# debug state, user-property coordination, recursive definitions, character
+# classes, callbacks, and snapshot ownership on both execution backends.
+test-threads-regex: check-java-gradle check-thread-regex-test-sources
+	@mkdir -p build/reports/threads
+	JPERL_THREAD_MODE=virtual perl dev/tools/perl_test_runner.pl --strict-exit --jobs 5 --timeout 600 --output build/reports/threads/regex-jvm-virtual.json $(THREAD_REGEX_ANCHOR_TESTS)
+	JPERL_INTERPRETER=1 JPERL_THREAD_MODE=virtual perl dev/tools/perl_test_runner.pl --strict-exit --jobs 5 --timeout 600 --output build/reports/threads/regex-interpreter-virtual.json $(THREAD_REGEX_ANCHOR_TESTS)
+
 # Thread release gate: extend the PR gate to the complete platform-carrier
 # distribution matrix. Together with test-threads this covers both backends on
 # both carrier policies without making every pull request repeat all four runs.
-test-threads-release: test-threads
+test-threads-release: test-threads test-threads-regex
 	JPERL_THREAD_MODE=platform perl dev/tools/perl_test_runner.pl --strict-exit --jobs 8 --timeout 300 --output build/reports/threads/jvm-platform.json $(THREAD_DIST_DIRS)
 	JPERL_INTERPRETER=1 JPERL_THREAD_MODE=platform perl dev/tools/perl_test_runner.pl --strict-exit --jobs 8 --timeout 300 --output build/reports/threads/interpreter-platform.json $(THREAD_DIST_DIRS)
+
+# Slow ecosystem release gate. Net::SSLeay exercises native callbacks and
+# concurrent SSL context ownership; DBIx::Class exercises DBI handle rejection,
+# cloned package graphs, closures, and a large real-world ORM suite. This target
+# is intentionally separate from pull-request CI because jcpan needs network
+# access and the complete DBIx::Class run can take about 40 minutes.
+test-threads-ecosystem: check-java-gradle
+	JPERL_TEST_FILTER=61_threads-cb-crash $(MAKE) test-bundled-modules
+	JPERL_TEST_FILTER=62_threads-ctx_new-deadlock $(MAKE) test-bundled-modules
+	timeout 3600 ./jcpan --jobs 8 -t DBIx::Class
 
 # Bundled CPAN module tests (XML::Parser, etc.)
 # Tests live under src/test/resources/module/{ModuleName}/t/

--- a/dev/design/concurrency.md
+++ b/dev/design/concurrency.md
@@ -214,8 +214,8 @@ gate. The same matrix runs on JVM/interpreter and platform/virtual carriers.
 `timeout 3600 ./jcpan --jobs 8 -t DBIx::Class` must pass before a pull request
 is opened. Merge additionally requires green Ubuntu and Windows CI.
 
-Direct regex-language parity, including Joni integration, is maintained
-separately.
+The callout-enabled Joni matcher and executable callback bridge are integrated.
+Remaining direct regex-language parity is maintained separately.
 Threaded regex wrappers remain preservation gates against their same-commit
 direct companions.
 
@@ -224,11 +224,12 @@ direct companions.
 - `dev/design/attributes.md` defines the supported `shared` attribute surface.
 - `dev/design/runtime-pooling-reset-contract.md` defines the implemented
   bounded pool reset and fresh-runtime replacement contract.
-- `dev/design/phase36-regex-parity.md` owns direct regex-language and Joni work.
+- `dev/design/phase36-regex-parity.md` owns remaining direct regex-language work
+  on top of the integrated Joni callout engine.
 
 ## 7. Progress Tracking
 
-### Current Status: delivered; Joni/regex parity is separate
+### Current Status: delivered; direct regex parity is separate
 
 `PerlRuntime` owns interpreter state, ithreads clone one isolated runtime graph,
 and `threads::shared` supplies explicit cross-runtime storage and synchronization.
@@ -236,9 +237,10 @@ The unchanged upstream `threads`, `threads-shared`, `Thread-Queue`, and
 `Thread-Semaphore` distributions are the executable compatibility contract on
 both execution backends and both Java carrier policies.
 
-Direct regex-language parity, including Joni integration, is maintained in the
-separate regex project. Threaded regex wrappers remain preservation gates
-against their same-commit direct companions.
+The callout-enabled Joni matcher is part of the shipped runtime. Remaining
+direct regex-language gaps are maintained in the separate regex project.
+Threaded regex wrappers remain preservation gates against their same-commit
+direct companions.
 
 Completed implementation history, validation evidence, and superseded decisions
 are intentionally omitted here and are recoverable from commit messages and pull
@@ -251,19 +253,24 @@ requests.
    signal, stack, wait, timeout, and deadlock coverage.
 2. Run `make test-threads-release` before any thread/runtime release. It extends
    the pull-request gate to the complete four-module matrix on platform carriers.
-3. Continue CPAN ecosystem hardening: opt-in Test2 stress tests, remaining Moose
-   thread-suite classification, Net::SSLeay callback suites 61/62, and permanent
-   DBI ownership plus DBIx::Class release coverage.
-4. Require every future native resource, I/O handle, and callback adapter to
+3. Keep `make test-threads-regex` in the release matrix: lexical regex
+   debugging, user-property coordination, recursive definitions, special
+   character classes, and callback-heavy psycho patterns. Its five unchanged
+   files contain 48 assertions and pass on both backends. Partial wrappers must
+   preserve their same-commit direct result until Phase 36 closes the direct gap.
+4. Run `make test-threads-ecosystem` for native callback and ORM releases. Add
+   the opt-in Test2 stress tests and remaining Moose thread-suite cases once
+   their unchanged upstream sources are available as a pinned test corpus.
+5. Require every future native resource, I/O handle, and callback adapter to
    declare its runtime ownership, snapshot, aliasing, and close policy.
-5. Monitor snapshot retention and startup cost. Runtime pooling remains bounded,
+6. Monitor snapshot retention and startup cost. Runtime pooling remains bounded,
    opt-in, and disabled by default; returned application runtimes are replaced,
    not partially reused.
-6. Keep direct regex-language and Joni work in the separate Phase 36 project.
+7. Keep remaining direct regex-language work in the separate Phase 36 project.
    Threaded regex wrappers must preserve their same-commit direct behavior.
 
-Direct regex-language work, including Joni integration, is not part of this
-release.
+Remaining direct regex-language work is not part of this release. The Joni
+callout engine and executable callback bridge are already integrated.
 Unchanged regex thread wrappers remain preservation gates and must not regress
 relative to their same-commit direct companions.
 

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-- **Project status:** Planned as a parallel project
-- **Current stage:** Baseline refresh and architecture validation
+- **Project status:** Active parallel project
+- **Current stage:** Stage 36.4 — callback scope and remaining direct parity
 - **Parent plan:** `dev/design/concurrency.md`
 - **Detailed callback design:** `dev/design/executable-regex-callbacks.md`
 - **Integration rule:** Direct regex semantics are implemented first. Thread
@@ -37,21 +37,25 @@ thread wrappers and protects the Phase 44 release matrix.
 - Phase 44 established timeout-free thread-wrapper execution and the supported
   regex anchors, including lexical debugging 6/6, user-property race 3/3, and
   `pat_psycho_thr.t` 17/17.
+- A namespaced callout-enabled Joni fork is vendored and packaged. JVM and
+  interpreter templates execute `(?{ code })` and callback conditions with
+  provisional captures, `$^R`, and matcher-driven backtracking unwind.
 
 ## Remaining Workstreams
 
-### A. Executable regex callbacks
+### A. Complete executable regex callback semantics
 
-Implement match-time `(?{ BLOCK })`, callback conditions `(?(?{ BLOCK })yes|no)`,
-optimistic evaluation `(*{ BLOCK })`, and dynamic patterns `(??{ EXPR })`.
+Finish the semantic matrix around the integrated match-time `(?{ BLOCK })` and
+callback-condition bridge, then implement optimistic evaluation `(*{ BLOCK })`
+and dynamic patterns `(??{ EXPR })`.
 Callbacks must run while the matcher owns its provisional captures and
 backtracking stack. Post-match callbacks and construction-time execution are not
 acceptable approximations.
 
-The architecture, semantic matrix, Joni callout proposal, and callback-specific
-risks live in `dev/design/executable-regex-callbacks.md`. Revalidate that
-document's historical prerequisites and library-version assumptions before
-implementation.
+The architecture, semantic matrix, and callback-specific risks live in
+`dev/design/executable-regex-callbacks.md`. The matcher seam is now delivered;
+keep that document aligned with the vendored fork rather than treating the
+callout API as a proposal.
 
 ### B. Conditionals and control verbs
 
@@ -102,11 +106,11 @@ the baseline has no orphaned JVMs or unexplained timeout-only zero-TAP results.
 
 ### Stage 36.1 — Validate the callback engine seam
 
-1. Refresh the Joni callout spike against the currently shipped matcher layer.
-2. Prove a runtime-neutral callout can observe provisional captures, repeat after
-   backtracking, and receive an exact unwind notification.
-3. Decide whether to publish a namespaced fork or propose the generic callout API
-   upstream.
+1. Keep the namespaced callout-enabled Joni fork isolated under `third_party/`.
+2. Preserve matcher tests proving that runtime-neutral callouts observe
+   provisional captures, repeat after backtracking, and receive exact unwind
+   notifications.
+3. Keep PerlOnJava runtime dependencies outside the regex-engine fork.
 
 **Exit criteria:** The spike demonstrates forward execution and backtracking
 unwind without PerlOnJava dependencies inside the regex engine.
@@ -234,14 +238,14 @@ timing delta is a regression only after a serialized same-commit reproduction.
 
 ## Progress Tracking
 
-### Current Status: Stage 36.0 ready
+### Current Status: Stage 36.4 in progress
 
 ### Completed stages
 
-- [ ] Stage 36.0: Refresh differential baseline
-- [ ] Stage 36.1: Validate callback engine seam
-- [ ] Stage 36.2: Structured frontend and callback templates
-- [ ] Stage 36.3: Plain callbacks and provisional match state
+- [x] Stage 36.0: Refresh differential baseline
+- [x] Stage 36.1: Validate callback engine seam
+- [x] Stage 36.2: Structured frontend and callback templates
+- [x] Stage 36.3: Plain callbacks and provisional match state
 - [ ] Stage 36.4: Backtracking, dynamic scope, and conditions
 - [ ] Stage 36.5: Dynamic patterns and recursive execution
 - [ ] Stage 36.6: Remaining declarative parity
@@ -249,19 +253,20 @@ timing delta is a regression only after a serialized same-commit reproduction.
 
 ### Next steps
 
-1. Refresh direct and wrapper counts on the Phase 36 checkout.
-2. Create and validate the callback semantic matrix with system Perl.
-3. Revalidate the Joni callout spike against the current matcher abstraction.
-4. Record the fork/upstream decision before starting structured frontend work.
+1. Refresh direct and wrapper counts on the merged callout engine.
+2. Extend the callback semantic matrix with dynamic-local unwind, exceptions,
+   interruption, timeout, and nested matches.
+3. Complete Stage 36.4 without changing thread wrappers.
+4. Implement dynamic patterns and then the remaining declarative parity slices.
 
 ### Open blockers
 
-- The current Java/Joni matcher paths do not expose Perl callouts during
-  backtracking.
 - Several callback-localization and dynamic-pattern capture rules still require
   standard-Perl differential evidence.
-- The detailed callback design contains historical PR and library assumptions
-  that must be refreshed during Stage 36.0.
+- Dynamic `(??{ EXPR })`, optimistic callback execution, and several declarative
+  controls are not complete.
+- Partial direct core tests still contain diagnostic, parser, Unicode, and
+  regex-object gaps; their wrappers must not be mistaken for thread failures.
 
 ## Related Documents and Skills
 

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -389,7 +389,7 @@ my @copy = @{$z};         # ERROR
 
 - ❌  **Dynamically-scoped regex variables**: Regex variables are not dynamically-scoped.
 - 🟡  **Recursive Patterns**: `(?R)` and `(?0)` execute through Joni. Constant `(??{ code })` expressions fold to a pattern; runtime-dependent dynamic patterns remain unsupported.
-- ❌  **Backtracking Control Verbs and Definitions**: Features such as `(*PRUNE)`, `(*SKIP)`, and `(?(DEFINE)...)` are not supported. Atomic groups `(?>...)` are supported as noted above.
+- 🟡  **Backtracking Control Verbs and Definitions**: `(?(DEFINE)...)` and named recursive definitions execute through Joni. Control verbs such as `(*PRUNE)`, `(*SKIP)`, `(*THEN)`, and `(*COMMIT)` are not yet complete. Atomic groups `(?>...)` are supported as noted above.
 - ❌  **Lookbehind Assertions**: Variable-length negative or positive lookbehind assertions, e.g., `(?<=...)` or `(?<!...)`, are not supported.
 - ❌  **Branch Reset Groups**: Use of `(?|...)` to reset group numbering across branches is not supported.
 - ✅  **Advanced Subroutine Calls**: Sub-pattern calls with numbered or named references like `(?1)` and `(?&name)` execute through Joni.
@@ -397,7 +397,7 @@ my @copy = @{$z};         # ERROR
 - ❌  **Extended Unicode Regex Features**: Some extended Unicode regex functionalities are not supported.
 - ❌  **Extended Grapheme Clusters**: Matching with `\X` for extended grapheme clusters is not supported.
 - 🟡  **Embedded Code in Regex**: `(?{ code })` and executable callback conditions run as lexical closures in Joni with provisional captures, `$^R`, and backtracking unwind. Runtime-dependent `(??{ code })` remains unsupported.
-- ❌  **Regex Debugging**: Debugging patterns with `use re 'debug';` to inspect regex engine operations is not supported.
+- 🟡  **Regex Debugging**: Lexical `use/no re 'debug'` and `debugcolor` state is runtime-owned and produces a stable compile/execution trace on both backends and in child threads. Exact Perl optimizer opcodes and diagnostic wording are not complete.
 - ❌  **Regex Optimizations**: Using `use re 'eval';` for runtime regex compilation is not supported.
 - ❌  **Regex Compilation Flags**: Setting default regex flags with `use re '/flags';` is not supported.
 - ❌  **Stricter named captures**
@@ -875,7 +875,7 @@ storage as their parent counterparts. Values explicitly shared through
 | Effective stack sizing | Platform-backed children honor supported `stack_size` create/import requests. A nonzero request under the default virtual policy transparently selects a platform child. |
 | Additional introspection | `threads->object` and creation-context `wantarray` are implemented. CLI shutdown reports running and finished unjoined threads; detached children are silent. |
 | Native resources and callbacks | File, socket, process, native-descriptor, scalar, layered, duplicated, borrowed, directory, and standard handles have explicit inheritance policies. Net::SSLeay handles remain runtime-owned and stored callbacks bind their registering runtime. |
-| Upstream suite coverage | The four bundled thread distributions pass 64 files and 1,891 assertions in each backend/carrier configuration. The PR gate runs two complete virtual configurations plus focused platform lifecycle coverage; the release gate runs all four complete configurations. Direct regex-language gaps remain in the separate Phase 36 project. |
+| Upstream suite coverage | The four bundled thread distributions pass 64 files and 1,891 assertions in each backend/carrier configuration. The PR gate runs two complete virtual configurations plus focused platform lifecycle coverage; the release gate runs all four complete configurations and five post-Joni regex-thread files (48 assertions) on both backends. `make test-threads-ecosystem` adds Net::SSLeay 61/62 and DBIx::Class. Remaining direct regex-language gaps stay in the separate Phase 36 project. |
 | PSGI | The default single-runtime handler advertises `psgi.multithread => \0`. A bounded opt-in pool gives every concurrent request an independent app snapshot and advertises `\1`; pool size defaults to zero. |
 
 See the [Perl threads reference](threads.md) for behavior and test commands and

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -47,19 +47,33 @@ make test-threads
 Skip the clone when the gitignored `perl5/` source tree is already present. CI
 uses a sparse checkout containing the four required distributions and the core
 test harness at the same pinned commit.
+The release-only regex anchors use the imported `perl5_t/t/re` tree; populate it
+with `perl dev/import-perl5/sync.pl` when necessary.
 
 Before a thread/runtime release, extend that gate to the complete four-mode
-matrix (both execution backends on virtual and platform carriers):
+matrix (both execution backends on virtual and platform carriers) and the
+post-Joni regex-thread anchors:
 
 ```bash
 make test-threads-release
 ```
 
-Both targets use eight jobs and a hard 300-second timeout for each file. JSON
-reports are written under `build/reports/threads/`. The shorter target is used
-by Ubuntu pull-request CI and uses the runner's strict exit mode, so any failed,
-errored, timed-out, or incomplete file fails the Make target. Windows continues
-to run the Java/unit build gate.
+The distribution matrix uses eight jobs and a hard 300-second timeout for each
+file. The five regex anchors contain 48 assertions per backend and use a
+600-second bound. JSON reports are written under
+`build/reports/threads/`. The shorter target is used by Ubuntu pull-request CI
+and uses the runner's strict exit mode, so any failed, errored, timed-out, or
+incomplete file fails the Make target. Windows continues to run the Java/unit
+build gate.
+
+For a native callback or ORM release, run the slow ecosystem gate as well:
+
+```bash
+make test-threads-ecosystem
+```
+
+It runs unchanged Net::SSLeay thread tests 61/62 and DBIx::Class through
+`jcpan --jobs 8`, with a hard one-hour outer bound.
 See the [Perl threads reference](threads.md) for the compatibility contract and
 resource policies.
 

--- a/docs/reference/threads.md
+++ b/docs/reference/threads.md
@@ -105,6 +105,9 @@ The clone is required only when an adjacent `perl5/` source tree is not already
 present. CI performs a sparse checkout of the four distributions and their core
 test harness at this exact compatibility-corpus commit.
 
+The release-only regex anchors also require the imported `perl5_t/t/re` corpus;
+run `perl dev/import-perl5/sync.pl` when that gitignored tree is absent.
+
 Before a thread/runtime release, run the complete four-mode matrix:
 
 ```bash
@@ -114,15 +117,23 @@ make test-threads-release
 Both targets use eight test jobs, a hard 300-second timeout per file, and write
 JSON reports under `build/reports/threads/`. Timing-sensitive join coverage is
 given an exclusive runner slot, and strict exit mode makes any non-passing file
-fail the gate. DBIx::Class is a separate long release gate:
+fail the gate. The release target also runs the post-Joni regex-thread anchors
+on both execution backends: five files and 48 assertions per backend, with a
+600-second per-file bound.
+
+Native callback and ORM compatibility form a separate slow ecosystem gate:
 
 ```bash
-timeout 3600 ./jcpan --jobs 8 -t DBIx::Class
+make test-threads-ecosystem
 ```
 
-Direct regex-language compatibility and Joni integration are maintained in the
-separate Phase 36 project. Threaded regex tests remain preservation checks
-against their same-commit direct companions.
+It runs the unchanged Net::SSLeay 61/62 thread suites and then executes
+`timeout 3600 ./jcpan --jobs 8 -t DBIx::Class`.
+
+The callout-enabled Joni matcher and executable regex callbacks are integrated.
+Remaining direct regex-language compatibility is maintained in the separate
+Phase 36 project. Threaded regex tests remain preservation checks against their
+same-commit direct companions.
 
 See also the [feature matrix](feature-matrix.md#concurrency-and-perl-threads),
 [testing guide](testing.md), and the [thread examples](../../examples/threads/).

--- a/src/test/java/org/perlonjava/ModuleTestExecutionTest.java
+++ b/src/test/java/org/perlonjava/ModuleTestExecutionTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.perlonjava.app.cli.CompilerOptions;
 import org.perlonjava.runtime.io.StandardIO;
 import org.perlonjava.runtime.runtimetypes.RuntimeArray;
+import org.perlonjava.runtime.runtimetypes.RuntimeEnvironment;
 import org.perlonjava.runtime.runtimetypes.RuntimeIO;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 import org.perlonjava.runtime.runtimetypes.PerlExitException;
@@ -168,6 +169,7 @@ public class ModuleTestExecutionTest extends PerlRuntimeTestBase {
         System.setOut(originalOut);
 
         // Restore original working directory
+        RuntimeEnvironment.setCurrentDirectory(originalUserDir);
         System.setProperty("user.dir", originalUserDir);
     }
 
@@ -232,6 +234,7 @@ public class ModuleTestExecutionTest extends PerlRuntimeTestBase {
             // Resolve the module directory and chdir to it
             Path moduleDir = resolveModuleDir(filename);
             System.setProperty("user.dir", moduleDir.toAbsolutePath().toString());
+            RuntimeEnvironment.setCurrentDirectory(moduleDir.toString());
 
             String content = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
             if (content.indexOf('\r') >= 0) {
@@ -253,6 +256,16 @@ public class ModuleTestExecutionTest extends PerlRuntimeTestBase {
             Path moduleLibPath = moduleDir.resolve("lib");
             if (Files.isDirectory(moduleLibPath)) {
                 RuntimeArray.push(options.inc, new RuntimeScalar(moduleLibPath.toAbsolutePath().toString()));
+            }
+
+            // Upstream distributions commonly keep test-only helpers under
+            // inc/. Setting user.dir above does not change the JVM process
+            // working directory, so a source-level `use lib 'inc'` alone
+            // cannot resolve that tree. Mirror the lib/ handling with an
+            // absolute include path while keeping the upstream test unchanged.
+            Path moduleIncPath = moduleDir.resolve("inc");
+            if (Files.isDirectory(moduleIncPath)) {
+                RuntimeArray.push(options.inc, new RuntimeScalar(moduleIncPath.toAbsolutePath().toString()));
             }
 
             PerlLanguageProvider.executePerlCode(options, true);


### PR DESCRIPTION
## Summary

- add a strict post-Joni regex-thread release target for both execution backends
- add a slow ecosystem gate for unchanged Net::SSLeay 61/62 and DBIx::Class
- make bundled module tests honor runtime working directories and test-only `inc/` trees
- refresh the concurrency, Phase 36, testing, thread, and feature documentation after the Joni merge

## Validation

- `make` — passed (17 tasks, all five unit shards, Joni tests and packaging)
- `make check-links` — 0 errors
- `make test-threads` — JVM/interpreter virtual 64/64 files and 1,891/1,891 assertions; platform focused 19/19 files and 485/485 assertions
- `make test-threads-regex` — JVM and interpreter each 5/5 files and 48/48 assertions
- full platform release matrix — JVM and interpreter each 64/64 files and 1,891/1,891 assertions
- Net::SSLeay `61_threads-cb-crash.t` and `62_threads-ctx_new-deadlock.t` — passed unchanged
- `timeout 3600 ./jcpan --jobs 8 -t DBIx::Class` — 325 files, 42,681 assertions, PASS

## Scope

The callout-enabled Joni matcher is now treated as delivered. Remaining direct regex-language gaps continue in the separate Phase 36 project; unchanged thread wrappers remain preservation gates.
