### PR TITLE
Fix compiler and tooling for Ceph, Tie, DBIx, and Time modules

### DIFF
--- a/dev/design/cpan-tooling-ceph-tie-dbix-time.md
+++ b/dev/design/cpan-tooling-ceph-tie-dbix-time.md
@@ -1,0 +1,107 @@
+# CPAN tooling fixes for Ceph, Tie, DBIx, and Time modules
+
+## Goal
+
+Fix reusable PerlOnJava compiler, runtime, and CPAN tooling defects exposed by:
+
+- `Ceph::RadosGW::Admin`
+- `Kwiki::Edit::AdvisoryLock`
+- `Tie::Config`
+- `DBIx::Class::Sims::REST`
+- `Time::TAI::Now`
+
+`File::LckPwdF` and `Finance::FXCM::Simple` are baseline-only controls because
+their native distributions also fail under system Perl on this macOS host.
+
+## Baseline
+
+| Module | PerlOnJava | System Perl | Disposition |
+|---|---|---|---|
+| Ceph::RadosGW::Admin | nested `Test::Spec` context becomes `undef` | minimal nested spec passes | fix runtime ownership |
+| Kwiki::Edit::AdvisoryLock | passes | not needed | regression smoke only |
+| Tie::Config | iterator exception and missing persisted write | passes all 21 tests | fix hash iteration and tied cleanup |
+| File::LckPwdF | missing XS implementation | fails to load `_lckpwdf` on macOS | ignore |
+| DBIx::Class::Sims::REST | `map { { $_->get_columns } }` produces a scalar count instead of a hashref | focused expression produces a populated hashref | fix parser block/hash disambiguation |
+| Finance::FXCM::Simple | missing XS implementation | cannot compile without ForexConnect SDK | ignore |
+| Time::TAI::Now | `Time::UTC::Now` XS dependency cannot build | `Time::UTC::Now` compiles; 57/58 tests pass, with only `Time::Unix` absent | add Java XS replacement |
+
+## Design
+
+1. Preserve Perl reference identity and strong ownership when a reference is
+   stored inside a pure-Perl tied container implementation such as
+   `Tie::IxHash`. Weak back-references must remain defined while that storage
+   path remains reachable.
+2. Make plain-hash `each` iteration mutation-tolerant. Perl permits deleting
+   the current key while iterating; Java fail-fast map iterators must not leak
+   `ConcurrentModificationException` into Perl code.
+3. Ensure tied handlers receive deterministic finalization at the same visible
+   lifecycle boundary as Perl so `Tie::Config` writes dirty state.
+4. Bundle a Java XS implementation of `Time::UTC::Now`. Use `java.time.Instant`
+   as an explicitly unbounded-accuracy clock source: normal calls return time
+   with an undefined accuracy bound, while `DEMAND_ACCURACY` dies as documented.
+   Keep the upstream Perl module and XSLoader API unchanged.
+5. Add small unit regressions validated with system Perl before relying on
+   upstream distribution suites.
+6. Resolve top-level `SUPER::method` using the package at the method token's
+   source location. Dynamically requiring a module from inside another sub must
+   not inherit that caller's current subroutine package.
+7. Parse an ambiguous inner brace at the start of a `map`, `grep`, or `sort`
+   block in term context, while retaining the existing statement indicators
+   for genuine nested blocks.
+
+## Progress Tracking
+
+### Current Status: Implementation and verification complete; pull request pending
+
+### Completed Phases
+
+- [x] Phase 1: Baseline and system-Perl classification (2026-08-16)
+  - Captured full logs for all requested `jcpan -t` runs.
+  - Confirmed `Kwiki::Edit::AdvisoryLock` already passes.
+  - Confirmed native-only `File::LckPwdF` and `Finance::FXCM::Simple` also fail
+    with system Perl and are out of scope.
+  - Reduced the Ceph failure to nested `Test::Spec` plus `Tie::IxHash` weak
+    ownership.
+- [x] Phase 2: Shared compiler and runtime repairs (2026-08-16)
+  - Snapshot plain-hash `each` entries so deleting the current key does not
+    expose Java's fail-fast iterator behavior.
+  - Include pure-Perl tie handlers in ownership/reachability walks and release
+    global tie handlers during final destruction.
+  - Resolve source-level `SUPER::method` calls from their lexical package in
+    both execution backends.
+  - Treat an ambiguous inner brace at the start of a block-taking operator as
+    an anonymous hash constructor, fixing DBIx result serialization.
+- [x] Phase 3: `Time::UTC::Now` Java port (2026-08-16)
+  - Added the upstream-compatible Perl API and Java XS replacement backed by
+    `java.time.Instant`.
+  - Kept accuracy deliberately unbounded: ordinary calls return `undef` for
+    accuracy and `DEMAND_ACCURACY` calls fail.
+- [x] Phase 4: Regression coverage (2026-08-16)
+  - Added focused tests for mutable `each`, tied ownership and shutdown,
+    dynamically required `SUPER`, and `map` anonymous hashes.
+  - Added a bundled-module suite for all `Time::UTC::Now` representations and
+    conversions.
+  - Validated both new suites against system Perl before PerlOnJava.
+- [x] Phase 5: Distribution and project verification (2026-08-16)
+  - `Ceph::RadosGW::Admin`, `Kwiki::Edit::AdvisoryLock`, `Tie::Config`,
+    `DBIx::Class::Sims::REST`, and `Time::TAI::Now` pass their requested
+    `jcpan -t` suites.
+  - The focused regression passes on both JVM and interpreter backends, the
+    bundled `Time::UTC::Now` suite passes, and the complete `make` build passes.
+
+### Next Steps
+
+1. Open a pull request and monitor CI to completion.
+
+### Open Questions
+
+- None. The DBIx failure was an independent parser ambiguity, and
+  `Time::UTC::Now::_try_all` exposes the single mechanism actually used by the
+  Java replacement.
+
+## Related References
+
+- `.agents/skills/debug-perlonjava/SKILL.md`
+- `.agents/skills/port-cpan-module/SKILL.md`
+- `docs/guides/module-porting.md`
+- `dev/design/patch-and-cpan-prefs-layout.md`

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -12,6 +12,14 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
   source preserves lexical warning and package context. The full 80-file core
   regex gate improves the PR 958 baseline by 729 passing assertions with no
   per-file pass-count regressions.
+- CPAN/compiler tooling: preserve tied-container ownership through weak
+  references, make plain-hash `each` tolerant of deleting the current key,
+  release global tie handlers during final destruction, and resolve top-level
+  `SUPER::method` calls in dynamically required modules from their lexical
+  package. Also distinguish anonymous hashes at the start of `map` blocks. Add
+  a Java-backed `Time::UTC::Now` clock using `java.time.Instant`. This unblocks
+  Ceph::RadosGW::Admin, Tie::Config, DBIx::Class::Sims::REST, and Time::TAI::Now
+  without distribution preferences.
 - CPAN/compiler tooling: run MakeMaker `CONFIGURE` callbacks and prefer their
   generated root modules over auxiliary metadata stubs; enforce known
   subroutine lvalue errors at compile time; preserve blessed anonymous-glob

--- a/docs/reference/bundled-modules.md
+++ b/docs/reference/bundled-modules.md
@@ -343,6 +343,7 @@ These are loaded automatically or via `use`:
 | Module | Implementation | Notes |
 |--------|---------------|-------|
 | `Time::HiRes` | Java | `System.nanoTime()` |
+| `Time::UTC::Now` | Java + Perl | `java.time.Instant`; reports no trusted accuracy bound |
 | `Time::Piece` | Java + Perl | |
 | `Time::Local` | Perl | |
 | `DateTime` | Java + Perl | Java backend bundled; install `DateTime` from CPAN with `jcpan -i DateTime` (timezone data gets frequent updates) |

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -746,6 +746,7 @@ The `:encoding()` layer supports all encodings provided by Java's `Charset.forNa
 - ✅  **Tie::Hash::Indexed** module, with a Java replacement for its XS backend.
 - ✅  **Tie::Scalar** module.
 - ✅  **Time::HiRes** module.
+- ✅  **Time::UTC::Now** module, backed by `java.time.Instant`; unbounded clocks return an undefined accuracy bound as documented.
 - ✅  **Time::Local** module.
 - ✅  **UNIVERSAL**: `isa`, `can`, `DOES`, `VERSION` are implemented. `isa` operator is implemented.
 - ✅  **URI::Escape** module.

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
@@ -2,6 +2,7 @@ package org.perlonjava.backend.bytecode;
 
 import org.perlonjava.frontend.analysis.ConstantFoldingVisitor;
 import org.perlonjava.frontend.astnode.*;
+import org.perlonjava.backend.jvm.ByteCodeSourceMapper;
 import org.perlonjava.runtime.runtimetypes.NameNormalizer;
 import org.perlonjava.runtime.runtimetypes.RuntimeCode;
 import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
@@ -259,6 +260,14 @@ public class CompileBinaryOperator {
                     }
                     if (methodNode instanceof IdentifierNode) {
                         String methodName = ((IdentifierNode) methodNode).name;
+                        if (methodName.startsWith("SUPER::") && methodNode.getIndex() > 0) {
+                            String lexicalPackage = ByteCodeSourceMapper.getPackageAtLocation(
+                                    bytecodeCompiler.sourceName, methodNode.getIndex());
+                            if (lexicalPackage == null || lexicalPackage.isEmpty()) {
+                                lexicalPackage = bytecodeCompiler.getCurrentPackage();
+                            }
+                            methodName = lexicalPackage + "::" + methodName;
+                        }
                         methodNode = new StringNode(methodName, methodNode.getIndex());
                     }
 

--- a/src/main/java/org/perlonjava/backend/jvm/Dereference.java
+++ b/src/main/java/org/perlonjava/backend/jvm/Dereference.java
@@ -896,7 +896,16 @@ public class Dereference {
                 }
             }
             if (method instanceof IdentifierNode) {
-                method = new StringNode(((IdentifierNode) method).name, ((IdentifierNode) method).tokenIndex);
+                String methodName = ((IdentifierNode) method).name;
+                if (methodName.startsWith("SUPER::") && method.getIndex() > 0) {
+                    String lexicalPackage = ByteCodeSourceMapper.getPackageAtLocation(
+                            emitterVisitor.ctx.compilerOptions.fileName, method.getIndex());
+                    if (lexicalPackage == null || lexicalPackage.isEmpty()) {
+                        lexicalPackage = emitterVisitor.ctx.symbolTable.getCurrentPackage();
+                    }
+                    methodName = lexicalPackage + "::" + methodName;
+                }
+                method = new StringNode(methodName, method.getIndex());
             }
 
             object.accept(scalarVisitor);

--- a/src/main/java/org/perlonjava/frontend/parser/ListParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ListParser.java
@@ -194,7 +194,13 @@ public class ListParser {
             }
             if (TokenUtils.peek(parser).text.equals("{")) {
                 TokenUtils.consume(parser);
-                expr.handle = ParseBlock.parseBlock(parser);
+                boolean previousBlockOperatorArgument = parser.insideBlockOperatorArgument;
+                parser.insideBlockOperatorArgument = true;
+                try {
+                    expr.handle = ParseBlock.parseBlock(parser);
+                } finally {
+                    parser.insideBlockOperatorArgument = previousBlockOperatorArgument;
+                }
                 TokenUtils.consume(parser, LexerTokenType.OPERATOR, "}");
             }
             if (!isSpaceAfterPrintBlock(parser) || looksLikeEmptyList(parser)) {

--- a/src/main/java/org/perlonjava/frontend/parser/Parser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/Parser.java
@@ -64,6 +64,9 @@ public class Parser {
     // Are we parsing inside a braced dereference like %{...} or @{...}?
     // When true, inner {} should default to hash constructor, not block.
     public boolean insideBracedDereference = false;
+    // map/grep/sort blocks start in term context. An ambiguous leading inner
+    // brace is therefore an anonymous hashref, not a nested block.
+    public boolean insideBlockOperatorArgument = false;
     // List to store ADJUST blocks for the current class
     public List<Node> classAdjustBlocks = new ArrayList<>();
     // List to store heredoc nodes encountered during parsing.

--- a/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementResolver.java
@@ -1345,6 +1345,14 @@ public class StatementResolver {
             // Example: %{ {map { $_ => 1 } @_} } — inner {} is a hashref.
             if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("isHashLiteral RESULT: TRUE - inside braced dereference context");
             return true;
+        } else if (parser.insideBlockOperatorArgument) {
+            // A map/grep/sort block begins in term context.
+            // Thus `map { { expression_returning_pairs() } } @items` treats
+            // the inner braces as an anonymous hash constructor. Semicolons,
+            // assignments, and control statements were already classified as
+            // block indicators above, so this only resolves the ambiguous case.
+            if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("isHashLiteral RESULT: TRUE - block operator term context");
+            return true;
         } else {
             if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("isHashLiteral RESULT: FALSE - default for ambiguous case (assuming block)");
             return false; // Default: assume block when we can't determine

--- a/src/main/java/org/perlonjava/runtime/perlmodule/TimeUTCNow.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/TimeUTCNow.java
@@ -1,0 +1,138 @@
+package org.perlonjava.runtime.perlmodule;
+
+import org.perlonjava.runtime.operators.ModuleOperators;
+import org.perlonjava.runtime.operators.WarnDie;
+import org.perlonjava.runtime.runtimetypes.GlobalVariable;
+import org.perlonjava.runtime.runtimetypes.RuntimeArray;
+import org.perlonjava.runtime.runtimetypes.RuntimeCode;
+import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
+import org.perlonjava.runtime.runtimetypes.RuntimeHash;
+import org.perlonjava.runtime.runtimetypes.RuntimeList;
+import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+
+import java.time.Instant;
+
+import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarUndef;
+
+/** Java backend for the XS portion of Time::UTC::Now. */
+public class TimeUTCNow extends PerlModuleBase {
+    public static final String XS_VERSION = "0.013";
+    private static final long UNIX_EPOCH_DAYNO = 40587L - 36204L;
+
+    public TimeUTCNow() {
+        super("Time::UTC::Now", false);
+    }
+
+    public static void initialize() {
+        TimeUTCNow module = new TimeUTCNow();
+        try {
+            module.registerMethod("CLONE", null);
+            module.registerMethod("now_utc_rat", ";$");
+            module.registerMethod("now_utc_sna", ";$");
+            module.registerMethod("now_utc_flt", ";$");
+            module.registerMethod("now_utc_dec", ";$");
+            module.registerMethod("_try_all", "");
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Missing Time::UTC::Now Java method", e);
+        }
+    }
+
+    public static RuntimeList CLONE(RuntimeArray args, int ctx) {
+        return new RuntimeList();
+    }
+
+    public static RuntimeList now_utc_rat(RuntimeArray args, int ctx) {
+        Now now = currentOrDie(args);
+        if (now == null) return new RuntimeList();
+        RuntimeList result = new RuntimeList();
+        result.add(bigRat(Long.toString(now.dayno)));
+        result.add(bigRat(now.decimalSeconds()));
+        result.add(scalarUndef);
+        return result;
+    }
+
+    public static RuntimeList now_utc_sna(RuntimeArray args, int ctx) {
+        Now now = currentOrDie(args);
+        if (now == null) return new RuntimeList();
+        RuntimeArray tod = new RuntimeArray();
+        RuntimeArray.push(tod, new RuntimeScalar(now.seconds));
+        RuntimeArray.push(tod, new RuntimeScalar(now.nanos));
+        RuntimeArray.push(tod, new RuntimeScalar(0));
+        RuntimeList result = new RuntimeList();
+        result.add(new RuntimeScalar(now.dayno));
+        result.add(tod.createReference());
+        result.add(scalarUndef);
+        return result;
+    }
+
+    public static RuntimeList now_utc_flt(RuntimeArray args, int ctx) {
+        Now now = currentOrDie(args);
+        if (now == null) return new RuntimeList();
+        RuntimeList result = new RuntimeList();
+        result.add(new RuntimeScalar(now.dayno));
+        result.add(new RuntimeScalar(now.seconds + now.nanos / 1_000_000_000.0));
+        result.add(scalarUndef);
+        return result;
+    }
+
+    public static RuntimeList now_utc_dec(RuntimeArray args, int ctx) {
+        Now now = currentOrDie(args);
+        if (now == null) return new RuntimeList();
+        RuntimeList result = new RuntimeList();
+        result.add(new RuntimeScalar(now.dayno));
+        result.add(new RuntimeScalar(now.decimalSeconds()));
+        result.add(scalarUndef);
+        return result;
+    }
+
+    public static RuntimeList _try_all(RuntimeArray args, int ctx) {
+        Now now = Now.current();
+        RuntimeHash mechanism = new RuntimeHash();
+        mechanism.put("name", new RuntimeScalar("java.time.Instant"));
+        mechanism.put("max_got", new RuntimeScalar(1));
+        mechanism.put("got", new RuntimeScalar(1));
+        mechanism.put("dayno", new RuntimeScalar(now.dayno));
+        mechanism.put("tod", new RuntimeScalar(now.decimalSeconds()));
+        RuntimeArray mechanisms = new RuntimeArray();
+        RuntimeArray.push(mechanisms, mechanism.createReference());
+        return mechanisms.createReference().getList();
+    }
+
+    private static Now currentOrDie(RuntimeArray args) {
+        if (!args.isEmpty() && args.get(0).getBoolean()) {
+            WarnDie.die(new RuntimeScalar("can't find time accurately"), new RuntimeScalar("\n"));
+            return null;
+        }
+        return Now.current();
+    }
+
+    private static RuntimeScalar bigRat(String value) {
+        if (!GlobalVariable.getGlobalHash("main::INC").exists("Math/BigRat.pm").getBoolean()) {
+            ModuleOperators.require(new RuntimeScalar("Math/BigRat.pm"));
+        }
+        RuntimeArray constructorArgs = new RuntimeArray();
+        RuntimeArray.push(constructorArgs, new RuntimeScalar("Math::BigRat"));
+        RuntimeArray.push(constructorArgs, new RuntimeScalar(value));
+        return RuntimeCode.apply(
+                GlobalVariable.getGlobalCodeRef("Math::BigRat::new"),
+                constructorArgs,
+                RuntimeContextType.SCALAR).scalar();
+    }
+
+    private record Now(long dayno, long seconds, int nanos) {
+        static Now current() {
+            Instant instant = Instant.now();
+            long unixDay = Math.floorDiv(instant.getEpochSecond(), 86400L);
+            long seconds = Math.floorMod(instant.getEpochSecond(), 86400L);
+            return new Now(UNIX_EPOCH_DAYNO + unixDay, seconds, instant.getNano());
+        }
+
+        String decimalSeconds() {
+            if (nanos == 0) return Long.toString(seconds);
+            String decimal = String.format(java.util.Locale.ROOT, "%d.%09d", seconds, nanos);
+            int end = decimal.length();
+            while (decimal.charAt(end - 1) == '0') end--;
+            return decimal.substring(0, end);
+        }
+    }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalDestruction.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalDestruction.java
@@ -56,7 +56,14 @@ public class GlobalDestruction {
             if (hash == null) continue;  // defensive
             // Skip tied hashes — iterating them dispatches through FIRSTKEY/
             // NEXTKEY/FETCH which may fail if the tie object is already gone.
-            if (hash.type == RuntimeHash.TIED_HASH) continue;
+            // The tie handler itself is still owned by the global hash, though,
+            // and must be released so its DESTROY method runs at process exit.
+            if (hash.type == RuntimeHash.TIED_HASH) {
+                if (hash.elements instanceof TieHash tieHash) {
+                    tieHash.releaseTiedObject();
+                }
+                continue;
+            }
             for (RuntimeScalar elem : new ArrayList<>(hash.elements.values())) {
                 destroyIfTracked(elem, visited);
             }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/MortalList.java
@@ -1224,6 +1224,22 @@ public class MortalList {
                 // RuntimeCode.clearPadConstantWeakRefs() clears it when the
                 // sub's glob is replaced, matching Perl optree reaping.
                 base.refCount = 1;
+            } else if (hasWeakRefs && restoreReachableOwnerCount(base)) {
+                // A counted owner that is still reachable through a real
+                // Perl root is authoritative, including for classes with
+                // DESTROY.  Pure-Perl tied containers expose this shape:
+                // Test::Spec stores a context in Tie::IxHash and weakens the
+                // child's parent link. Method/argument temporaries can make
+                // the selective count dip to zero, but the tied handler's
+                // array slot remains a strong owner.  Destroying here clears
+                // that weak parent and corrupts the context tree.
+            } else if (hasWeakRefs
+                    && ReachabilityWalker.isReachableThroughTiedHash(base)) {
+                // The active-owner set starts recording at the first weaken,
+                // so a handler slot populated just before weaken can be absent
+                // from it. Confirm the missing ownership through the narrower
+                // tied-handler root walk before protecting DESTROY objects.
+                base.refCount = 1;
             } else if (base.blessId == 0
                     && hasWeakRefs
                     && (ReachabilityWalker.isReachableFromLiveCodeCaptures(base)
@@ -1295,6 +1311,13 @@ public class MortalList {
     private static boolean blessedClassHasDestroy(RuntimeBase base) {
         String className = NameNormalizer.getBlessStr(base.blessId);
         return className != null && DestroyDispatch.classHasDestroy(base.blessId, className);
+    }
+
+    private static boolean restoreReachableOwnerCount(RuntimeBase base) {
+        int ownerCount = base.reachableOwnerCount();
+        if (ownerCount == 0) return false;
+        base.refCount = ownerCount;
+        return true;
     }
 
     public static void flush() {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ReachabilityWalker.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ReachabilityWalker.java
@@ -798,6 +798,10 @@ public class ReachabilityWalker {
             if (cur == target) return true;
             if (cur instanceof RuntimeStash) continue;
             if (cur instanceof RuntimeHash h) {
+                if (h.elements instanceof TieHash tieHash
+                        && followScalar(tieHash.getSelf(), target, seen, todo)) {
+                    return true;
+                }
                 for (RuntimeScalar v : h.elements.values()) {
                     if (followScalar(v, target, seen, todo)) return true;
                 }
@@ -910,6 +914,20 @@ public class ReachabilityWalker {
                 continue;
             } else if (cur instanceof RuntimeHash hash) {
                 if (hash.elements instanceof HashSpecialVariable) continue;
+                // A tied hash's Java Map facade does not expose the values
+                // retained by its pure-Perl handler.  Follow the handler
+                // object, then its arrays/hashes, so an owner scalar stored by
+                // implementations such as Tie::IxHash is recognized as a real
+                // strong path.  Without this edge, undefining a different
+                // strong scalar can clear weak back-references prematurely.
+                if (hash.elements instanceof TieHash tieHash) {
+                    RuntimeScalar self = tieHash.getSelf();
+                    if (self == target) return true;
+                    if (self != null && !WeakRefRegistry.isweak(self)
+                            && seen.add(self)) {
+                        todo.addLast(self);
+                    }
+                }
                 for (RuntimeScalar val : hash.elements.values()) {
                     if (val == null) continue;
                     // Skip weak refs — they don't keep their referent alive.
@@ -1089,6 +1107,10 @@ public class ReachabilityWalker {
             // Phase D-W2 (perf): skip RuntimeStash — see bfs().
             if (cur instanceof RuntimeStash) continue;
             if (cur instanceof RuntimeHash h) {
+                if (h.elements instanceof TieHash tieHash
+                        && followScalar(tieHash.getSelf(), target, seen, todo)) {
+                    return true;
+                }
                 for (RuntimeScalar v : h.elements.values()) {
                     if (followScalar(v, target, seen, todo)) return true;
                 }
@@ -1136,6 +1158,92 @@ public class ReachabilityWalker {
         walker.bfs(todo, true);
         return walker.reachable.contains(target);
     }
+
+    /**
+     * Return true when a strong path from a package or live lexical root to
+     * {@code target} crosses a tied hash handler.  This is intentionally more
+     * specific than the ordinary root queries: objects with DESTROY normally
+     * use strict selective-refcount handling, but a pure-Perl tie handler can
+     * hold a real owner that the count temporarily misses.
+     */
+    public static boolean isReachableThroughTiedHash(RuntimeBase target) {
+        if (target == null) return false;
+        final int maxVisits = 50_000;
+        Set<RuntimeBase> seenPlain = Collections.newSetFromMap(new IdentityHashMap<>());
+        Set<RuntimeBase> seenTied = Collections.newSetFromMap(new IdentityHashMap<>());
+        java.util.ArrayDeque<TiedPathStep> todo = new java.util.ArrayDeque<>();
+
+        for (RuntimeScalar scalar : GlobalVariable.globalCodeRefs.values()) {
+            addTiedPathScalar(scalar, false, seenPlain, seenTied, todo);
+        }
+        for (RuntimeScalar scalar : GlobalVariable.globalVariables.values()) {
+            addTiedPathScalar(scalar, false, seenPlain, seenTied, todo);
+        }
+        for (RuntimeArray array : GlobalVariable.globalArrays.values()) {
+            addTiedPath(array, false, seenPlain, seenTied, todo);
+        }
+        for (RuntimeHash hash : GlobalVariable.globalHashes.values()) {
+            addTiedPath(hash, false, seenPlain, seenTied, todo);
+        }
+        for (Object liveVar : MyVarCleanupStack.snapshotLiveVars()) {
+            if (liveVar instanceof RuntimeBase base) {
+                addTiedPath(base, false, seenPlain, seenTied, todo);
+            }
+        }
+
+        int visits = 0;
+        while (!todo.isEmpty() && visits++ < maxVisits) {
+            TiedPathStep step = todo.removeFirst();
+            RuntimeBase cur = step.base;
+            if (cur == target && step.crossedTie) return true;
+            if (cur instanceof RuntimeStash) continue;
+            if (cur instanceof RuntimeHash hash) {
+                if (hash.elements instanceof HashSpecialVariable) continue;
+                if (hash.elements instanceof TieHash tieHash) {
+                    addTiedPathScalar(tieHash.getSelf(), true,
+                            seenPlain, seenTied, todo);
+                }
+                for (RuntimeScalar value : hash.elements.values()) {
+                    addTiedPathScalar(value, step.crossedTie,
+                            seenPlain, seenTied, todo);
+                }
+            } else if (cur instanceof RuntimeArray array) {
+                for (RuntimeScalar value : array.elements) {
+                    addTiedPathScalar(value, step.crossedTie,
+                            seenPlain, seenTied, todo);
+                }
+            } else if (cur instanceof RuntimeScalar scalar) {
+                addTiedPathScalar(scalar, step.crossedTie,
+                        seenPlain, seenTied, todo);
+            }
+        }
+        return false;
+    }
+
+    private static void addTiedPathScalar(
+            RuntimeScalar scalar, boolean crossedTie,
+            Set<RuntimeBase> seenPlain, Set<RuntimeBase> seenTied,
+            java.util.ArrayDeque<TiedPathStep> todo) {
+        if (scalar == null || WeakRefRegistry.isweak(scalar)) return;
+        addTiedPath(scalar, crossedTie, seenPlain, seenTied, todo);
+        if ((scalar.type & RuntimeScalarType.REFERENCE_BIT) != 0
+                && scalar.value instanceof RuntimeBase base) {
+            addTiedPath(base, crossedTie, seenPlain, seenTied, todo);
+        }
+    }
+
+    private static void addTiedPath(
+            RuntimeBase base, boolean crossedTie,
+            Set<RuntimeBase> seenPlain, Set<RuntimeBase> seenTied,
+            java.util.ArrayDeque<TiedPathStep> todo) {
+        if (base == null) return;
+        Set<RuntimeBase> seen = crossedTie ? seenTied : seenPlain;
+        if (seen.add(base)) {
+            todo.addLast(new TiedPathStep(base, crossedTie));
+        }
+    }
+
+    private record TiedPathStep(RuntimeBase base, boolean crossedTie) {}
 
     /**
      * Target-specific reachability query for scope-exit cleanup of a named
@@ -1200,6 +1308,10 @@ public class ReachabilityWalker {
             if (cur instanceof RuntimeStash) continue;
             if (cur instanceof RuntimeHash h) {
                 if (h.elements instanceof HashSpecialVariable) continue;
+                if (h.elements instanceof TieHash tieHash
+                        && followScalar(tieHash.getSelf(), target, seen, todo)) {
+                    return true;
+                }
                 for (RuntimeScalar v : h.elements.values()) {
                     if (followScalar(v, target, seen, todo)) return true;
                 }
@@ -1280,6 +1392,9 @@ public class ReachabilityWalker {
             if (cur instanceof RuntimeStash) return;
             if (cur instanceof RuntimeHash h) {
                 if (h.elements instanceof HashSpecialVariable) return;
+                if (h.elements instanceof TieHash tieHash) {
+                    seedNonLexicalScalar(tieHash.getSelf(), nonLexicalTodo);
+                }
                 for (RuntimeScalar v : h.elements.values()) {
                     seedNonLexicalScalar(v, nonLexicalTodo);
                 }
@@ -1393,6 +1508,9 @@ public class ReachabilityWalker {
             if (cur instanceof RuntimeStash) return;
             if (cur instanceof RuntimeHash h) {
                 if (h.elements instanceof HashSpecialVariable) return;
+                if (h.elements instanceof TieHash tieHash) {
+                    seedDirectScalar(tieHash.getSelf(), origin, todo);
+                }
                 for (RuntimeScalar v : h.elements.values()) {
                     seedDirectScalar(v, origin, todo);
                 }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
@@ -1651,7 +1651,22 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
          * Constructs a RuntimeHashIterator for iterating over hash elements.
          */
         public RuntimeHashIterator() {
-            this.entryIterator = elements.entrySet().iterator();
+            // Perl's each() iterator remains usable when the current entry is
+            // deleted.  Java map iterators are fail-fast, so exposing the live
+            // entrySet iterator leaks ConcurrentModificationException into
+            // otherwise valid Perl such as:
+            //
+            //   while (my ($key, $value) = each %hash) { delete $hash{$key} }
+            //
+            // Snapshot the key/value pairs at iterator creation.  Hash
+            // iteration order is intentionally unspecified by Perl, while the
+            // returned scalar values must retain their original identity.
+            List<Map.Entry<String, RuntimeScalar>> entries = new ArrayList<>(elements.size());
+            for (Map.Entry<String, RuntimeScalar> entry : elements.entrySet()) {
+                entries.add(new AbstractMap.SimpleImmutableEntry<>(
+                        entry.getKey(), entry.getValue()));
+            }
+            this.entryIterator = entries.iterator();
             this.returnKey = true;
         }
 

--- a/src/main/perl/lib/Time/UTC/Now.pm
+++ b/src/main/perl/lib/Time/UTC/Now.pm
@@ -1,0 +1,52 @@
+package Time::UTC::Now;
+
+use 5.006;
+use strict;
+use warnings;
+use parent 'Exporter';
+
+our $VERSION = '0.013';
+our @EXPORT_OK = qw(
+    now_utc_rat now_utc_sna now_utc_flt now_utc_dec
+    utc_day_to_mjdn utc_day_to_cjdn
+);
+
+require XSLoader;
+XSLoader::load('Time::UTC::Now', $VERSION);
+
+use constant _TAI_EPOCH_MJDN => 36204;
+use constant _TAI_EPOCH_CJDN => 2436205;
+
+sub utc_day_to_mjdn($) {
+    return _TAI_EPOCH_MJDN + $_[0];
+}
+
+sub utc_day_to_cjdn($) {
+    return _TAI_EPOCH_CJDN + $_[0];
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Time::UTC::Now - determine the current UTC time
+
+=head1 DESCRIPTION
+
+This PerlOnJava port preserves the Time::UTC::Now 0.013 API.  The Java
+backend uses C<java.time.Instant>, which supplies UTC-like POSIX wall-clock
+time with nanosecond fields but no trustworthy inaccuracy bound.  The third
+result is therefore C<undef>, and calls which demand accuracy die.
+
+=head1 AUTHOR AND COPYRIGHT
+
+Original module by Andrew Main (Zefram) E<lt>zefram@fysh.orgE<gt>.
+
+Copyright (C) 2006, 2007, 2009, 2010, 2012, 2017 Andrew Main.
+
+This module is free software; you can redistribute it and/or modify it under
+the same terms as Perl itself.
+
+=cut

--- a/src/test/resources/module/Time-UTC-Now/t/basic.t
+++ b/src/test/resources/module/Time-UTC-Now/t/basic.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Time::UTC::Now qw(
+    now_utc_rat now_utc_sna now_utc_flt now_utc_dec
+    utc_day_to_mjdn utc_day_to_cjdn
+);
+
+is utc_day_to_mjdn(0), 36204, 'TAI epoch converts to MJDN';
+is utc_day_to_cjdn(0), 2436205, 'TAI epoch converts to CJDN';
+
+my @rat = now_utc_rat();
+is scalar(@rat), 3, 'rational form has three values';
+isa_ok $rat[0], 'Math::BigRat';
+isa_ok $rat[1], 'Math::BigRat';
+ok $rat[0]->is_int, 'rational day is integral';
+ok $rat[1] >= 0 && $rat[1] < 86401, 'rational seconds are within a UTC day';
+
+my @sna = now_utc_sna();
+is scalar(@sna), 3, 'seconds/nanoseconds form has three values';
+like $sna[0], qr/\A-?[0-9]+\z/, 'day number is integral';
+is ref($sna[1]), 'ARRAY', 'time of day is an array';
+is scalar(@{$sna[1]}), 3, 'time of day has seconds, nanoseconds, attoseconds';
+ok $sna[1][0] >= 0 && $sna[1][0] < 86401, 'seconds are within a UTC day';
+ok $sna[1][1] >= 0 && $sna[1][1] < 1_000_000_000, 'nanoseconds are normalized';
+is $sna[1][2], 0, 'attoseconds are zero at nanosecond resolution';
+
+my @flt = now_utc_flt();
+is scalar(@flt), 3, 'floating form has three values';
+ok $flt[1] >= 0 && $flt[1] < 86401, 'floating seconds are within a UTC day';
+
+my @dec = now_utc_dec();
+is scalar(@dec), 3, 'decimal form has three values';
+like $dec[1], qr/\A(?:0|[1-9][0-9]*)(?:\.[0-9]*[1-9])?\z/,
+    'decimal seconds are canonical';
+
+if (defined $dec[2]) {
+    my @accurate = eval { now_utc_dec(1) };
+    ok !$@ && @accurate == 3, 'accuracy demand succeeds when a bound exists';
+} else {
+    eval { now_utc_dec(1) };
+    like $@, qr/can't find time accurately/, 'accuracy demand rejects an unbounded clock';
+}
+
+done_testing;

--- a/src/test/resources/unit/cpan_ceph_tie_runtime.t
+++ b/src/test/resources/unit/cpan_ceph_tie_runtime.t
@@ -1,0 +1,160 @@
+use strict;
+use warnings;
+use Test::More tests => 9;
+use File::Temp qw(tempdir);
+use Scalar::Util qw(refaddr weaken);
+
+{
+    my %hash = (alpha => 1, beta => 2, gamma => 3);
+    my @seen;
+    while (my ($key, $value) = each %hash) {
+        push @seen, $key;
+        delete $hash{$key};
+    }
+    is scalar(@seen), 3,
+        'deleting the current plain-hash key does not invalidate each';
+}
+
+{
+    package Local::Context;
+
+    sub new {
+        my $self = bless { callbacks => [] }, shift;
+        my $this = $self;
+        Scalar::Util::weaken($this);
+        push @{$self->{callbacks}}, sub { return $this };
+        return $self;
+    }
+
+    sub set_parent {
+        my ($self, $parent) = @_;
+        $self->{parent} = $parent;
+        Scalar::Util::weaken($self->{parent});
+    }
+
+    sub DESTROY { }
+}
+
+{
+    package Local::OrderedHash;
+
+    sub TIEHASH {
+        return bless [ {}, [], [] ], shift;
+    }
+
+    sub STORE {
+        my ($self, $key, $value) = @_;
+        if (!exists $self->[0]{$key}) {
+            $self->[0]{$key} = scalar @{$self->[1]};
+            push @{$self->[1]}, $key;
+        }
+        $self->[2][$self->[0]{$key}] = $value;
+    }
+
+    sub FETCH {
+        my ($self, $key) = @_;
+        return undef unless exists $self->[0]{$key};
+        return $self->[2][$self->[0]{$key}];
+    }
+}
+
+{
+    tie my %top, 'Local::OrderedHash';
+    my $outer = Local::Context->new;
+    $top{outer} = $outer;
+
+    tie my %children, 'Local::OrderedHash';
+    $outer->{children} = \%children;
+    my $inner = Local::Context->new;
+    $inner->set_parent($outer);
+    $children{inner} = $inner;
+
+    undef $inner;
+    undef $outer;
+    my $stored_inner = $top{outer}{children}{inner};
+    ok defined($stored_inner->{parent}),
+        'nested tied context keeps its weak parent through temporary cleanup';
+}
+
+{
+    tie my %ordered, 'Local::OrderedHash';
+    my $owner = bless {}, 'Local::Owner';
+    my $owner_addr = refaddr($owner);
+    $ordered{owner} = $owner;
+
+    my $backref = $owner;
+    weaken($backref);
+    undef $owner;
+
+    ok defined($backref),
+        'pure-Perl tied storage remains a strong owner of a weak referent';
+    is refaddr($ordered{owner}), $owner_addr,
+        'tied storage preserves reference identity';
+    is refaddr($backref), $owner_addr,
+        'weak reference still points at the tied container value';
+}
+
+{
+    my $dir = tempdir(CLEANUP => 1);
+    my $script = "$dir/global_tie_destroy.pl";
+    my $marker = "$dir/destroyed";
+    open my $fh, '>', $script or die "open $script: $!";
+    print {$fh} <<'CHILD';
+use strict;
+use warnings;
+{
+    package Local::ShutdownHash;
+    sub TIEHASH { bless { marker => $_[1] }, $_[0] }
+    sub DESTROY {
+        open my $out, '>', $_[0]{marker} or die $!;
+        print {$out} "destroyed\n";
+        close $out or die $!;
+    }
+}
+
+tie our %shutdown_hash, 'Local::ShutdownHash', $ARGV[0];
+CHILD
+    close $fh or die "close $script: $!";
+    my $status = system($^X, $script, $marker);
+    ok $status == 0 && -s $marker,
+        'global tied hash releases its handler at shutdown';
+}
+
+{
+    my $dir = tempdir(CLEANUP => 1);
+    my $module = "$dir/runtime_child.pm";
+    open my $fh, '>', $module or die "open $module: $!";
+    print {$fh} <<'MODULE';
+package Local::RuntimeParent;
+sub new { bless {}, $_[0] }
+
+package Local::RuntimeChild;
+our @ISA = ('Local::RuntimeParent');
+our $singleton = __PACKAGE__->SUPER::new;
+1;
+MODULE
+    close $fh or die "close $module: $!";
+
+    sub load_runtime_child {
+        require $module;
+        no warnings 'once';
+        return $Local::RuntimeChild::singleton;
+    }
+
+    isa_ok load_runtime_child(), 'Local::RuntimeChild',
+        'top-level SUPER resolves lexically when require runs inside a sub';
+}
+
+{
+    package Local::Columns;
+    sub get_columns { return (id => 1, name => 'A', color => 'purple') }
+}
+
+{
+    my @rows = (bless({}, 'Local::Columns'));
+    my $flattened = [ map { { $_->get_columns } } @rows ];
+    is ref($flattened->[0]), 'HASH',
+        'map block preserves an inner anonymous hash constructor';
+    is_deeply $flattened->[0], { id => 1, name => 'A', color => 'purple' },
+        'method-returned key/value pairs populate the anonymous hash';
+}


### PR DESCRIPTION
## Summary

- preserve strong ownership through pure-Perl tied hash handlers, make plain-hash `each` safe when deleting the current key, and release global tie handlers during shutdown
- resolve source-level `SUPER::method` calls from their lexical package in both backends and parse anonymous hashes correctly at the start of `map` blocks
- bundle an upstream-compatible Java implementation of `Time::UTC::Now` backed by `java.time.Instant`, reporting an undefined accuracy bound instead of inventing one
- add system-Perl-validated unit and bundled-module regression coverage, without distribution preferences

This unblocks `Ceph::RadosGW::Admin`, `Tie::Config`, `DBIx::Class::Sims::REST`, and `Time::TAI::Now`. `Kwiki::Edit::AdvisoryLock` remains green. `File::LckPwdF` and `Finance::FXCM::Simple` were excluded because their native distributions also fail under system Perl on this macOS host (`_lckpwdf` is unavailable and ForexConnect SDK headers are absent, respectively).

## Validation

- `make` after rebasing onto current `master` — passed (`BUILD SUCCESSFUL`, all five unit shards and Joni checks)
- new focused regression with system Perl — passed, 9 assertions
- new focused regression with PerlOnJava JVM backend — passed, 9 assertions
- new focused regression with PerlOnJava interpreter backend — passed, 9 assertions
- bundled `Time::UTC::Now` suite with system Perl's upstream XS — passed, 19 assertions
- filtered `make test-bundled-modules` for `Time-UTC-Now` — passed
- `./jcpan -t Ceph::RadosGW::Admin` — passed, 3 files / 15 tests
- `./jcpan -t Kwiki::Edit::AdvisoryLock` — passed, 1 file / 1 test
- `./jcpan -t Tie::Config` — passed, 6 files / 21 tests
- `./jcpan -t DBIx::Class::Sims::REST` — passed, 1 file / 4 tests
- `./jcpan -t Time::TAI::Now` — passed, target functional test green; POD-only tests skipped for missing optional test modules

Generated with [Codex](https://openai.com/codex)
