### PR TITLE
Fix reusable CPAN compiler and process tooling

### DIFF
--- a/dev/modules/cpan_tooling_perl6_greple.md
+++ b/dev/modules/cpan_tooling_perl6_greple.md
@@ -1,0 +1,89 @@
+# CPAN compiler/tooling batch: Perl::ToPerl6 through Devel::SlowBless
+
+## Goal
+
+Classify and repair the reusable compiler, regex, runtime, and CPAN-tooling
+defects exposed by `jcpan -t` for Perl::ToPerl6,
+Game::HeroesVsAliens::Alien, App::Greple::update, GCJ::Cni,
+Data::Semantic, Text::HTML::CollapseWhitespace, DBM::Deep::Blue, and
+Devel::SlowBless. Distributions that fail under the same local system Perl are
+out of scope, as requested.
+
+## System Perl classification (2026-08-16)
+
+| Target | Classification |
+|---|---|
+| Perl::ToPerl6 | Ignore: system Perl also fails `t/05_utils.t` test 136. |
+| Game::HeroesVsAliens::Alien | Ignore: system Perl cannot build Alien::SDL/SDL; the native dependency download/build fails. |
+| App::Greple::update | In scope: system Perl passes 2 files / 4 tests. |
+| GCJ::Cni | Ignore: system Perl cannot find the obsolete `gcj/cni.h` toolchain. |
+| Data::Semantic | In scope: system Perl passes 15 files / 16 tests. |
+| Text::HTML::CollapseWhitespace | Ignore: its Text-HTML-Turndown distribution also fails under system Perl (`t/01-turndown.t` test 46). |
+| DBM::Deep::Blue | Ignore: its native source includes unavailable `malloc.h` and fails compilation on this host. |
+| Devel::SlowBless | In scope: system Perl passes 1 file / 4 tests. |
+
+Full baseline output is captured in `/tmp/jcpan_*_baseline.log` and
+`/tmp/system_perl_*` logs.
+
+## Progress Tracking
+
+### Current Status: Complete (2026-08-16)
+
+### Completed Phases
+
+- [x] Phase 1: Baseline and system-Perl classification (2026-08-16)
+  - Ran every requested `jcpan -t` target sequentially with hard timeouts.
+  - Installed missing system-Perl prerequisites into an isolated `/tmp` tree
+    and tested the exact unpacked distributions.
+- [x] Phase 2: Root-cause reduction (2026-08-16)
+  - App::Greple::update requires named-capture regex conditionals, which the
+    vendored Joni engine supports but the backend router did not select.
+  - Data::Semantic exposes a lazy generated-sub VerifyError after module
+    registration side effects; file-level interpreter retry then duplicates
+    those registrations.
+  - Devel::SlowBless needs its two XS generation-counter functions backed by
+    runtime-owned Java state.
+- [x] Phase 3: Implementation (2026-08-16)
+  - Routed named-capture conditionals to Joni.
+  - Translated Perl brace-form named backreferences for Joni and covered
+    recursive named patterns.
+  - Added eager lazy-sub verification so only the invalid sub falls back.
+  - Added the Devel::SlowBless Java XS bridge and runtime sub-generation
+    counter.
+  - Corrected string typeglob aliases and ampersand calls inside
+    `delete`/`exists` subscripts.
+  - Implemented registered-child handling for `wait`/`waitpid`, made pipe
+    output pumps drain before close returns, and isolated replay-process STDIN
+    until the fork point. These fixes make Perl's `open HANDLE, '|-'` filter
+    pattern reliable without distribution-specific changes.
+  - Added system-Perl-validated regression tests.
+- [x] Phase 4: End-to-end validation (2026-08-16)
+  - `App::Greple::update`: 2 files / 4 tests, PASS.
+  - `Data::Semantic`: 15 files / 16 tests, PASS.
+  - `Devel::SlowBless`: bundled upstream suite, 1 file / 4 tests, PASS.
+  - All new unit tests pass under system Perl and both PerlOnJava backends.
+  - Full `make` completed successfully.
+
+### Files Changed
+
+- Compiler/backend: `EmitSubroutine.java`, `ParseInfix.java`.
+- Regex: `JoniRegexPattern.java`.
+- Process and IO runtime: `PerlRuntime.java`, `RuntimeIO.java`,
+  `PipeOutputChannel.java`, `WaitpidOperator.java`.
+- Runtime semantics: `RuntimeGlob.java`, `MroRuntimeState.java`, `Mro.java`.
+- Java module bridge: `DevelSlowBless.java`, `Devel/SlowBless.pm`.
+- Regression coverage: eight focused tests in `src/test/resources/unit`.
+
+### Next Steps
+
+1. Merge after CI and review.
+
+### Open Questions
+
+- None. Native distributions excluded by the system-Perl rule remain
+  documented rather than hidden behind distribution preferences.
+
+## Related References
+
+- `.agents/skills/debug-perlonjava/SKILL.md`
+- `docs/guides/module-porting.md`

--- a/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
@@ -14,6 +14,7 @@ import org.perlonjava.frontend.semantic.SymbolTable;
 import org.perlonjava.runtime.runtimetypes.NameNormalizer;
 import org.perlonjava.runtime.runtimetypes.GlobalVariable;
 import org.perlonjava.runtime.runtimetypes.PerlCompilerException;
+import org.perlonjava.runtime.runtimetypes.RuntimeArray;
 import org.perlonjava.runtime.runtimetypes.RuntimeBase;
 import org.perlonjava.runtime.runtimetypes.RuntimeCode;
 import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
@@ -262,6 +263,22 @@ public class EmitSubroutine {
                     EmitterMethodCreator.createClassWithMethod(
                             subCtx, node.block, node.useTryCatch
                     );
+            try {
+                // HotSpot can defer verification of a generated lazy sub until
+                // it is first invoked. If that happens after the enclosing file
+                // body has made writes, a file-level retry replays those writes.
+                // Resolve apply() now so only the invalid sub falls back.
+                generatedClass.getDeclaredMethod(
+                        "apply", RuntimeArray.class, int.class);
+            } catch (VerifyError | ClassFormatError verificationFailure) {
+                InterpretedCode interpreted = EmitterMethodCreator.compileToInterpreter(
+                        node.block, subCtx, node.useTryCatch);
+                throw new InterpreterFallbackException(interpreted, newEnv);
+            } catch (NoSuchMethodException reflectionFailure) {
+                throw new PerlCompilerException(
+                        "Failed to resolve generated subroutine: "
+                                + reflectionFailure.getMessage());
+            }
             String newClassNameDot = subCtx.javaClassInfo.javaClassName.replace('/', '.');
             if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("Generated class name: " + newClassNameDot + " internal " + subCtx.javaClassInfo.javaClassName);
             if (CompilerOptions.DEBUG_ENABLED) ctx.logDebug("Generated class env:  " + Arrays.toString(newEnv));

--- a/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
@@ -489,7 +489,17 @@ public class ParseInfix {
         // backtrack
         parser.tokenIndex = currentIndex;
 
-        return ListParser.parseList(parser, "]", 1);
+        // A subscript is an ordinary expression context even when its outer
+        // operator is delete/exists/defined (or reference-taking syntax).
+        // In particular, delete $array[&index] must invoke &index with the
+        // caller's @_, not turn it into a CODE value.
+        boolean savedParsingTakeReference = parser.parsingTakeReference;
+        parser.parsingTakeReference = false;
+        try {
+            return ListParser.parseList(parser, "]", 1);
+        } finally {
+            parser.parsingTakeReference = savedParsingTakeReference;
+        }
 
     }
 
@@ -540,7 +550,17 @@ public class ParseInfix {
         // backtrack
         parser.tokenIndex = currentIndex;
 
-        return ListParser.parseList(parser, "}", 1);
+        // The reference-taking mode used while parsing delete/exists applies
+        // to their direct operand, not to expressions inside a subscript.
+        // Getopt::EX relies on delete $hash{&CONSTANT_SUB} calling the sub and
+        // using its return value as the key.
+        boolean savedParsingTakeReference = parser.parsingTakeReference;
+        parser.parsingTakeReference = false;
+        try {
+            return ListParser.parseList(parser, "}", 1);
+        } finally {
+            parser.parsingTakeReference = savedParsingTakeReference;
+        }
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/io/PipeOutputChannel.java
+++ b/src/main/java/org/perlonjava/runtime/io/PipeOutputChannel.java
@@ -81,6 +81,13 @@ public class PipeOutputChannel implements IOHandle {
      */
     private BufferedReader outputReader;
 
+    /** Pumps must finish before close() returns or callers can restore STDOUT
+     * and lose the final child output. */
+    private Thread outputThread;
+    private Thread errorThread;
+    private RuntimeIO outputDestination;
+    private RuntimeIO errorDestination;
+
     /**
      * Tracks whether the pipe has been closed
      */
@@ -180,6 +187,15 @@ public class PipeOutputChannel implements IOHandle {
 
     private void setupProcess(ProcessBuilder processBuilder, Map<String, String> environmentOverrides)
             throws IOException {
+        // Capture the destinations before IOOperator installs this pipe into
+        // the target glob.  For `open STDOUT, '|-'`, looking up STDOUT from the
+        // pump thread later would find this same pipe and feed child output
+        // back into its stdin instead of forwarding it to the saved stdout.
+        outputDestination = borrowedDestination(
+                GlobalVariable.getGlobalIO("main::STDOUT").getRuntimeIO());
+        errorDestination = borrowedDestination(
+                GlobalVariable.getGlobalIO("main::STDERR").getRuntimeIO());
+
         // Set working directory to current directory
         String userDir = org.perlonjava.runtime.runtimetypes.RuntimeEnvironment.currentDirectory();
         processBuilder.directory(new File(userDir));
@@ -201,13 +217,13 @@ public class PipeOutputChannel implements IOHandle {
         // Start threads to consume stdout and stderr and route through Perl handles
         // This ensures Perl-level redirections are honored
         PerlRuntime runtime = PerlRuntime.current();
-        Thread outputThread = new Thread(() -> {
+        outputThread = new Thread(() -> {
             try (PerlRuntime.Binding ignored = runtime.bind();
                  BufferedReader out = outputReader) {
                 String line;
                 while ((line = out.readLine()) != null) {
                     try {
-                        RuntimeIO perlStdout = GlobalVariable.getGlobalIO("main::STDOUT").getRuntimeIO();
+                        RuntimeIO perlStdout = outputDestination;
                         if (perlStdout != null) {
                             perlStdout.write(line + "\n");
                         } else {
@@ -224,13 +240,13 @@ public class PipeOutputChannel implements IOHandle {
         outputThread.setDaemon(true);
         outputThread.start();
 
-        Thread errorThread = new Thread(() -> {
+        errorThread = new Thread(() -> {
             try (PerlRuntime.Binding ignored = runtime.bind();
                  BufferedReader err = errorReader) {
                 String line;
                 while ((line = err.readLine()) != null) {
                     try {
-                        RuntimeIO perlStderr = GlobalVariable.getGlobalIO("main::STDERR").getRuntimeIO();
+                        RuntimeIO perlStderr = errorDestination;
                         if (perlStderr != null) {
                             perlStderr.write(line + "\n");
                         } else {
@@ -246,6 +262,13 @@ public class PipeOutputChannel implements IOHandle {
         });
         errorThread.setDaemon(true);
         errorThread.start();
+    }
+
+    private static RuntimeIO borrowedDestination(RuntimeIO destination) {
+        if (destination == null) return null;
+        RuntimeIO borrowed = new RuntimeIO(destination.ioHandle);
+        borrowed.globName = destination.globName;
+        return borrowed;
     }
 
     /**
@@ -334,12 +357,23 @@ public class PipeOutputChannel implements IOHandle {
                     exitCode = -1;
                 }
             }
+            joinPump(outputThread);
+            joinPump(errorThread);
             getGlobalVariable("main::?").set(exitCode << 8);
 
             isClosed = true;
             return exitCode == 0 ? scalarTrue : scalarFalse;
         } catch (IOException e) {
             return handleIOException(e, "close pipe failed");
+        }
+    }
+
+    private static void joinPump(Thread pump) {
+        if (pump == null || pump == Thread.currentThread()) return;
+        try {
+            pump.join();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/src/main/java/org/perlonjava/runtime/mro/MroRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/mro/MroRuntimeState.java
@@ -31,6 +31,7 @@ public final class MroRuntimeState {
     private InheritanceResolver.MROAlgorithm defaultMro = InheritanceResolver.MROAlgorithm.DFS;
     private boolean autoloadEnabled = true;
     private long isaGeneration;
+    private long subGeneration = 1;
     private long isaRevGeneration = -1;
     private long observedSymbolMutationEpoch;
     private long observedIsaMutationEpoch;
@@ -85,6 +86,14 @@ public final class MroRuntimeState {
 
     public long isaGeneration() {
         return isaGeneration;
+    }
+
+    public long subGeneration() {
+        return subGeneration;
+    }
+
+    public void incrementSubGeneration() {
+        subGeneration++;
     }
 
     public long isaRevGeneration() {

--- a/src/main/java/org/perlonjava/runtime/operators/WaitpidOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/WaitpidOperator.java
@@ -67,6 +67,11 @@ public class WaitpidOperator {
             if (javaProcess != null) {
                 return waitpidJavaProcess(pid, javaProcess, flags);
             }
+        } else {
+            RuntimeScalar javaChildResult = waitForAnyJavaProcess(flags);
+            if (javaChildResult != null) {
+                return javaChildResult;
+            }
         }
         try {
             int[] status = new int[1];
@@ -88,6 +93,38 @@ public class WaitpidOperator {
         } catch (Exception e) {
             return new RuntimeScalar(-1);
         }
+    }
+
+    /**
+     * Wait for a child created by pipe open or another Java ProcessBuilder path.
+     * On POSIX the JDK has its own native reaper, so calling libc waitpid(-1)
+     * after reading a pipe can report ECHILD even though PerlOnJava still owns
+     * an unreaped logical child.  Prefer the registered Process objects before
+     * falling through to native children.
+     */
+    private static RuntimeScalar waitForAnyJavaProcess(int flags) {
+        Map<Long, Process> children = RuntimeIO.childProcessesSnapshot();
+        if (children.isEmpty()) return null;
+
+        boolean nonBlocking = (flags & WNOHANG) != 0;
+        for (Map.Entry<Long, Process> entry : children.entrySet()) {
+            if (!entry.getValue().isAlive()) {
+                return waitpidJavaProcess(entry.getKey().intValue(), entry.getValue(), flags);
+            }
+        }
+        if (nonBlocking) return new RuntimeScalar(0);
+
+        java.util.concurrent.CompletableFuture<?>[] exits = children.values().stream()
+                .map(Process::onExit)
+                .toArray(java.util.concurrent.CompletableFuture[]::new);
+        java.util.concurrent.CompletableFuture.anyOf(exits).join();
+
+        for (Map.Entry<Long, Process> entry : RuntimeIO.childProcessesSnapshot().entrySet()) {
+            if (!entry.getValue().isAlive()) {
+                return waitpidJavaProcess(entry.getKey().intValue(), entry.getValue(), flags);
+            }
+        }
+        return new RuntimeScalar(-1);
     }
 
     private static RuntimeScalar waitpidJavaProcess(int pid, Process process, int flags) {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/DevelSlowBless.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/DevelSlowBless.java
@@ -1,0 +1,36 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.runtime.runtimetypes.PerlRuntime;
+import org.perlonjava.runtime.runtimetypes.RuntimeArray;
+import org.perlonjava.runtime.runtimetypes.RuntimeList;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+
+/** Java XS implementation of Devel::SlowBless's generation counters. */
+public class DevelSlowBless extends PerlModuleBase {
+
+    public static final String XS_VERSION = "0.06";
+
+    public DevelSlowBless() {
+        super("Devel::SlowBless", false);
+    }
+
+    public static void initialize() {
+        DevelSlowBless module = new DevelSlowBless();
+        try {
+            module.registerMethod("sub_gen", null);
+            module.registerMethod("amg_gen", null);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static RuntimeList sub_gen(RuntimeArray args, int ctx) {
+        return new RuntimeScalar(PerlRuntime.current().mroState().subGeneration()).getList();
+    }
+
+    public static RuntimeList amg_gen(RuntimeArray args, int ctx) {
+        // PL_amagic_generation was removed from Perl in 5.17.1. The XS
+        // distribution returns zero on all modern Perls.
+        return new RuntimeScalar(0).getList();
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Mro.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Mro.java
@@ -443,9 +443,10 @@ public class Mro extends PerlModuleBase {
      * @param packageName The name of the package.
      */
     public static void incrementPackageGeneration(String packageName) {
-        Map<String, Integer> packageGenerations =
-                PerlRuntime.current().mroState().packageGenerations();
+        var state = PerlRuntime.current().mroState();
+        Map<String, Integer> packageGenerations = state.packageGenerations();
         Integer current = packageGenerations.getOrDefault(packageName, 1);
         packageGenerations.put(packageName, current + 1);
+        state.incrementSubGeneration();
     }
 }

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -76,6 +76,8 @@ final class JoniRegexPattern {
         return pattern.contains("(?{=CALL:")
                 || pattern.contains("(?{=DYNAMIC:")
                 || pattern.contains("(?(?{=CALL:")
+                || pattern.contains("(?(<")
+                || pattern.contains("(?('")
                 || pattern.matches("(?s).*\\(\\?[+-]?\\d+\\).*" )
                 || pattern.contains("(?&")
                 || pattern.contains("(?P>");
@@ -99,6 +101,19 @@ final class JoniRegexPattern {
                 continue;
             }
             if (ch == '\\') {
+                // In Perl, \g{name} is a backreference.  Ruby/Oniguruma uses
+                // \g<name> for a subexpression call and \k<name> for the
+                // backreference, so passing the brace form through makes Joni
+                // diagnose it as an invalid subexpression call.  Numeric and
+                // relative brace forms follow the same translation.
+                if (!inClass && pattern.startsWith("\\g{", i)) {
+                    int end = pattern.indexOf('}', i + 3);
+                    if (end > i + 3) {
+                        out.append("\\k<").append(pattern, i + 3, end).append('>');
+                        i = end;
+                        continue;
+                    }
+                }
                 out.append(ch);
                 escaped = true;
                 continue;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlRuntime.java
@@ -135,7 +135,15 @@ public final class PerlRuntime implements AutoCloseable {
                 true));
         ioStderr = new RuntimeIO(new StandardIO(System.err, false));
         ioStderr.autoFlush = true;
-        ioStdin = new RuntimeIO(new StandardIO(System.in));
+        // A no-command fork-open child replays the program up to the selected
+        // open.  Its OS stdin is already the new parent-to-child pipe, but real
+        // fork semantics do not expose that pipe until the fork point.  Mute it
+        // during replay so pre-fork input probes cannot consume the data the
+        // parent will send to the output filter.
+        ioStdin = new RuntimeIO(new StandardIO(
+                ForkOpenState.isReplayProcess()
+                        ? java.io.InputStream.nullInputStream()
+                        : System.in));
         ioSelectedHandle = ioStdout;
         ioLastWrittenHandle = ioStdout;
 
@@ -154,8 +162,11 @@ public final class PerlRuntime implements AutoCloseable {
     public void activateForkOpenChildStdout() {
         RuntimeIO muted = ioStdout;
         RuntimeIO stdout = new RuntimeIO(new StandardIO(System.out, true));
+        RuntimeIO stdin = new RuntimeIO(new StandardIO(System.in));
         replaceStandardHandle("main::STDOUT", stdout);
         replaceStandardHandle("main::stdout", stdout);
+        replaceStandardHandle("main::STDIN", stdin);
+        replaceStandardHandle("main::stdin", stdin);
         if (ioSelectedHandle == muted) ioSelectedHandle = stdout;
         if (ioLastWrittenHandle == muted) ioLastWrittenHandle = stdout;
         GlobalVariable.getGlobalVariable("main::$").set(pid);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
@@ -632,8 +632,6 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
                 return value;
             case INTEGER:
             case DOUBLE:
-            case STRING:
-            case BYTE_STRING:
             case BOOLEAN:
             case VSTRING:
             case DUALVAR:
@@ -659,6 +657,27 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
                 // that look up by name see the override regardless of whether
                 // they reached the lvalue before or after `local` swapped the
                 // glob. See dev/modules/anon_sub_naming.md.
+                if (this.globName != null) {
+                    RuntimeGlob currentGlob = GlobalVariable.peekGlobalIO(this.globName);
+                    if (currentGlob == null) currentGlob = this;
+                    currentGlob.nameOverride = value.toString();
+                }
+                return value;
+            case STRING:
+            case BYTE_STRING:
+                // A string assigned to a typeglob names another typeglob; it is
+                // not a scalar-slot value.  This is the dynamic form of
+                // `*foo = *bar` used by modules such as Getopt::EX::Module to
+                // borrow a package's DATA handle with
+                // `local *data = "$mod\::DATA"`.
+                String aliasName = NameNormalizer.normalizeVariableName(
+                        value.toString(), RuntimeCode.getCurrentPackage());
+                this.set(GlobalVariable.getGlobalIO(aliasName));
+
+                // Perl also uses `local *PKG::__ANON__ = 'name'` to provide a
+                // dynamic display name for anonymous subs.  Keep that metadata
+                // on the localized destination glob while applying the normal
+                // all-slot typeglob alias semantics above.
                 if (this.globName != null) {
                     RuntimeGlob currentGlob = GlobalVariable.peekGlobalIO(this.globName);
                     if (currentGlob == null) currentGlob = this;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
@@ -467,6 +467,15 @@ public class RuntimeIO extends RuntimeScalar {
     }
 
     /**
+     * Returns a stable view of children launched through Java's Process API.
+     * wait()/waitpid(-1, ...) need this because the JVM's process reaper may
+     * consume the native wait status before a direct POSIX waitpid call sees it.
+     */
+    public static Map<Long, Process> childProcessesSnapshot() {
+        return new LinkedHashMap<>(registry().childProcesses);
+    }
+
+    /**
      * Sets a custom output stream as the last accessed handle.
      * This is primarily used for testing and special output redirection.
      *

--- a/src/main/perl/lib/Devel/SlowBless.pm
+++ b/src/main/perl/lib/Devel/SlowBless.pm
@@ -1,0 +1,44 @@
+package Devel::SlowBless;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.06';
+
+require Exporter;
+our @ISA = qw(Exporter);
+our @EXPORT_OK = qw(amg_gen sub_gen);
+our %EXPORT_TAGS = (all => \@EXPORT_OK);
+
+require XSLoader;
+XSLoader::load(__PACKAGE__, $VERSION);
+
+my $pid = 0;
+my $amg_gen = 0;
+my $sub_gen = 0;
+my $warn = 0;
+
+sub start_warning { $warn = 1 }
+sub stop_warning  { $warn = 0 }
+
+sub DB::DB {
+    my $cur_amg = amg_gen();
+    my $cur_sub = sub_gen();
+
+    if ($pid != $$) {
+        $pid = $$;
+        $amg_gen = $cur_amg;
+        $sub_gen = $cur_sub;
+    }
+
+    require Carp;
+    Carp::cluck("[$pid] AMAGIC $amg_gen -> $cur_amg\n")
+        if $warn && $amg_gen != $cur_amg;
+    Carp::cluck("[$pid] SUB GEN $sub_gen - $cur_sub\n")
+        if $warn && $sub_gen != $cur_sub;
+
+    $amg_gen = $cur_amg;
+    $sub_gen = $cur_sub;
+}
+
+1;

--- a/src/test/resources/unit/devel_slowbless_java_xs.t
+++ b/src/test/resources/unit/devel_slowbless_java_xs.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More;
+
+BEGIN {
+    plan skip_all => 'PerlOnJava Java XS bridge test' unless $^X =~ /jperl/;
+}
+
+use Devel::SlowBless;
+
+my $before = Devel::SlowBless::sub_gen();
+eval 'sub SlowBlessGeneration::installed { 42 }';
+is($@, '', 'named subroutine compiles through eval');
+cmp_ok(Devel::SlowBless::sub_gen(), '>', $before,
+    'sub_gen advances when a named subroutine is installed');
+
+is(Devel::SlowBless::amg_gen(), 0,
+    'amg_gen is zero on modern Perl-compatible runtimes');
+
+done_testing;

--- a/src/test/resources/unit/fork_open_output_pump.t
+++ b/src/test/resources/unit/fork_open_output_pump.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+use File::Temp qw(tempfile);
+
+my $capture_path = $ENV{PERLONJAVA_FORK_OPEN_CAPTURE};
+if (!defined $capture_path) {
+    my ($initial, $path) = tempfile();
+    close $initial;
+    $capture_path = $ENV{PERLONJAVA_FORK_OPEN_CAPTURE} = $path;
+}
+open my $capture, '>>', $capture_path or die "open capture: $!";
+open my $saved_stdout, '>&', \*STDOUT or die "save stdout: $!";
+open STDOUT, '>&', $capture or die "redirect stdout: $!";
+
+# A replay child must not see the parent-to-child pipe before the fork point.
+# Real-world filters commonly probe or drain their original STDIN while doing
+# pre-fork setup.
+my $pre_fork_input = <STDIN>;
+
+my $pid = open STDOUT, '|-';
+if (defined($pid) && !$pid) {
+    exec 'cat';
+    die "exec cat: $!";
+}
+if (defined $pid) {
+    print STDOUT "pumped output\n";
+    close STDOUT or die "close pipe: $!";
+}
+
+open STDOUT, '>&', $saved_stdout or die "restore stdout: $!";
+close $capture;
+ok(defined($pid) && $pid > 0, 'output fork-open creates a child');
+open my $readback, '<', $capture_path or die "open capture: $!";
+is(do { local $/; <$readback> }, "pumped output\n",
+    'close drains child output before returning');

--- a/src/test/resources/unit/fork_open_wait.t
+++ b/src/test/resources/unit/fork_open_wait.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+use IO::File;
+
+my $pipe = IO::File->new;
+my $pid = $pipe->open('-|');
+
+if (!defined $pid) {
+    fail('fork-open creates a pipe child');
+    fail('parent reads the pipe child output');
+    fail('wait returns the pipe child pid');
+}
+elsif (!$pid) {
+    print "pipe child output\n";
+    exit 0;
+}
+else {
+    ok($pid > 0, 'fork-open creates a pipe child');
+    is(do { local $/; <$pipe> }, "pipe child output\n",
+        'parent reads the pipe child output');
+    is(wait, $pid, 'wait returns the pipe child pid');
+}

--- a/src/test/resources/unit/lazy_sub_verification_side_effects.t
+++ b/src/test/resources/unit/lazy_sub_verification_side_effects.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+use charnames ();
+
+my %registered;
+sub register_name {
+    my ($name) = @_;
+    die "duplicate registration for $name" if $registered{$name}++;
+}
+
+register_name('delimited');
+register_name('quoted');
+
+my @bracket_pairs =
+    map { ref $_ ? $_ :
+            /!/ ? [(do { my $x = $_; $x =~ s/!/TOP/;    $x },
+                    do { my $x = $_; $x =~ s/!/BOTTOM/; $x })]
+                : [(do { my $x = $_; $x =~ s/\?/LEFT/;  $x },
+                    do { my $x = $_; $x =~ s/\?/RIGHT/; $x })] }
+        '? PARENTHESIS',
+        '? SQUARE BRACKET',
+        '? CURLY BRACKET',
+        '? DOUBLE QUOTATION MARK',
+        '? SINGLE QUOTATION MARK',
+        '! PARENTHESIS';
+
+@bracket_pairs = grep {
+    defined charnames::string_vianame($_->[0]) &&
+    defined charnames::string_vianame($_->[1])
+} @bracket_pairs;
+
+register_name('bquoted') if @bracket_pairs;
+
+is_deeply([sort keys %registered], [qw(bquoted delimited quoted)],
+    'lazy-sub verifier fallback occurs before enclosing side effects');

--- a/src/test/resources/unit/regex_named_capture_conditional.t
+++ b/src/test/resources/unit/regex_named_capture_conditional.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+my $loader_spec = qr/
+    ^ (?<name> \w+ (?: :: \w+)* )
+    (?:
+        ::
+        (?<call>
+            \w+
+            (?: (?<P>[(]) | = )
+            (?<arg> [^)]* )
+            (?(<P>) [)] | )
+        )
+    )?
+    $
+/x;
+
+ok('Package::method(argument)' =~ $loader_spec,
+    'named-capture conditional takes its parenthesized branch');
+is($+{arg}, 'argument', 'parenthesized loader argument is captured');
+ok('Package::method=argument' =~ $loader_spec,
+    'named-capture conditional takes its empty branch');
+is($+{arg}, 'argument', 'equals loader argument is captured');

--- a/src/test/resources/unit/regex_recursive_named_backref.t
+++ b/src/test/resources/unit/regex_recursive_named_backref.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+my $parenthesized = qr/( \( (?: [^()]++ | (?-1) )*+ \) )/x;
+my $option = qr{
+    \G \s* (?<key>(?>(?:[^,=*/]+)))
+    (?: \*= (?<value>.*)
+      | /= (?<delim>.) (?<value>.*?) \g{delim} (?=,|\z) ,*
+      | (?: = (?<value> (?:[^,()]++ | ${parenthesized})*+ ) )? ,* )
+}x;
+
+ok('name/=/two words/' =~ $option,
+    'named brace backreference works in a recursive Joni pattern');
+is($+{value}, 'two words', 'named brace backreference captures its value');
+ok('name=outer(inner)' =~ $option,
+    'interpolated relative recursion remains available');

--- a/src/test/resources/unit/subscript_ampersand_calls.t
+++ b/src/test/resources/unit/subscript_ampersand_calls.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+my ($hash_calls, $array_calls) = (0, 0);
+sub hash_key  { ++$hash_calls;  return $_[0] }
+sub array_key { ++$array_calls; return $_[0] }
+
+sub exercise_hash {
+    my %values = (target => 'value');
+    is(delete $values{&hash_key}, 'value',
+        'delete invokes an ampersand subroutine in a hash subscript');
+    %values = (target => 'value');
+    ok(exists $values{&hash_key},
+        'exists invokes an ampersand subroutine in a hash subscript');
+}
+
+sub exercise_array {
+    my @values = ('zero', 'one');
+    is(delete $values[&array_key], 'one',
+        'delete invokes an ampersand subroutine in an array subscript');
+    @values = ('zero', 'one');
+    ok(exists $values[&array_key],
+        'exists invokes an ampersand subroutine in an array subscript');
+}
+
+exercise_hash('target');
+exercise_array(1);
+
+die "hash key callback count: $hash_calls" unless $hash_calls == 2;
+die "array key callback count: $array_calls" unless $array_calls == 2;

--- a/src/test/resources/unit/typeglob_string_alias.t
+++ b/src/test/resources/unit/typeglob_string_alias.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+no warnings 'once';
+use Test::More tests => 4;
+
+our $source = 7;
+our $alias = 3;
+
+{
+    local *alias = 'main::source';
+    is($alias, 7, 'string typeglob assignment aliases the scalar slot');
+    $alias = 8;
+    is($source, 8, 'writes through the string typeglob alias');
+}
+is($alias, 3, 'local string typeglob assignment restores the old glob');
+
+my $payload = "payload\n";
+open SOURCE_HANDLE, '<', \$payload or die "open scalar handle: $!";
+{
+    local *BORROWED_HANDLE = 'main::SOURCE_HANDLE';
+    is(scalar <BORROWED_HANDLE>, "payload\n",
+        'string typeglob assignment aliases the IO slot');
+}


### PR DESCRIPTION
## Summary

- route Perl named-capture conditionals and brace-form backreferences through the Joni-compatible path
- verify generated lazy subs before enclosing-file side effects can be replayed, and fix ampersand subscript calls plus string typeglob aliases
- add a Java-backed `Devel::SlowBless` implementation using runtime-owned generation state
- make fork-open children work with `wait`, isolate replay-child STDIN until the fork point, and drain output pumps before close returns
- document the system-Perl classification for every requested distribution

## End-to-end CPAN results

- `App::Greple::update`: PASS (2 files, 4 tests)
- `Data::Semantic`: PASS (15 files, 16 tests)
- `Devel::SlowBless`: PASS with bundled upstream tests (1 file, 4 tests)

The remaining requested targets were excluded because their exact distributions also fail with system Perl on this host: `Perl::ToPerl6`, `Game::HeroesVsAliens::Alien`, `GCJ::Cni`, `Text::HTML::CollapseWhitespace`, and `DBM::Deep::Blue`.

## Validation

- all eight focused regression tests pass with system Perl
- all focused tests pass with both PerlOnJava backends
- full `make` passes (`BUILD SUCCESSFUL`)

AI-assisted contribution; attribution is included in the commit message.
