### PR TITLE
Fix CPAN compiler and stream tooling

### DIFF
--- a/dev/modules/cpan_tooling_batch_20260816.md
+++ b/dev/modules/cpan_tooling_batch_20260816.md
@@ -1,0 +1,108 @@
+# CPAN compiler and tooling compatibility batch (2026-08-16)
+
+## Goal
+
+Make `jcpan -t` work for Thread::CriticalSection, Types::Namespace,
+Catalyst::Plugin::Unicode, Search::Sitemap, Method::Signatures::PP,
+Authen::SimplePam, Text::RecordParser, and their supported dependencies.
+Prefer reusable compiler, runtime, and CPAN-tooling fixes over distribution
+preferences. A target that also fails under the isolated local system Perl may
+be left unsupported with the failure recorded.
+
+## Baseline
+
+All `jcpan` invocations use a hard timeout and write complete logs under
+`/tmp/jcpan_*_baseline.log`.
+
+| Target | PerlOnJava baseline |
+|---|---|
+| Thread::CriticalSection | Passes (4 files / 5 tests). |
+| Types::Namespace | URI::NamespaceMap dependency aborts while compiling generated Moo accessors: `Can't modify non-lvalue subroutine call of &__ANON__ in scalar assignment`. |
+| Catalyst::Plugin::Unicode | `IO::Scalar` rejects a blessed anonymous glob during `tie *$self` and cleanup. |
+| Search::Sitemap | Compressed sitemap read fails; two DateTime coercion checks cross a one-second wall-clock boundary. |
+| Method::Signatures::PP | PPR's generated grammar fails regex compilation after unsupported `\\g`/`\\X` handling and an invalid character class. |
+| Authen::SimplePam | XS-only Authen::PAM installs Perl files without a Java implementation, so `Authen/PAM.pm` does not load. |
+| Text::RecordParser | `IO::Scalar` rejects a blessed anonymous glob; 15 of 17 files otherwise pass. |
+
+The isolated system-Perl reference root is
+`/tmp/perlonjava-system-cpan-local`; its CPAN home is
+`/tmp/perlonjava-system-cpan-home`. Text::RecordParser passes 17 files / 205
+tests under Perl 5.42. Types::Namespace's containing URI::NamespaceMap
+distribution passes 9 files / 70 tests. Catalyst::Plugin::Unicode and
+Search::Sitemap also pass. Authen::SimplePam's one-test suite passes after its
+Authen::PAM dependency is built; Authen::PAM's own interactive test requires a
+real account password and was not exercised. Method::Signatures::PP fails its
+own upstream suite under system Perl 5.42 and is excluded under the stated
+system-Perl rule.
+
+## Progress Tracking
+
+### Current Status: Implementation and local validation complete
+
+### Completed Phases
+
+- [x] Feature branch and PerlOnJava baseline (2026-08-16)
+  - Captured all seven requested targets sequentially to avoid CPAN cache races.
+  - Confirmed Thread::CriticalSection already passes on current master.
+- [x] System Perl classification (2026-08-16)
+  - All actionable targets pass system Perl.
+  - Excluded Method::Signatures::PP because its own upstream suite fails on
+    system Perl 5.42.
+- [x] Compiler/runtime/tooling fixes (2026-08-16)
+  - Fixed compile-time rejection of assignment to known non-lvalue
+    subroutines; URI::NamespaceMap now passes 9 files / 70 tests.
+  - Added strict anonymous-glob-reference dereferencing and blessed underlying
+    `GLOB` type parity for IO::Scalar; Catalyst::Plugin::Unicode passes 4 files
+    / 13 tests and Text::RecordParser passes 17 files / 205 tests.
+  - Added MakeMaker `CONFIGURE` callback execution and authoritative-root
+    destination collision handling for generated modules such as Authen::PAM.
+  - Routed XML::Parser stream reads through tied-handle `READ`, restored
+    blessed-glob stream detection, and preserved the original tied object;
+    Search::Sitemap's compressed-index test now passes.
+  - Added an Authen::PAM Java XS boundary which exposes its constants and
+    reports `PAM_SYSTEM_ERR` for native operations until FFM conversation
+    callbacks can be implemented safely.
+- [x] Requested-target and full-build validation (2026-08-16)
+  - `make` passes all 486 unit tests (two skipped) and Joni packaging/tests.
+  - Thread::CriticalSection passes 4 files / 5 tests.
+  - URI::NamespaceMap (the distribution selected for `Types::Namespace`)
+    passes 9 files / 70 tests.
+  - Catalyst::Plugin::Unicode passes 4 files / 13 tests.
+  - Authen::SimplePam passes its one-test suite after building the generated
+    Authen::PAM Perl layer against the Java compatibility boundary.
+  - Text::RecordParser passes 17 files / 205 tests.
+  - Search::Sitemap's functional compressed-input regression is fixed and
+    125/126 assertions pass. Its remaining `'now'` assertion captures the
+    expected wall clock several seconds before evaluating the coercion and is
+    therefore one second stale on PerlOnJava. JFR confirmed general compiler,
+    DateTime setup, and reachability work between those points; disabling
+    auto-GC alone does not remove the delay. Runtime clock semantics and the
+    upstream test were intentionally left unchanged.
+- [ ] PR and CI validation
+
+### Next Steps
+
+1. Open the PR and monitor CI to completion.
+2. Follow up upstream on Search::Sitemap's speed-sensitive `'now'` assertion;
+   it should compare within a tolerance or capture the clock at coercion time.
+3. Implement native PAM conversations only after an FFM ownership design is
+   available.
+
+### Open Questions
+
+- A future full Authen::PAM port needs an FFM upcall with libc-owned response
+  buffers and carefully scoped Perl runtime ownership; the current boundary
+  deliberately returns `PAM_SYSTEM_ERR` instead of risking unsafe callbacks or
+  reporting false authentication success.
+- Search::Sitemap passes under the faster system Perl run, but its test expects
+  a later `'now'` conversion to equal a timestamp captured during fixture
+  construction. PerlOnJava correctly returns the current epoch second, so the
+  assertion fails when setup takes more than one second.
+
+## Related References
+
+- `docs/guides/module-porting.md`
+- `.agents/skills/debug-perlonjava/SKILL.md`
+- `.agents/skills/port-cpan-module/SKILL.md`
+- `.agents/skills/port-native-module/SKILL.md`
+- `.agents/skills/profile-perlonjava/SKILL.md`

--- a/dev/modules/cpan_tooling_batch_20260816.md
+++ b/dev/modules/cpan_tooling_batch_20260816.md
@@ -37,7 +37,7 @@ system-Perl rule.
 
 ## Progress Tracking
 
-### Current Status: Implementation and local validation complete
+### Current Status: PR open and CI green
 
 ### Completed Phases
 
@@ -78,11 +78,14 @@ system-Perl rule.
     DateTime setup, and reachability work between those points; disabling
     auto-GC alone does not remove the delay. Runtime clock semantics and the
     upstream test were intentionally left unchanged.
-- [ ] PR and CI validation
+- [x] PR and CI validation (2026-08-16)
+  - Opened [PR #976](https://github.com/fglock/PerlOnJava/pull/976).
+  - GitHub Actions passed on Ubuntu (21m13s) and Windows (18m34s) for
+    implementation commit `c9dcfb1e4`.
 
 ### Next Steps
 
-1. Open the PR and monitor CI to completion.
+1. Review and merge PR #976.
 2. Follow up upstream on Search::Sitemap's speed-sensitive `'now'` assertion;
    it should compare within a tolerance or capture the clock at coercion time.
 3. Implement native PAM conversations only after an FFM ownership design is

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -4,6 +4,16 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 
 ## Work in progress
 
+- CPAN/compiler tooling: run MakeMaker `CONFIGURE` callbacks and prefer their
+  generated root modules over auxiliary metadata stubs; enforce known
+  subroutine lvalue errors at compile time; preserve blessed anonymous-glob
+  dereferencing and `isa('GLOB')`; and route XML parsing through tied-handle
+  `READ`. Add an honest `Authen::PAM` Java boundary that reports
+  `PAM_SYSTEM_ERR` until native conversations are implemented. This unblocks
+  Types::Namespace, Catalyst::Plugin::Unicode, Search::Sitemap's compressed
+  input, Authen::SimplePam, and Text::RecordParser without distribution
+  preferences. Search::Sitemap retains one upstream speed-sensitive `'now'`
+  assertion on the slower JVM runtime.
 - CPAN/compiler tooling: restore YAML::PP's object `dump` API, recognize
   TAP-indented missing prerequisites, report gzip stream completion for CPAN
   single-file distributions, and route Object::Pad's core syntax through the

--- a/docs/reference/bundled-modules.md
+++ b/docs/reference/bundled-modules.md
@@ -30,6 +30,7 @@ Recent CPAN compatibility additions include:
 | `B::Flags` | Pure Perl over portable `B` objects | Named OP/SV flags without access to Perl C structures |
 | `Data::Util` | Java XS bridge plus upstream pure-Perl fallback | Scalar classification preserves XS non-vivifying behavior; the remaining API uses `Data::Util::PurePerl` |
 | `YAML::Syck` | Pure Perl over bundled `YAML::PP` | Compatibility loader/dumper for distributions that use the legacy Syck API |
+| `Authen::PAM` | Java XS compatibility bridge | Constants and load-time API for PAM consumers; native conversations currently return `PAM_SYSTEM_ERR` rather than authenticating |
 
 ---
 

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -779,6 +779,9 @@ The `:encoding()` layer supports all encodings provided by Java's `Charset.forNa
   scalar taint inspection.
 - ✅  **String::Similarity**: Java XS replacement for Unicode-aware string
   similarity scoring.
+- 🟡 **Authen::PAM**: the generated CPAN Perl API loads through a Java XS
+  compatibility bridge and exposes PAM constants; native conversations are
+  not yet implemented and return `PAM_SYSTEM_ERR`.
 - ✅  **Crypt::Blowfish**: Java XS replacement backed by the bundled
   BouncyCastle engine, including the variable key sizes and 8-byte block API
   required by `Crypt::CBC`.

--- a/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
@@ -8,7 +8,9 @@ import org.perlonjava.frontend.lexer.LexerToken;
 import org.perlonjava.frontend.lexer.LexerTokenType;
 import org.perlonjava.frontend.semantic.SymbolTable;
 import org.perlonjava.runtime.perlmodule.Strict;
+import org.perlonjava.runtime.runtimetypes.NameNormalizer;
 import org.perlonjava.runtime.runtimetypes.PerlCompilerException;
+import org.perlonjava.runtime.runtimetypes.RuntimeCode;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
 import java.util.ArrayList;
@@ -184,6 +186,7 @@ public class ParseInfix {
             // Validate that state variables are not initialized in list context
             if (operator.equals("=")) {
                 validateNoStateInListAssignment(parser, left);
+                validateKnownSubroutineLvalue(parser, left);
             }
 
             BinaryOperatorNode node = new BinaryOperatorNode(operator, left, right, parser.tokenIndex);
@@ -470,6 +473,36 @@ public class ParseInfix {
                 }
                 throw new PerlCompilerException(Math.max(0, errorIndex), "syntax error", parser.ctx.errorUtil);
         }
+    }
+
+    /**
+     * Perl rejects assignment to a known non-lvalue subroutine while compiling
+     * the assignment, even when it follows an unreachable {@code return} in a
+     * string eval.  Class::Method::Modifiers relies on this behavior to probe a
+     * localized coderef with {@code eval 'return 1; &_sub = 1'}.
+     */
+    private static void validateKnownSubroutineLvalue(Parser parser, Node left) {
+        if (!(left instanceof BinaryOperatorNode call) || !"(".equals(call.operator)
+                || !(call.left instanceof OperatorNode ampersand)
+                || !"&".equals(ampersand.operator)) {
+            return;
+        }
+
+        Object annotated = ampersand.getAnnotation("parseTimeCodeRef");
+        if (!(annotated instanceof RuntimeScalar codeRef)
+                || !(codeRef.value instanceof RuntimeCode code)
+                || RuntimeCode.isLvalueCode(code)) {
+            return;
+        }
+
+        String name = "__ANON__";
+        if (ampersand.operand instanceof IdentifierNode identifier) {
+            name = NameNormalizer.normalizeVariableName(
+                    identifier.name,
+                    parser.ctx.symbolTable.getCurrentPackage());
+        }
+        parser.throwError("Can't modify non-lvalue subroutine call of &" + name
+                + " in scalar assignment");
     }
 
     private static List<Node> parseArraySubscript(Parser parser) {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/AuthenPAM.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/AuthenPAM.java
@@ -1,0 +1,154 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.runtime.runtimetypes.GlobalVariable;
+import org.perlonjava.runtime.runtimetypes.RuntimeArray;
+import org.perlonjava.runtime.runtimetypes.RuntimeList;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+
+import java.util.Map;
+
+import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarUndef;
+
+/**
+ * Load-time compatibility backend for Authen::PAM.
+ *
+ * <p>The CPAN distribution's generated Perl layer provides the public OO and
+ * Exporter API.  This class supplies its XS entry points and constants so
+ * dependent modules can load on the JVM.  Native PAM conversations are not
+ * yet safe to expose without a complete FFM upcall/lifetime implementation;
+ * operational entry points therefore return {@code PAM_SYSTEM_ERR} instead
+ * of claiming that authentication succeeded.</p>
+ */
+public final class AuthenPAM extends PerlModuleBase {
+    private static final int PAM_SYSTEM_ERR = 4;
+
+    private static final Map<String, Integer> CONSTANTS = Map.ofEntries(
+            Map.entry("PAM_SUCCESS", 0),
+            Map.entry("PAM_OPEN_ERR", 1),
+            Map.entry("PAM_SYMBOL_ERR", 2),
+            Map.entry("PAM_SERVICE_ERR", 3),
+            Map.entry("PAM_SYSTEM_ERR", PAM_SYSTEM_ERR),
+            Map.entry("PAM_BUF_ERR", 5),
+            Map.entry("PAM_PERM_DENIED", 6),
+            Map.entry("PAM_AUTH_ERR", 7),
+            Map.entry("PAM_CRED_INSUFFICIENT", 8),
+            Map.entry("PAM_AUTHINFO_UNAVAIL", 9),
+            Map.entry("PAM_USER_UNKNOWN", 10),
+            Map.entry("PAM_MAXTRIES", 11),
+            Map.entry("PAM_NEW_AUTHTOK_REQD", 12),
+            Map.entry("PAM_AUTHTOKEN_REQD", 12),
+            Map.entry("PAM_ACCT_EXPIRED", 13),
+            Map.entry("PAM_SESSION_ERR", 14),
+            Map.entry("PAM_CRED_UNAVAIL", 15),
+            Map.entry("PAM_CRED_EXPIRED", 16),
+            Map.entry("PAM_CRED_ERR", 17),
+            Map.entry("PAM_NO_MODULE_DATA", 18),
+            Map.entry("PAM_AUTHTOK_ERR", 20),
+            Map.entry("PAM_AUTHTOK_RECOVER_ERR", 21),
+            Map.entry("PAM_AUTHTOK_RECOVERY_ERR", 21),
+            Map.entry("PAM_AUTHTOK_LOCK_BUSY", 22),
+            Map.entry("PAM_AUTHTOK_DISABLE_AGING", 23),
+            Map.entry("PAM_TRY_AGAIN", 24),
+            Map.entry("PAM_IGNORE", 25),
+            Map.entry("PAM_ABORT", 26),
+            Map.entry("PAM_AUTHTOK_EXPIRED", 27),
+            Map.entry("PAM_MODULE_UNKNOWN", 28),
+            Map.entry("PAM_BAD_ITEM", 29),
+            Map.entry("PAM_CONV_ERR", 19),
+            Map.entry("PAM_CONV_AGAIN", 30),
+            Map.entry("PAM_INCOMPLETE", 31),
+            Map.entry("PAM_SERVICE", 1),
+            Map.entry("PAM_USER", 2),
+            Map.entry("PAM_TTY", 3),
+            Map.entry("PAM_RHOST", 4),
+            Map.entry("PAM_CONV", 5),
+            Map.entry("PAM_AUTHTOK", 6),
+            Map.entry("PAM_OLDAUTHTOK", 7),
+            Map.entry("PAM_RUSER", 8),
+            Map.entry("PAM_USER_PROMPT", 9),
+            Map.entry("PAM_FAIL_DELAY", 10),
+            Map.entry("PAM_SILENT", 0x8000),
+            Map.entry("PAM_DISALLOW_NULL_AUTHTOK", 0x0001),
+            Map.entry("PAM_ESTABLISH_CRED", 0x0002),
+            Map.entry("PAM_CRED_ESTABLISH", 0x0002),
+            Map.entry("PAM_DELETE_CRED", 0x0004),
+            Map.entry("PAM_CRED_DELETE", 0x0004),
+            Map.entry("PAM_REINITIALIZE_CRED", 0x0008),
+            Map.entry("PAM_CRED_REINITIALIZE", 0x0008),
+            Map.entry("PAM_REFRESH_CRED", 0x0010),
+            Map.entry("PAM_CRED_REFRESH", 0x0010),
+            Map.entry("PAM_CHANGE_EXPIRED_AUTHTOK", 0x0020),
+            Map.entry("PAM_PROMPT_ECHO_OFF", 1),
+            Map.entry("PAM_PROMPT_ECHO_ON", 2),
+            Map.entry("PAM_ERROR_MSG", 3),
+            Map.entry("PAM_TEXT_INFO", 4),
+            Map.entry("PAM_RADIO_TYPE", 5),
+            Map.entry("PAM_BINARY_PROMPT", 7),
+            Map.entry("PAM_MAX_MSG_SIZE", 512),
+            Map.entry("PAM_MAX_RESP_SIZE", 512),
+            Map.entry("HAVE_PAM_FAIL_DELAY", 0),
+            Map.entry("HAVE_PAM_ENV_FUNCTIONS", 0),
+            Map.entry("HAVE_PAM_SYSTEM_LOG", 0)
+    );
+
+    private AuthenPAM() {
+        super("Authen::PAM", false);
+    }
+
+    public static void initialize() {
+        AuthenPAM module = new AuthenPAM();
+        try {
+            module.registerMethod("constant", null);
+            module.registerMethod("_pam_start", "unsupported", null);
+            module.registerMethod("pam_end", "unsupported", null);
+            module.registerMethod("pam_set_item", "unsupported", null);
+            module.registerMethod("pam_get_item", "unsupported", null);
+            module.registerMethod("pam_putenv", "unsupported", null);
+            module.registerMethod("pam_fail_delay", "unsupported", null);
+            module.registerMethod("pam_authenticate", "unsupported", null);
+            module.registerMethod("pam_setcred", "unsupported", null);
+            module.registerMethod("pam_acct_mgmt", "unsupported", null);
+            module.registerMethod("pam_open_session", "unsupported", null);
+            module.registerMethod("pam_close_session", "unsupported", null);
+            module.registerMethod("pam_chauthtok", "unsupported", null);
+            module.registerMethod("pam_strerror", null);
+            module.registerMethod("pam_getenv", null);
+            module.registerMethod("_pam_getenvlist", null);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Unable to initialize Authen::PAM", e);
+        }
+    }
+
+    public static RuntimeList constant(RuntimeArray args, int ctx) {
+        String name = args.isEmpty() ? "" : args.get(0).toString();
+        Integer value = CONSTANTS.get(name);
+        if (value == null) {
+            // EINVAL is the contract used by Authen::PAM's AUTOLOAD fallback.
+            GlobalVariable.getGlobalVariable("main::!").set(new RuntimeScalar(22));
+            return new RuntimeScalar(0).getList();
+        }
+        GlobalVariable.getGlobalVariable("main::!").set(new RuntimeScalar(0));
+        return new RuntimeScalar(value).getList();
+    }
+
+    public static RuntimeList unsupported(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(PAM_SYSTEM_ERR).getList();
+    }
+
+    public static RuntimeList pam_strerror(RuntimeArray args, int ctx) {
+        int error = args.size() > 1 ? args.get(1).getInt()
+                : args.isEmpty() ? PAM_SYSTEM_ERR : args.get(0).getInt();
+        String message = error == PAM_SYSTEM_ERR
+                ? "System error: native PAM conversations are not available in PerlOnJava"
+                : "PAM error " + error;
+        return new RuntimeScalar(message).getList();
+    }
+
+    public static RuntimeList pam_getenv(RuntimeArray args, int ctx) {
+        return scalarUndef.getList();
+    }
+
+    public static RuntimeList _pam_getenvlist(RuntimeArray args, int ctx) {
+        return new RuntimeList();
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Universal.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Universal.java
@@ -348,7 +348,10 @@ public class Universal extends PerlModuleBase {
             if ((argString.equals("HASH") && baseValue instanceof RuntimeHash)
                     || (argString.equals("ARRAY") && baseValue instanceof RuntimeArray)
                     || (argString.equals("SCALAR") && baseValue instanceof RuntimeScalar)
-                    || (argString.equals("GLOB") && baseValue instanceof RuntimeGlob)
+                    || (argString.equals("GLOB")
+                        && (baseValue instanceof RuntimeGlob
+                            || baseValue instanceof RuntimeScalar scalar
+                                && scalar.type == RuntimeScalarType.GLOB))
                     || (argString.equals("FORMAT") && baseValue instanceof RuntimeFormat)
                     || (argString.equals("CODE") && baseValue instanceof RuntimeCode)) {
                 return getScalarBoolean(true).getList();

--- a/src/main/java/org/perlonjava/runtime/perlmodule/XMLParserExpat.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/XMLParserExpat.java
@@ -769,17 +769,23 @@ public class XMLParserExpat extends PerlModuleBase {
                 }
             } else {
                 // No delimiter - read entire stream in chunks
-                byte[] buffer = new byte[8192];
                 while (true) {
-                    RuntimeScalar result = fh.ioHandle.read(buffer.length);
-                    if (result.type == RuntimeScalarType.UNDEF) {
+                    // read() expects a scalar-reference argument because the compiler
+                    // normally supplies one for its lvalue buffer operand.  Starting
+                    // with undef here lets Readline.read() autovivify that reference;
+                    // the tied READ method then updates its referent through @_.
+                    RuntimeScalar bufferReference = new RuntimeScalar();
+                    RuntimeScalar count = Readline.read(new RuntimeList(
+                            ioref, bufferReference, new RuntimeScalar(8192)));
+                    if (count.type == RuntimeScalarType.UNDEF || count.getInt() <= 0) {
                         break;
                     }
-                    String chunk = result.toString();
+                    RuntimeScalar buffer = bufferReference.scalarDeref();
+                    String chunk = buffer.toString();
                     if (chunk.isEmpty()) {
                         break;
                     }
-                    java.nio.charset.Charset cs = (result.type == RuntimeScalarType.BYTE_STRING)
+                    java.nio.charset.Charset cs = (buffer.type == RuntimeScalarType.BYTE_STRING)
                             ? StandardCharsets.ISO_8859_1 : StandardCharsets.UTF_8;
                     baos.write(chunk.getBytes(cs));
                 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -2951,6 +2951,17 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         return switch (type) {
             case TIED_SCALAR -> tiedFetch().globDeref();
             case READONLY_SCALAR -> ((RuntimeScalar) this.value).globDeref();
+            case REFERENCE -> {
+                // `\do { local *FH }` is represented as a generic scalar
+                // reference whose referent is a RuntimeGlob.  It is still a
+                // single Perl glob reference and remains dereferenceable after
+                // blessing (the IO::Scalar construction idiom).  Do not unwrap
+                // GLOBREFERENCE here: that is a true reference-to-reference.
+                if (value instanceof RuntimeScalar scalar && scalar.type == GLOB) {
+                    yield scalar.globDeref();
+                }
+                throw new PerlCompilerException("Not a GLOB reference");
+            }
             case UNDEF -> throw new PerlCompilerException("Can't use an undefined value as a GLOB reference");
             case GLOBREFERENCE -> {
                 // Some internal representations store PVIO as GLOBREFERENCE with a RuntimeIO value.
@@ -3020,6 +3031,12 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         return switch (type) {
             case TIED_SCALAR -> tiedFetch().globDerefNonStrict(packageName);
             case READONLY_SCALAR -> ((RuntimeScalar) this.value).globDerefNonStrict(packageName);
+            case REFERENCE -> {
+                if (value instanceof RuntimeScalar scalar && scalar.type == GLOB) {
+                    yield scalar.globDerefNonStrict(packageName);
+                }
+                throw new PerlCompilerException("Not a GLOB reference");
+            }
             case GLOBREFERENCE -> {
                 // Some internal representations store PVIO as GLOBREFERENCE with a RuntimeIO value.
                 if (value instanceof RuntimeIO io) {

--- a/src/main/perl/lib/ExtUtils/MakeMaker.pm
+++ b/src/main/perl/lib/ExtUtils/MakeMaker.pm
@@ -76,6 +76,21 @@ sub WriteMakefile {
         $args{$key} = $cli{$key};
     }
 
+    # ExtUtils::MakeMaker's CONFIGURE hook runs while WriteMakefile is
+    # processing its arguments.  Older XS distributions use it for much more
+    # than compiler flags: Authen::PAM, for example, generates its real PAM.pm
+    # here and returns additional MakeMaker options.  Skipping the hook made
+    # PerlOnJava stage that distribution's deliberately-false CPAN metadata
+    # stub instead of the generated module.
+    if (exists $args{CONFIGURE}) {
+        my $configure = $args{CONFIGURE};
+        die "CONFIGURE must be a code reference\n" unless ref($configure) eq 'CODE';
+        my $extra = $configure->();
+        die "CONFIGURE must return a hash reference\n"
+            unless ref($extra) eq 'HASH';
+        @args{keys %$extra} = values %$extra;
+    }
+
     my $name = $args{NAME} or die "NAME is required\n";
     my $version = $args{VERSION} || ($args{VERSION_FROM} && _extract_version($args{VERSION_FROM})) || '0';
 
@@ -488,8 +503,21 @@ sub _install_pure_perl {
                                 if ($line =~ /^\s*package\s+([A-Za-z_]\w*(?:::\w+)*)\s*[,;]/
                                     && ($1 eq $name || index($1, "${name}::") == 0)) {
                                     (my $rel = $1) =~ s{::}{/}g;
-                                    $pm{$src} = _install_dest($INSTALL_BASE, "$rel.pm")
-                                        unless exists $pm{$src};
+                                    my $dest = _install_dest($INSTALL_BASE, "$rel.pm");
+                                    # A configured root module or lib/ source
+                                    # is authoritative over auxiliary copies in
+                                    # distribution-support directories.  Old
+                                    # Authen::PAM tarballs contain d/PAM.pm as
+                                    # a deliberately false metadata stub while
+                                    # CONFIGURE generates the loadable PAM.pm
+                                    # at the root; staging both to the same
+                                    # destination let the stub win by copy
+                                    # order.
+                                    my $destination_already_mapped
+                                        = grep { $_ eq $dest } values %pm;
+                                    $pm{$src} = $dest
+                                        unless exists $pm{$src}
+                                            || $destination_already_mapped;
                                     last;
                                 }
                             }

--- a/src/main/perl/lib/XML/Parser/Expat.pm
+++ b/src/main/perl/lib/XML/Parser/Expat.pm
@@ -483,6 +483,12 @@ sub parse {
                 if ( ref $arg eq 'GLOB' ) {
                     $ioref = *{$arg}{IO};
                 }
+                elsif ( UNIVERSAL::isa( $arg, 'GLOB' ) ) {
+                    # IO::Zlib and similar classes bless a glob reference.
+                    # Preserve the original object so tied READ/READLINE
+                    # dispatch remains available to the Java stream bridge.
+                    $ioref = $arg;
+                }
                 elsif ( ref \$arg eq 'GLOB' ) {
                     $ioref = *{$arg}{IO};
                 }

--- a/src/test/resources/unit/anonymous_glob_reference.t
+++ b/src/test/resources/unit/anonymous_glob_reference.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+use Test::More tests => 6;
+
+my $globref = \do { local *FH };
+is(ref(\*$globref), 'GLOB', 'anonymous glob reference dereferences under strict refs');
+
+my $object = bless $globref, 'Local::GlobHandle';
+is(ref(\*$object), 'GLOB', 'blessed anonymous glob reference remains dereferenceable');
+ok(UNIVERSAL::isa($object, 'GLOB'), 'blessed anonymous glob reports its underlying ref type');
+
+*$object->{marker} = 42;
+is(*$object->{marker}, 42, 'blessed anonymous glob exposes its hash slot');
+
+{
+    package Local::GlobHandle;
+    sub TIEHANDLE { $_[1] }
+}
+
+ok(tie(*$object, 'Local::GlobHandle', $object), 'blessed anonymous glob can be tied');
+is(ref(tied(*$object)), 'Local::GlobHandle', 'tied handle retains the supplied object');

--- a/src/test/resources/unit/eval_lvalue_compile_check.t
+++ b/src/test/resources/unit/eval_lvalue_compile_check.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+sub ordinary { 41 }
+sub assignable :lvalue { our $slot }
+
+my $ordinary = eval 'return 1; &ordinary = 2';
+ok(!$ordinary, 'known non-lvalue sub assignment fails during eval compilation');
+like($@, qr/Can't modify non-lvalue subroutine call/, 'compile failure is reported in $@');
+
+my $assignable = eval 'return 1; &assignable = 2';
+is($assignable, 1, 'unreachable assignment to known lvalue sub compiles');
+
+{
+    no strict 'refs';
+    local *_probe = \&ordinary;
+    my $probe = eval 'return 1; &_probe = 2';
+    ok(!$probe, 'localized glob coderef retains compile-time lvalue metadata');
+}

--- a/src/test/resources/unit/makemaker_configure_callback.t
+++ b/src/test/resources/unit/makemaker_configure_callback.t
@@ -1,0 +1,50 @@
+use strict;
+use warnings;
+use Test::More;
+use Cwd qw(getcwd);
+use File::Path qw(make_path);
+use File::Temp qw(tempdir);
+
+my $orig_dir = getcwd();
+my $tmpdir = tempdir(CLEANUP => 1);
+my $configure_calls = 0;
+
+END {
+    chdir $orig_dir if defined $orig_dir;
+}
+
+chdir $tmpdir or die "chdir $tmpdir: $!";
+
+make_path('d');
+open my $dummy, '>', 'd/Configured.pm' or die "create metadata stub: $!";
+print {$dummy} "package Fixture::Configured;\n0;\n";
+close $dummy or die "close metadata stub: $!";
+
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+    NAME         => 'Fixture::Configured',
+    VERSION_FROM => 'Configured.pm',
+    CONFIGURE    => sub {
+        $configure_calls++;
+        open my $pm, '>', 'Configured.pm' or die "create Configured.pm: $!";
+        print {$pm} "package Fixture::Configured;\nour \$VERSION = '0.016';\n1;\n";
+        close $pm or die "close Configured.pm: $!";
+        return {
+            PM => { 'Configured.pm' => '$(INST_LIBDIR)/Configured.pm' },
+        };
+    },
+);
+
+is($configure_calls, 1, 'CONFIGURE callback runs exactly once');
+ok(-f 'Configured.pm', 'CONFIGURE callback can generate the module source');
+
+open my $mf, '<', 'Makefile' or die "open generated Makefile: $!";
+my $makefile = do { local $/; <$mf> };
+close $mf or die "close generated Makefile: $!";
+
+like($makefile, qr/Configured\.pm/, 'CONFIGURE return values are merged into MakeMaker arguments');
+like($makefile, qr/0\.016/, 'version is read after CONFIGURE generated VERSION_FROM');
+unlike($makefile, qr{d/Configured\.pm}, 'generated root module wins over auxiliary metadata stub');
+
+done_testing();

--- a/src/test/resources/unit/xml_parser_tied_handle.t
+++ b/src/test/resources/unit/xml_parser_tied_handle.t
@@ -1,0 +1,64 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+use IO::Handle;
+use IO::Zlib;
+use File::Temp qw(tempfile);
+use Symbol qw(gensym);
+use XML::Parser;
+
+{
+    package Local::ChunkHandle;
+
+    sub TIEHANDLE {
+        my ($class, $data) = @_;
+        return bless { data => $data, offset => 0 }, $class;
+    }
+
+    sub READ {
+        my ($self, undef, $length) = @_;
+        if ($self->{offset} >= length $self->{data}) {
+            $_[1] = '';
+            return 0;
+        }
+        my $chunk = substr($self->{data}, $self->{offset}, $length);
+        $_[1] = $chunk;
+        $self->{offset} += length $chunk;
+        return length $chunk;
+    }
+}
+
+my $xml = '<root><value>from tied READ</value></root>';
+my $input = gensym();
+tie *$input, 'Local::ChunkHandle', $xml;
+bless $input, 'Local::ChunkIO';
+
+{
+    package Local::ChunkIO;
+    our @ISA = ('IO::Handle');
+}
+
+my @values;
+my $parser = XML::Parser->new(
+    Handlers => {
+        Char => sub {
+            my ($expat, $text) = @_;
+            push @values, $text if $text =~ /\S/;
+        },
+    },
+);
+
+ok($parser->parse($input), 'XML::Parser accepts a tied input handle');
+is(join('', @values), 'from tied READ', 'parser consumes bytes through tied READ');
+
+my ($plain, $gzip_file) = tempfile(SUFFIX => '.xml.gz');
+close $plain;
+my $gzip_out = IO::Zlib->new($gzip_file => 'wb');
+print {$gzip_out} $xml;
+close $gzip_out;
+
+@values = ();
+my $gzip_in = IO::Zlib->new($gzip_file => 'rb');
+ok($parser->parse($gzip_in), 'XML::Parser accepts a blessed glob input handle');
+is(join('', @values), 'from tied READ', 'parser consumes decompressed IO::Zlib bytes');
+close $gzip_in;


### PR DESCRIPTION
## Summary

- enforce compile-time assignment errors for known non-lvalue subroutines
- preserve dereference and type semantics for blessed anonymous glob references
- run ExtUtils::MakeMaker `CONFIGURE` callbacks before resolving generated module sources
- preserve tied blessed-glob streams through XML::Parser, including IO::Zlib input
- add a safe Authen::PAM Java compatibility boundary that returns `PAM_SYSTEM_ERR` for unsupported native conversations
- add system-Perl-validated regression coverage and document the CPAN validation matrix

## Validation

- `make`: pass (486 unit tests, 2 skipped; Joni tests and packaging pass)
- `./jcpan -t Thread::CriticalSection`: pass (4 files / 5 tests)
- `./jcpan -t Types::Namespace`: pass via URI::NamespaceMap (9 files / 70 tests)
- `./jcpan -t Catalyst::Plugin::Unicode`: pass (4 files / 13 tests)
- `./jcpan -t Authen::SimplePam`: pass (1 test)
- `./jcpan -t Text::RecordParser`: pass (17 files / 205 tests)
- `./jcpan -t Search::Sitemap`: compressed sitemap regression fixed; 125/126 assertions pass

Method::Signatures::PP is excluded because its upstream suite also fails under the isolated system Perl 5.42 reference run.

Search::Sitemap's remaining assertion captures `time()` while building fixtures, then expects a later `'now'` coercion to remain in that same epoch second. It passes on the faster system Perl run but is consistently one second stale on the JVM. JFR confirmed setup/compiler/runtime work occurs between the two calls; runtime clock semantics and upstream tests are intentionally unchanged.

## Authen::PAM boundary

The generated Perl/Exporter layer and constants load normally. PAM operations deliberately return `PAM_SYSTEM_ERR`; a real native implementation requires a separately designed FFM callback and native-buffer ownership model. This avoids both unsafe callback lifetimes and false authentication success.

Generated with [Codex](https://openai.com/codex)
