### PR TITLE
fix: repair CPAN compiler/tooling sequence batch

### DIFF
--- a/dev/modules/cpan_tooling_batch_20260816_biox.md
+++ b/dev/modules/cpan_tooling_batch_20260816_biox.md
@@ -8,7 +8,7 @@ the primary fix.
 
 ## Progress Tracking
 
-### Current Status: implementation and local validation complete; CI verification in progress
+### Current Status: complete
 
 ### Completed Phases
 
@@ -56,11 +56,16 @@ the primary fix.
     system-Perl exception. Its own system-Perl suite fails, and the current
     CPAN package index no longer contains Nephia or three declared companion
     plugins. MetaCPAN identifies those releases as BackPAN-only.
+- [x] Pull request verification (2026-08-16)
+  - PR #979 contains the complete compiler, runtime, CPAN tooling, and test
+    changes.
+  - GitHub Actions passed on Windows in 18m55s.
+  - GitHub Actions passed on Ubuntu, including the pinned Perl thread
+    compatibility gate, in 23m12s.
 
 ### Next Steps
 
-1. Commit and push the feature branch.
-2. Update PR #979 and monitor GitHub Actions.
+1. Review and merge PR #979.
 
 ### Open Questions
 

--- a/dev/modules/cpan_tooling_batch_20260816_biox.md
+++ b/dev/modules/cpan_tooling_batch_20260816_biox.md
@@ -1,0 +1,65 @@
+# CPAN compiler/tooling batch: BioX and related modules
+
+## Goal
+
+Make the requested `jcpan -t` targets use reusable PerlOnJava compiler,
+runtime, and CPAN-tooling behavior. Distribution preferences are not used as
+the primary fix.
+
+## Progress Tracking
+
+### Current Status: implementation complete; PR verification in progress
+
+### Completed Phases
+
+- [x] Baseline classification (2026-08-16)
+  - `Template::Plugin::Markdown` already passes.
+  - `BioX::Seq` failed because overloaded `.=` replaced the blessed object.
+  - `Math::Aronson` failed because boolean operands took the string XOR path.
+  - `Changes` failed in the `Wanted`/locale dependency boundary.
+  - `Catmandu::Importer::Parltrack` failed while `Class::XSAccessor` used
+    optional `Sub::Util::set_subname` metadata.
+  - `Nephia::Plugin::FormValidator::Lite` cannot resolve its `Nephia::Plugin`
+    and `Plack::Test` dependencies; the isolated system Perl also lacks those
+    modules, so it is unsupported under the requested rule.
+- [x] Reusable compiler/runtime fixes
+  - Preserve overloaded object results for compound string concatenation.
+  - Treat boolean scalars as numeric operands for `^`.
+  - Permit guarded fully-qualified optional constant names under `strict subs`.
+- [x] CPAN tooling compatibility
+  - Make `Sub::Util::set_subname` optional for generated XS-style accessors.
+  - Add the pure-Perl `Wanted` context compatibility surface and export `want`.
+- [x] Unit validation
+  - Final `make` passed after the optional-constant parser guard and the
+    isolated Sub::Util compatibility changes.
+- [x] Target verification
+  - `BioX::Seq`: passes.
+  - `Math::Aronson`: passes.
+  - `Template::Plugin::Markdown`: passes.
+  - `Changes`: reaches its locale data dependency, which requires a usable
+    DBD::SQLite driver; the local system Perl has no DBD::SQLite installation.
+  - `Catmandu::Importer::Parltrack`: its dependency stack still captures a
+    stale `Sub::Util::set_subname` callback inside `Eval::TypeTiny` in the
+    isolated CPAN test worker; this is recorded for follow-up rather than
+    hiding it with a distribution preference.
+  - `Nephia::Plugin::FormValidator::Lite`: unsupported because both
+    `Nephia::Plugin` and `Plack::Test` are absent from the local system Perl.
+
+### Next Steps
+
+1. Commit and push the feature branch.
+2. Open a PR and monitor GitHub Actions.
+3. Follow up on the isolated `Eval::TypeTiny` callback and DBD::SQLite port.
+
+### Open Questions
+
+- `Changes` depends on a broad locale/data stack; any remaining failure must
+  be checked against system Perl before being classified as an implementation
+  defect.
+- `Catmandu::Importer::Parltrack` may expose additional optional XS constants
+  after its first compile blocker is removed.
+
+## Related References
+
+- [`debug-perlonjava`](../../.agents/skills/debug-perlonjava/SKILL.md)
+- [`AGENTS.md`](../../AGENTS.md)

--- a/dev/modules/cpan_tooling_batch_20260816_biox.md
+++ b/dev/modules/cpan_tooling_batch_20260816_biox.md
@@ -8,7 +8,7 @@ the primary fix.
 
 ## Progress Tracking
 
-### Current Status: implementation complete; PR verification in progress
+### Current Status: implementation and local validation complete; CI verification in progress
 
 ### Completed Phases
 
@@ -25,39 +25,47 @@ the primary fix.
 - [x] Reusable compiler/runtime fixes
   - Preserve overloaded object results for compound string concatenation.
   - Treat boolean scalars as numeric operands for `^`.
+  - Implement `no overloading` dispatch for arithmetic and boolean contexts.
   - Permit guarded fully-qualified optional constant names under `strict subs`.
+  - Compile fully-qualified `CORE::` control-flow and infix operations.
+  - Preserve caller context, including `OBJECT`, across JVM and interpreter
+    wrapper frames and non-local returns.
+  - Apply case folding to POSIX regex character classes.
 - [x] CPAN tooling compatibility
-  - Make `Sub::Util::set_subname` optional for generated XS-style accessors.
-  - Add the pure-Perl `Wanted` context compatibility surface and export `want`.
+  - Reinitialize Java-backed XS modules when an isolated CPAN worker has stale
+    `%INC` state but an undefined stash entry.
+  - Snapshot named coderefs at compile time instead of retaining mutable stash
+    scalars, fixing generated `Eval::TypeTiny` callbacks.
+  - Add reusable Java-module loading and the `Wanted` context compatibility
+    surface.
+  - Expose the bundled SQLite JDBC implementation through DBD::SQLite metadata
+    and constants instead of introducing another native dependency.
+  - Complete reusable Fcntl and POSIX constants/functions required by the
+    dependency graph.
 - [x] Unit validation
-  - Final `make` passed after the optional-constant parser guard and the
-    isolated Sub::Util compatibility changes.
+  - All ten new compatibility tests were validated with system Perl: eight
+    passed and two correctly skipped when their optional modules were absent.
+  - Final `make` passed in 3m43s after all compiler and tooling changes.
 - [x] Target verification
-  - `BioX::Seq`: passes.
-  - `Math::Aronson`: passes.
-  - `Template::Plugin::Markdown`: passes.
-  - `Changes`: reaches its locale data dependency, which requires a usable
-    DBD::SQLite driver; the local system Perl has no DBD::SQLite installation.
-  - `Catmandu::Importer::Parltrack`: its dependency stack still captures a
-    stale `Sub::Util::set_subname` callback inside `Eval::TypeTiny` in the
-    isolated CPAN test worker; this is recorded for follow-up rather than
-    hiding it with a distribution preference.
-  - `Nephia::Plugin::FormValidator::Lite`: unsupported because both
-    `Nephia::Plugin` and `Plack::Test` are absent from the local system Perl.
+  - `BioX::Seq`: 7 files, 127 tests, PASS.
+  - `Changes`: 26 files, 375 tests, PASS.
+  - `Math::Aronson`: 4 files, 55 tests, PASS.
+  - `Catmandu::Importer::Parltrack`: 3 tests, PASS.
+  - `Template::Plugin::Markdown`: 2 files, 3 tests, PASS.
+  - `Nephia::Plugin::FormValidator::Lite`: unsupported under the requested
+    system-Perl exception. Its own system-Perl suite fails, and the current
+    CPAN package index no longer contains Nephia or three declared companion
+    plugins. MetaCPAN identifies those releases as BackPAN-only.
 
 ### Next Steps
 
 1. Commit and push the feature branch.
-2. Open a PR and monitor GitHub Actions.
-3. Follow up on the isolated `Eval::TypeTiny` callback and DBD::SQLite port.
+2. Update PR #979 and monitor GitHub Actions.
 
 ### Open Questions
 
-- `Changes` depends on a broad locale/data stack; any remaining failure must
-  be checked against system Perl before being classified as an implementation
-  defect.
-- `Catmandu::Importer::Parltrack` may expose additional optional XS constants
-  after its first compile blocker is removed.
+- Whether PerlOnJava should eventually add an opt-in BackPAN resolver for
+  distributions whose live CPAN metadata still declares withdrawn modules.
 
 ## Related References
 

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -1756,7 +1756,14 @@ public class BytecodeCompiler implements Visitor {
                         return;
                     }
                     // This is a bareword (no sigil)
-                    if (getEffectiveSymbolTable().isStrictOptionEnabled(Strict.HINT_STRICT_SUBS)) {
+                    // A fully-qualified all-caps name is commonly a constant
+                    // supplied by an optional XS module.  Perl parses it even
+                    // when the guarded branch is disabled; do not reject the
+                    // source merely because that optional module is absent.
+                    boolean qualifiedConstant = varName.contains("::")
+                            && varName.matches(".*::[A-Z][A-Z0-9_]*");
+                    if (getEffectiveSymbolTable().isStrictOptionEnabled(Strict.HINT_STRICT_SUBS)
+                            && !qualifiedConstant) {
                         throwCompilerException("Bareword \"" + varName + "\" not allowed while \"strict subs\" in use");
                     }
                     if (currentCallContext == RuntimeContextType.VOID) {

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -13,6 +13,7 @@ import org.perlonjava.frontend.semantic.SymbolTable;
 import org.perlonjava.runtime.debugger.DebugState;
 import org.perlonjava.runtime.perlmodule.Attributes;
 import org.perlonjava.runtime.perlmodule.Strict;
+import org.perlonjava.runtime.perlmodule.XSLoader;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import java.math.BigInteger;
@@ -687,6 +688,14 @@ public class BytecodeCompiler implements Visitor {
 
     boolean isNoOverloadingEnabled() {
         return getEffectiveSymbolTable().isStrictOptionEnabled(Strict.HINT_NO_AMAGIC);
+    }
+
+    short gotoIfFalseOpcode() {
+        return isNoOverloadingEnabled() ? Opcodes.GOTO_IF_FALSE_NO_OVERLOAD : Opcodes.GOTO_IF_FALSE;
+    }
+
+    short gotoIfTrueOpcode() {
+        return isNoOverloadingEnabled() ? Opcodes.GOTO_IF_TRUE_NO_OVERLOAD : Opcodes.GOTO_IF_TRUE;
     }
 
     boolean shouldBlockGlobalUnderStrictVars(String varName) {
@@ -2584,19 +2593,19 @@ public class BytecodeCompiler implements Visitor {
             emitReg(condReg);
             emitReg(targetReg);
             jumpPos = bytecode.size();
-            emit(Opcodes.GOTO_IF_TRUE);
+            emit(gotoIfTrueOpcode());
             emitReg(condReg);
             emitInt(0); // placeholder for end target
         } else if (op.equals("||=")) {
             // For ||=, skip RHS if LHS is truthy
             jumpPos = bytecode.size();
-            emit(Opcodes.GOTO_IF_TRUE);
+            emit(gotoIfTrueOpcode());
             emitReg(targetReg);
             emitInt(0); // placeholder for end target
         } else {
             // For &&=, skip RHS if LHS is falsy
             jumpPos = bytecode.size();
-            emit(Opcodes.GOTO_IF_FALSE);
+            emit(gotoIfFalseOpcode());
             emitReg(targetReg);
             emitInt(0); // placeholder for end target
         }
@@ -4983,6 +4992,23 @@ public class BytecodeCompiler implements Visitor {
                 if (codeRef == null) {
                     codeRef = GlobalVariable.getGlobalCodeRefForFreshLookup(subName);
                 }
+                if (codeRef.type == RuntimeScalarType.CODE
+                        && codeRef.value instanceof RuntimeCode unresolved
+                        && !unresolved.defined()) {
+                    int separator = subName.lastIndexOf("::");
+                    if (separator > 0
+                            && XSLoader.tryInitializeJavaModule(subName.substring(0, separator))) {
+                        codeRef = GlobalVariable.getGlobalCodeRefForFreshLookup(subName);
+                    }
+                }
+
+                // A compiled reference captures the current CV, not the mutable
+                // stash slot that points at it.  namespace::clean can remove the
+                // glob later while existing \&name references remain callable.
+                RuntimeScalar codeSnapshot = new RuntimeScalar();
+                codeSnapshot.type = codeRef.type;
+                codeSnapshot.value = codeRef.value;
+                codeRef = codeSnapshot;
 
                 // Allocate register and load from constant pool
                 int rd = allocateOutputRegister();
@@ -6594,7 +6620,7 @@ public class BytecodeCompiler implements Visitor {
                 }
 
                 // Step 8: If condition is true, jump back to start
-                emit(Opcodes.GOTO_IF_TRUE);
+                emit(gotoIfTrueOpcode());
                 emitReg(condReg);
                 emitInt(loopStartPc);
             }
@@ -6617,7 +6643,7 @@ public class BytecodeCompiler implements Visitor {
             }
 
             // Step 4: If condition is false, jump to end
-            emit(Opcodes.GOTO_IF_FALSE);
+            emit(gotoIfFalseOpcode());
             emitReg(condReg);
             loopEndJumpPc = bytecode.size();
             emitInt(0);  // Placeholder for jump target (will be patched)
@@ -6721,9 +6747,9 @@ public class BytecodeCompiler implements Visitor {
         int ifFalsePos = bytecode.size();
         // Invert condition for 'unless'
         if ("unless".equals(node.operator)) {
-            emit(Opcodes.GOTO_IF_TRUE);
+            emit(gotoIfTrueOpcode());
         } else {
-            emit(Opcodes.GOTO_IF_FALSE);
+            emit(gotoIfFalseOpcode());
         }
         emitReg(condReg);
         emitInt(0); // Placeholder for else/end target
@@ -6784,7 +6810,7 @@ public class BytecodeCompiler implements Visitor {
         int condReg = lastResultReg;
 
         int ifFalsePos = bytecode.size();
-        emit(Opcodes.GOTO_IF_FALSE);
+        emit(gotoIfFalseOpcode());
         emitReg(condReg);
         emitInt(0);
 

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -700,6 +700,32 @@ public class BytecodeInterpreter {
                                 }
                             }
 
+                            case Opcodes.GOTO_IF_FALSE_NO_OVERLOAD -> {
+                                int condReg = bytecode[pc++];
+                                int target = readInt(bytecode, pc);
+                                pc += 1;
+                                RuntimeBase condBase = registers[condReg];
+                                RuntimeScalar cond = (condBase instanceof RuntimeScalar)
+                                        ? (RuntimeScalar) condBase
+                                        : condBase.scalar();
+                                if (!cond.getBooleanNoOverload()) {
+                                    pc = target;
+                                }
+                            }
+
+                            case Opcodes.GOTO_IF_TRUE_NO_OVERLOAD -> {
+                                int condReg = bytecode[pc++];
+                                int target = readInt(bytecode, pc);
+                                pc += 1;
+                                RuntimeBase condBase = registers[condReg];
+                                RuntimeScalar cond = (condBase instanceof RuntimeScalar)
+                                        ? (RuntimeScalar) condBase
+                                        : condBase.scalar();
+                                if (cond.getBooleanNoOverload()) {
+                                    pc = target;
+                                }
+                            }
+
                             // =================================================================
                             // REGISTER OPERATIONS
                             // =================================================================
@@ -1191,7 +1217,7 @@ public class BytecodeInterpreter {
 
                             case Opcodes.COMPARE_NUM, Opcodes.COMPARE_STR, Opcodes.EQ_NUM, Opcodes.NE_NUM,
                                  Opcodes.LT_NUM, Opcodes.GT_NUM, Opcodes.LE_NUM, Opcodes.GE_NUM, Opcodes.EQ_STR,
-                                 Opcodes.NE_STR, Opcodes.NOT -> {
+                                 Opcodes.NE_STR, Opcodes.NOT, Opcodes.NOT_NO_OVERLOAD -> {
                                 pc = executeComparisons(opcode, bytecode, pc, registers);
                             }
 
@@ -1504,6 +1530,8 @@ public class BytecodeInterpreter {
                                 // resolve it from the actual calling context in register 2.
                                 if (context == RuntimeContextType.RUNTIME) {
                                     context = ((RuntimeScalar) registers[2]).getInt();
+                                } else if (context == RuntimeContextType.INHERITED) {
+                                    context = RuntimeCode.currentRawCallContext();
                                 }
 
                                 // Auto-convert coderef to scalar if needed
@@ -1574,10 +1602,13 @@ public class BytecodeInterpreter {
                                     CallerStack.pop();
                                 }
 
-                                // Convert to scalar if called in scalar or lvalue context
-                                if (context == RuntimeContextType.SCALAR || context == RuntimeContextType.LVALUE) {
+                                // OBJECT is a raw Wanted parent-op context, but its
+                                // value semantics are the same as scalar context.
+                                if (context == RuntimeContextType.SCALAR || context == RuntimeContextType.LVALUE
+                                        || context == RuntimeContextType.OBJECT) {
                                     RuntimeBase scalarResult = result.scalar();
-                                    registers[rd] = context == RuntimeContextType.SCALAR && isImmutableProxy(scalarResult)
+                                    registers[rd] = (context == RuntimeContextType.SCALAR
+                                            || context == RuntimeContextType.OBJECT) && isImmutableProxy(scalarResult)
                                             ? ensureMutableScalar(scalarResult) : scalarResult;
                                 } else {
                                     registers[rd] = result;
@@ -1652,6 +1683,8 @@ public class BytecodeInterpreter {
                                 // Resolve RUNTIME context from register 2 (wantarray)
                                 if (context == RuntimeContextType.RUNTIME) {
                                     context = ((RuntimeScalar) registers[2]).getInt();
+                                } else if (context == RuntimeContextType.INHERITED) {
+                                    context = RuntimeCode.currentRawCallContext();
                                 }
 
                                 RuntimeScalar invocant = (RuntimeScalar) registers[invocantReg];
@@ -1696,10 +1729,13 @@ public class BytecodeInterpreter {
                                     CallerStack.pop();
                                 }
 
-                                // Convert to scalar if called in scalar or lvalue context
-                                if (context == RuntimeContextType.SCALAR || context == RuntimeContextType.LVALUE) {
+                                // OBJECT is a raw Wanted parent-op context, but its
+                                // value semantics are the same as scalar context.
+                                if (context == RuntimeContextType.SCALAR || context == RuntimeContextType.LVALUE
+                                        || context == RuntimeContextType.OBJECT) {
                                     RuntimeBase scalarResult = result.scalar();
-                                    registers[rd] = context == RuntimeContextType.SCALAR && isImmutableProxy(scalarResult)
+                                    registers[rd] = (context == RuntimeContextType.SCALAR
+                                            || context == RuntimeContextType.OBJECT) && isImmutableProxy(scalarResult)
                                             ? ensureMutableScalar(scalarResult) : scalarResult;
                                 } else {
                                     registers[rd] = result;
@@ -3168,6 +3204,15 @@ public class BytecodeInterpreter {
                         : registers[rs].scalar();
                 registers[rd] = val.getBoolean() ?
                         RuntimeScalarCache.scalarFalse : RuntimeScalarCache.scalarTrue;
+                return pc;
+            }
+            case Opcodes.NOT_NO_OVERLOAD -> {
+                int rd = bytecode[pc++];
+                int rs = bytecode[pc++];
+                RuntimeScalar val = (registers[rs] instanceof RuntimeScalar)
+                        ? (RuntimeScalar) registers[rs] : registers[rs].scalar();
+                registers[rd] = val.getBooleanNoOverload()
+                        ? RuntimeScalarCache.scalarFalse : RuntimeScalarCache.scalarTrue;
                 return pc;
             }
 

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
@@ -243,6 +243,13 @@ public class CompileBinaryOperator {
                         invocantNode = new StringNode(className, invocantNode.getIndex());
                     }
 
+                    if (invocantNode instanceof BinaryOperatorNode innerArrow
+                            && "->".equals(innerArrow.operator)
+                            && innerArrow.right instanceof BinaryOperatorNode innerCall
+                            && "(".equals(innerCall.operator)) {
+                        innerArrow.setAnnotation("wantedObjectContext", true);
+                    }
+
                     // Convert method name to string if needed
                     if (methodNode instanceof OperatorNode methodOp) {
                         // &method is introduced by parser if method is predeclared
@@ -293,7 +300,11 @@ public class CompileBinaryOperator {
                     bytecodeCompiler.emitReg(methodReg);
                     bytecodeCompiler.emitReg(currentSubReg);
                     bytecodeCompiler.emitReg(argsReg);
-                    bytecodeCompiler.emit(bytecodeCompiler.currentCallContext);
+                    bytecodeCompiler.emit(node.getBooleanAnnotation("wantedObjectContext")
+                            ? RuntimeContextType.OBJECT
+                            : node.getBooleanAnnotation("inheritRawCallContext")
+                            ? RuntimeContextType.INHERITED
+                            : bytecodeCompiler.currentCallContext);
 
                     bytecodeCompiler.lastResultReg = rd;
                     return;
@@ -503,7 +514,7 @@ public class CompileBinaryOperator {
             bytecodeCompiler.emitAliasWithTarget(rd, rs1);
 
             int skipRightPos = bytecodeCompiler.bytecode.size();
-            bytecodeCompiler.emit(Opcodes.GOTO_IF_FALSE);
+            bytecodeCompiler.emit(bytecodeCompiler.gotoIfFalseOpcode());
             bytecodeCompiler.emitReg(rd);
             bytecodeCompiler.emitInt(0);
 
@@ -530,7 +541,7 @@ public class CompileBinaryOperator {
             bytecodeCompiler.emitAliasWithTarget(rd, rs1);
 
             int skipRightPos = bytecodeCompiler.bytecode.size();
-            bytecodeCompiler.emit(Opcodes.GOTO_IF_TRUE);
+            bytecodeCompiler.emit(bytecodeCompiler.gotoIfTrueOpcode());
             bytecodeCompiler.emitReg(rd);
             bytecodeCompiler.emitInt(0);
 

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -790,7 +790,8 @@ public class CompileOperator {
             case "$", "@", "%", "*", "&", "\\" -> { bytecodeCompiler.compileVariableReference(node, op); return; }
 
             // Simple unary ops (dispatchOperator)
-            case "not", "!" -> emitSimpleUnaryScalar(bytecodeCompiler, node, Opcodes.NOT);
+            case "not", "!" -> emitSimpleUnaryScalar(bytecodeCompiler, node,
+                    bytecodeCompiler.isNoOverloadingEnabled() ? Opcodes.NOT_NO_OVERLOAD : Opcodes.NOT);
             case "~" -> {
                 Object integerAnnotation = node.getAnnotation("useInteger");
                 boolean useInteger = integerAnnotation instanceof Boolean value
@@ -1153,9 +1154,21 @@ public class CompileOperator {
                     bytecodeCompiler.emit(0);
                     bytecodeCompiler.lastResultReg = listReg;
                 } else if (node.operand instanceof ListNode list && list.elements.size() == 1) {
-                    bytecodeCompiler.compileNode(
-                            list.elements.getFirst(), -1, RuntimeContextType.RUNTIME);
+                    Node returnExpression = list.elements.getFirst();
+                    Node returnedCall = returnExpression;
+                    while (returnedCall instanceof ListNode returnedList
+                            && returnedList.elements.size() == 1) {
+                        returnedCall = returnedList.elements.getFirst();
+                    }
+                    returnedCall.setAnnotation("inheritRawCallContext", true);
+                    bytecodeCompiler.compileNode(returnExpression, -1, RuntimeContextType.RUNTIME);
                 } else {
+                    Node returnedCall = node.operand;
+                    while (returnedCall instanceof ListNode returnedList
+                            && returnedList.elements.size() == 1) {
+                        returnedCall = returnedList.elements.getFirst();
+                    }
+                    returnedCall.setAnnotation("inheritRawCallContext", true);
                     bytecodeCompiler.compileNode(node.operand, -1, RuntimeContextType.RUNTIME);
                 }
                 int exprReg = bytecodeCompiler.lastResultReg;

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -101,6 +101,18 @@ public class Disassemble {
                         pc += 1;
                         sb.append("GOTO_IF_TRUE r").append(condReg).append(" -> ").append(target).append("\n");
                         break;
+                    case Opcodes.GOTO_IF_FALSE_NO_OVERLOAD:
+                        condReg = interpretedCode.bytecode[pc++];
+                        target = InterpretedCode.readInt(interpretedCode.bytecode, pc);
+                        pc += 1;
+                        sb.append("GOTO_IF_FALSE_NO_OVERLOAD r").append(condReg).append(" -> ").append(target).append("\n");
+                        break;
+                    case Opcodes.GOTO_IF_TRUE_NO_OVERLOAD:
+                        condReg = interpretedCode.bytecode[pc++];
+                        target = InterpretedCode.readInt(interpretedCode.bytecode, pc);
+                        pc += 1;
+                        sb.append("GOTO_IF_TRUE_NO_OVERLOAD r").append(condReg).append(" -> ").append(target).append("\n");
+                        break;
                     case Opcodes.ALIAS:
                         int dest = interpretedCode.bytecode[pc++];
                         int src = interpretedCode.bytecode[pc++];
@@ -411,6 +423,12 @@ public class Disassemble {
                         rd = interpretedCode.bytecode[pc++];
                         int rsNegNo = interpretedCode.bytecode[pc++];
                         sb.append("NEG_NO_OVERLOAD r").append(rd).append(" = -r").append(rsNegNo).append("\n");
+                        break;
+                    }
+                    case Opcodes.NOT_NO_OVERLOAD: {
+                        rd = interpretedCode.bytecode[pc++];
+                        int rsNotNo = interpretedCode.bytecode[pc++];
+                        sb.append("NOT_NO_OVERLOAD r").append(rd).append(" = !r").append(rsNotNo).append("\n");
                         break;
                     }
                     case Opcodes.ADD_SCALAR_INT:

--- a/src/main/java/org/perlonjava/backend/bytecode/InterpretedCode.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InterpretedCode.java
@@ -363,7 +363,7 @@ public class InterpretedCode extends RuntimeCode implements PerlSubroutine {
         // Push args for getCallerArgs() support (used by List::Util::any/all/etc.)
         // This matches what RuntimeCode.apply() does for JVM-compiled subs
         RuntimeCode.pushArgs(args);
-        RuntimeCode.pushCallContext(effectiveContext);
+        RuntimeCode.pushCallContext(callContext);
         RuntimeCode.pushActiveCode(this);
         // Push warning bits for FATAL warnings support
         // This allows runtime code to check current warning context
@@ -416,7 +416,7 @@ public class InterpretedCode extends RuntimeCode implements PerlSubroutine {
                 : RuntimeCode.effectiveCallContext(this, callContext);
         // Push args for getCallerArgs() support (used by List::Util::any/all/etc.)
         RuntimeCode.pushArgs(args);
-        RuntimeCode.pushCallContext(effectiveContext);
+        RuntimeCode.pushCallContext(callContext);
         RuntimeCode.pushActiveCode(this);
         // Push warning bits for FATAL warnings support
         if (warningBitsString != null) {

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -2467,6 +2467,13 @@ public class Opcodes {
     /** Build an interpolated regex template while preserving callback objects. Format: rd partsReg. */
     public static final short REGEX_TEMPLATE = 521;
 
+    /** Conditional jumps using raw Perl truth without overload dispatch. */
+    public static final short GOTO_IF_FALSE_NO_OVERLOAD = 522;
+    public static final short GOTO_IF_TRUE_NO_OVERLOAD = 523;
+
+    /** Logical negation using raw Perl truth without overload dispatch. Format: rd rs. */
+    public static final short NOT_NO_OVERLOAD = 524;
+
     /** Return the mutable {@code $#array} cell. Format: ARRAY_LAST_INDEX_LVALUE rd arrayReg. */
     public static final short ARRAY_LAST_INDEX_LVALUE = 518;
 

--- a/src/main/java/org/perlonjava/backend/jvm/Dereference.java
+++ b/src/main/java/org/perlonjava/backend/jvm/Dereference.java
@@ -879,6 +879,15 @@ public class Dereference {
                 object = new StringNode(className, ((IdentifierNode) object).tokenIndex);
             }
 
+            // Wanted reports OBJECT when a method result is immediately used
+            // as the invocant of another method call ($obj->first->second).
+            if (object instanceof BinaryOperatorNode innerArrow
+                    && "->".equals(innerArrow.operator)
+                    && innerArrow.right instanceof BinaryOperatorNode innerCall
+                    && "(".equals(innerCall.operator)) {
+                innerArrow.setAnnotation("wantedObjectContext", true);
+            }
+
             // Convert method to StringNode if needed
             if (method instanceof OperatorNode op) {
                 // &method is introduced by the parser if the method is predeclared
@@ -1000,7 +1009,18 @@ public class Dereference {
             mv.visitVarInsn(Opcodes.ALOAD, methodSlot);
             mv.visitVarInsn(Opcodes.ALOAD, subSlot);
             mv.visitVarInsn(Opcodes.ALOAD, argsArraySlot);
-            emitterVisitor.pushCallContext();   // push call context
+            if (node.getBooleanAnnotation("wantedObjectContext")) {
+                mv.visitLdcInsn(RuntimeContextType.OBJECT);
+            } else if (node.getBooleanAnnotation("inheritRawCallContext")) {
+                mv.visitMethodInsn(
+                        Opcodes.INVOKESTATIC,
+                        "org/perlonjava/runtime/runtimetypes/RuntimeCode",
+                        "currentRawCallContext",
+                        "()I",
+                        false);
+            } else {
+                emitterVisitor.pushCallContext();
+            }
             mv.visitMethodInsn(
                     Opcodes.INVOKESTATIC,
                     "org/perlonjava/runtime/runtimetypes/RuntimeCode",
@@ -1082,7 +1102,18 @@ public class Dereference {
                 mv.visitVarInsn(Opcodes.ALOAD, emitterVisitor.ctx.javaClassInfo.tailCallCodeRefSlot);
                 mv.visitLdcInsn("tailcall");
                 mv.visitVarInsn(Opcodes.ALOAD, emitterVisitor.ctx.javaClassInfo.tailCallArgsSlot);
-                emitterVisitor.pushCallContext();  // context of the original call site
+                if (node.getBooleanAnnotation("wantedObjectContext")) {
+                    mv.visitLdcInsn(RuntimeContextType.OBJECT);
+                } else if (node.getBooleanAnnotation("inheritRawCallContext")) {
+                    mv.visitMethodInsn(
+                            Opcodes.INVOKESTATIC,
+                            "org/perlonjava/runtime/runtimetypes/RuntimeCode",
+                            "currentRawCallContext",
+                            "()I",
+                            false);
+                } else {
+                    emitterVisitor.pushCallContext();
+                }
                 mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                         "org/perlonjava/runtime/runtimetypes/RuntimeCode",
                         "apply",

--- a/src/main/java/org/perlonjava/backend/jvm/EmitControlFlow.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitControlFlow.java
@@ -328,8 +328,21 @@ public class EmitControlFlow {
                     "()V",
                     false);
         } else if (node.operand instanceof ListNode list && list.elements.size() == 1) {
-            list.elements.getFirst().accept(emitterVisitor.with(RuntimeContextType.RUNTIME));
+            Node returnExpression = list.elements.getFirst();
+            Node returnedCall = returnExpression;
+            while (returnedCall instanceof ListNode returnedList
+                    && returnedList.elements.size() == 1) {
+                returnedCall = returnedList.elements.getFirst();
+            }
+            returnedCall.setAnnotation("inheritRawCallContext", true);
+            returnExpression.accept(emitterVisitor.with(RuntimeContextType.RUNTIME));
         } else {
+            Node returnedCall = node.operand;
+            while (returnedCall instanceof ListNode returnedList
+                    && returnedList.elements.size() == 1) {
+                returnedCall = returnedList.elements.getFirst();
+            }
+            returnedCall.setAnnotation("inheritRawCallContext", true);
             node.operand.accept(emitterVisitor.with(RuntimeContextType.RUNTIME));
         }
 

--- a/src/main/java/org/perlonjava/backend/jvm/EmitLiteral.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitLiteral.java
@@ -692,7 +692,9 @@ public class EmitLiteral {
             return;
         }
 
-        if (ctx.symbolTable.isStrictOptionEnabled(HINT_STRICT_SUBS)) {
+        boolean qualifiedConstant = node.name.contains("::")
+                && node.name.matches(".*::[A-Z][A-Z0-9_]*");
+        if (ctx.symbolTable.isStrictOptionEnabled(HINT_STRICT_SUBS) && !qualifiedConstant) {
             throw new PerlCompilerException(
                     node.tokenIndex,
                     "Bareword \"" + node.name + "\" not allowed while \"strict subs\" in use",

--- a/src/main/java/org/perlonjava/backend/jvm/EmitLogicalOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitLogicalOperator.java
@@ -101,6 +101,7 @@ public class EmitLogicalOperator {
      * @param getBoolean     The method name to convert the result to a boolean.
      */
     static void emitLogicalAssign(EmitterVisitor emitterVisitor, BinaryOperatorNode node, int compareOpcode, String getBoolean) {
+        getBoolean = EmitOperator.booleanConversionMethod(emitterVisitor, getBoolean);
         MethodVisitor mv = emitterVisitor.ctx.mv;
         Label endLabel = new Label(); // Label for the end of the operation
         Node left = scalarizeSingleElementSliceLvalue(node.left);
@@ -204,6 +205,7 @@ public class EmitLogicalOperator {
      * @param getBoolean     The method name to convert the result to a boolean.
      */
     static void emitLogicalOperator(EmitterVisitor emitterVisitor, BinaryOperatorNode node, int compareOpcode, String getBoolean) {
+        getBoolean = EmitOperator.booleanConversionMethod(emitterVisitor, getBoolean);
         int savedCallerLineOverride = emitterVisitor.ctx.javaClassInfo.callerLineTokenOverride;
         if (!"getDefinedBoolean".equals(getBoolean) && savedCallerLineOverride <= 0) {
             emitterVisitor.ctx.javaClassInfo.callerLineTokenOverride =
@@ -497,7 +499,8 @@ public class EmitLogicalOperator {
         node.condition.accept(emitterVisitor.with(RuntimeContextType.SCALAR));
 
         // Convert the result to a boolean
-        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/runtimetypes/RuntimeBase", "getBoolean", "()Z", false);
+        mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/runtimetypes/RuntimeBase",
+                EmitOperator.booleanConversionMethod(emitterVisitor, "getBoolean"), "()Z", false);
 
         // Jump to the else label if the condition is false
         mv.visitJumpInsn(Opcodes.IFEQ, elseLabel);

--- a/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
@@ -21,6 +21,16 @@ public class EmitOperator {
 
     private static final boolean ENABLE_SPILL_BINARY_LHS = true;
 
+    static String booleanConversionMethod(EmitterVisitor emitterVisitor, String defaultMethod) {
+        boolean noOverloading = "getBoolean".equals(defaultMethod)
+                && emitterVisitor.ctx.symbolTable != null
+                && emitterVisitor.ctx.symbolTable.isStrictOptionEnabled(Strict.HINT_NO_AMAGIC);
+        if (noOverloading) {
+            return "getBooleanNoOverload";
+        }
+        return defaultMethod;
+    }
+
     static void emitOperator(Node node, EmitterVisitor emitterVisitor) {
         // Extract operator string from the node
         String operator = null;
@@ -37,7 +47,6 @@ public class EmitOperator {
         boolean noOverloading = symbolTable != null &&
                 symbolTable.isStrictOptionEnabled(Strict.HINT_NO_AMAGIC);
         OperatorHandler operatorHandler = noOverloading ? OperatorHandler.getNoOverload(operator) : null;
-
         // Check if uninitialized warnings are enabled at compile time
         // Use warn variant for zero-overhead when warnings disabled
         if (operatorHandler == null) {
@@ -72,12 +81,18 @@ public class EmitOperator {
     }
 
     static void emitOperatorWithKey(String operator, Node node, EmitterVisitor emitterVisitor) {
+        boolean noOverloading = emitterVisitor.ctx.symbolTable != null
+                && emitterVisitor.ctx.symbolTable.isStrictOptionEnabled(Strict.HINT_NO_AMAGIC);
+        OperatorHandler operatorHandler = noOverloading
+                ? OperatorHandler.getNoOverload(operator) : null;
         // Check if uninitialized warnings are enabled at compile time
         // Use warn variant for zero-overhead when warnings disabled
-        boolean warnUninit = emitterVisitor.ctx.symbolTable.isWarningCategoryEnabled("uninitialized");
-        OperatorHandler operatorHandler = warnUninit 
-                ? OperatorHandler.getWarn(operator)
-                : OperatorHandler.get(operator);
+        if (operatorHandler == null) {
+            boolean warnUninit = emitterVisitor.ctx.symbolTable.isWarningCategoryEnabled("uninitialized");
+            operatorHandler = warnUninit
+                    ? OperatorHandler.getWarn(operator)
+                    : OperatorHandler.get(operator);
+        }
         if (operatorHandler == null) {
             throw new PerlCompilerException(node.getIndex(), "Operator \"" + operator + "\" doesn't have a defined JVM descriptor", emitterVisitor.ctx.errorUtil);
         }

--- a/src/main/java/org/perlonjava/backend/jvm/EmitStatement.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitStatement.java
@@ -489,7 +489,8 @@ public class EmitStatement {
         }
 
         // Convert the result to a boolean
-        emitterVisitor.ctx.mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/runtimetypes/RuntimeBase", "getBoolean", "()Z", false);
+        emitterVisitor.ctx.mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/runtimetypes/RuntimeBase",
+                EmitOperator.booleanConversionMethod(emitterVisitor, "getBoolean"), "()Z", false);
 
         // Jump to the else label if the condition is false
         emitterVisitor.ctx.mv.visitJumpInsn(node.operator.equals("unless") ? Opcodes.IFNE : Opcodes.IFEQ, elseLabel);
@@ -616,7 +617,8 @@ public class EmitStatement {
                 }
 
                 // Convert the result to a boolean
-                mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/runtimetypes/RuntimeBase", "getBoolean", "()Z", false);
+                mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/runtimetypes/RuntimeBase",
+                        EmitOperator.booleanConversionMethod(emitterVisitor, "getBoolean"), "()Z", false);
 
                 // Jump to the end label if the condition is false (exit the loop)
                 mv.visitJumpInsn(Opcodes.IFEQ, endLabel);
@@ -836,7 +838,8 @@ public class EmitStatement {
         } else {
             // Non-constant condition — emit normal runtime evaluation
             node.condition.accept(emitterVisitor.with(RuntimeContextType.SCALAR));
-            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/runtimetypes/RuntimeBase", "getBoolean", "()Z", false);
+            mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/runtimetypes/RuntimeBase",
+                    EmitOperator.booleanConversionMethod(emitterVisitor, "getBoolean"), "()Z", false);
             mv.visitJumpInsn(Opcodes.IFNE, startLabel);
         }
 

--- a/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitVariable.java
@@ -1153,7 +1153,7 @@ public class EmitVariable {
         // Emit condition
         ternary.condition.accept(emitterVisitor.with(RuntimeContextType.SCALAR));
         mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/runtimetypes/RuntimeBase",
-                "getBoolean", "()Z", false);
+                EmitOperator.booleanConversionMethod(emitterVisitor, "getBoolean"), "()Z", false);
         mv.visitJumpInsn(Opcodes.IFEQ, elseLabel);
 
         // True branch

--- a/src/main/java/org/perlonjava/frontend/parser/Parser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/Parser.java
@@ -209,6 +209,18 @@ public class Parser {
             // Peek at the next token to determine what to do next.
             LexerToken token = peek(this);
 
+            // Perl permits infix operators to be explicitly qualified through
+            // CORE, for example `$a CORE::eq $b`. Collapse the three-token
+            // spelling in infix position so normal precedence handling applies.
+            if ("CORE".equals(token.text) && tokenIndex + 2 < tokens.size()
+                    && "::".equals(tokens.get(tokenIndex + 1).text)
+                    && ParserTables.INFIX_OP.contains(tokens.get(tokenIndex + 2).text)) {
+                token.text = tokens.get(tokenIndex + 2).text;
+                token.type = LexerTokenType.OPERATOR;
+                tokens.remove(tokenIndex + 2);
+                tokens.remove(tokenIndex + 1);
+            }
+
             // Check if we have reached the end of the input (EOF) or a terminator (like `;`).
             if (isExpressionTerminator(token)) {
                 break; // Exit the loop if we're done parsing.

--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -14,6 +14,7 @@ import org.perlonjava.runtime.operators.ModuleOperators;
 import org.perlonjava.runtime.operators.WarnDie;
 import org.perlonjava.runtime.operators.VersionHelper;
 import org.perlonjava.runtime.perlmodule.FilterUtilCall;
+import org.perlonjava.runtime.perlmodule.Strict;
 import org.perlonjava.runtime.perlmodule.Universal;
 import org.perlonjava.runtime.HintHashRegistry;
 import org.perlonjava.runtime.runtimetypes.*;
@@ -1037,6 +1038,18 @@ public class StatementParser {
                                     res = RuntimeCode.apply(codeRef, "tailcall", callArgs, RuntimeContextType.SCALAR);
                                 } else {
                                     break;
+                                }
+                            }
+
+                            // overloading.pm stores HINT_NO_AMAGIC in $^H. Its
+                            // pure-Perl import method executes in a synthetic
+                            // BEGIN wrapper, so apply the public hint directly
+                            // to the enclosing compiler scope as Perl does.
+                            if ("overloading".equals(packageName)) {
+                                if (isNoDeclaration) {
+                                    parser.ctx.symbolTable.enableStrictOption(Strict.HINT_NO_AMAGIC);
+                                } else {
+                                    parser.ctx.symbolTable.disableStrictOption(Strict.HINT_NO_AMAGIC);
                                 }
                             }
 

--- a/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
@@ -42,6 +42,9 @@ public class StatementResolver {
             "pass", "fail", "require", "diag", "note", "explain",
             "skip", "warning_like", "warning_is", "warnings_like");
 
+    private static final Set<String> CORE_QUALIFIED_CONTROL_STATEMENTS = Set.of(
+            "if", "unless", "for", "foreach", "while", "until");
+
     /**
      * Parses a single statement from the parser's token stream.
      *
@@ -52,6 +55,23 @@ public class StatementResolver {
     public static Node parseStatement(Parser parser, String label) {
         int currentIndex = parser.tokenIndex;
         LexerToken token = peek(parser);
+
+        // Perl permits control-flow keywords to be explicitly qualified, e.g.
+        // CORE::for (...) { ... }. ParsePrimary handles CORE:: function-style
+        // operators, but statement keywords must be normalized before the
+        // statement switch because they have dedicated grammar.
+        if (token.type == LexerTokenType.IDENTIFIER && token.text.equals("CORE")
+                && parser.tokenIndex + 2 < parser.tokens.size()
+                && parser.tokens.get(parser.tokenIndex + 1).text.equals("::")) {
+            LexerToken coreKeyword = parser.tokens.get(parser.tokenIndex + 2);
+            if (coreKeyword.type == LexerTokenType.IDENTIFIER
+                    && CORE_QUALIFIED_CONTROL_STATEMENTS.contains(coreKeyword.text)) {
+                consume(parser, LexerTokenType.IDENTIFIER); // CORE
+                consume(parser, LexerTokenType.OPERATOR, "::");
+                currentIndex = parser.tokenIndex;
+                token = peek(parser);
+            }
+        }
         if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("parseStatement `" + token.text + "`");
 
         // Store the current source location - this will be used for stack trace generation

--- a/src/main/java/org/perlonjava/runtime/operators/BitwiseOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/BitwiseOperators.java
@@ -52,7 +52,7 @@ public class BitwiseOperators {
         // Fast path: both INTEGER - skip all checks (defined, looksLikeNumber, tied)
         int t1 = runtimeScalar.type;
         int t2 = arg2.type;
-        if (t1 == RuntimeScalarType.INTEGER && t2 == RuntimeScalarType.INTEGER) {
+        if (isNumericBitwiseOperand(t1) && isNumericBitwiseOperand(t2)) {
             return unsignedResult(unsignedValue(runtimeScalar).and(unsignedValue(arg2)))
                     .propagateTaint(runtimeScalar, arg2);
         }
@@ -210,11 +210,17 @@ public class BitwiseOperators {
         // - If both are non-numeric (strings from pack/vec, etc.), use string bitwise
         int vt1 = val1.type;
         int vt2 = val2.type;
-        if (vt1 == RuntimeScalarType.INTEGER || vt1 == RuntimeScalarType.DOUBLE || vt1 == RuntimeScalarType.DUALVAR ||
-                vt2 == RuntimeScalarType.INTEGER || vt2 == RuntimeScalarType.DOUBLE || vt2 == RuntimeScalarType.DUALVAR) {
+        if (isNumericBitwiseOperand(vt1) || isNumericBitwiseOperand(vt2)) {
             return bitwiseXorBinary(val1, val2);
         }
         return bitwiseXorDot(val1, val2);
+    }
+
+    private static boolean isNumericBitwiseOperand(int type) {
+        return type == RuntimeScalarType.INTEGER
+                || type == RuntimeScalarType.DOUBLE
+                || type == RuntimeScalarType.BOOLEAN
+                || type == RuntimeScalarType.DUALVAR;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/operators/MathOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/MathOperators.java
@@ -1539,6 +1539,11 @@ public class MathOperators {
         };
     }
 
+    /** Logical negation for a lexical {@code no overloading} scope. */
+    public static RuntimeScalar notNoOverload(RuntimeScalar runtimeScalar) {
+        return runtimeScalar.getBooleanNoOverload() ? scalarFalse : scalarTrue;
+    }
+
     // =====================================================================
     // NoOverload variants - used when 'no overloading' pragma is in effect.
     // These skip overload dispatch entirely and treat blessed references

--- a/src/main/java/org/perlonjava/runtime/operators/OperatorHandler.java
+++ b/src/main/java/org/perlonjava/runtime/operators/OperatorHandler.java
@@ -49,6 +49,8 @@ public record OperatorHandler(String className, String methodName, int methodTyp
         put("%_noOverload", "modulusNoOverload", "org/perlonjava/runtime/operators/MathOperators");
         put("**_noOverload", "powNoOverload", "org/perlonjava/runtime/operators/MathOperators", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");
         put("unaryMinus_noOverload", "unaryMinusNoOverload", "org/perlonjava/runtime/operators/MathOperators", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");
+        put("!_noOverload", "notNoOverload", "org/perlonjava/runtime/operators/MathOperators", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");
+        put("not_noOverload", "notNoOverload", "org/perlonjava/runtime/operators/MathOperators", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");
 
         put("^^", "xor", "org/perlonjava/runtime/operators/Operator", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");
         put("xor", "xor", "org/perlonjava/runtime/operators/Operator", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");

--- a/src/main/java/org/perlonjava/runtime/operators/StringOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/StringOperators.java
@@ -518,7 +518,22 @@ public class StringOperators {
      * not turn concat-assignment into warning-aware concatenation.
      */
     public static RuntimeScalar stringConcatAssign(RuntimeScalar runtimeScalar, RuntimeScalar b) {
-        return stringConcat(runtimeScalar, b, false);
+        int blessId = RuntimeScalarType.blessedId(runtimeScalar);
+        int blessId2 = RuntimeScalarType.blessedId(b);
+        if (blessId < 0 || blessId2 < 0) {
+            RuntimeScalar result = OverloadContext.tryTwoArgumentOverload(
+                    runtimeScalar, b, blessId, blessId2, "(.=", ".=", "(.");
+            if (result != null) {
+                // Compound overloads return the value that Perl assigns back to
+                // the lvalue.  Preserve that reference instead of converting it
+                // through the ordinary string-concat result path.
+                runtimeScalar.set(result);
+                return runtimeScalar;
+            }
+        }
+        RuntimeScalar result = stringConcat(runtimeScalar, b, false);
+        runtimeScalar.set(result);
+        return runtimeScalar;
     }
 
     private static RuntimeScalar stringConcat(RuntimeScalar runtimeScalar, RuntimeScalar b,

--- a/src/main/java/org/perlonjava/runtime/operators/WaitpidOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/WaitpidOperator.java
@@ -8,7 +8,9 @@ import org.perlonjava.runtime.runtimetypes.RuntimeIO;
 import org.perlonjava.runtime.runtimetypes.PerlRuntime;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.perlonjava.runtime.runtimetypes.GlobalVariable.getGlobalHash;
@@ -114,14 +116,18 @@ public class WaitpidOperator {
         }
         if (nonBlocking) return new RuntimeScalar(0);
 
-        java.util.concurrent.CompletableFuture<?>[] exits = children.values().stream()
-                .map(Process::onExit)
-                .toArray(java.util.concurrent.CompletableFuture[]::new);
-        java.util.concurrent.CompletableFuture.anyOf(exits).join();
+        Map<Long, CompletableFuture<Process>> exits = new LinkedHashMap<>();
+        for (Map.Entry<Long, Process> entry : children.entrySet()) {
+            exits.put(entry.getKey(), entry.getValue().onExit());
+        }
+        CompletableFuture.anyOf(exits.values().toArray(CompletableFuture[]::new)).join();
 
-        for (Map.Entry<Long, Process> entry : RuntimeIO.childProcessesSnapshot().entrySet()) {
-            if (!entry.getValue().isAlive()) {
-                return waitpidJavaProcess(entry.getKey().intValue(), entry.getValue(), flags);
+        // The completed onExit future is authoritative.  On Windows,
+        // Process.isAlive() can briefly remain true after onExit completes;
+        // rechecking it here made blocking wait() incorrectly report ECHILD.
+        for (Map.Entry<Long, CompletableFuture<Process>> entry : exits.entrySet()) {
+            if (entry.getValue().isDone()) {
+                return waitpidJavaProcess(entry.getKey().intValue(), entry.getValue().join(), flags);
             }
         }
         return new RuntimeScalar(-1);

--- a/src/main/java/org/perlonjava/runtime/perlmodule/ModuleGeneric.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/ModuleGeneric.java
@@ -1,0 +1,164 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.runtime.runtimetypes.*;
+
+import java.util.regex.Pattern;
+
+import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarFalse;
+import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarTrue;
+import static org.perlonjava.runtime.runtimetypes.RuntimeScalarType.*;
+
+/**
+ * Java replacement for the helpers in Module::Generic 1.7.0's Generic.xs.
+ *
+ * <p>The original module and XS implementation are copyright Jacques Deguest,
+ * DEGUEST Pte. Ltd., and are distributed under the same terms as Perl.</p>
+ */
+public class ModuleGeneric extends PerlModuleBase {
+    private static final Pattern CLASS_NAME =
+            Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(?:::[A-Za-z_][A-Za-z0-9_]*)*");
+
+    public ModuleGeneric() {
+        super("Module::Generic", false);
+    }
+
+    public static void initialize() {
+        ModuleGeneric module = new ModuleGeneric();
+        try {
+            module.registerMethod("_get_args_as_array", null);
+            module.registerMethod("_is_array", null);
+            module.registerMethod("_is_class_loaded_xs", null);
+            module.registerMethod("_is_code", null);
+            module.registerMethod("_is_glob", null);
+            module.registerMethod("_is_hash", null);
+            module.registerMethod("_is_integer", null);
+            module.registerMethod("_is_number", null);
+            module.registerMethod("_is_object", null);
+            module.registerMethod("_is_overloaded", null);
+            module.registerMethod("_is_scalar", null);
+            module.registerMethod("_obj2h", null);
+            module.registerMethod("_refaddr", null);
+        } catch (NoSuchMethodException e) {
+            System.err.println("Warning: Missing Module::Generic method: " + e.getMessage());
+        }
+    }
+
+    private static RuntimeScalar arg(RuntimeArray args, int index) {
+        return args.size() > index ? args.get(index) : new RuntimeScalar();
+    }
+
+    private static RuntimeList bool(boolean value) {
+        return (value ? scalarTrue : scalarFalse).getList();
+    }
+
+    public static RuntimeList _get_args_as_array(RuntimeArray args, int ctx) {
+        if (args.size() == 2 && args.get(1).type == ARRAYREFERENCE) {
+            return args.get(1).getList();
+        }
+        RuntimeArray result = new RuntimeArray();
+        for (int i = 1; i < args.size(); i++) {
+            RuntimeArray.push(result, new RuntimeScalar(args.get(i)));
+        }
+        return result.createReference().getList();
+    }
+
+    public static RuntimeList _is_array(RuntimeArray args, int ctx) {
+        return bool(arg(args, 1).type == ARRAYREFERENCE);
+    }
+
+    public static RuntimeList _is_class_loaded_xs(RuntimeArray args, int ctx) {
+        RuntimeScalar klass = arg(args, 1);
+        if (!klass.getDefinedBoolean() || RuntimeScalarType.isReference(klass)) return scalarFalse.getList();
+        String name = klass.toString();
+        if (!CLASS_NAME.matcher(name).matches()) return scalarFalse.getList();
+
+        String modulePath = name.replace("::", "/") + ".pm";
+        RuntimeHash inc = GlobalVariable.getGlobalHash("main::INC");
+        if (inc.exists(modulePath).getBoolean()) return scalarTrue.getList();
+
+        RuntimeScalar version = GlobalVariable.globalVariables.get(name + "::VERSION");
+        if (version != null && version.getDefinedBoolean()) return scalarTrue.getList();
+
+        RuntimeArray isa = GlobalVariable.globalArrays.get(name + "::ISA");
+        if (isa != null && !isa.isEmpty()) return scalarTrue.getList();
+
+        String prefix = name + "::";
+        for (String symbol : GlobalVariable.globalCodeRefs.keySet()) {
+            if (symbol.startsWith(prefix)
+                    && RuntimeCode.isCodeDefined(GlobalVariable.globalCodeRefs.get(symbol))) {
+                return scalarTrue.getList();
+            }
+        }
+        return scalarFalse.getList();
+    }
+
+    public static RuntimeList _is_code(RuntimeArray args, int ctx) {
+        return bool(arg(args, 1).type == CODE);
+    }
+
+    public static RuntimeList _is_glob(RuntimeArray args, int ctx) {
+        return bool(arg(args, 1).type == GLOBREFERENCE);
+    }
+
+    public static RuntimeList _is_hash(RuntimeArray args, int ctx) {
+        RuntimeScalar value = arg(args, 1);
+        if (value.type != HASHREFERENCE) return scalarFalse.getList();
+        String option = args.size() > 2 ? args.get(2).toString() : "";
+        boolean strict = option.equals("strict") || option.equals("native");
+        return bool(!strict || RuntimeScalarType.blessedId(value) == 0);
+    }
+
+    public static RuntimeList _is_integer(RuntimeArray args, int ctx) {
+        RuntimeScalar value = arg(args, 1);
+        if (!value.getDefinedBoolean() || RuntimeScalarType.isReference(value)) return scalarFalse.getList();
+        return bool(value.toString().matches("[+-]?[0-9]+"));
+    }
+
+    public static RuntimeList _is_number(RuntimeArray args, int ctx) {
+        RuntimeScalar value = arg(args, 1);
+        return bool(value.type == INTEGER || value.type == DOUBLE || value.type == BOOLEAN);
+    }
+
+    public static RuntimeList _is_object(RuntimeArray args, int ctx) {
+        return bool(RuntimeScalarType.blessedId(arg(args, 1)) != 0);
+    }
+
+    public static RuntimeList _is_overloaded(RuntimeArray args, int ctx) {
+        int blessId = RuntimeScalarType.blessedId(arg(args, 1));
+        return bool(blessId != 0 && OverloadContext.prepare(blessId) != null);
+    }
+
+    public static RuntimeList _is_scalar(RuntimeArray args, int ctx) {
+        RuntimeScalar value = arg(args, 1);
+        if (value.type != REFERENCE || !(value.value instanceof RuntimeScalar referent)) {
+            return scalarFalse.getList();
+        }
+        return bool(!RuntimeScalarType.isReference(referent));
+    }
+
+    public static RuntimeList _obj2h(RuntimeArray args, int ctx) {
+        RuntimeScalar self = arg(args, 0);
+        if (self.type == HASHREFERENCE) return self.getList();
+        if (self.type == GLOBREFERENCE && self.value instanceof RuntimeGlob glob) {
+            return glob.getGlobHash().createReference().getList();
+        }
+        if (RuntimeScalarType.isReference(self)) {
+            return new RuntimeHash().createReference().getList();
+        }
+
+        String className = self.toString();
+        RuntimeHash result = new RuntimeHash();
+        RuntimeScalar debug = GlobalVariable.globalVariables.get(className + "::DEBUG");
+        RuntimeScalar verbose = GlobalVariable.globalVariables.get(className + "::VERBOSE");
+        RuntimeScalar error = GlobalVariable.globalVariables.get(className + "::ERROR");
+        result.put("debug", debug == null ? new RuntimeScalar(0) : new RuntimeScalar(debug));
+        result.put("verbose", verbose == null ? new RuntimeScalar(0) : new RuntimeScalar(verbose));
+        result.put("error", error == null ? new RuntimeScalar(0) : new RuntimeScalar(error));
+        result.setBlessId(NameNormalizer.getBlessId(className));
+        return result.createReference().getList();
+    }
+
+    public static RuntimeList _refaddr(RuntimeArray args, int ctx) {
+        return ScalarUtil.refaddr(new RuntimeArray(arg(args, 1)), ctx);
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/OverloadingPragma.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/OverloadingPragma.java
@@ -45,9 +45,7 @@ public class OverloadingPragma extends PerlModuleBase {
      */
     public static RuntimeList useOverloading(RuntimeArray args, int ctx) {
         ScopedSymbolTable currentScope = getCurrentScope();
-        if (currentScope != null) {
-            currentScope.disableStrictOption(Strict.HINT_NO_AMAGIC);
-        }
+        if (currentScope != null) currentScope.disableStrictOption(Strict.HINT_NO_AMAGIC);
         return new RuntimeList();
     }
 
@@ -61,9 +59,7 @@ public class OverloadingPragma extends PerlModuleBase {
      */
     public static RuntimeList noOverloading(RuntimeArray args, int ctx) {
         ScopedSymbolTable currentScope = getCurrentScope();
-        if (currentScope != null) {
-            currentScope.enableStrictOption(Strict.HINT_NO_AMAGIC);
-        }
+        if (currentScope != null) currentScope.enableStrictOption(Strict.HINT_NO_AMAGIC);
         return new RuntimeList();
     }
 }

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Strict.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Strict.java
@@ -39,17 +39,18 @@ public class Strict extends PerlModuleBase {
     // Bitmask for utf8 source code
     public static final int HINT_UTF8 = 0x00800000;
 
-    // Bitmask for `no overloading` pragma
-    public static final int HINT_NO_AMAGIC = 0x00000010;
+    // Perl's public HINT_NO_AMAGIC bit, written to $^H by overloading.pm.
+    public static final int HINT_NO_AMAGIC = 0x01000000;
 
-    // Bitmask for `use re` regex modifiers
-    public static final int HINT_RE_ASCII = 0x01000000;     // use re '/a'
-    public static final int HINT_RE_UNICODE = 0x02000000;   // use re '/u'
-    public static final int HINT_RE_ASCII_AA = 0x04000000;  // use re '/aa'
-    public static final int HINT_RE_EVAL = 0x08000000;      // use re 'eval'
-    public static final int HINT_RE_TAINT = 0x10000000;     // use re 'taint'
-    public static final int HINT_RE_DEBUG = 0x20000000;     // use re 'debug'
-    public static final int HINT_RE_DEBUGCOLOR = 0x40000000; // use re 'debugcolor'
+    // Internal bitmasks for `use re` modifiers. These must not collide with
+    // Perl's public $^H bits above.
+    public static final int HINT_RE_ASCII = 0x00000010;      // use re '/a'
+    public static final int HINT_RE_UNICODE = 0x00000100;    // use re '/u'
+    public static final int HINT_RE_ASCII_AA = 0x00000800;   // use re '/aa'
+    public static final int HINT_RE_EVAL = 0x00001000;       // use re 'eval'
+    public static final int HINT_RE_TAINT = 0x00002000;      // use re 'taint'
+    public static final int HINT_RE_DEBUG = 0x00004000;      // use re 'debug'
+    public static final int HINT_RE_DEBUGCOLOR = 0x00008000; // use re 'debugcolor'
 
     /**
      * Constructor for Strict.
@@ -218,6 +219,10 @@ public class Strict extends PerlModuleBase {
                 result.append(", ");
             }
             result.append("BYTES");
+        }
+        if ((strictOptions & HINT_NO_AMAGIC) != 0) {
+            if (!result.isEmpty()) result.append(", ");
+            result.append("NO_AMAGIC");
         }
 
         // Handle strict options

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Wanted.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Wanted.java
@@ -1,0 +1,104 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.runtime.runtimetypes.*;
+
+import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarFalse;
+import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarTrue;
+
+/** Native caller-context and double-return support for Wanted. */
+public class Wanted extends PerlModuleBase {
+    public Wanted() {
+        super("Wanted", false);
+    }
+
+    public static void initialize() {
+        Wanted module = new Wanted();
+        GlobalVariable.getGlobalVariable("Wanted::VERSION").set(new RuntimeScalar("0.1.2"));
+        try {
+            module.registerMethod("want", null);
+            module.registerMethod("context", null);
+            module.registerMethod("wantref", null);
+            module.registerMethod("howmany", null);
+            module.registerMethod("rreturn", null);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Missing Wanted implementation", e);
+        }
+    }
+
+    private static Integer callerContext() {
+        return RuntimeCode.getCallContextAtCallerFrame(1);
+    }
+
+    public static RuntimeList context(RuntimeArray args, int ctx) {
+        Integer caller = callerContext();
+        if (caller == null || caller == RuntimeContextType.VOID) {
+            return new RuntimeScalar("VOID").getList();
+        }
+        if (caller == RuntimeContextType.OBJECT) {
+            return new RuntimeScalar("OBJECT").getList();
+        }
+        return new RuntimeScalar(RuntimeContextType.isListLike(caller) ? "LIST" : "SCALAR").getList();
+    }
+
+    public static RuntimeList wantref(RuntimeArray args, int ctx) {
+        return new RuntimeScalar("").getList();
+    }
+
+    public static RuntimeList howmany(RuntimeArray args, int ctx) {
+        Integer caller = callerContext();
+        if (caller == null || RuntimeContextType.isListLike(caller)) {
+            return new RuntimeScalar().getList();
+        }
+        return new RuntimeScalar(caller == RuntimeContextType.VOID ? 0 : 1).getList();
+    }
+
+    public static RuntimeList want(RuntimeArray args, int ctx) {
+        Integer caller = callerContext();
+        for (int i = 0; i < args.size(); i++) {
+            for (String requestedText : args.get(i).toString().split("\\s+")) {
+                boolean negative = requestedText.startsWith("!");
+                String requested = negative ? requestedText.substring(1) : requestedText;
+                if (requested.equalsIgnoreCase("COUNT")) {
+                    return howmany(new RuntimeArray(), ctx);
+                }
+                boolean matches = switch (requested.toUpperCase()) {
+                    case "VOID" -> caller != null && caller == RuntimeContextType.VOID;
+                    case "LIST" -> caller != null && RuntimeContextType.isListLike(caller);
+                    case "SCALAR" -> caller != null && (caller == RuntimeContextType.SCALAR
+                            || caller == RuntimeContextType.LVALUE);
+                    case "LVALUE", "ASSIGN" -> caller != null && (caller == RuntimeContextType.LVALUE
+                            || caller == RuntimeContextType.LVALUE_LIST);
+                    case "RVALUE" -> caller == null || (caller != RuntimeContextType.LVALUE
+                            && caller != RuntimeContextType.LVALUE_LIST);
+                    case "INFINITY" -> caller != null && RuntimeContextType.isListLike(caller);
+                    case "OBJECT" -> caller != null && caller == RuntimeContextType.OBJECT;
+                    case "BOOL", "BOOLEAN", "ARRAY", "HASH", "CODE", "GLOB",
+                            "REF", "REFSCALAR" -> false;
+                    default -> {
+                        if (requested.matches("[0-9]+")) {
+                            if (caller != null && RuntimeContextType.isListLike(caller)) yield true;
+                            int count = caller != null && caller == RuntimeContextType.VOID ? 0 : 1;
+                            yield count >= Integer.parseInt(requested);
+                        }
+                        yield false;
+                    }
+                };
+                if (negative ? matches : !matches) return scalarFalse.getList();
+            }
+        }
+        return scalarTrue.getList();
+    }
+
+    public static RuntimeList rreturn(RuntimeArray args, int ctx) {
+        RuntimeList value = new RuntimeList();
+        if (RuntimeContextType.isListLike(ctx)) {
+            value.elements.addAll(args.elements);
+        } else if (!args.isEmpty()) {
+            value.elements.add(args.get(args.size() - 1));
+        }
+
+        RuntimeCode caller = RuntimeCode.getOutermostActiveCodeAtCallerFrame(1);
+        if (caller == null) return value;
+        throw new PerlNonLocalReturnException(value, caller);
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/perlmodule/XSLoader.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/XSLoader.java
@@ -15,6 +15,20 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarTrue;
 
 public class XSLoader extends PerlModuleBase {
 
+    /** Reinstall a Java-backed module whose Perl stash was cleaned or reloaded. */
+    public static boolean tryInitializeJavaModule(String moduleName) {
+        if (moduleName == null || moduleName.isEmpty()) return false;
+        StringBuilder className = new StringBuilder("org.perlonjava.runtime.perlmodule.");
+        for (String part : moduleName.split("::")) className.append(part);
+        try {
+            Class<?> clazz = Class.forName(className.toString());
+            clazz.getMethod("initialize").invoke(null);
+            return true;
+        } catch (ReflectiveOperationException e) {
+            return false;
+        }
+    }
+
     /** Guard against recursive loadJarShimOverrides calls (e.g. Clone.pm evals XSLoader::load). */
     /**
      * Non-functional base classes that should be ignored when checking @ISA

--- a/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessor.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexPreprocessor.java
@@ -649,6 +649,23 @@ public class RegexPreprocessor {
                 escaped = true;
                 continue;
             }
+            // A POSIX character class such as [[:blank:]] has its own
+            // bracket pair inside the surrounding regular class. Do not
+            // mistake the POSIX closing bracket for the end of the outer
+            // class; otherwise /i preprocessing case-folds syntax letters
+            // (notably the k in "blank") as literal class contents.
+            if (ch == '[' && i + 1 < pattern.length()
+                    && (pattern.charAt(i + 1) == ':'
+                        || pattern.charAt(i + 1) == '.'
+                        || pattern.charAt(i + 1) == '=')) {
+                char delimiter = pattern.charAt(i + 1);
+                String terminator = String.valueOf(delimiter) + ']';
+                int nestedEnd = pattern.indexOf(terminator, i + 2);
+                if (nestedEnd >= 0) {
+                    i = nestedEnd + 1;
+                    continue;
+                }
+            }
             if (ch == ']') {
                 return i;
             }
@@ -1135,6 +1152,23 @@ public class RegexPreprocessor {
                 result.append(pattern, i, j + 2);
                 i = j + 2;
                 continue;
+            }
+
+            // POSIX/collating/equivalence-class tokens nested inside a
+            // regular character class are regex syntax, not literal class
+            // contents. Preserve the complete token before considering
+            // Unicode case-fold expansion of individual characters.
+            if (!escaped && inCharClass && ch == '[' && i + 1 < len
+                    && (pattern.charAt(i + 1) == ':'
+                        || pattern.charAt(i + 1) == '.'
+                        || pattern.charAt(i + 1) == '=')) {
+                char delimiter = pattern.charAt(i + 1);
+                int nestedEnd = pattern.indexOf(String.valueOf(delimiter) + ']', i + 2);
+                if (nestedEnd >= 0) {
+                    result.append(pattern, i, nestedEnd + 2);
+                    i = nestedEnd + 2;
+                    continue;
+                }
             }
 
             // Track if we're inside a character class [...]

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/PerlNonLocalReturnException.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/PerlNonLocalReturnException.java
@@ -21,10 +21,16 @@ public class PerlNonLocalReturnException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     public final RuntimeBase returnValue;
+    public final RuntimeCode targetCode;
 
     public PerlNonLocalReturnException(RuntimeBase returnValue) {
+        this(returnValue, null);
+    }
+
+    public PerlNonLocalReturnException(RuntimeBase returnValue, RuntimeCode targetCode) {
         // Suppress stack trace for performance - this is control flow, not an error
         super(null, null, true, false);
         this.returnValue = returnValue;
+        this.targetCode = targetCode;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeBase.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeBase.java
@@ -573,6 +573,15 @@ public abstract class RuntimeBase implements DynamicState, Iterable<RuntimeScala
     public abstract boolean getBoolean();
 
     /**
+     * Boolean conversion with lexical operator overloading disabled.
+     * Aggregate runtime values have no overload dispatch of their own, so the
+     * default implementation is identical to ordinary boolean conversion.
+     */
+    public boolean getBooleanNoOverload() {
+        return getBoolean();
+    }
+
+    /**
      * Retrieves the defined boolean value of the object.
      *
      * @return a boolean indicating whether the object is defined

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -398,6 +398,11 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         callContextStack().push(callContext);
     }
 
+    public static int currentRawCallContext() {
+        Integer context = getCallContextAtCallerFrame(0);
+        return context != null ? context : RuntimeContextType.SCALAR;
+    }
+
     /**
      * Pop @_ and hasargs flag from their respective stacks when exiting a subroutine.
      * Both stacks are pushed in the instance apply() methods and must be popped together.
@@ -510,6 +515,34 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         return null;
     }
 
+    /**
+     * Return the outermost raw context for one logical Perl call frame.
+     * Interpreter execution can add an adjacent compiler-wrapper frame with
+     * effective scalar context; parent-op consumers need the outer raw frame.
+     */
+    public static Integer getCallContextAtCallerFrame(int logicalFrame) {
+        if (logicalFrame < 0) return null;
+        java.util.List<RuntimeCode> codes = new java.util.ArrayList<>(activeCodeStack());
+        java.util.List<Integer> contexts = new java.util.ArrayList<>(callContextStack());
+        int size = Math.min(codes.size(), contexts.size());
+        int logicalIndex = 0;
+        for (int i = 0; i < size; ) {
+            RuntimeCode previous = codes.get(i);
+            Integer outermostContext = contexts.get(i);
+            int j = i + 1;
+            while (j < size) {
+                RuntimeCode next = codes.get(j);
+                if (next != previous && !isCompilerWrapperPair(next, previous)) break;
+                outermostContext = contexts.get(j);
+                previous = next;
+                j++;
+            }
+            if (logicalIndex++ == logicalFrame) return outermostContext;
+            i = j;
+        }
+        return null;
+    }
+
     private static RuntimeScalar callerWantarrayScalar(Integer callContext) {
         if (callContext == null) {
             return RuntimeScalarCache.scalarUndef;
@@ -517,7 +550,8 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         if (RuntimeContextType.isListLike(callContext)) {
             return RuntimeScalarCache.scalarTrue;
         }
-        if (callContext == RuntimeContextType.SCALAR || callContext == RuntimeContextType.LVALUE) {
+        if (callContext == RuntimeContextType.SCALAR || callContext == RuntimeContextType.LVALUE
+                || callContext == RuntimeContextType.OBJECT) {
             return RuntimeScalarCache.scalarFalse;
         }
         return RuntimeScalarCache.scalarUndef;
@@ -562,7 +596,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     public static int effectiveCallContext(int callContext) {
-        return callContext == RuntimeContextType.LVALUE
+        return callContext == RuntimeContextType.LVALUE || callContext == RuntimeContextType.OBJECT
                 ? RuntimeContextType.SCALAR
                 : callContext;
     }
@@ -3387,6 +3421,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             // forbidden lvalue method assignment into an ordinary scalar call.
             return code.apply(args, callContext);
         } catch (PerlNonLocalReturnException e) {
+            if (e.targetCode != null && e.targetCode != code) {
+                throw e;
+            }
             if (code.isMapGrepBlock) {
                 throw e;
             }
@@ -4163,6 +4200,29 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     }
 
     /**
+     * Return the outermost runtime frame implementing one logical Perl caller.
+     * Lvalue/interpreted subs can have an adjacent body + compiler-wrapper pair;
+     * non-local returns must cross both before they have left the Perl sub.
+     */
+    public static RuntimeCode getOutermostActiveCodeAtCallerFrame(int logicalFrame) {
+        if (logicalFrame < 0) return null;
+        RuntimeCode previous = null;
+        RuntimeCode candidate = null;
+        int logicalIndex = -1;
+        for (RuntimeCode active : activeCodeStack()) {
+            boolean sameFrame = previous != null
+                    && (active == previous || isCompilerWrapperPair(active, previous));
+            if (!sameFrame) {
+                logicalIndex++;
+                if (logicalIndex > logicalFrame) break;
+            }
+            if (logicalIndex == logicalFrame) candidate = active;
+            previous = active;
+        }
+        return candidate;
+    }
+
+    /**
      * Resolve a PadWalker caller level from inside its Perl wrapper.
      * Java builtins and map/grep block CVs are runtime implementation frames,
      * not Perl subroutine levels, and therefore must not shift LEVEL.
@@ -4505,7 +4565,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             RuntimeArray argsForCall = curArgs;
             try {
                 // Cast the value to RuntimeCode and call apply()
-                RuntimeList result = code.apply(argsForCall, effectiveContext);
+                RuntimeList result = code.apply(argsForCall, callContext);
                 // Handle tail calls (goto &func).
                 // JVM-generated bytecode has its own trampoline; this handles calls from Java code.
                 if (result instanceof RuntimeControlFlowList cfList
@@ -4539,6 +4599,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     return coerceScalarCallResult(result, effectiveContext, callContext, !isLvalueCode(code));
                 }
             } catch (PerlNonLocalReturnException e) {
+                if (e.targetCode != null && e.targetCode != code) {
+                    throw e;
+                }
                 // Non-local return from map/grep block
                 if (code.isMapGrepBlock) {
                     throw e;  // Propagate through nested map/grep blocks
@@ -4841,7 +4904,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 MortalList.pushMark();
                 try {
                     // Cast the value to RuntimeCode and call apply()
-                    RuntimeList result = code.apply(subroutineName, a, effectiveContext);
+                    RuntimeList result = code.apply(subroutineName, a, callContext);
                     // Flush deferred DESTROY decrements for void-context calls.
                     // See the 3-arg apply() overload for detailed rationale.
                     if (effectiveContext == RuntimeContextType.VOID) {
@@ -4850,6 +4913,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     }
                     return result;
                 } catch (PerlNonLocalReturnException e) {
+                    if (e.targetCode != null && e.targetCode != code) {
+                        throw e;
+                    }
                     // Non-local return from map/grep block
                     if (code.isMapGrepBlock) {
                         throw e;  // Propagate through nested map/grep blocks
@@ -5099,7 +5165,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 MortalList.pushMark();
                 try {
                     // Cast the value to RuntimeCode and call apply()
-                    RuntimeList result = code.apply(subroutineName, a, effectiveContext);
+                    RuntimeList result = code.apply(subroutineName, a, callContext);
                     // Flush deferred DESTROY decrements for void-context calls.
                     // See the 3-arg apply() overload for detailed rationale.
                     if (effectiveContext == RuntimeContextType.VOID) {
@@ -5108,6 +5174,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                     }
                     return result;
                 } catch (PerlNonLocalReturnException e) {
+                    if (e.targetCode != null && e.targetCode != code) {
+                        throw e;
+                    }
                     // Non-local return from map/grep block
                     if (code.isMapGrepBlock) {
                         throw e;  // Propagate through nested map/grep blocks

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeContextType.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeContextType.java
@@ -57,6 +57,16 @@ public class RuntimeContextType {
      */
     public static final int LVALUE_LIST = 5;
 
+    /**
+     * Scalar context where the returned value is immediately used as a method
+     * invocant. Wanted distinguishes this parent-op context as OBJECT while
+     * ordinary Perl wantarray semantics remain scalar.
+     */
+    public static final int OBJECT = 6;
+
+    /** Preserve the enclosing Perl subroutine's raw parent-op context. */
+    public static final int INHERITED = 7;
+
     public static boolean isListLike(int context) {
         return context == LIST || context == LVALUE_LIST;
     }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -1163,6 +1163,28 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         return getBooleanLarge();
     }
 
+    /** Perl truth without invoking a blessed value's bool/0+/"" overload. */
+    @Override
+    public boolean getBooleanNoOverload() {
+        return switch (type) {
+            case INTEGER -> ((Number) value).longValue() != 0;
+            case DOUBLE -> (double) value != 0.0;
+            case STRING, BYTE_STRING -> {
+                String s = (String) value;
+                yield !s.isEmpty() && !s.equals("0");
+            }
+            case UNDEF -> false;
+            case BOOLEAN -> (boolean) value;
+            case JAVAOBJECT -> value != null;
+            case TIED_SCALAR -> this.tiedFetch().getBooleanNoOverload();
+            case READONLY_SCALAR -> ((RuntimeScalar) value).getBooleanNoOverload();
+            case DUALVAR -> ((DualVar) value).stringValue().getBooleanNoOverload();
+            case CODE -> value != null && (((RuntimeCode) value).packageName != null
+                    || ((RuntimeCode) value).subName != null || ((RuntimeCode) value).defined());
+            default -> true;
+        };
+    }
+
     // Slow path for getBoolean()
     private boolean getBooleanLarge() {
         // Cases 0-8 are listed in order from RuntimeScalarType, and compile to fast tableswitch

--- a/src/main/perl/lib/Class/XSAccessor.pm
+++ b/src/main/perl/lib/Class/XSAccessor.pm
@@ -130,7 +130,11 @@ sub _check_hash_invocant {
 
 sub _install {
     my ($name, $code) = @_;
-    $code = Sub::Util::set_subname($name, $code);
+    # set_subname is metadata only.  During isolated CPAN compile tests the
+    # Java Sub::Util registration can be temporarily unavailable even though
+    # the pure-Perl accessor itself is fully usable.
+    $code = Sub::Util::set_subname($name, $code)
+        if defined &Sub::Util::set_subname;
     $_is_emulated_xsub{refaddr($code)} = 1;
     no strict 'refs';
     no warnings 'redefine';

--- a/src/main/perl/lib/DBD/SQLite.pm
+++ b/src/main/perl/lib/DBD/SQLite.pm
@@ -4,6 +4,12 @@ use warnings;
 
 our $VERSION = '1.74';
 
+# Match the public compatibility variable provided by CPAN's DBD::SQLite.
+# Consumers such as Locale::Unicode::Data inspect this before opening a
+# connection to reject SQLite engines that are too old.  Xerial sqlite-jdbc
+# 3.53.2.1 embeds SQLite 3.53.2.
+our $sqlite_version = '3.53.2';
+
 # Inherit the driver factory + handle classes from DBD::JDBC. We only
 # need to implement DSN translation. Real DBI discovers DBD::SQLite via
 # install_driver, calls SQLite->driver (inherited), gets a drh, then

--- a/src/main/perl/lib/DBD/SQLite/Constants.pm
+++ b/src/main/perl/lib/DBD/SQLite/Constants.pm
@@ -1,0 +1,16 @@
+package DBD::SQLite::Constants;
+
+use strict;
+use warnings;
+use Exporter 'import';
+
+our $VERSION = '1.74';
+our @EXPORT_OK = qw(
+    SQLITE_OPEN_READONLY
+    DBD_SQLITE_STRING_MODE_UNICODE_FALLBACK
+);
+
+sub SQLITE_OPEN_READONLY () { 1 }
+sub DBD_SQLITE_STRING_MODE_UNICODE_FALLBACK () { 5 }
+
+1;

--- a/src/main/perl/lib/Fcntl.pm
+++ b/src/main/perl/lib/Fcntl.pm
@@ -12,6 +12,7 @@ our @ISA = qw(Exporter);
 use constant O_RDONLY   => 0;      # Open for reading only
 use constant O_WRONLY   => 1;      # Open for writing only
 use constant O_RDWR     => 2;      # Open for reading and writing
+use constant O_ACCMODE  => 3;      # Mask for the file access mode
 
 # File creation flags
 use constant O_CREAT    => 0100;   # Create file if it doesn't exist

--- a/src/main/perl/lib/POSIX.pm
+++ b/src/main/perl/lib/POSIX.pm
@@ -60,6 +60,42 @@ sub strtod {
     return (0 + $1, $2);
 }
 
+# C99 floating-point helpers exposed by current core POSIX releases.
+sub cbrt {
+    my ($number) = @_;
+    return $number < 0 ? -((-$number) ** (1 / 3)) : $number ** (1 / 3);
+}
+
+sub isnan {
+    my ($number) = @_;
+    return defined($number) && $number != $number ? 1 : 0;
+}
+
+sub isinf {
+    my ($number) = @_;
+    return 0 unless defined $number;
+    return ($number == HUGE_VAL || $number == -HUGE_VAL) ? 1 : 0;
+}
+
+sub isfinite {
+    my ($number) = @_;
+    return defined($number) && $number == $number && !isinf($number) ? 1 : 0;
+}
+
+sub isnormal {
+    my ($number) = @_;
+    return 0 unless isfinite($number) && $number != 0;
+    return abs($number) >= 2.2250738585072014e-308 ? 1 : 0;
+}
+
+sub signbit {
+    my ($number) = @_;
+    return 0 unless defined $number;
+    return 1 if $number < 0;
+    return 0 if $number > 0;
+    return sprintf('%g', $number) =~ /^-/ ? 1 : 0;
+}
+
 # Export tags for different groups of functions/constants
 # Native Perl's POSIX exports its commonly used constants and math helpers by
 # default.  Only export names that are actually implemented in this module.
@@ -91,7 +127,8 @@ our @EXPORT_OK = qw(
     getgrent setgrent endgrent
 
     # Math functions
-    abs acos asin atan atan2 ceil cos cosh exp fabs floor fmod frexp
+    abs acos asin atan atan2 cbrt ceil cos cosh exp fabs floor fmod frexp
+    isfinite isinf isnan isnormal signbit
     ldexp log log10 log2 modf pow sin sinh sqrt tan tanh strtod
     HUGE_VAL
 

--- a/src/main/perl/lib/Sub/Util.pm
+++ b/src/main/perl/lib/Sub/Util.pm
@@ -6,4 +6,15 @@ our $VERSION = '1.70';
 use XSLoader;
 XSLoader::load('Sub::Util', $VERSION);
 
+# Some CPAN build/test environments load this compatibility file directly
+# while the Java module registry is not yet visible.  Keep the small naming
+# API usable for pure-Perl consumers such as Class::XSAccessor; the runtime
+# still supplies the complete implementation whenever it is registered.
+sub set_subname {
+    die 'set_subname requires a name and CODE reference'
+        unless @_ == 2 && ref($_[1]) eq 'CODE';
+    return $_[1];
+}
+sub subname { return undef }
+
 1;

--- a/src/main/perl/lib/Wanted.pm
+++ b/src/main/perl/lib/Wanted.pm
@@ -1,0 +1,20 @@
+package Wanted;
+
+use strict;
+use warnings;
+use Exporter 'import';
+
+our $VERSION = '0.1.2';
+our @EXPORT = qw(want);
+
+# Wanted's XS implementation inspects the caller's requested return type.
+# PerlOnJava already propagates scalar/list/void context through the call
+# frame, but the CPAN module is often loaded before its XS registration is
+# available.  The callers supported by the pure-Perl compatibility layer use
+# OBJECT only as an optional null-object branch; scalar context is the safe
+# default for that branch.
+sub want {
+    return 0;
+}
+
+1;

--- a/src/main/perl/lib/Wanted.pm
+++ b/src/main/perl/lib/Wanted.pm
@@ -2,19 +2,85 @@ package Wanted;
 
 use strict;
 use warnings;
+use Config ();
 use Exporter 'import';
 
 our $VERSION = '0.1.2';
-our @EXPORT = qw(want);
+our @EXPORT = qw(want rreturn lnoreturn);
+our @EXPORT_OK = qw(context howmany wantref);
 
-# Wanted's XS implementation inspects the caller's requested return type.
-# PerlOnJava already propagates scalar/list/void context through the call
-# frame, but the CPAN module is often loaded before its XS registration is
-# available.  The callers supported by the pure-Perl compatibility layer use
-# OBJECT only as an optional null-object branch; scalar context is the safe
-# default for that branch.
+# Wanted's XS implementation also inspects the parent op tree for reference,
+# assignment, boolean, and lvalue contexts.  Perl's caller() interface exposes
+# scalar/list/void context, which covers the portable subset without XS.
+sub _caller_gimme {
+    my ($level) = @_;
+    my @frame = caller($level + 1);
+    return @frame ? $frame[5] : undef;
+}
+
+sub context {
+    my $gimme = _caller_gimme(1);
+    return 'VOID' unless defined $gimme;
+    return $gimme ? 'LIST' : 'SCALAR';
+}
+
+sub wantref {
+    return '';
+}
+
+sub howmany {
+    my $gimme = _caller_gimme(1);
+    return 0 unless defined $gimme;
+    return undef if $gimme;
+    return 1;
+}
+
 sub want {
-    return 0;
+    my @wanted = map { split } @_;
+    my $gimme = _caller_gimme(1);
+
+    for my $wanted (@wanted) {
+        my $negative = $wanted =~ s/^!//;
+        my $matches;
+
+        if ($wanted eq 'VOID') {
+            $matches = !defined $gimme;
+        } elsif ($wanted eq 'LIST') {
+            $matches = defined($gimme) && $gimme;
+        } elsif ($wanted eq 'SCALAR') {
+            $matches = defined($gimme) && !$gimme;
+        } elsif ($wanted eq 'RVALUE') {
+            $matches = 1;
+        } elsif ($wanted eq 'COUNT') {
+            return howmany();
+        } elsif ($wanted =~ /^\d+$/) {
+            my $count = defined($gimme) ? ($gimme ? undef : 1) : 0;
+            $matches = !defined($count) || $count >= $wanted;
+        } elsif (lc($wanted) eq 'infinity') {
+            $matches = defined($gimme) && $gimme;
+        } else {
+            # Parent-op-only contexts (ASSIGN, LVALUE, BOOL and reference
+            # types) cannot be inferred through caller().
+            $matches = 0;
+        }
+
+        return 0 if $negative ? $matches : !$matches;
+    }
+    return 1;
+}
+
+sub rreturn(@) {
+    return wantarray ? @_ : $_[-1];
+}
+
+our $LNORETURN_VALUE;
+sub lnoreturn() :lvalue {
+    $LNORETURN_VALUE = undef;
+}
+
+if ($Config::Config{archname} =~ /^java-/) {
+    require XSLoader;
+    XSLoader::load('Wanted', $VERSION);
 }
 
 1;

--- a/src/main/perl/lib/overloading.pm
+++ b/src/main/perl/lib/overloading.pm
@@ -27,6 +27,7 @@ sub import ($, @ops) {
 	delete $^H{overloading};
 	$^H &= ~$HINT_NO_AMAGIC;
     }
+
 }
 
 sub unimport ($, @ops) {

--- a/src/test/resources/unit/boolean_bitwise_xor.t
+++ b/src/test/resources/unit/boolean_bitwise_xor.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+my $true = !!1;
+my $false = !!0;
+
+is($true ^ $true, 0, 'boolean XOR true/true');
+is($false ^ $true, 1, 'boolean XOR false/true');
+is($true ^ $false, 1, 'boolean XOR true/false');
+is($false ^ $false, 0, 'boolean XOR false/false');

--- a/src/test/resources/unit/coderef_survives_stash_delete.t
+++ b/src/test/resources/unit/coderef_survives_stash_delete.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+sub named_sub { 'original' }
+
+my $saved = \&named_sub;
+undef *named_sub;
+
+ok(!defined(&named_sub), 'named stash entry was removed');
+is($saved->(), 'original', 'saved coderef retains the compiled CV');

--- a/src/test/resources/unit/core_qualified_control_flow.t
+++ b/src/test/resources/unit/core_qualified_control_flow.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+use Test::More;
+
+my @seen;
+CORE::for (my $i = 0; $i < 3; $i++) {
+    push @seen, $i;
+}
+is_deeply(\@seen, [0, 1, 2], 'CORE::for parses as a three-part loop');
+
+my $count = 0;
+CORE::while ($count < 2) {
+    $count++;
+}
+is($count, 2, 'CORE::while parses as a loop');
+
+CORE::if ($count == 2) {
+    pass('CORE::if parses as a conditional');
+}
+
+done_testing;

--- a/src/test/resources/unit/core_qualified_infix.t
+++ b/src/test/resources/unit/core_qualified_infix.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+my $dot = '.';
+ok($dot CORE::eq '.', 'CORE-qualified string equality');
+ok($dot CORE::ne '..', 'CORE-qualified string inequality');
+ok(2 CORE::lt 3, 'CORE-qualified relational comparison');
+ok((2 CORE::cmp 10) gt 0, 'CORE-qualified cmp keeps string semantics');

--- a/src/test/resources/unit/dbd_sqlite_version.t
+++ b/src/test/resources/unit/dbd_sqlite_version.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More;
+
+BEGIN {
+    eval { require DBI; require DBD::SQLite; require DBD::SQLite::Constants; 1 }
+        or plan skip_all => 'DBI and DBD::SQLite required';
+}
+
+ok(defined $DBD::SQLite::sqlite_version,
+    'DBD::SQLite exposes the embedded SQLite version');
+like($DBD::SQLite::sqlite_version, qr/^\d+\.\d+\.\d+$/,
+    'embedded SQLite version has the expected format');
+
+my $dbh = DBI->connect('dbi:SQLite:dbname=:memory:', '', '', {
+    RaiseError => 1,
+});
+my ($runtime_version) = $dbh->selectrow_array('select sqlite_version()');
+is($DBD::SQLite::sqlite_version, $runtime_version,
+    'reported SQLite version matches the running engine');
+is(DBD::SQLite::Constants::SQLITE_OPEN_READONLY(), 1,
+    'read-only open flag matches DBD::SQLite');
+is(DBD::SQLite::Constants::DBD_SQLITE_STRING_MODE_UNICODE_FALLBACK(), 5,
+    'Unicode fallback mode matches DBD::SQLite');
+
+done_testing;

--- a/src/test/resources/unit/fcntl_accmode.t
+++ b/src/test/resources/unit/fcntl_accmode.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+use Fcntl qw(O_ACCMODE O_RDONLY O_WRONLY O_RDWR);
+
+is(O_ACCMODE, 3, 'O_ACCMODE is the POSIX access-mode mask');
+is(O_RDONLY & O_ACCMODE, O_RDONLY, 'O_ACCMODE extracts read-only mode');
+is(O_WRONLY & O_ACCMODE, O_WRONLY, 'O_ACCMODE extracts write-only mode');
+is(O_RDWR & O_ACCMODE, O_RDWR, 'O_ACCMODE extracts read-write mode');

--- a/src/test/resources/unit/module_generic_xs.t
+++ b/src/test/resources/unit/module_generic_xs.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Test::More;
+use Scalar::Util ();
+
+BEGIN {
+    eval { require Module::Generic; 1 }
+        or plan skip_all => 'Module::Generic required';
+}
+
+my $object = bless {}, 'Module::Generic';
+my $array = [];
+my $hash = {};
+my $code = sub { 1 };
+my $scalar = 1;
+
+is_deeply($object->_get_args_as_array(1, 2), [1, 2], 'wraps arguments in an array');
+ok($object->_is_array($array), 'recognizes array references');
+ok($object->_is_hash($hash), 'recognizes hash references');
+ok($object->_is_code($code), 'recognizes code references');
+ok($object->_is_scalar(\$scalar), 'recognizes scalar references');
+ok($object->_is_integer('-42'), 'recognizes integer strings');
+ok(!$object->_is_integer('4.2'), 'rejects non-integer strings');
+ok($object->_is_number(42), 'recognizes numeric scalars');
+ok(!$object->_is_number('42'), 'does not treat numeric strings as numeric scalars');
+ok($object->_is_object($object), 'recognizes blessed references');
+ok(!$object->_is_class_loaded_xs('No::Such::Class'), 'rejects an unloaded class');
+ok($object->_is_class_loaded_xs('Module::Generic'), 'recognizes a loaded class');
+is($object->_refaddr($array), Scalar::Util::refaddr($array), 'returns the referent address');
+
+done_testing;

--- a/src/test/resources/unit/overload/no_overloading_bool.t
+++ b/src/test/resources/unit/overload/no_overloading_bool.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+use Test::More tests => 13;
+
+{
+    package FalseObject;
+    our $BOOL_CALLS = 0;
+    use overload
+        bool => sub { $BOOL_CALLS++; 0 },
+        '0+' => sub { 0 },
+        '""' => sub { '0' },
+        fallback => 1;
+
+    sub new { bless {}, shift }
+}
+
+my $object = FalseObject->new;
+ok(!$object, 'bool overload is active normally');
+is($FalseObject::BOOL_CALLS, 1, 'normal logical not invokes bool overload');
+
+{
+    no overloading;
+    is(!$object, '', 'logical not ignores bool overload');
+    is($FalseObject::BOOL_CALLS, 1, 'disabled logical not does not invoke overload');
+    ok($object ? 1 : 0, 'conditional truth ignores bool overload');
+    is($object ? 'yes' : 'no', 'yes', 'ternary condition ignores bool overload');
+    is($object && 'rhs', 'rhs', 'logical and uses raw reference truth');
+    is($object || 'rhs', $object, 'logical or uses raw reference truth');
+    my $assigned = $object;
+    $assigned ||= 'rhs';
+    is($assigned, $object, 'logical assignment uses raw reference truth');
+    is($FalseObject::BOOL_CALLS, 1, 'disabled conditions do not invoke overload');
+
+    {
+        use overloading;
+        ok(!$object, 'use overloading restores dispatch in nested scope');
+    }
+
+    is(!$object, '', 'no overloading remains active after nested scope');
+}
+
+ok(!$object, 'overloading is restored outside lexical scope');

--- a/src/test/resources/unit/posix_c99_math.t
+++ b/src/test/resources/unit/posix_c99_math.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use Test::More;
+use POSIX qw(cbrt isfinite isinf isnan isnormal signbit HUGE_VAL);
+
+cmp_ok(abs(cbrt(-8) + 2), '<', 1e-12, 'cbrt handles negative numbers');
+ok(isfinite(42), 'finite number is finite');
+ok(!isfinite(HUGE_VAL), 'infinity is not finite');
+ok(isinf(HUGE_VAL), 'detects infinity');
+ok(isnan(HUGE_VAL - HUGE_VAL), 'detects NaN');
+ok(isnormal(1), 'detects a normal number');
+ok(!isnormal(0), 'zero is not normal');
+ok(signbit(-1), 'detects a negative sign bit');
+ok(!signbit(1), 'positive number has no sign bit');
+
+done_testing;

--- a/src/test/resources/unit/qualified_optional_constant.t
+++ b/src/test/resources/unit/qualified_optional_constant.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+
+my $has_optional = 0;
+my $value = $has_optional
+    ? Optional::Constants::OPTIONAL_VALUE
+    : 'fallback';
+
+is($value, 'fallback', 'guarded optional fully-qualified constant parses');

--- a/src/test/resources/unit/regex_posix_class_casefold.t
+++ b/src/test/resources/unit/regex_posix_class_casefold.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+my $blank = qr/[[:blank:]\h]/i;
+
+ok(' ' =~ $blank, 'case-insensitive POSIX blank class matches space');
+ok("\t" =~ $blank, 'case-insensitive POSIX blank class matches tab');
+ok('k' !~ $blank, 'POSIX class name is not treated as class contents');
+ok("\x{212a}" !~ $blank, 'Kelvin fold is not injected into POSIX class syntax');

--- a/src/test/resources/unit/wanted_portable_context.t
+++ b/src/test/resources/unit/wanted_portable_context.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Test::More;
+
+BEGIN {
+    eval { require Wanted; Wanted->import(qw(want rreturn)); 1 }
+        or plan skip_all => 'Wanted required';
+}
+
+sub detected_context {
+    return Wanted::context();
+}
+
+sub returned_value {
+    rreturn('first', 'last');
+}
+
+sub double_returned_value {
+    rreturn('returned from caller');
+    die 'rreturn continued in its caller';
+}
+
+is(scalar(detected_context()), 'SCALAR', 'detects scalar context');
+my @contexts = detected_context();
+is_deeply(\@contexts, ['LIST'], 'detects list context');
+is(scalar(returned_value()), 'last', 'rreturn preserves scalar result');
+my @values = returned_value();
+is_deeply(\@values, ['first', 'last'], 'rreturn preserves list result');
+is(double_returned_value(), 'returned from caller', 'rreturn returns from its caller');
+
+done_testing;


### PR DESCRIPTION
## Summary

- Preserve overloaded blessed objects through `.=` compound assignment.
- Treat boolean values as numeric operands for `^`.
- Allow guarded fully-qualified optional constants under `strict subs`.
- Harden `Sub::Util`/`Class::XSAccessor` CPAN isolation and add the reusable `Wanted` compatibility layer.
- Add focused unit regressions and target progress documentation.

## Validation

- `make` — PASS
- `jcpan -t BioX::Seq` — PASS (7 files / 127 tests)
- `jcpan -t Math::Aronson` — PASS (4 files / 55 tests)
- `jcpan -t Template::Plugin::Markdown` — PASS (2 files / 3 tests)
- `Changes` reaches the locale data stack but needs the DBD::SQLite/SQLite path to complete.
- `Catmandu::Importer::Parltrack` still captures an unavailable `Sub::Util::set_subname` callback inside Eval::TypeTiny in the isolated CPAN worker.
- `Nephia::Plugin::FormValidator::Lite` remains unsupported because its Nephia/Plack dependencies are absent from the local system Perl.

Generated with [Codex](https://openai.com/codex)
