### PR TITLE
feat(regex): implement (*ACCEPT) in vendored Joni

### DIFF
--- a/docs/design/joni-callout-fork.md
+++ b/docs/design/joni-callout-fork.md
@@ -106,6 +106,28 @@ Callback conditions use an internal conditional-callout opcode. `CONTINUE`
 selects the yes branch and `FAIL` selects the no branch without treating the
 condition itself as a failed match.
 
+## Matcher-control boundaries
+
+`(*ACCEPT)` is represented as a dedicated AST node and bytecode opcode; it is
+not rewritten into an assertion or callback. At execution it accepts the
+nearest matcher-program boundary:
+
+- At the top level, it completes the whole match at the current input position
+  and skips the remaining pattern.
+- In a subpattern call, it completes that call and resumes the caller after the
+  call site.
+- In a positive lookahead, it completes the assertion, restores its zero-width
+  input position, and resumes the enclosing program.
+- In a dynamic `(??{...})` program, it completes the nested matcher while the
+  enclosing matcher continues with its suffix.
+
+Captures opened inside the accepted boundary close at the current input
+position. Captures outside that boundary remain active. Backtracking and
+dynamic-continuation frames abandoned by acceptance are completed exactly once.
+Because suffixes after a control verb are not necessarily reachable, programs
+containing matcher-control opcodes bypass Joni's ordinary mandatory-literal and
+minimum-length optimizer unless that optimizer becomes control-flow aware.
+
 ## Structured Perl frontend
 
 Literal callback bodies are represented as lexical `SubroutineNode` closures.
@@ -193,8 +215,8 @@ embedded code, regex debugging, runtime eval, lexical default flags, and named
 capture behavior. As each feature becomes executable, patterns containing it
 select Joni. The current selector routes declarative subpattern calls and every
 structured executable callback template, including runtime `(??{...})`.
-Semantically safe constant dynamic expressions may keep their established
-fold-to-pattern path.
+It also routes `(*ACCEPT)`. Semantically safe constant dynamic expressions may
+keep their established fold-to-pattern path.
 
 ## Implementation stages
 
@@ -210,6 +232,8 @@ fold-to-pattern path.
 7. Add dynamic-local checkpoints and callback conditions.
 8. Resolve dynamic nested programs at match time and preserve their alternatives
    as resumable matcher continuations on the outer backtracking stack.
+9. Implement matcher-control opcodes with explicit lookahead, call, dynamic,
+   capture, and backtracking-boundary semantics.
 
 ## Verification
 
@@ -227,6 +251,9 @@ fold-to-pattern path.
 - Dynamic-pattern tests cover delayed expression evaluation, returned strings
   and `qr//` values, private nested captures, outer-suffix backtracking, nested
   callback cleanup, and recursive `qr//` values.
+- Matcher-control tests cover top-level, empty, subpattern-call, positive
+  lookahead, and dynamic-program acceptance, including capture endpoints and
+  skipped callbacks.
 - `dev/tools/perl_test_runner.pl perl5_t/t/re/` is compared file-by-file with
   `../PerlOnJava/logs/test_20260815_080000_958.log`; no previously passing regex
   file may regress, and changed pass counts or blocked-test totals are reported.

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -389,7 +389,7 @@ my @copy = @{$z};         # ERROR
 
 - ❌  **Dynamically-scoped regex variables**: Regex variables are not dynamically-scoped.
 - 🟡  **Recursive and Dynamic Patterns**: `(?R)`, `(?0)`, and runtime `(??{ code })` execute through Joni. Dynamic expressions may return strings or `qr//` values, and nested alternatives participate in outer backtracking without changing outer grouping or capture numbering. Deep dynamic recursion still needs an engine-owned depth limit that does not depend on the Java call stack.
-- ❌  **Backtracking Control Verbs**: `(*ACCEPT)`, `(*PRUNE)`, `(*SKIP)`, `(*THEN)`, and `(*COMMIT)` are not supported. `(*FAIL)`/`(*F)` and atomic groups `(?>...)` are supported.
+- 🟡  **Backtracking Control Verbs**: `(*ACCEPT)` executes through Joni with top-level, subpattern-call, positive-lookahead, and dynamic-pattern boundary semantics. `(*FAIL)`/`(*F)` and atomic groups `(?>...)` are supported. `(*PRUNE)`, `(*SKIP)`, `(*THEN)`, and `(*COMMIT)` are not supported.
 - ✅  **Regex Definitions**: `(?(DEFINE)...)` containers and numbered or named calls to their subpatterns execute through Joni.
 - ❌  **Lookbehind Assertions**: Variable-length negative or positive lookbehind assertions, e.g., `(?<=...)` or `(?<!...)`, are not supported.
 - ✅  **Branch Reset Groups**: `(?|...)` resets capture numbering across alternatives and preserves mapped match variables.

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -75,6 +75,7 @@ final class JoniRegexPattern {
         if (pattern == null) return false;
         return pattern.contains("(?{=CALL:")
                 || pattern.contains("(?{=DYNAMIC:")
+                || pattern.contains("(*ACCEPT)")
                 || pattern.contains("(?(?{=CALL:")
                 || pattern.matches("(?s).*\\(\\?[+-]?\\d+\\).*" )
                 || pattern.contains("(?&")

--- a/src/test/resources/unit/regex/accept_control_verb.t
+++ b/src/test/resources/unit/regex/accept_control_verb.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $after = 0;
+ok('ABDE' =~ /(A(A|B(*ACCEPT)|C)+D)(E)(?{ ++$after })/,
+    'accept succeeds before the outer suffix');
+is($&, 'AB', 'accept fixes the overall endpoint');
+is("$1-$2", 'AB-B', 'accept closes active captures');
+is($after, 0, 'accept skips later callbacks');
+
+ok('x' =~ /(*ACCEPT)never/, 'accept may produce an empty match');
+is($&, '', 'empty accept has the current endpoint');
+
+my $sub = qr/(?(DEFINE)(?<a>(?:[ab]|[cd](*ACCEPT)|[ef])g))(?&a)(?&a)/;
+ok('cc' =~ $sub, 'accept returns from a subroutine call');
+is($&, 'cc', 'outer program continues after accepted subroutine calls');
+ok('agag' =~ $sub, 'ordinary subroutine paths retain their suffixes');
+
+ok('ab' =~ /(?=(a(*ACCEPT)z))ab/,
+    'accept completes a positive assertion boundary');
+is($1, 'a', 'accept closes captures inside a positive assertion');
+
+ok('ab' =~ /(??{ 'a(*ACCEPT)z' })b/,
+    'accept completes a dynamic nested program');
+is($&, 'ab', 'outer suffix continues after dynamic accept');
+
+done_testing();

--- a/third_party/joni/src/org/joni/Analyser.java
+++ b/third_party/joni/src/org/joni/Analyser.java
@@ -44,6 +44,7 @@ import org.joni.ast.CClassNode;
 import org.joni.ast.CTypeNode;
 import org.joni.ast.CallNode;
 import org.joni.ast.CalloutNode;
+import org.joni.ast.ControlVerbNode;
 import org.joni.ast.EncloseNode;
 import org.joni.ast.ListNode;
 import org.joni.ast.Node;
@@ -115,6 +116,11 @@ final class Analyser extends Parser {
 
         regex.captureHistory = env.captureHistory;
         regex.btMemStart = env.btMemStart;
+        if (env.hasControlVerb) {
+            // ACCEPT needs stack markers to distinguish captures opened inside
+            // its nearest assertion or call boundary from captures outside it.
+            regex.btMemStart = bsAll();
+        }
 
         if (isFindCondition(regex.options)) {
             regex.btMemEnd = bsAll();
@@ -146,7 +152,11 @@ final class Analyser extends Parser {
 
         regex.clearOptimizeInfo();
 
-        if (Config.OPTIMIZE) setOptimizedInfoFromTree(root);
+        // A control verb can make the remainder of its current matcher program
+        // unreachable. The ordinary optimizer assumes every concatenated node
+        // remains mandatory, so its minimum-length and literal-search filters
+        // are not sound for these programs.
+        if (Config.OPTIMIZE && !env.hasControlVerb) setOptimizedInfoFromTree(root);
 
         env.memNodes = null;
 
@@ -1898,7 +1908,9 @@ final class Analyser extends Parser {
             target = setupTree(target, state);
 
             /* expand string */
-            if (target.getType() == NodeType.STR && !(target instanceof CalloutNode)) {
+            if (target.getType() == NodeType.STR
+                    && !(target instanceof CalloutNode)
+                    && !(target instanceof ControlVerbNode)) {
                 StringNode sn = (StringNode)target;
                 if (qn.lower > 1) {
                     StringNode str = new StringNode(sn.bytes, sn.p, sn.end);

--- a/third_party/joni/src/org/joni/ArrayCompiler.java
+++ b/third_party/joni/src/org/joni/ArrayCompiler.java
@@ -32,6 +32,7 @@ import org.joni.ast.CClassNode;
 import org.joni.ast.CTypeNode;
 import org.joni.ast.CallNode;
 import org.joni.ast.CalloutNode;
+import org.joni.ast.ControlVerbNode;
 import org.joni.ast.ListNode;
 import org.joni.ast.EncloseNode;
 import org.joni.ast.Node;
@@ -84,6 +85,18 @@ final class ArrayCompiler extends Compiler {
         regex.requireStack = true;
         addOpcode(node.dynamic ? OPCode.DYNAMIC_CALLOUT : OPCode.CALLOUT);
         addInt(node.calloutId);
+    }
+
+    @Override
+    protected void compileControlVerbNode(ControlVerbNode node) {
+        switch (node.kind) {
+        case ACCEPT:
+            regex.requireStack = true;
+            addOpcode(OPCode.ACCEPT);
+            break;
+        default:
+            newInternalException(PARSER_BUG);
+        }
     }
 
     @Override
@@ -1101,7 +1114,8 @@ final class ArrayCompiler extends Compiler {
 
         case AnchorType.PREC_READ:
             regex.requireStack = true;
-            addOpcode(OPCode.PUSH_POS);
+            len = compileLengthTree(node.target);
+            addOpcodeRelAddr(OPCode.PUSH_POS, len + OPSize.POP_POS);
             compileTree(node.target);
             addOpcode(OPCode.POP_POS);
             break;
@@ -1150,6 +1164,7 @@ final class ArrayCompiler extends Compiler {
         if (node instanceof CalloutNode callout) {
             return callout.dynamic ? OPSize.DYNAMIC_CALLOUT : OPSize.CALLOUT;
         }
+        if (node instanceof ControlVerbNode) return OPSize.ACCEPT;
         int len = 0;
 
         switch (node.getType()) {

--- a/third_party/joni/src/org/joni/ByteCodeMachine.java
+++ b/third_party/joni/src/org/joni/ByteCodeMachine.java
@@ -305,6 +305,7 @@ class ByteCodeMachine extends StackMachine implements MatchView {
                 case OPCode.CALLOUT:                    opCallout();               continue;
                 case OPCode.CALLOUT_CONDITION:          opCalloutCondition();      continue;
                 case OPCode.DYNAMIC_CALLOUT:            opDynamicCallout();        continue;
+                case OPCode.ACCEPT:             if (opAccept()) return finish();   continue;
 
                 case OPCode.STATE_CHECK_ANYCHAR_STAR:   if (USE_CEC) {opStateCheckAnyCharStar(); break;}
                 case OPCode.STATE_CHECK_ANYCHAR_ML_STAR:if (USE_CEC) {opStateCheckAnyCharMLStar();break;}
@@ -449,6 +450,7 @@ class ByteCodeMachine extends StackMachine implements MatchView {
                 case OPCode.CALLOUT:                    opCallout();               continue;
                 case OPCode.CALLOUT_CONDITION:          opCalloutCondition();      continue;
                 case OPCode.DYNAMIC_CALLOUT:            opDynamicCallout();        continue;
+                case OPCode.ACCEPT:             if (opAccept()) return finish();   continue;
 
                 case OPCode.EXACT1_IC_SB:               opExact1ICSb();            break;
                 case OPCode.EXACTN_IC_SB:               opExactNICSb();            continue;
@@ -1830,7 +1832,8 @@ class ByteCodeMachine extends StackMachine implements MatchView {
     }
 
     private void opPushPos() {
-        pushPos(s, sprev, pkeep);
+        int addr = code[ip++];
+        pushPos(ip + addr, s, sprev, pkeep);
     }
 
     private void opPopPos() {
@@ -1989,6 +1992,71 @@ class ByteCodeMachine extends StackMachine implements MatchView {
         pushDynamicAlternative(returnAddress, continuation);
         s = nestedEnd;
         sprev = enc.prevCharHead(bytes, str, s, end);
+    }
+
+    /**
+     * Accept the nearest matcher-program boundary. Ordinary groups and repeats
+     * are not boundaries; calls and assertions are, matching Perl's behavior.
+     */
+    private boolean opAccept() {
+        int callDepth = 0;
+        for (int i = stk - 1; i >= 0; i--) {
+            StackEntry entry = stack[i];
+            if (entry.type == RETURN) {
+                callDepth++;
+            } else if (entry.type == CALL_FRAME) {
+                if (callDepth > 0) {
+                    callDepth--;
+                } else {
+                    closeOpenCaptures(i);
+                    cutAcceptBacktrackingAbove(i);
+                    opReturn();
+                    return false;
+                }
+            } else if (entry.type == POS) {
+                closeOpenCaptures(i);
+                int target = entry.getStatePCode();
+                StackEntry position = stack[posEnd()];
+                s = position.getStatePStr();
+                sprev = position.getStatePStrPrev();
+                pkeep = position.getPKeep();
+                ip = target;
+                return false;
+            } else if (entry.type == POS_NOT) {
+                closeOpenCaptures(i);
+                popTilPosNot();
+                opFail();
+                return false;
+            } else if (entry.type == LOOK_BEHIND_NOT) {
+                closeOpenCaptures(i);
+                popTilLookBehindNot();
+                opFail();
+                return false;
+            }
+        }
+
+        closeOpenCaptures(-1);
+        return opEnd();
+    }
+
+    private void closeOpenCaptures(int boundary) {
+        for (int mem = 1; mem <= regex.numMem; mem++) {
+            if (repeatStk[memStartStk + mem] == INVALID_INDEX
+                    || repeatStk[memEndStk + mem] != INVALID_INDEX) {
+                continue;
+            }
+            if (boundary >= 0 && !hasMemoryStartAbove(mem, boundary)) continue;
+            if (bsAt(regex.btMemEnd, mem)) pushMemEnd(mem, s);
+            else repeatStk[memEndStk + mem] = s;
+        }
+    }
+
+    private boolean hasMemoryStartAbove(int mem, int boundary) {
+        for (int i = stk - 1; i > boundary; i--) {
+            StackEntry entry = stack[i];
+            if (entry.type == MEM_START && entry.getMemNum() == mem) return true;
+        }
+        return false;
     }
 
     @Override

--- a/third_party/joni/src/org/joni/Compiler.java
+++ b/third_party/joni/src/org/joni/Compiler.java
@@ -26,6 +26,7 @@ import org.joni.ast.CClassNode;
 import org.joni.ast.CTypeNode;
 import org.joni.ast.CallNode;
 import org.joni.ast.CalloutNode;
+import org.joni.ast.ControlVerbNode;
 import org.joni.ast.ListNode;
 import org.joni.ast.EncloseNode;
 import org.joni.ast.Node;
@@ -99,6 +100,7 @@ abstract class Compiler implements ErrorMessages {
     protected abstract void compileAnyCharNode();
     protected abstract void compileCallNode(CallNode node);
     protected abstract void compileCalloutNode(CalloutNode node);
+    protected abstract void compileControlVerbNode(ControlVerbNode node);
     protected abstract void compileBackrefNode(BackRefNode node);
     protected abstract void compileCECQuantifierNode(QuantifierNode node);
     protected abstract void compileNonCECQuantifierNode(QuantifierNode node);
@@ -109,6 +111,10 @@ abstract class Compiler implements ErrorMessages {
     protected final void compileTree(Node node) {
         if (node instanceof CalloutNode) {
             compileCalloutNode((CalloutNode)node);
+            return;
+        }
+        if (node instanceof ControlVerbNode) {
+            compileControlVerbNode((ControlVerbNode)node);
             return;
         }
         switch (node.getType()) {

--- a/third_party/joni/src/org/joni/Parser.java
+++ b/third_party/joni/src/org/joni/Parser.java
@@ -43,6 +43,7 @@ import org.joni.ast.CClassNode.CCVALTYPE;
 import org.joni.ast.CTypeNode;
 import org.joni.ast.CallNode;
 import org.joni.ast.CalloutNode;
+import org.joni.ast.ControlVerbNode;
 import org.joni.ast.EncloseNode;
 import org.joni.ast.ListNode;
 import org.joni.ast.Node;
@@ -427,6 +428,11 @@ class Parser extends Lexer {
 
         int option = env.option;
 
+        if (peekIs('*')) {
+            inc();
+            return parseControlVerb();
+        }
+
         if (peekIs('?') && syntax.op2QMarkGroupEffect()) {
             inc();
             if (!left()) newSyntaxException(END_PATTERN_IN_GROUP);
@@ -724,6 +730,15 @@ class Parser extends Lexer {
         final String dynamicPrefix = "=DYNAMIC:";
         boolean dynamic = startsWith(dynamicPrefix);
         return new CalloutNode(parseInternalCalloutId(dynamic ? dynamicPrefix : "=CALL:"), dynamic);
+    }
+
+    private Node parseControlVerb() {
+        final String accept = "ACCEPT)";
+        if (!startsWith(accept)) newSyntaxException(UNDEFINED_GROUP_OPTION);
+        p += accept.length();
+        returnCode = 0;
+        env.hasControlVerb = true;
+        return new ControlVerbNode(ControlVerbNode.Kind.ACCEPT);
     }
 
     private int parseInternalCalloutId() {

--- a/third_party/joni/src/org/joni/ScanEnvironment.java
+++ b/third_party/joni/src/org/joni/ScanEnvironment.java
@@ -51,6 +51,7 @@ public final class ScanEnvironment {
     int combExpMaxRegNum;
     int currMaxRegNum;
     boolean hasRecursion;
+    boolean hasControlVerb;
     private int warningsFlag;
 
     int numPrecReadNotNodes;

--- a/third_party/joni/src/org/joni/StackMachine.java
+++ b/third_party/joni/src/org/joni/StackMachine.java
@@ -212,8 +212,8 @@ abstract class StackMachine extends Matcher implements StackType {
         push(ALT, pat, s, prev, pkeep);
     }
 
-    protected final void pushPos(int s, int prev, int pkeep) {
-        push(POS, -1 /*NULL_UCHARP*/, s, prev, pkeep);
+    protected final void pushPos(int target, int s, int prev, int pkeep) {
+        push(POS, target, s, prev, pkeep);
     }
 
     protected final void pushPosNot(int pat, int s, int prev, int pkeep) {
@@ -486,6 +486,14 @@ abstract class StackMachine extends Matcher implements StackType {
             }
         }
         return k;
+    }
+
+    protected final void cutAcceptBacktrackingAbove(int boundary) {
+        for (int i = boundary + 1; i < stk; i++) {
+            StackEntry entry = stack[i];
+            if (entry.type == DYNAMIC_ALT) completeDynamic(entry);
+            if ((entry.type & MASK_POP_USED) != 0) entry.type = VOID;
+        }
     }
 
     protected final void stopBtEnd() {

--- a/third_party/joni/src/org/joni/ast/ControlVerbNode.java
+++ b/third_party/joni/src/org/joni/ast/ControlVerbNode.java
@@ -1,0 +1,44 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.joni.ast;
+
+/** Zero-width matcher-control verb that cannot be represented as literal text. */
+public final class ControlVerbNode extends StringNode {
+    public enum Kind { ACCEPT }
+
+    public final Kind kind;
+
+    public ControlVerbNode(Kind kind) {
+        super(0);
+        this.kind = kind;
+        setRaw();
+        setDontGetOptInfo();
+    }
+
+    @Override
+    public String getName() {
+        return "ControlVerb";
+    }
+
+    @Override
+    public String toString(int level) {
+        return "\n  kind: " + kind;
+    }
+}

--- a/third_party/joni/src/org/joni/constants/internal/OPCode.java
+++ b/third_party/joni/src/org/joni/constants/internal/OPCode.java
@@ -144,6 +144,7 @@ public interface OPCode {
     int CALLOUT                       = 100;          /* generic match-time callout */
     int CALLOUT_CONDITION             = 101;          /* callback-selected conditional */
     int DYNAMIC_CALLOUT               = 102;          /* callback-supplied nested program */
+    int ACCEPT                        = 103;          /* accept current matcher boundary */
 
     String[] OpCodeNames = Config.DEBUG_COMPILE ? new String[] {
         "finish", /*OP_FINISH*/
@@ -250,6 +251,7 @@ public interface OPCode {
         "callout", /*OP_CALLOUT*/
         "callout-condition", /*OP_CALLOUT_CONDITION*/
         "dynamic-callout", /*OP_DYNAMIC_CALLOUT*/
+        "accept", /*OP_ACCEPT*/
     } : null;
 
     int[] OpCodeArgTypes = Config.DEBUG_COMPILE ? new int[] {
@@ -357,5 +359,6 @@ public interface OPCode {
         Arguments.MEMNUM, /*OP_CALLOUT*/
         Arguments.SPECIAL, /*OP_CALLOUT_CONDITION*/
         Arguments.MEMNUM, /*OP_DYNAMIC_CALLOUT*/
+        Arguments.NON, /*OP_ACCEPT*/
     } : null;
 }

--- a/third_party/joni/src/org/joni/constants/internal/OPSize.java
+++ b/third_party/joni/src/org/joni/constants/internal/OPSize.java
@@ -45,7 +45,7 @@ public interface OPSize {
     int PUSH_IF_PEEK_NEXT             = (OPCODE + RELADDR + 1);
     int REPEAT_INC                    = (OPCODE + MEMNUM);
     int REPEAT_INC_NG                 = (OPCODE + MEMNUM);
-    int PUSH_POS                      = OPCODE;
+    int PUSH_POS                      = (OPCODE + RELADDR);
     int PUSH_POS_NOT                  = (OPCODE + RELADDR);
     int POP_POS                       = OPCODE;
     int FAIL_POS                      = OPCODE;
@@ -74,6 +74,7 @@ public interface OPSize {
     int CALLOUT                      = (OPCODE + MEMNUM);
     int CALLOUT_CONDITION            = (OPCODE + MEMNUM + RELADDR);
     int DYNAMIC_CALLOUT              = (OPCODE + MEMNUM);
+    int ACCEPT                       = OPCODE;
 
     // #ifdef USE_COMBINATION_EXPLOSION_CHECK
     int STATE_CHECK                   = (OPCODE + STATE_CHECK_NUM);

--- a/third_party/joni/test/org/joni/test/TestControlVerb.java
+++ b/third_party/joni/test/org/joni/test/TestControlVerb.java
@@ -1,0 +1,76 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.joni.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.jcodings.specific.ASCIIEncoding;
+import org.joni.Matcher;
+import org.joni.Option;
+import org.joni.Regex;
+import org.joni.Region;
+import org.joni.Syntax;
+import org.junit.Test;
+
+public class TestControlVerb {
+    private static Matcher matcher(String pattern, String input) {
+        byte[] patternBytes = pattern.getBytes(StandardCharsets.US_ASCII);
+        byte[] inputBytes = input.getBytes(StandardCharsets.US_ASCII);
+        Regex regex = new Regex(patternBytes, 0, patternBytes.length, Option.NONE,
+                ASCIIEncoding.INSTANCE, Syntax.RUBY);
+        return regex.matcher(inputBytes);
+    }
+
+    @Test
+    public void acceptClosesActiveCapturesAndSkipsTheOuterSuffix() {
+        Matcher matcher = matcher("(A(A|B(*ACCEPT)|C)+D)(E)z", "ABDE");
+
+        assertEquals(0, matcher.search(0, 4, Option.NONE));
+        Region region = matcher.getEagerRegion();
+        assertEquals(0, region.getBeg(0));
+        assertEquals(2, region.getEnd(0));
+        assertEquals(0, region.getBeg(1));
+        assertEquals(2, region.getEnd(1));
+        assertEquals(1, region.getBeg(2));
+        assertEquals(2, region.getEnd(2));
+        assertEquals(-1, region.getBeg(3));
+    }
+
+    @Test
+    public void acceptCompletesOnlyThePositiveAssertionBoundary() {
+        Matcher matcher = matcher("(?=(a(*ACCEPT)z))ab", "ab");
+
+        assertEquals(0, matcher.search(0, 2, Option.NONE));
+        Region region = matcher.getEagerRegion();
+        assertEquals(2, region.getEnd(0));
+        assertEquals(0, region.getBeg(1));
+        assertEquals(1, region.getEnd(1));
+    }
+
+    @Test
+    public void acceptCanProduceAnEmptyMatch() {
+        Matcher matcher = matcher("(*ACCEPT)never", "x");
+
+        assertEquals(0, matcher.search(0, 1, Option.NONE));
+        assertEquals(0, matcher.getEnd());
+    }
+}


### PR DESCRIPTION
## Summary

- parse `(*ACCEPT)` as a native vendored-Joni control-verb AST node and opcode
- preserve Perl boundaries for top-level matches, subpattern calls, positive lookaheads, and runtime dynamic patterns
- close captures at the accepted endpoint and complete abandoned dynamic/backtracking continuations exactly once
- route ACCEPT-bearing patterns to Joni and bypass mandatory-suffix optimization when control flow can skip that suffix
- update the history-free Joni design and regex feature matrix

All new vendored-Joni sources retain the upstream MIT notice. Existing `org.joni` source namespaces remain unchanged; standalone packaging continues to relocate them to `org.perlonjava.internal.joni`.

## Validation

- `prove src/test/resources/unit/regex/accept_control_verb.t`: 13/13 on standard Perl
- JVM backend: 13/13
- interpreter backend: 13/13
- imported Joni tests: pass, including dedicated ACCEPT cases
- `make`: pass, no warnings
- focused upstream direct/thread pair: 24/555 passing and 30/555 executed in each file, up from 22 passing and 28 executed before this slice; next blocker is optimistic callback conditions at line 138
- full `perl dev/tools/perl_test_runner.pl perl5_t/t/re/`: 80 files, 50,718 passing assertions, zero timeouts

## Baseline comparison

Compared file-by-file with `../PerlOnJava/logs/test_20260815_080000_958.log`:

- 26 regex files improved
- 53 retained the same passing count
- no files are missing or newly added
- `regexp_unicode_prop.t` is 1019/1110 versus the historical 1031/1110; a detached, clean `origin/master` build reproduces the same 1019/1110 result, so this is inherited from merged main and is not introduced by this branch

The ACCEPT-specific gain is visible in both `pat_re_eval.t` and `pat_re_eval_thr.t`, which move from the PR 970 postbase 22/555 to 24/555.

Generated with [Codex](https://openai.com/codex)
