### PR TITLE
Fix quote-heavy CPAN parsing and Want contexts

### DIFF
--- a/dev/design/jcpan-six-module-tooling-20260817.md
+++ b/dev/design/jcpan-six-module-tooling-20260817.md
@@ -1,0 +1,61 @@
+# jcpan compiler and tooling compatibility batch (2026-08-17)
+
+## Objective
+
+Fix reusable compiler, runtime, and CPAN-tooling failures exposed by
+`WordNet::SenseRelate::WordToSet`, `SPVM::Sys::Time::Timezone`,
+`Data::OpenStruct::Deep`, `App::column::run`,
+`Dist::Zilla::Plugin::Rinci::AddPrereqs`, `Oracle::Loader`, and their
+dependencies. Targets that fail under system Perl may be excluded.
+
+## Progress Tracking
+
+### Current Status: implementation and local validation complete
+
+### Completed Phases
+
+- [x] Phase 1: initial reproduction and system-Perl gate (2026-08-17)
+  - `WordNet::SenseRelate::WordToSet` fails under system Perl because its
+    `WordNet::QueryData` prerequisite cannot be loaded, so that target is
+    excluded unless an earlier independent tooling defect is found.
+  - `Data::OpenStruct::Deep` exposed a bundled `Want` arity/prototype mismatch.
+  - `App::column::run` exposed quadratic parsing of the 2.3 MB PERLANCAR
+    `CHECKSUMS` file; a JVM thread dump located the repeated prefix scan in
+    `StringParser.parseRawStringWithDelimiter`.
+- [x] Phase 2: reusable compiler and runtime fixes (2026-08-17)
+  - Indexed each parser's token source-line offsets once by token identity,
+    preserving line numbers through token rewrites/removals while eliminating
+    the repeated prefix scan.
+  - Changed bundled `Want::want` from a one-scalar prototype to varargs and
+    matched combined, negated, scalar, list, lvalue, and chained-object
+    predicates against PerlOnJava's existing raw call contexts.
+- [x] Phase 3: target and project validation (2026-08-17)
+  - `Data::OpenStruct::Deep` passes 3 files / 11 tests on both system Perl and
+    PerlOnJava.
+  - `App::column::run` passes 5 files / 2 tests on PerlOnJava after its 2.3 MB
+    author `CHECKSUMS` file is parsed without the former timeout.
+  - `Dist::Zilla::Plugin::Rinci::AddPrereqs` passes 4 files / 1 test after its
+    full dependency graph is built.
+  - `WordNet::SenseRelate::WordToSet` is excluded because system Perl cannot
+    load its `WordNet::QueryData` prerequisite.
+  - `SPVM::Sys::Time::Timezone` is excluded because system Perl cannot build
+    the SPVM and SPVM::Resource prerequisite chain.
+  - `Oracle::Loader` is excluded because its unchanged distribution installs
+    root `Loader.pm` while its test requires `Oracle/Loader.pm`; system Perl
+    fails before running any assertions.
+  - The upstream Want behavior regression was validated with system Perl, and
+    the full project `make` passes all unit shards and packaging checks.
+
+### Next Steps
+
+1. Run final post-documentation validation and commit with attribution.
+2. Publish the pull request and monitor Linux and Windows CI.
+
+### Open Questions
+
+- None. The three excluded targets have reproducible system-Perl failures.
+
+## Related References
+
+- `.agents/skills/debug-perlonjava/SKILL.md`
+- `docs/guides/module-porting.md`

--- a/dev/design/jcpan-six-module-tooling-20260817.md
+++ b/dev/design/jcpan-six-module-tooling-20260817.md
@@ -10,7 +10,7 @@ dependencies. Targets that fail under system Perl may be excluded.
 
 ## Progress Tracking
 
-### Current Status: implementation and local validation complete
+### Current Status: complete; PR #997 open with passing CI
 
 ### Completed Phases
 
@@ -45,11 +45,15 @@ dependencies. Targets that fail under system Perl may be excluded.
     fails before running any assertions.
   - The upstream Want behavior regression was validated with system Perl, and
     the full project `make` passes all unit shards and packaging checks.
+- [x] Phase 4: publication and CI (2026-08-17)
+  - Opened PR #997 from `fix/jcpan-tooling-six-modules-20260817`.
+  - GitHub Actions run 32033100182 passes both required jobs: Ubuntu's full
+    build and Perl thread compatibility gate, and Windows' full build and
+    focused thread gate.
 
 ### Next Steps
 
-1. Run final post-documentation validation and commit with attribution.
-2. Publish the pull request and monitor Linux and Windows CI.
+1. Wait for review and merge of PR #997.
 
 ### Open Questions
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -4,6 +4,12 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 
 ## Work in progress
 
+- CPAN/compiler tooling: index token source-line offsets once per parser so
+  quote-heavy generated sources such as multi-megabyte CPAN `CHECKSUMS` files
+  parse linearly instead of quadratically. Complete bundled `Want::want`
+  varargs and chained-object context handling. This unblocks
+  Data::OpenStruct::Deep, App::column::run, and
+  Dist::Zilla::Plugin::Rinci::AddPrereqs without distribution preferences.
 - CPAN/compiler tooling: permit exact-identity literal argument assignment,
   parse indirect constructors after trailing package separators, create nested
   MakeMaker `.PL` targets safely, and finish fixed test plans with explicit

--- a/src/main/java/org/perlonjava/frontend/parser/Parser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/Parser.java
@@ -17,6 +17,7 @@ import org.perlonjava.runtime.runtimetypes.RuntimeArray;
 import org.perlonjava.runtime.CompilationRuntimeState;
 
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
 
 import static org.perlonjava.frontend.parser.SpecialBlockParser.setCurrentScope;
@@ -80,6 +81,11 @@ public class Parser {
     // re-tokenized string content and __LINE__ should use this as the base line,
     // counting newlines from the inner token list to offset from it.
     public int baseLineNumber = 0;
+    // Source-line offsets are indexed once by token identity. String parsing used
+    // to rescan every preceding token for every quote-like operator, which made
+    // large generated Perl data files (notably CPAN CHECKSUMS) quadratic to parse.
+    // Identity keys remain valid when parsing rewrites or removes nearby tokens.
+    private final IdentityHashMap<LexerToken, Integer> sourceLineOffsets = new IdentityHashMap<>();
     /**
      * When {@code true} (qq and normal strings), {@link Variable#parseBracedVariable} may rewrite
      * {@code \"} before {@code "} inside {@code ${...}} so patterns like {@code "${\"name\"}"}
@@ -98,6 +104,7 @@ public class Parser {
     public Parser(EmitterContext ctx, List<LexerToken> tokens) {
         this.ctx = ctx;
         this.tokens = tokens;
+        indexSourceLines();
         if (ctx != null && ctx.symbolTable != null) {
             setCurrentScope(ctx.symbolTable);
         }
@@ -108,11 +115,42 @@ public class Parser {
         this.ctx = ctx;
         this.tokens = tokens;
         this.tokenIndex = 0;
+        indexSourceLines();
         // Share the heredoc nodes list instead of creating a new one
         this.heredocNodes = sharedHeredocNodes;
         if (ctx != null && ctx.symbolTable != null) {
             setCurrentScope(ctx.symbolTable);
         }
+    }
+
+    private void indexSourceLines() {
+        int lineOffset = 0;
+        for (LexerToken token : tokens) {
+            sourceLineOffsets.put(token, lineOffset);
+            if (token.type == LexerTokenType.NEWLINE) {
+                lineOffset++;
+            }
+        }
+    }
+
+    /** Return the source line at a token without repeatedly scanning the token list. */
+    public int sourceLineAt(int tokenIndex) {
+        int baseLine = baseLineNumber > 0 ? baseLineNumber : 1;
+        if (tokenIndex >= 0 && tokenIndex < tokens.size()) {
+            Integer offset = sourceLineOffsets.get(tokens.get(tokenIndex));
+            if (offset != null) {
+                return baseLine + offset;
+            }
+        }
+
+        // Synthetic tokens are rare; retain a correctness fallback for them.
+        int sourceLine = baseLine;
+        for (int i = 0; i < Math.min(tokenIndex, tokens.size()); i++) {
+            if (tokens.get(i).type == LexerTokenType.NEWLINE) {
+                sourceLine++;
+            }
+        }
+        return sourceLine;
     }
 
     public static boolean isExpressionTerminator(LexerToken token) {

--- a/src/main/java/org/perlonjava/frontend/parser/StringParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringParser.java
@@ -313,12 +313,7 @@ public class StringParser {
         }
         ParsedString parsed = new ParsedString(index, tokPos, buffers, startDelim, endDelim,
                 secondBufferStartDelim, secondBufferEndDelim);
-        int sourceLine = parser != null && parser.baseLineNumber > 0
-                ? parser.baseLineNumber : 1;
-        for (int i = 0; i < Math.min(index, tokens.size()); i++) {
-            if (tokens.get(i).type == LexerTokenType.NEWLINE) sourceLine++;
-        }
-        parsed.sourceLine = sourceLine;
+        parsed.sourceLine = parser != null ? parser.sourceLineAt(index) : 1;
         return parsed;
     }
 

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Want.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Want.java
@@ -19,32 +19,55 @@ public class Want extends PerlModuleBase {
         Want want = new Want();
         GlobalVariable.getGlobalVariable("Want::VERSION").set(new RuntimeScalar("0.29"));
         try {
-            want.registerMethod("want", "$");
+            want.registerMethod("want", "@");
         } catch (NoSuchMethodException e) {
             throw new IllegalStateException("Missing Want::want implementation", e);
         }
     }
 
     public static RuntimeList want(RuntimeArray args, int ctx) {
-        if (args.size() != 1) {
-            throw new IllegalStateException("want() expects exactly one argument");
+        Integer callerContext = RuntimeCode.getCallContextAtCallerFrame(1);
+        for (RuntimeScalar arg : args) {
+            for (String requested : arg.toString().trim().split("\\s+")) {
+                if (requested.isEmpty()) continue;
+                boolean negative = requested.startsWith("!");
+                String kind = (negative ? requested.substring(1) : requested).toUpperCase();
+                boolean matches = switch (kind) {
+                    case "VOID" -> callerContext != null && callerContext == RuntimeContextType.VOID;
+                    case "LIST" -> callerContext != null && RuntimeContextType.isListLike(callerContext);
+                    case "SCALAR" -> callerContext != null
+                            && (callerContext == RuntimeContextType.SCALAR
+                            || callerContext == RuntimeContextType.LVALUE
+                            || callerContext == RuntimeContextType.OBJECT);
+                    case "LVALUE", "ASSIGN" -> callerContext != null
+                            && (callerContext == RuntimeContextType.LVALUE
+                            || callerContext == RuntimeContextType.LVALUE_LIST);
+                    case "OBJECT" -> callerContext != null
+                            && callerContext == RuntimeContextType.OBJECT;
+                    case "RVALUE" -> callerContext == null
+                            || (callerContext != RuntimeContextType.LVALUE
+                            && callerContext != RuntimeContextType.LVALUE_LIST);
+                    case "INFINITY" -> callerContext != null
+                            && RuntimeContextType.isListLike(callerContext);
+                    case "BOOL", "BOOLEAN", "ARRAY", "HASH", "CODE", "GLOB",
+                            "REF", "REFSCALAR" -> false;
+                    default -> {
+                        if (kind.matches("[0-9]+")) {
+                            if (callerContext != null && RuntimeContextType.isListLike(callerContext)) {
+                                yield true;
+                            }
+                            int count = callerContext != null
+                                    && callerContext == RuntimeContextType.VOID ? 0 : 1;
+                            yield count >= Integer.parseInt(kind);
+                        }
+                        yield false;
+                    }
+                };
+                if (negative ? matches : !matches) {
+                    return RuntimeScalarCache.scalarFalse.getList();
+                }
+            }
         }
-
-        String kind = args.get(0).toString().toUpperCase();
-        Integer callerContext = RuntimeCode.getCallContextAt(1);
-        boolean matches = switch (kind) {
-            case "VOID" -> callerContext != null && callerContext == RuntimeContextType.VOID;
-            case "LIST" -> callerContext != null && RuntimeContextType.isListLike(callerContext);
-            case "SCALAR" -> callerContext != null
-                    && (callerContext == RuntimeContextType.SCALAR
-                    || callerContext == RuntimeContextType.LVALUE);
-            case "LVALUE", "ASSIGN" -> callerContext != null
-                    && (callerContext == RuntimeContextType.LVALUE
-                    || callerContext == RuntimeContextType.LVALUE_LIST);
-            case "OBJECT", "RVALUE" -> true;
-            case "BOOL" -> false;
-            default -> false;
-        };
-        return (matches ? RuntimeScalarCache.scalarTrue : RuntimeScalarCache.scalarFalse).getList();
+        return RuntimeScalarCache.scalarTrue.getList();
     }
 }

--- a/src/main/perl/lib/Want.pm
+++ b/src/main/perl/lib/Want.pm
@@ -15,19 +15,23 @@ our $VERSION = '0.29';
 our @EXPORT = qw(want rreturn lnoreturn wantref want_ref);
 
 sub want {
-    my ($kind) = @_;
-    return !defined wantarray if $kind eq 'VOID';
-    return defined(wantarray) && wantarray if $kind eq 'LIST';
-    return defined(wantarray) && !wantarray if $kind eq 'SCALAR';
+    my @wanted = map { split } @_;
+    for my $kind (@wanted) {
+        my $matches;
+        $matches = !defined wantarray if $kind eq 'VOID';
+        $matches = defined(wantarray) && wantarray if $kind eq 'LIST';
+        $matches = defined(wantarray) && !wantarray if $kind eq 'SCALAR';
 
-    # PerlOnJava currently has no runtime op tree.  Method chaining is the
-    # useful OBJECT case supported by this compatibility layer.  RVALUE is
-    # the safe default outside lvalue calls; BOOL remains conservative.
-    return 1 if $kind eq 'OBJECT';
-    return 1 if $kind eq 'RVALUE';
-    return 0 if $kind eq 'BOOL';
-    return 0 if $kind eq 'LVALUE' || $kind eq 'ASSIGN';
-    return 0;
+        # PerlOnJava's portable fallback has no runtime op tree. OBJECT
+        # requires parent-op inspection and is supplied by the Java
+        # bridge. RVALUE is the safe fallback outside lvalue calls; BOOL and
+        # other parent-op-only predicates remain conservative here.
+        $matches = 1 if $kind eq 'RVALUE';
+        $matches = 0 if $kind eq 'OBJECT' || $kind eq 'BOOL'
+            || $kind eq 'LVALUE' || $kind eq 'ASSIGN';
+        return 0 unless $matches;
+    }
+    return 1;
 }
 
 sub rreturn { return wantarray ? @_ : $_[-1] }

--- a/src/test/java/org/perlonjava/frontend/parser/ParserSourceLineIndexTest.java
+++ b/src/test/java/org/perlonjava/frontend/parser/ParserSourceLineIndexTest.java
@@ -1,0 +1,37 @@
+package org.perlonjava.frontend.parser;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.perlonjava.frontend.lexer.Lexer;
+import org.perlonjava.frontend.lexer.LexerToken;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("unit")
+class ParserSourceLineIndexTest {
+    @Test
+    void sourceLinesRemainStableWhenEarlierTokensAreRemoved() {
+        List<LexerToken> tokens = new Lexer("q{first};\nq{second};\nq{third};").tokenize();
+        Parser parser = new Parser(null, tokens);
+        List<LexerToken> quoteOperators = new ArrayList<>();
+        for (LexerToken token : tokens) {
+            if (token.text.equals("q")) {
+                quoteOperators.add(token);
+            }
+        }
+
+        assertEquals(3, quoteOperators.size());
+        assertEquals(1, parser.sourceLineAt(tokens.indexOf(quoteOperators.get(0))));
+        assertEquals(2, parser.sourceLineAt(tokens.indexOf(quoteOperators.get(1))));
+        assertEquals(3, parser.sourceLineAt(tokens.indexOf(quoteOperators.get(2))));
+
+        tokens.remove(quoteOperators.get(0));
+        assertEquals(3, parser.sourceLineAt(tokens.indexOf(quoteOperators.get(2))));
+
+        parser.baseLineNumber = 40;
+        assertEquals(42, parser.sourceLineAt(tokens.indexOf(quoteOperators.get(2))));
+    }
+}

--- a/src/test/resources/unit/want_combined_context.t
+++ b/src/test/resources/unit/want_combined_context.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+use Want ();
+
+{
+    package Local::WantChain;
+    sub new { bless {}, shift }
+    sub step {
+        my ($self) = @_;
+        return Want::want('OBJECT', 'SCALAR') ? $self : 'done';
+    }
+}
+
+my $chain = Local::WantChain->new;
+is($chain->step, 'done', 'OBJECT predicate rejects an ordinary scalar result');
+is($chain->step->step, 'done', 'combined OBJECT and SCALAR match a chained invocant');
+my @list = $chain->step;
+is_deeply(\@list, ['done'], 'combined predicates reject list context');
+is($chain->step, 'done', 'ordinary scalar context remains stable after a chain');


### PR DESCRIPTION
## Summary

- index token source-line offsets once per parser, eliminating quadratic parsing of quote-heavy generated sources such as CPAN author `CHECKSUMS`
- complete bundled `Want::want` varargs and raw chained-object context behavior
- add upstream-validated regressions and document the six-module compatibility batch

## Target results

- `Data::OpenStruct::Deep`: passes 3 files / 11 tests on system Perl and PerlOnJava
- `App::column::run`: passes 5 files / 2 tests on PerlOnJava; its 2.3 MB author `CHECKSUMS` no longer times out
- `Dist::Zilla::Plugin::Rinci::AddPrereqs`: passes 4 files / 1 test on PerlOnJava
- `WordNet::SenseRelate::WordToSet`: excluded because system Perl cannot load `WordNet::QueryData`
- `SPVM::Sys::Time::Timezone`: excluded because system Perl cannot build its SPVM/SPVM::Resource prerequisite chain
- `Oracle::Loader`: excluded because the unchanged distribution installs root `Loader.pm` while its own test requires `Oracle/Loader.pm`, and system Perl runs zero assertions

## Validation

- `make` — all unit shards, Joni tests, packaging verification, and shadow JAR build pass
- upstream `Want` regression under system Perl — 4/4 assertions pass
- `want_combined_context.t` under both JVM and interpreter backends — 4/4 assertions pass
- no distribution preference overrides added

Generated with [Codex](https://openai.com/codex)
