### PR TITLE
Execute optimistic regex callbacks in Joni

### DIFF
--- a/docs/design/joni-callout-fork.md
+++ b/docs/design/joni-callout-fork.md
@@ -135,6 +135,13 @@ The parser emits a `regexTemplate` operation whose ordered parts contain normal
 interpolation values and explicit `regexCallback` wrappers. Runtime template
 construction assigns callback IDs and produces the engine-facing skeleton.
 
+Optimistic callbacks use the same structured path. Standalone `(*{ code })`
+callbacks execute as zero-width BLOCK callouts and publish their result through
+`$^R`; `(?(*{ code })yes|no)` predicates execute as CONDITION callouts, select
+their branch from the result's truth, and leave `$^R` unchanged. The matcher
+publishes `$^N` from capture-close order rather than deriving it from `$+`, whose
+meaning is the highest-numbered defined capture.
+
 An interpolated coderef remains ordinary interpolation because only the parser
 can create a callback wrapper. Runtime strings containing Perl eval groups never
 become trusted callback skeletons. They retain the existing security checks and,
@@ -242,6 +249,8 @@ keep their established fold-to-pattern path.
 - Focused tests cover provisional captures, repeated execution after
   backtracking, `FAIL`, nested frames, handler exceptions, interruption, and
   exact-once reverse-order unwind.
+- Optimistic-callback tests cover standalone execution, conditional truth,
+  `$^R`, exact `$^N` capture-close order, `$+`, and alternative reachability.
 - The standalone JAR contains no `org/joni` or `org/jcodings` classes, contains
   both relocated trees, and includes all required notices.
 - An embedding smoke test can load stock Joni and PerlOnJava together.

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -394,10 +394,10 @@ my @copy = @{$z};         # ERROR
 - ❌  **Lookbehind Assertions**: Variable-length negative or positive lookbehind assertions, e.g., `(?<=...)` or `(?<!...)`, are not supported.
 - ✅  **Branch Reset Groups**: `(?|...)` resets capture numbering across alternatives and preserves mapped match variables.
 - ✅  **Advanced Subroutine Calls**: Sub-pattern calls with numbered or named references like `(?1)` and `(?&name)` execute through Joni.
-- 🟡  **Conditional Expressions**: Executable callback conditions `(?(?{ code })yes|no)` execute through Joni; other condition forms are not yet complete.
+- 🟡  **Conditional Expressions**: Executable callback conditions `(?(?{ code })yes|no)` and optimistic predicates `(?(*{ code })yes|no)` execute through Joni; other condition forms are not yet complete.
 - ❌  **Extended Unicode Regex Features**: Some extended Unicode regex functionalities are not supported.
 - ❌  **Extended Grapheme Clusters**: Matching with `\X` for extended grapheme clusters is not supported.
-- 🟡  **Embedded Code in Regex**: `(?{ code })`, executable callback conditions, and `(??{ code })` run as lexical closures in Joni with provisional captures and backtracking unwind. Optimistic callbacks `(*{ code })` are not supported.
+- ✅  **Embedded Code in Regex**: `(?{ code })`, optimistic callbacks `(*{ code })`, executable callback conditions, and `(??{ code })` run as lexical closures in Joni with provisional captures and backtracking unwind. `$^N` follows capture-close order independently of `$+`.
 - ✅  **Regex Debugging**: Lexically scoped `use/no re 'debug'` and `debugcolor` are supported, including runtime snapshot ownership.
 - 🟡  **Runtime Regex Evaluation**: `use re 'eval'` controls whether interpolated patterns containing eval groups may compile, but runtime strings cannot manufacture trusted callback closures.
 - ❌  **Regex Compilation Flags**: Setting default regex flags with `use re '/flags';` is not supported.

--- a/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
@@ -804,6 +804,9 @@ public abstract class StringSegmentParser {
                 } else if (isRegex && regexCodeBlocksAreActive() && isRegexRecursiveBlock()) {
                     parseRegexCodeBlock(true);   // (??{...}) - recursive pattern
                     yield true;
+                } else if (isRegex && regexCodeBlocksAreActive() && isRegexOptimisticBlock()) {
+                    parseRegexOptimisticBlock(); // (*{...}) - optimization-preserving callback
+                    yield true;
                 }
                 yield false;
             }
@@ -835,7 +838,8 @@ public abstract class StringSegmentParser {
         return currentPos + 3 < parser.tokens.size()
                 && "?".equals(parser.tokens.get(currentPos).text)
                 && "(".equals(parser.tokens.get(currentPos + 1).text)
-                && "?".equals(parser.tokens.get(currentPos + 2).text)
+                && ("?".equals(parser.tokens.get(currentPos + 2).text)
+                    || "*".equals(parser.tokens.get(currentPos + 2).text))
                 && "{".equals(parser.tokens.get(currentPos + 3).text);
     }
 
@@ -844,13 +848,34 @@ public abstract class StringSegmentParser {
         int start = tokenIndex;
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, "?");
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, "(");
-        TokenUtils.consume(parser, LexerTokenType.OPERATOR, "?");
+        LexerToken callbackType = TokenUtils.consume(parser);
+        if (!"?".equals(callbackType.text) && !"*".equals(callbackType.text)) {
+            throw new IllegalStateException("invalid regex callback condition marker");
+        }
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, "{");
         Node block = parseBlock(parser);
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, "}");
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, ")");
         segments.add(new StringNode("(?(", start));
         segments.add(regexCallback(block, "CONDITION", start));
+    }
+
+    private boolean isRegexOptimisticBlock() {
+        int currentPos = parser.tokenIndex;
+        return currentPos + 1 < parser.tokens.size()
+                && "*".equals(parser.tokens.get(currentPos).text)
+                && "{".equals(parser.tokens.get(currentPos + 1).text);
+    }
+
+    private void parseRegexOptimisticBlock() {
+        flushCurrentSegment();
+        int start = tokenIndex;
+        TokenUtils.consume(parser, LexerTokenType.OPERATOR, "*");
+        TokenUtils.consume(parser, LexerTokenType.OPERATOR, "{");
+        Node block = parseBlock(parser);
+        TokenUtils.consume(parser, LexerTokenType.OPERATOR, "}");
+        TokenUtils.consume(parser, LexerTokenType.OPERATOR, ")");
+        segments.add(regexCallback(block, "BLOCK", start));
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -421,6 +421,7 @@ final class JoniRegexPattern {
         }
 
         @Override public int groupCount() { return regex.numberOfCaptures(); }
+        @Override public int lastClosedCapture() { return matcher.lastClosedCapture(); }
         @Override public Map<String, Integer> namedGroups() { return namedGroups; }
         @Override public String patternDescription() { return sourcePattern; }
 
@@ -633,6 +634,9 @@ final class JoniRegexPattern {
                     state.lastCaptureGroups[group - 1] = input.substring(begin, end);
                 }
             }
+            int lastClosed = match.lastClosedCapture();
+            state.lastClosedCapture = lastClosed > 0 && lastClosed <= count
+                    ? state.lastCaptureGroups[lastClosed - 1] : null;
         }
 
         private int charOffset(int byteOffset) {

--- a/src/main/java/org/perlonjava/runtime/regex/RegexMatcher.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexMatcher.java
@@ -32,6 +32,21 @@ public interface RegexMatcher {
 
     int groupCount();
 
+    /** Most recently closed capture number, or -1 when the backend cannot provide it. */
+    default int lastClosedCapture() {
+        int selected = -1;
+        int selectedEnd = -1;
+        for (int group = 1; group <= groupCount(); group++) {
+            int end = end(group);
+            if (end > selectedEnd || (end == selectedEnd && end >= 0
+                    && (selected < 0 || group < selected))) {
+                selected = group;
+                selectedEnd = end;
+            }
+        }
+        return selected;
+    }
+
     Map<String, Integer> namedGroups();
 
     String patternDescription();

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -1543,6 +1543,9 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         regexState.manualCaptureStarts = null;
         regexState.manualCaptureEnds = null;
         int captureCount = matcher.groupCount();
+        int lastClosedCapture = matcher.lastClosedCapture();
+        regexState.lastClosedCapture = lastClosedCapture > 0
+                && lastClosedCapture <= captureCount ? matcher.group(lastClosedCapture) : null;
         if (captureCount == 0) {
             regexState.lastCaptureGroups = null;
             return;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
@@ -75,8 +75,8 @@ public class GlobalContext {
             String varName = "main::" + Character.toString(c - 'A' + 1);
             GlobalVariable.getGlobalVariable(varName);
         }
-        // $^N - last capture group closed (not yet implemented, but must be read-only)
-        GlobalVariable.globalVariables.put(encodeSpecialVar("N"), new RuntimeScalarReadOnly());
+        GlobalVariable.globalVariables.put(encodeSpecialVar("N"),
+                new ScalarSpecialVariable(ScalarSpecialVariable.Id.LAST_CLOSED_PAREN_MATCH));
         // $^S - current state of the interpreter (undef=compiling, 0=not in eval, 1=in eval)
         GlobalVariable.globalVariables.put("main::" + Character.toString('S' - 'A' + 1),
                 new ScalarSpecialVariable(ScalarSpecialVariable.Id.EVAL_STATE));

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RegexState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RegexState.java
@@ -22,6 +22,7 @@ public class RegexState implements DynamicState {
     private final boolean lastMatchUsedPFlag;
     private final boolean lastMatchUsedBackslashK;
     private final String[] lastCaptureGroups;
+    private final String lastClosedCapture;
     private final Map<String, List<String>> lastNamedCaptureGroups;
     private final boolean lastMatchWasByteString;
     private final boolean lastMatchResultsTainted;
@@ -44,6 +45,7 @@ public class RegexState implements DynamicState {
         lastMatchUsedPFlag = state.lastMatchUsedPFlag;
         lastMatchUsedBackslashK = state.lastMatchUsedBackslashK;
         lastCaptureGroups = state.lastCaptureGroups;
+        lastClosedCapture = state.lastClosedCapture;
         lastNamedCaptureGroups = state.lastNamedCaptureGroups;
         lastMatchWasByteString = state.lastMatchWasByteString;
         lastMatchResultsTainted = state.lastMatchResultsTainted;
@@ -82,6 +84,7 @@ public class RegexState implements DynamicState {
         state.lastMatchUsedPFlag = lastMatchUsedPFlag;
         state.lastMatchUsedBackslashK = lastMatchUsedBackslashK;
         state.lastCaptureGroups = lastCaptureGroups;
+        state.lastClosedCapture = lastClosedCapture;
         state.lastNamedCaptureGroups = lastNamedCaptureGroups;
         state.lastMatchWasByteString = lastMatchWasByteString;
         state.lastMatchResultsTainted = lastMatchResultsTainted;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeRegexState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeRegexState.java
@@ -32,6 +32,7 @@ public final class RuntimeRegexState {
     public boolean lastMatchUsedPFlag;
     public boolean lastMatchUsedBackslashK;
     public String[] lastCaptureGroups;
+    public String lastClosedCapture;
     public Map<String, List<String>> lastNamedCaptureGroups;
     public boolean lastMatchWasByteString;
     public boolean lastMatchResultsTainted;
@@ -85,6 +86,7 @@ public final class RuntimeRegexState {
         lastMatchUsedPFlag = false;
         lastMatchUsedBackslashK = false;
         lastCaptureGroups = null;
+        lastClosedCapture = null;
         lastNamedCaptureGroups = null;
         lastMatchWasByteString = false;
         lastMatchResultsTainted = false;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarSpecialVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarSpecialVariable.java
@@ -227,6 +227,10 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
                     String lastCapture = RuntimeRegex.lastCaptureString();
                     yield lastCapture != null ? makeRegexResultScalar(lastCapture) : scalarUndef;
                 }
+                case LAST_CLOSED_PAREN_MATCH -> {
+                    String lastCapture = PerlRuntime.current().regexState.lastClosedCapture;
+                    yield lastCapture != null ? makeRegexResultScalar(lastCapture) : scalarUndef;
+                }
                 case LAST_SUCCESSFUL_PATTERN -> PerlRuntime.current().regexState.lastSuccessfulPattern != null
                         ? new RuntimeScalar(PerlRuntime.current().regexState.lastSuccessfulPattern) : scalarUndef;
                 case LAST_REGEXP_CODE_RESULT -> {
@@ -527,6 +531,7 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
         LAST_FH,    // Represents the last filehandle used in an input operation.
         INPUT_LINE_NUMBER, // Represents the current line number in an input operation.
         LAST_PAREN_MATCH, // The highest capture variable ($1, $2, ...) which has a defined value.
+        LAST_CLOSED_PAREN_MATCH, // $^N - most recently closed capture in the current match.
         LAST_SUCCESSFUL_PATTERN, // ${^LAST_SUCCESSFUL_PATTERN}
         LAST_REGEXP_CODE_RESULT, // $^R - Result of last (?{...}) code block in regex
         HINTS, // $^H - Compile-time hints (strict, etc.)

--- a/src/test/resources/unit/regex/optimistic_callback.t
+++ b/src/test/resources/unit/regex/optimistic_callback.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $count = 0;
+local $^R = 'before';
+ok('ab' =~ /a(*{ ++$count; 0 })b/,
+    'standalone optimistic callback is zero width');
+is($count, 1, 'standalone optimistic callback executes');
+is($^R, 0, 'standalone optimistic callback updates $^R');
+
+local $^R = 'condition-before';
+ok('AB' =~ /(A)(?(*{ 1 })B|C)/,
+    'true optimistic condition selects the yes branch');
+is($1, 'A', 'true condition preserves ordinary capture state');
+is($^R, 'condition-before', 'optimistic condition does not update $^R');
+ok('AC' =~ /(A)(?(*{ 0 })B|C)/,
+    'false optimistic condition selects the no branch');
+
+my @seen;
+ok('ab' =~ /(a)(*{
+    push @seen, [defined $^N ? $^N : 'undef', defined $+ ? $+ : 'undef'];
+})b/, 'standalone optimistic callback sees captures');
+is_deeply($seen[0], ['a', 'a'],
+    'optimistic capture view publishes $^N and $+');
+
+my @nested;
+ok('ab' =~ /((a)b)(*{
+    push @nested, [defined $^N ? $^N : 'undef', defined $+ ? $+ : 'undef'];
+})/, 'nested captures close before the optimistic callback');
+is_deeply($nested[0], ['ab', 'a'], '$^N tracks close order independently of $+');
+
+my @paths;
+ok('ac' =~ /a(?:b(*{ push @paths, 'ab' })d|c(*{ push @paths, 'ac' }))/,
+    'optimistic callback follows the reached alternative');
+is_deeply(\@paths, ['ac'], 'unreached optimistic callbacks do not execute');
+
+done_testing();

--- a/third_party/joni/src/org/joni/Analyser.java
+++ b/third_party/joni/src/org/joni/Analyser.java
@@ -122,7 +122,7 @@ final class Analyser extends Parser {
             regex.btMemStart = bsAll();
         }
 
-        if (isFindCondition(regex.options)) {
+        if (isFindCondition(regex.options) || env.hasCallout) {
             regex.btMemEnd = bsAll();
         } else {
             regex.btMemEnd = env.btMemEnd;

--- a/third_party/joni/src/org/joni/ByteCodeMachine.java
+++ b/third_party/joni/src/org/joni/ByteCodeMachine.java
@@ -2087,6 +2087,17 @@ class ByteCodeMachine extends StackMachine implements MatchView {
         return (bsAt(regex.btMemEnd, capture) ? stack[value].getMemPStr() : value) - str;
     }
 
+    @Override
+    public int lastClosedCapture() {
+        for (int i = stk - 1; i >= 0; i--) {
+            StackEntry entry = stack[i];
+            if (entry.type != MEM_END) continue;
+            int mem = entry.getMemNum();
+            if (repeatStk[memEndStk + mem] == i) return mem;
+        }
+        return -1;
+    }
+
     private void checkCapture(int capture) {
         if (capture < 0 || capture > regex.numMem) {
             throw new IndexOutOfBoundsException("capture " + capture);

--- a/third_party/joni/src/org/joni/MatchView.java
+++ b/third_party/joni/src/org/joni/MatchView.java
@@ -28,4 +28,7 @@ public interface MatchView {
     int captureBegin(int capture);
 
     int captureEnd(int capture);
+
+    /** Number of the most recently closed active capture, or -1 if none. */
+    int lastClosedCapture();
 }

--- a/third_party/joni/src/org/joni/Matcher.java
+++ b/third_party/joni/src/org/joni/Matcher.java
@@ -99,6 +99,11 @@ public abstract class Matcher extends IntHolder {
         return msaEnd;
     }
 
+    /** Most recently closed active capture; engines without this view return -1. */
+    public int lastClosedCapture() {
+        return -1;
+    }
+
     protected final void msaInit(int option, int start, int gpos) {
         msaOptions = option;
         msaStart = start;

--- a/third_party/joni/src/org/joni/Parser.java
+++ b/third_party/joni/src/org/joni/Parser.java
@@ -746,6 +746,7 @@ class Parser extends Lexer {
     }
 
     private int parseInternalCalloutId(String prefix) {
+        env.hasCallout = true;
         for (int i = 0; i < prefix.length(); i++) {
             if (!left()) newSyntaxException(END_PATTERN_IN_GROUP);
             fetch();

--- a/third_party/joni/src/org/joni/ScanEnvironment.java
+++ b/third_party/joni/src/org/joni/ScanEnvironment.java
@@ -52,6 +52,7 @@ public final class ScanEnvironment {
     int currMaxRegNum;
     boolean hasRecursion;
     boolean hasControlVerb;
+    boolean hasCallout;
     private int warningsFlag;
 
     int numPrecReadNotNodes;

--- a/third_party/joni/test/org/joni/test/TestCallout.java
+++ b/third_party/joni/test/org/joni/test/TestCallout.java
@@ -79,6 +79,28 @@ public class TestCallout {
     }
 
     @Test
+    public void exposesMostRecentlyClosedCaptureIndependentlyOfHighestNumber() {
+        List<String> events = new ArrayList<>();
+        Regex regex = regex("((a)b)(?{=CALL:3})");
+        CalloutHandler handler = new CalloutHandler() {
+            @Override
+            public CalloutResult execute(int id, MatchView match) {
+                events.add(id + ":" + match.lastClosedCapture() + ":"
+                        + match.captureBegin(1) + "-" + match.captureEnd(1) + ":"
+                        + match.captureBegin(2) + "-" + match.captureEnd(2));
+                return CalloutResult.CONTINUE;
+            }
+
+            @Override
+            public void unwind(Object token) {
+            }
+        };
+
+        assertEquals(0, search(regex, "ab", handler));
+        assertEquals(Arrays.asList("3:1:0-2:0-1"), events);
+    }
+
+    @Test
     public void unwindsBacktrackedAndSuccessfulPathsExactlyOnce() {
         List<String> events = new ArrayList<>();
         Regex regex = regex("(a(?{=CALL:1})b|a(?{=CALL:2})c)");


### PR DESCRIPTION
## Summary

- execute standalone `(*{ ... })` optimistic callbacks and `(?(*{ ... })yes|no)` callback conditions through the structured Joni callout path
- expose exact Joni capture-close order so `$^N` remains distinct from `$+`
- document the completed feature coverage while preserving the vendored Joni copyright and authorship notices

## Validation

- `make` — passes after final rebase; no compiler or make warnings
- system Perl: `prove src/test/resources/unit/regex/optimistic_callback.t` — 13/13
- JVM and interpreter backends: `optimistic_callback.t` — 13/13 each
- focused `pat_re_eval.t` / threaded run — 44/555 passing per backend, up from 24/555 before this phase
- full `perl5_t/t/re/` comparison against `../PerlOnJava/logs/test_20260815_080000_958.log` — 50,971 passing assertions, +698 across 80 files

The only file below the older PR 958 baseline is `regexp_unicode_prop.t`; a clean build of current `origin/master` reproduces the same 1019/1110 result, so it is inherited rather than introduced here.
