### PR TITLE
fix(regex): isolate callback pseudo-block scope

### DIFF
--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -250,7 +250,18 @@ they remain visible to later callbacks on the active path, unwind on
 backtracking, and restore after success, failure, or exception. Regex callbacks
 also behave as pseudo-blocks for `caller`, `__SUB__`, and escaping
 `last`/`next`/`goto` on both execution backends. Named unary `scalar` now keeps a
-following match in scalar context, including callback-bearing matches.
+following match in scalar context, including callback-bearing matches. Recursive
+callback re-entry is bounded independently of the configured JVM stack.
+
+The 2026-08-16 Stage 36.4 validation slice compared all 80 `perl5_t/t/re/`
+files with `../PerlOnJava/logs/test_20260815_080000_958.log`. The result is
+50,959/94,829 versus 50,273/94,771: 686 additional passing assertions, 58
+additional planned assertions, and no per-file pass-count regression. The
+resource-sensitive `pat.t`, `pat_thr.t`, `pat_advanced.t`, and
+`pat_advanced_thr.t` files ran serially because they share temporary files;
+`pat_psycho*` and `speed*` ran concurrently as isolated runner processes. This
+gate also found and fixed stale cache eviction for deferred user-defined Unicode
+properties, restoring `regexp_unicode_prop.t` to its 1,031/1,110 baseline.
 
 ### Completed stages
 
@@ -262,6 +273,15 @@ following match in scalar context, including callback-bearing matches.
 - [ ] Stage 36.5: Dynamic patterns and recursive execution
 - [ ] Stage 36.6: Remaining declarative parity
 - [ ] Stage 36.7: Integration and release
+
+### Completed slices
+
+- [x] Callback pseudo-block scope and diagnostics (2026-08-16)
+  - Preserved matcher-owned dynamic locals and callback source locations on the
+    JVM and interpreter backends.
+  - Bounded recursive callback re-entry independently of the Java stack size.
+  - Restored deferred Unicode-property cache eviction and recorded a
+    no-regression 80-file differential gate against PR 958.
 
 ### Next steps
 
@@ -289,6 +309,8 @@ following match in scalar context, including callback-bearing matches.
   behavior is established with differential tests.
 - Dynamic `(??{ EXPR })` execution is integrated, but its full Stage 36.5 CPAN
   and unchanged-core exit matrix is not yet recorded.
+- Pure-pattern deep recursion still needs an engine-owned limit; callback
+  re-entry is now bounded without relying on the Java stack.
 - Partial direct core tests still contain diagnostic, parser, Unicode, and
   regex-object gaps; their wrappers must not be mistaken for thread failures.
 

--- a/docs/design/joni-callout-fork.md
+++ b/docs/design/joni-callout-fork.md
@@ -152,7 +152,18 @@ At execution, the bridge publishes provisional numbered captures and offsets,
 runs the closure in scalar context, and updates `$^R` for plain callbacks only.
 Each token checkpoints regex state, `$^R`, and the dynamic-local stack. Backtrack
 unwind restores all three; successful completion restores dynamic scope while
-retaining the last successful plain callback result.
+retaining the last successful plain callback result. Dynamic locals created by
+one callback remain active along the matcher's forward path, including later
+callbacks, until that path is unwound or the match completes. The ordinary
+closure epilogue therefore does not tear down a callback's local frame; the
+matcher token owns it.
+
+Callback closures are Perl pseudo blocks, not ordinary subroutine or loop
+boundaries. An unhandled `last`, `next`, `redo`, or `goto` cannot target a loop
+or label outside the callback. The bridge converts escaped control flow to the
+corresponding pseudo-block diagnostic before it can reach surrounding Perl
+frames. Recursive callback re-entry has an engine-owned depth ceiling independent
+of the JVM's configured native stack size.
 
 Every structured executable callback template selects Joni, including a
 callback whose body happens to return a constant: `(?{ 1 })` still has match-time

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -388,7 +388,7 @@ my @copy = @{$z};         # ERROR
 ### Missing Regular Expression Features
 
 - ❌  **Dynamically-scoped regex variables**: Regex variables are not dynamically-scoped.
-- 🟡  **Recursive and Dynamic Patterns**: `(?R)`, `(?0)`, and runtime `(??{ code })` execute through Joni. Dynamic expressions may return strings or `qr//` values, and nested alternatives participate in outer backtracking without changing outer grouping or capture numbering. Deep dynamic recursion still needs an engine-owned depth limit that does not depend on the Java call stack.
+- 🟡  **Recursive and Dynamic Patterns**: `(?R)`, `(?0)`, and runtime `(??{ code })` execute through Joni. Dynamic expressions may return strings or `qr//` values, and nested alternatives participate in outer backtracking without changing outer grouping or capture numbering. Callback re-entry has an engine-owned depth ceiling; deep pure-pattern recursion still needs a limit that does not depend on the Java call stack.
 - 🟡  **Backtracking Control Verbs**: `(*ACCEPT)` executes through Joni with top-level, subpattern-call, positive-lookahead, and dynamic-pattern boundary semantics. `(*FAIL)`/`(*F)` and atomic groups `(?>...)` are supported. `(*PRUNE)`, `(*SKIP)`, `(*THEN)`, and `(*COMMIT)` are not supported.
 - ✅  **Regex Definitions**: `(?(DEFINE)...)` containers and numbered or named calls to their subpatterns execute through Joni.
 - ❌  **Lookbehind Assertions**: Variable-length negative or positive lookbehind assertions, e.g., `(?<=...)` or `(?<!...)`, are not supported.
@@ -397,7 +397,7 @@ my @copy = @{$z};         # ERROR
 - 🟡  **Conditional Expressions**: Executable callback conditions `(?(?{ code })yes|no)` and optimistic predicates `(?(*{ code })yes|no)` execute through Joni; other condition forms are not yet complete.
 - ❌  **Extended Unicode Regex Features**: Some extended Unicode regex functionalities are not supported.
 - ❌  **Extended Grapheme Clusters**: Matching with `\X` for extended grapheme clusters is not supported.
-- ✅  **Embedded Code in Regex**: `(?{ code })`, optimistic callbacks `(*{ code })`, executable callback conditions, and `(??{ code })` run as lexical closures in Joni with provisional captures and backtracking unwind. `$^N` follows capture-close order independently of `$+`.
+- ✅  **Embedded Code in Regex**: `(?{ code })`, optimistic callbacks `(*{ code })`, executable callback conditions, and `(??{ code })` run as lexical closures in Joni with provisional captures and backtracking unwind. Callback `local` frames follow matcher paths, and escaped loop control or `goto` stops at the callback pseudo-block boundary. `$^N` follows capture-close order independently of `$+`.
 - ✅  **Regex Debugging**: Lexically scoped `use/no re 'debug'` and `debugcolor` are supported, including runtime snapshot ownership.
 - 🟡  **Runtime Regex Evaluation**: `use re 'eval'` controls whether interpolated patterns containing eval groups may compile, but runtime strings cannot manufacture trusted callback closures.
 - ❌  **Regex Compilation Flags**: Setting default regex flags with `use re '/flags';` is not supported.

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -5908,6 +5908,11 @@ public class BytecodeCompiler implements Visitor {
         subCode.attributes = node.attributes;
         subCode.packageName = getCurrentPackage();
         subCode.isTryExpressionWrapper = node.getBooleanAnnotation("tryExpressionWrapper");
+        Object callbackSourceLine = node.getAnnotation("regexCallbackSourceLine");
+        if (callbackSourceLine instanceof Number number) {
+            subCode.cvStartLine = number.intValue();
+            subCode.cvStartFile = sourceName;
+        }
 
         // Copy the isMapGrepBlock flag to the runtime code object so that
         // ListOperators.map/grep and RuntimeCode.apply() can detect non-local returns

--- a/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
@@ -296,6 +296,10 @@ public class EmitSubroutine {
             } else if (ctx.compilerOptions != null && ctx.compilerOptions.fileName != null) {
                 cvStartFile = ctx.compilerOptions.fileName;
             }
+            Object callbackSourceLine = node.getAnnotation("regexCallbackSourceLine");
+            if (callbackSourceLine instanceof Number number) {
+                cvStartLine = number.intValue();
+            }
             int deparseSourceOffset = -1;
             int deparseSourceEnd = -1;
             if (ctx.errorUtil != null) {

--- a/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
@@ -846,6 +846,7 @@ public abstract class StringSegmentParser {
     private void parseRegexCallbackCondition() {
         flushCurrentSegment();
         int start = tokenIndex;
+        int sourceLine = regexCallbackSourceLine();
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, "?");
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, "(");
         LexerToken callbackType = TokenUtils.consume(parser);
@@ -857,7 +858,7 @@ public abstract class StringSegmentParser {
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, "}");
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, ")");
         segments.add(new StringNode("(?(", start));
-        segments.add(regexCallback(block, "CONDITION", start));
+        segments.add(regexCallback(block, "CONDITION", start, sourceLine));
     }
 
     private boolean isRegexOptimisticBlock() {
@@ -870,12 +871,13 @@ public abstract class StringSegmentParser {
     private void parseRegexOptimisticBlock() {
         flushCurrentSegment();
         int start = tokenIndex;
+        int sourceLine = regexCallbackSourceLine();
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, "*");
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, "{");
         Node block = parseBlock(parser);
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, "}");
         TokenUtils.consume(parser, LexerTokenType.OPERATOR, ")");
-        segments.add(regexCallback(block, "BLOCK", start));
+        segments.add(regexCallback(block, "BLOCK", start, sourceLine));
     }
 
     /**
@@ -923,6 +925,7 @@ public abstract class StringSegmentParser {
         flushCurrentSegment();
 
         int savedTokenIndex = tokenIndex;
+        int sourceLine = regexCallbackSourceLine();
 
         // Consume the "?" token(s)
         TokenUtils.consume(parser); // consume first "?"
@@ -951,19 +954,20 @@ public abstract class StringSegmentParser {
             }
             RuntimeScalar constant = ConstantFoldingVisitor.getConstantValue(folded);
             if (constant == null || !isSafeDynamicConstantFold(constant.toString())) {
-                segments.add(regexCallback(block, "DYNAMIC", savedTokenIndex));
+                segments.add(regexCallback(block, "DYNAMIC", savedTokenIndex, sourceLine));
             } else {
                 segments.add(new StringNode(constant.toString(), savedTokenIndex));
             }
         } else {
-            segments.add(regexCallback(block, "BLOCK", savedTokenIndex));
+            segments.add(regexCallback(block, "BLOCK", savedTokenIndex, sourceLine));
         }
     }
 
-    private Node regexCallback(Node block, String kind, int index) {
+    private Node regexCallback(Node block, String kind, int index, int sourceLine) {
         SubroutineNode closure = new SubroutineNode(null, null, null, block, false, index);
         closure.setAnnotation("inheritsSelfReference", true);
         closure.setAnnotation("regexCallbackPseudoBlock", true);
+        closure.setAnnotation("regexCallbackSourceLine", sourceLine);
         if (block instanceof AbstractNode abstractBlock) {
             // (?{ ... }) is a regex pseudo-block, not an ordinary anonymous-sub
             // scope. Its top-level local() frames belong to the matcher path and
@@ -974,6 +978,19 @@ public abstract class StringSegmentParser {
         callback.setAnnotation("regexCallbackKind", kind);
         hasExecutableRegexCallbacks = true;
         return callback;
+    }
+
+    private int regexCallbackSourceLine() {
+        int line = parser.baseLineNumber;
+        if (line <= 0) {
+            line = ctx.errorUtil.getLineNumberAccurate(originalTokenOffset);
+        }
+        for (int i = 0; i < parser.tokenIndex && i < parser.tokens.size(); i++) {
+            if (parser.tokens.get(i).type == LexerTokenType.NEWLINE) {
+                line++;
+            }
+        }
+        return line;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/operators/WaitpidOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/WaitpidOperator.java
@@ -160,7 +160,19 @@ public class WaitpidOperator {
         boolean nonBlocking = (flags & WNOHANG) != 0;
 
         if (pid <= 0) {
+            // Pipe-open children use RuntimeIO's cross-platform Java Process
+            // registry. Perl wait() reaches this method as waitpid(-1, 0), so
+            // consult that registry before reporting that no child exists.
+            RuntimeScalar javaChildResult = waitForAnyJavaProcess(flags);
+            if (javaChildResult != null) {
+                return javaChildResult;
+            }
             return new RuntimeScalar(-1);
+        }
+
+        Process javaProcess = RuntimeIO.getChildProcess(pid);
+        if (javaProcess != null) {
+            return waitpidJavaProcess(pid, javaProcess, flags);
         }
 
         Process childProcess = windowsChildProcesses().get((long) pid);

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -606,7 +606,7 @@ final class JoniRegexPattern {
                 // path observes local() values; unwind() still owns the token's
                 // pre-callback level and rolls the frame back on backtracking.
                 DynamicVariableManager.resumeSuspended(frame.states());
-                rejectEscapedControlFlow(frame.result());
+                rejectEscapedControlFlow(callback, frame.result());
                 RuntimeScalar result = frame.result().scalar();
                 boolean block = callback.kind == RuntimeRegexCallback.Kind.BLOCK;
                 if (block) rVariable.set(result);
@@ -676,15 +676,18 @@ final class JoniRegexPattern {
             }
         }
 
-        private static void rejectEscapedControlFlow(RuntimeList result) {
+        private static void rejectEscapedControlFlow(RuntimeRegexCallback callback,
+                                                     RuntimeList result) {
             if (!(result instanceof RuntimeControlFlowList flow)) return;
             ControlFlowMarker marker = flow.marker;
             if (marker.type == ControlFlowType.GOTO
                     || marker.type == ControlFlowType.TAILCALL) {
-                // The runtime location is the regex pseudo-block boundary (and
-                // can differ from the marker's inner goto location), so let the
-                // exception formatter attach it.
-                throw new PerlCompilerException("Can't \"goto\" out of a pseudo block");
+                String file = callback.code.cvStartFile != null
+                        ? callback.code.cvStartFile : marker.fileName;
+                int line = callback.code.cvStartLine > 0
+                        ? callback.code.cvStartLine : marker.lineNumber;
+                throw new PerlCompilerException("Can't \"goto\" out of a pseudo block at "
+                        + file + " line " + line + ".\n");
             }
             // Preserve the control op's own location. The terminating newline
             // tells PerlCompilerException this is already fully formatted.

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -749,7 +749,12 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         // Evict the old cached entry so compile() will actually recompile
         // instead of returning the stale regex with deferred placeholders.
         String cacheKey = regex.patternString + "/" + (regex.regexFlags == null ? "" : regex.regexFlags.toFlagString());
-        state().compiledRegexCache.remove(cacheKey + "#debug=" + regex.lexicalDebugMode);
+        // Deferred Unicode properties cannot contain executable callouts, so
+        // this is the same zero-callout key used by compile(). Keep the suffix
+        // in sync with compileSynchronized(): leaving the placeholder cached
+        // makes a later qr/\\p{Property}/ reuse its match-any stand-in.
+        state().compiledRegexCache.remove(cacheKey + "#debug=" + regex.lexicalDebugMode
+                + "#callouts=0");
 
         // User property subs can execute arbitrary Perl and block. Resolve them
         // before compile() takes its process-wide monitor; only simultaneous

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -955,6 +955,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
     // Depth threshold for the "Deep recursion on subroutine" warning.
     // Matches Perl's default PERL_SUB_DEPTH_WARN value.
     public static final int DEEP_RECURSION_WARN_DEPTH = 100;
+    private static final int REGEX_CALLBACK_RECURSION_LIMIT = 1024;
 
     // When the tail-call trampoline in the static apply() re-enters a sub,
     // we want to skip the "Deep recursion" tracking for that entry.
@@ -984,6 +985,14 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         ExecutionRuntimeState.CallDepthState callState =
                 executionState.callDepth(this);
         int depth = ++callState.depth;
+        if (isRegexCallbackPseudoBlock && depth > REGEX_CALLBACK_RECURSION_LIMIT) {
+            // Joni callback recursion consumes Java stack outside the matcher's
+            // own backtracking stack. Bound it independently of -Xss so a
+            // recursive callback cannot monopolize the process until the JVM
+            // eventually exhausts a large configured stack.
+            callState.depth--;
+            throw new StackOverflowError("Regex callback recursion limit exceeded");
+        }
         if (depth > DEEP_RECURSION_WARN_DEPTH && !callState.warned) {
             callState.warned = true;
             String name = (packageName != null && subName != null)

--- a/src/test/resources/unit/regex/callback_pseudo_scope.t
+++ b/src/test/resources/unit/regex/callback_pseudo_scope.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More tests => 9;
+
+our $value = 1;
+my @seen;
+ok('abc' =~ /a(?{ local $value = 2 })b(?{
+    push @seen, $value;
+    local $value = 3;
+})c(?{ push @seen, $value })/, 'callbacks match');
+is_deeply(\@seen, [2, 3], 'callback locals remain active during forward matching');
+is($value, 1, 'callback locals restore after match completion');
+
+my $last_result = eval q{ "a" =~ /(?{ last })a/; 1 };
+ok(!defined $last_result, 'last cannot escape a callback pseudo block');
+like($@, qr/Can't "last" outside a loop block/, 'last reports a loop-boundary error');
+
+my $next_result = eval q{ "a" =~ /(?{ next })a/; 1 };
+ok(!defined $next_result, 'next cannot escape a callback pseudo block');
+like($@, qr/Can't "next" outside a loop block/, 'next reports a loop-boundary error');
+
+my $goto_result = eval q{
+"a" =~ /(?{ goto FOO })a/;
+FOO: 1;
+};
+ok(!defined $goto_result, 'goto cannot escape a callback pseudo block');
+like($@, qr/Can't "goto" out of a pseudo block at \(eval \d+\) line 2/,
+    'goto reports the regex source line');

--- a/src/test/resources/unit/regex/deferred_unicode_property_cache.t
+++ b/src/test/resources/unit/regex/deferred_unicode_property_cache.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $deferred;
+BEGIN {
+    # The property sub is deliberately unavailable while this qr// compiles.
+    $deferred = qr/\p{InDeferredKana}/;
+}
+
+sub InDeferredKana {
+    return "3040\t309F\n30A0\t30FF\n";
+}
+
+ok("\x{3040}" =~ $deferred,
+   'deferred property resolves after its sub is defined');
+
+for my $case (
+    [ '\\p{InDeferredKana}', "\x{3040}", 1 ],
+    [ '\\P{InDeferredKana}', "\x{3040}", 0 ],
+    [ '\\P{InDeferredKana}', "\x{303F}", 1 ],
+    [ '\\p{InDeferredKana}', "\x{303F}", 0 ],
+) {
+    my ($source, $subject, $expected) = @$case;
+    my $pattern = eval "qr/$source/";
+    is($subject =~ $pattern ? 1 : 0, $expected,
+       "$source remains correct after deferred cache resolution");
+}
+
+done_testing();


### PR DESCRIPTION
## Summary

- preserve callback-created dynamic locals across the active matcher path and unwind them on backtracking or exit
- reject control flow escaping regex callback pseudo-blocks with exact callback source locations on both execution backends
- bound recursive callback re-entry independently of the configured JVM stack size
- fix deferred user-defined Unicode-property cache eviction after regex cache keys gained Joni callout counts
- make Windows `wait()` reap registered Java children, fixing the pre-existing `fork_open_wait.t` CI failure
- update the Phase 36 design and feature matrix with the completed validation slice

## Validation

- `make` — passed in 3m29s; no warnings
- standard Perl: `callback_pseudo_scope.t` 9/9 and `deferred_unicode_property_cache.t` 5/5
- PerlOnJava JVM and interpreter: both focused tests pass on both backends
- `reg_eval_scope.t` — 33/49, no timeout or incomplete file
- `regexp_unicode_prop.t` — restored to 1,031/1,110
- `fork_open_wait.t` — 3/3; Windows behavior is covered by the CI matrix
- full 80-file `perl5_t/t/re/` comparison against `../PerlOnJava/logs/test_20260815_080000_958.log`:
  - current: 50,959/94,829
  - baseline: 50,273/94,771
  - delta: +686 passing assertions, +58 planned assertions, no per-file regression
- resource-sensitive `pat*` files ran serially; independent `pat_psycho*` and `speed*` files ran concurrently
