### PR TITLE
Fix CPAN parser and tooling regressions

### DIFF
--- a/dev/design/jcpan-module-tooling-20260817.md
+++ b/dev/design/jcpan-module-tooling-20260817.md
@@ -8,7 +8,7 @@ Unblock compiler/runtime/tooling failures found while exercising:
 
 ## Progress Tracking
 
-### Current Status: implementation complete; PR/CI in progress
+### Current Status: complete
 
 ### Completed Phases
 
@@ -47,7 +47,10 @@ Unblock compiler/runtime/tooling failures found while exercising:
     failures safely without altering the feature branch.
   - The minimized branch passes the required `make`, including all five unit
     shards, Joni tests, packaging verification, and the shadow JAR build.
-- [ ] Phase 4b: publish the feature branch PR and verify CI checks.
+- [x] Phase 4b: publish the feature branch PR and verify CI checks
+  (2026-08-17).
+  - Opened PR #991 from `fix/jcpan-module-tooling`.
+  - GitHub Actions passed on Ubuntu and Windows.
 
 ### Open Questions / Handoffs
 
@@ -59,5 +62,4 @@ Unblock compiler/runtime/tooling failures found while exercising:
 
 ### Next Steps
 
-1. Commit with attribution, push the branch, and open the PR.
-2. Monitor and fix CI until all required checks pass.
+1. Await review of PR #991.

--- a/dev/design/jcpan-module-tooling-20260817.md
+++ b/dev/design/jcpan-module-tooling-20260817.md
@@ -1,0 +1,63 @@
+# jcpan module tooling follow-up (2026-08-17)
+
+## Objective
+
+Unblock compiler/runtime/tooling failures found while exercising:
+`Labyrinth::Plugin::Review`, `Log::Minimal::Indent`, `LinAlg::Vector`,
+`Text::TokenStream`, `Search::Typesense`, and `Astro::Constants`.
+
+## Progress Tracking
+
+### Current Status: implementation complete; PR/CI in progress
+
+### Completed Phases
+
+- [x] Phase 1: classify failures against the six distributions and their
+  dependency closures.
+  - System-Perl-only missing dependencies were not treated as runtime bugs.
+  - Pure-Perl dependencies were installed through `jcpan --notest` for local
+    validation.
+- [x] Phase 2: shared parser and bundled-tooling fixes.
+  - Fat-comma autoquoting now handles comparison keywords such as `eq =>` in
+    direct calls, including list-context lookahead.
+  - Constant-CV lookup and infix assignment validation preserve Perl's
+    constant-item diagnostic.
+  - Qualified scalar names now accept numeric package segments such as
+    `$Astro::Constants::2019::VERSION`.
+- [x] Phase 3: focused module validation and scope classification.
+  - `Astro::Constants`: all 23 test files pass (136 assertions).
+  - `Text::TokenStream`: non-regex lexer/token-stream coverage passes; the
+    remaining `(*MARK:NAME)` dependency is assigned to the Joni migration.
+  - `Labyrinth::Plugin::Review` and `Log::Minimal::Indent`: their remaining
+    blockers are the deferred XS-backed `Session::Token` and `Guard` paths.
+  - `LinAlg::Vector` is excluded by the system-Perl gate because its test
+    cannot load Moose in the system Perl environment. Direct Moose constructor
+    validation under PerlOnJava succeeds; the observed alias behavior belongs
+    to the excluded dependency path.
+  - `Search::Typesense` is excluded by the system-Perl gate because its test
+    stack cannot load `Devel::StackTrace`. Its remaining cached-fixture
+    assertion distinguishes JSON string `"125"` from numeric `125`.
+  - Added regression coverage validated first with system Perl and then with
+    both PerlOnJava backends.
+  - Removed an over-broad identifier lookahead change after the clean-master
+    baseline showed it regressed B::Deparse source offsets and XML module
+    parsing; the minimized parser changes retain the target fixes.
+- [x] Phase 4a: full local regression validation (2026-08-17).
+  - A clean `origin/master` worktree was used to baseline four initial
+    failures safely without altering the feature branch.
+  - The minimized branch passes the required `make`, including all five unit
+    shards, Joni tests, packaging verification, and the shadow JAR build.
+- [ ] Phase 4b: publish the feature branch PR and verify CI checks.
+
+### Open Questions / Handoffs
+
+- `(*MARK:NAME)` remains with the parallel Joni regex migration. This branch
+  deliberately does not duplicate that regex implementation.
+- XS-backed dependencies, including `Guard` and `Session::Token`, are deferred
+  from this compiler/tooling branch.
+- No distribution preference overrides were added.
+
+### Next Steps
+
+1. Commit with attribution, push the branch, and open the PR.
+2. Monitor and fix CI until all required checks pass.

--- a/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
@@ -491,10 +491,13 @@ public class IdentifierParser {
                     token = parser.tokens.get(parser.tokenIndex);
                     nextToken = parser.tokens.get(parser.tokenIndex + 1);
 
-                    // After ::, only identifiers or another :: are allowed (or ' as package separator)
+                    // After ::, identifiers and numeric package segments are allowed,
+                    // along with another separator.
                     // Note: Keywords CAN be valid identifier parts after :: (e.g., $Foo::and, &UNIVERSAL::isa)
                     // — but only when they are flush against ::, with no intervening whitespace.
-                    if (token.type != LexerTokenType.IDENTIFIER && !token.text.equals("::") && !token.text.equals("'")) {
+                    if (token.type != LexerTokenType.IDENTIFIER
+                            && token.type != LexerTokenType.NUMBER
+                            && !token.text.equals("::") && !token.text.equals("'")) {
                         // Nothing valid follows ::, so return what we have
                         return variableName.toString();
                     }

--- a/src/main/java/org/perlonjava/frontend/parser/ListParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ListParser.java
@@ -284,9 +284,13 @@ public class ListParser {
         return token;
     }
 
-    // Keywords that can be autoquoted as hash keys when followed by =>
+    // Keywords and comparison operators that can be autoquoted as hash keys
+    // when followed by =>.  The comparison operators are tokenized as infix
+    // operators, so this check must happen before the list parser decides that
+    // a call has no arguments (for example, token(eq => value)).
     private static final Set<String> AUTOQUOTABLE_KEYWORDS = Set.of(
-            "and", "or", "xor", "when", "if", "unless", "while", "until", "for", "foreach"
+            "and", "or", "xor", "when", "if", "unless", "while", "until", "for", "foreach",
+            "eq", "ne", "lt", "gt", "le", "ge", "cmp"
     );
 
     /**
@@ -409,7 +413,13 @@ public class ListParser {
             if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("parseZeroOrMoreList looks like bareword " + token.text);
         } else if (ParserTables.INFIX_OP.contains(token.text) || token.text.equals(",")) {
             if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("parseZeroOrMoreList infix `" + token.text + "` followed by `" + nextToken.text + "`");
-            if (token.text.equals("<") || token.text.equals("<<")) {
+            // Comparison operators are valid bareword hash keys before a fat
+            // comma.  They look like infix operators here because there is no
+            // left operand yet, but they must be parsed as the first call
+            // argument instead of making the call appear argument-less.
+            if (AUTOQUOTABLE_KEYWORDS.contains(token.text) && nextToken.text.equals("=>")) {
+                // Leave isEmptyList false.
+            } else if (token.text.equals("<") || token.text.equals("<<")) {
                 // Looks like diamond operator
                 if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("parseZeroOrMoreList looks like <>");
             } else if (token.text.equals("+")) {

--- a/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
@@ -8,6 +8,7 @@ import org.perlonjava.frontend.lexer.LexerToken;
 import org.perlonjava.frontend.lexer.LexerTokenType;
 import org.perlonjava.frontend.semantic.SymbolTable;
 import org.perlonjava.runtime.perlmodule.Strict;
+import org.perlonjava.runtime.runtimetypes.GlobalVariable;
 import org.perlonjava.runtime.runtimetypes.NameNormalizer;
 import org.perlonjava.runtime.runtimetypes.PerlCompilerException;
 import org.perlonjava.runtime.runtimetypes.RuntimeCode;
@@ -518,6 +519,10 @@ public class ParseInfix {
             name = NameNormalizer.normalizeVariableName(
                     identifier.name,
                     parser.ctx.symbolTable.getCurrentPackage());
+        }
+        if (code.isConstantCv || code.constantValue != null
+                || GlobalVariable.hasGlobalPseudoConstant(name)) {
+            parser.throwError("Can't modify constant item in scalar assignment");
         }
         parser.throwError("Can't modify non-lvalue subroutine call of &" + name
                 + " in scalar assignment");

--- a/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
@@ -57,6 +57,18 @@ public class ParsePrimary {
         String operator = token.text;
         Node operand;
 
+        // Infix keyword operators are also legal bareword keys before a fat
+        // comma (for example C<eq => '(==)'>). Handle this before dispatching
+        // the operator token through the infix parser.
+        if (token.type == LexerTokenType.OPERATOR
+                && java.util.Set.of("eq", "ne", "lt", "gt", "le", "ge", "cmp")
+                    .contains(operator)) {
+            int nextIndex = Whitespace.skipWhitespace(parser, parser.tokenIndex, parser.tokens);
+            if (parser.tokens.get(nextIndex).text.equals("=>")) {
+                return new StringNode(operator, parser.tokenIndex);
+            }
+        }
+
         switch (token.type) {
             case IDENTIFIER:
                 // Handle identifiers: variables, subroutines, keywords, etc.
@@ -284,9 +296,14 @@ public class ParsePrimary {
      */
     static Node parseOperator(Parser parser, LexerToken token, String operator) {
         // Check for autoquoting: keyword operators before => should be treated as barewords
-        // This handles cases like: and => {...}, or => {...}, xor => {...}
-        if (operator.equals("and") || operator.equals("or") || operator.equals("xor")) {
-            String peekTokenText = peek(parser).text;
+        // This handles keyword operators used as ordinary hash/list keys.
+        if (operator.equals("and") || operator.equals("or") || operator.equals("xor")
+                || operator.equals("eq") || operator.equals("ne")
+                || operator.equals("lt") || operator.equals("gt")
+                || operator.equals("le") || operator.equals("ge")
+                || operator.equals("cmp")) {
+            int nextIndex = Whitespace.skipWhitespace(parser, parser.tokenIndex, parser.tokens);
+            String peekTokenText = parser.tokens.get(nextIndex).text;
             if (peekTokenText.equals("=>")) {
                 // Autoquote: convert operator keyword to string literal
                 return new StringNode(token.text, parser.tokenIndex);

--- a/src/test/resources/unit/cpan_parser_tooling_regressions.t
+++ b/src/test/resources/unit/cpan_parser_tooling_regressions.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+sub token { join '|', @_ }
+
+is(token(eq => 'value'), 'eq|value',
+    'word operator before fat comma is a bareword key');
+is(token(cmp => 'value'), 'cmp|value',
+    'comparison operator before fat comma is a bareword key');
+
+use constant READ_ONLY_VALUE => 1;
+eval 'READ_ONLY_VALUE = 2';
+like($@, qr/Can't modify constant item in scalar assignment/,
+    'assignment to a constant reports the constant-item diagnostic');
+
+$Astro::Constants::2019::VERSION = '0.15';
+is($Astro::Constants::2019::VERSION, '0.15',
+    'qualified scalar permits a numeric package segment');


### PR DESCRIPTION
## Summary

- parse comparison operators such as `eq =>` and `cmp =>` as fat-comma keys in direct call arguments
- report Perl's constant-item assignment diagnostic for known pseudo-constants
- accept numeric package segments in qualified variables such as `$Astro::Constants::2019::VERSION`
- add system-Perl-validated regression coverage for the shared compiler behavior

## Validation

- `prove src/test/resources/unit/cpan_parser_tooling_regressions.t` with system Perl
- regression file with both PerlOnJava JVM and interpreter backends
- `./jcpan -t Astro::Constants`: 23 files, 136 tests, PASS
- `make`: BUILD SUCCESSFUL, including all unit shards and Joni packaging/tests

## Deferred / excluded

- `(*MARK:NAME)` remains assigned to the parallel Joni migration
- XS-backed `Guard` and `Session::Token` dependency paths are deferred
- `LinAlg::Vector` and `Search::Typesense` fail to load their test stacks under system Perl in this environment, so they are excluded under the requested system-Perl gate

No distribution preference overrides are added.
