### PR TITLE
docs: reconcile feature status and historical plans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,12 +255,16 @@ Example format at the end of a design doc:
 
 ### Unimplemented Features
 
+Perl ithreads are implemented on both execution backends, including the bundled
+`threads`, `threads::shared`, `Thread::Queue`, and `Thread::Semaphore` modules.
+See [docs/reference/threads.md](docs/reference/threads.md) for the supported
+surface and remaining ecosystem-specific limitations.
+
 PerlOnJava does **not** implement the following Perl features:
 
 | Feature | Impact |
 |---------|--------|
 | `fork` | Process forking not available; use `perl` (not `jperl`) to run `perl_test_runner.pl` |
-| `threads` | Perl threads not supported; use Java threading via inline Java if needed |
 
 ### Testing
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -178,16 +178,15 @@ public class TestPerl {
         // Execute Perl code
         engine.eval("print 'Hello from Java!\\n'");
 
-        // Pass variables
-        engine.put("name", "World");
-        engine.eval("say \"Hello, $name!\"");
-
         // Get results
         Object result = engine.eval("2 + 2");
         System.out.println("Result: " + result);
     }
 }
 ```
+
+Java `Bindings` are not yet exposed as Perl globals; return values from Perl
+source as shown above. See the full guide for the supported embedding surface.
 
 **Full guide:** **[Java Integration Guide](docs/guides/java-integration.md)**
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/fglock/PerlOnJava/workflows/Java%20CI%20with%20Gradle/badge.svg)](https://github.com/fglock/PerlOnJava/actions)
 [![License](https://img.shields.io/badge/license-Artistic_1.0_|_GPL_1+-blue.svg)](LICENSE.md)
 
-PerlOnJava compiles Perl to JVM bytecode — run existing Perl scripts on any platform with a JVM, with access to Java libraries. One jar file runs on Linux, macOS, and Windows — just add Java 24+. PerlOnJava is an independent project, not part of the Perl core distribution.
+PerlOnJava compiles Perl to JVM bytecode, so many existing Perl scripts can run on any platform with a JVM and use supported Java-backed libraries. Compatibility is substantial but not complete; check the [feature matrix](docs/reference/feature-matrix.md) and [bundled-module list](docs/reference/bundled-modules.md) before relying on a particular language feature or CPAN module. One jar file runs on Linux, macOS, and Windows — just add Java 24+. PerlOnJava is an independent project, not part of the Perl core distribution.
 
 ## Features
 
@@ -16,7 +16,7 @@ PerlOnJava compiles Perl to JVM bytecode — run existing Perl scripts on any pl
 - **Install more with jcpan** — [pure-Perl CPAN modules](docs/guides/using-cpan-modules.md) work out of the box
 - **JDBC database access** — [PostgreSQL, MySQL, SQLite, Oracle](docs/guides/database-access.md) via standard JDBC drivers
 - **Embed in Java apps** — [JSR-223 ScriptEngine](docs/guides/java-integration.md) integration
-- **Perl 5.44 language compatibility** — [see feature matrix](docs/reference/feature-matrix.md)
+- **Perl 5.44 language compatibility target** — implemented coverage and limitations are tracked in the [feature matrix](docs/reference/feature-matrix.md)
 
 ## Quick Start
 

--- a/dev/design/README.md
+++ b/dev/design/README.md
@@ -113,9 +113,14 @@ When adding new design documents:
 
 For the most important architectural decisions and current work, check:
 
-- **multiplicity.md** - Multiple independent Perl runtimes (enables fork/threads/web concurrency)
-- **jsr223-perlonjava-web.md** - JSR-223 compliance and web server integration
-- **fork.md** / **threads.md** - Concurrency model and limitations
+- [Concurrency and runtime isolation](concurrency.md) - Multiple independent
+  runtimes, ithread snapshots, shared storage, and resource ownership
+- [JSR-223 and web integration](jsr223-perlonjava-web.md) - Script-engine
+  compliance, runtime pooling, and web server integration
+- [Fork-open emulation](fork_open_emulation.md) - Supported pipe-open patterns
+  despite the absence of a general `fork` operator
+- [Public thread reference](../../docs/reference/threads.md) - Supported ithread
+  behavior, limitations, and test gates
 
 These represent major architectural directions for the project.
 

--- a/dev/design/caller_package_context.md
+++ b/dev/design/caller_package_context.md
@@ -1,5 +1,9 @@
 # Fix caller() Package Context for Inlined Code
 
+> **Historical document (completed).** Retained as implementation history; use
+> the [feature matrix](../../docs/reference/feature-matrix.md) for the supported
+> `caller` surface and current limitations.
+
 > **Note:** This document has been consolidated into `dev/design/caller_stack_fix_plan.md`.
 > See that document for the current plan and status. This document is kept for historical reference.
 

--- a/dev/design/caller_stack_fix_plan.md
+++ b/dev/design/caller_stack_fix_plan.md
@@ -1,6 +1,10 @@
 # Caller Stack Fix Plan - Consolidated
 
-## Status: Active Development
+> **Historical document (completed and superseded).** Retained as implementation
+> history; use the [feature matrix](../../docs/reference/feature-matrix.md) and
+> [runtime architecture](../../docs/reference/architecture.md) for current status.
+
+## Historical Status: Completed
 
 ## Branch: `fix/caller-line-numbers`
 

--- a/dev/design/destroy_weaken_plan.md
+++ b/dev/design/destroy_weaken_plan.md
@@ -1,5 +1,8 @@
 # DESTROY and weaken() — Design & Status
 
+> **Historical document (completed and superseded).** The maintained architecture
+> is [Weak References and Deterministic Destruction](../architecture/weaken-destroy.md).
+
 **Status**: Moo 71/71 (100%); DBIx::Class broad test suite passing  
 **Version**: 7.0  
 **Created**: 2026-04-08  

--- a/dev/design/documentation.md
+++ b/dev/design/documentation.md
@@ -1,4 +1,9 @@
-The current documentation structure can be enhanced by:
+# Historical Documentation Restructure Proposal
+
+> **Historical document (superseded).** This proposal predates the current
+> `docs/` hierarchy. Start with the [documentation index](../../docs/README.md).
+
+The documentation structure was proposed to be enhanced by:
 
 Creating topic-specific guides:
 

--- a/dev/design/getting_started.md
+++ b/dev/design/getting_started.md
@@ -1,4 +1,10 @@
-**Work in Progress**
+# Historical Getting-Started Draft
+
+> **Historical document (superseded).** Use the maintained
+> [installation guide](../../docs/getting-started/installation.md) and
+> [quick start](../../QUICKSTART.md).
+
+**Archived work in progress**
 
 # Getting Started with PerlOnJava
 
@@ -138,4 +144,3 @@ if ($@) {
 ```
 
 This guide covers the essentials to get you started with PerlOnJava. For more detailed information, refer to the specific guides in the docs directory.
-

--- a/dev/design/implementation_status.md
+++ b/dev/design/implementation_status.md
@@ -1,4 +1,11 @@
-Here are some effective strategies to make the implementation status visible:
+# Historical Implementation-Status Proposal
+
+> **Historical document (superseded).** The public
+> [feature matrix](../../docs/reference/feature-matrix.md),
+> [roadmap](../../docs/about/roadmap.md), and
+> [changelog](../../docs/about/changelog.md) are the maintained status sources.
+
+Here are some effective strategies that were considered for making implementation status visible:
 1. Documentation
 
 Feature Matrix:
@@ -98,4 +105,3 @@ Here's an example of how you might structure a feature matrix in your documentat
 ## Regular Expressions
 - [x] Basic Matching
 - [ ] Advanced Features (Buggy)
-

--- a/dev/design/object_lifecycle.md
+++ b/dev/design/object_lifecycle.md
@@ -1,5 +1,8 @@
 # Object Lifecycle: DESTROY and Weak References
 
+> **Historical document (superseded).** The maintained architecture is
+> [Weak References and Deterministic Destruction](../architecture/weaken-destroy.md).
+
 **Status**: Design Proposal (Technically Reviewed)  
 **Version**: 1.0  
 **Created**: 2026-03-26  

--- a/dev/design/state_variables.md
+++ b/dev/design/state_variables.md
@@ -1,3 +1,8 @@
+# State Variables Implementation Notes
+
+> **Historical document (completed).** Retained as implementation history;
+> `state` variables are implemented on both execution backends and their current
+> status is tracked in the [feature matrix](../../docs/reference/feature-matrix.md).
 
 Store state variables as instance fields within the dynamically generated classes in EmitterMethodCreator.java. This ensures that each instance of a subroutine has its own copy of the state variables, while still allowing these variables to persist across calls to the same instance.
 

--- a/dev/design/test_pass_rate_improvement_plan.md
+++ b/dev/design/test_pass_rate_improvement_plan.md
@@ -1,5 +1,9 @@
 # Test Pass Rate Improvement Plan
 
+> **Historical document (superseded).** Counts and priorities below are a
+> point-in-time planning snapshot. Use the current test reports, roadmap, and
+> feature matrix when choosing new compatibility work.
+
 **Date:** 2025-03-31
 **Branch:** fix/sregex-args-propagation
 **Baseline:** PR #410 test run — 93.4% individual test pass rate, 256/620 files fully passing

--- a/dev/design/unified_caller_stack.md
+++ b/dev/design/unified_caller_stack.md
@@ -1,5 +1,10 @@
 # Unified Caller Stack Implementation
 
+> **Historical document (superseded).** This plan records work that has been
+> incorporated into the current caller and runtime-isolation implementations.
+> Use the [feature matrix](../../docs/reference/feature-matrix.md) and
+> [runtime architecture](../../docs/reference/architecture.md) for current status.
+
 > **Note:** This document has been consolidated into `dev/design/caller_stack_fix_plan.md`.
 > See that document for the current plan and status.
 

--- a/dev/design/v1_9_0.md
+++ b/dev/design/v1_9_0.md
@@ -1,4 +1,11 @@
-The upcoming milestone for PerlOnJava v1.8.0 focuses on adding concurrency and security features. Here's a breakdown of what these features involve, their relevance, how Java handles them, and a possible plan for their implementation:
+# Historical v1.8/v1.9 Milestone Notes
+
+> **Historical document (superseded).** This early milestone proposal does not
+> describe the current release. Use the [roadmap](../../docs/about/roadmap.md),
+> [changelog](../../docs/about/changelog.md), and
+> [feature matrix](../../docs/reference/feature-matrix.md) for current status.
+
+The upcoming milestone for PerlOnJava v1.8.0 focused on adding concurrency and security features. Here's a breakdown of what these features involved, their relevance, how Java handles them, and a possible plan for their implementation:
 
 ### 1. **Concurrency and Parallelism:**
    - **Threads:** Introducing multithreading support allows for parallel execution of tasks, which improves performance in multi-core systems by dividing workloads. For PerlOnJava, it could mean enabling multiple parts of a Perl script to run in parallel using JVM’s native thread handling.
@@ -41,4 +48,3 @@ The upcoming milestone for PerlOnJava v1.8.0 focuses on adding concurrency and s
 5. **Community Feedback:** Encourage feedback and bug reports from PerlOnJava users, focusing on real-world concurrency and security use cases.
 
 By introducing these features, PerlOnJava can become more robust, making it suitable for larger, more secure, and concurrent workloads. Java’s ecosystem already has strong support for these features, so leveraging these tools would help bring PerlOnJava up to modern standards.
-

--- a/docs/about/relation-perlito.md
+++ b/docs/about/relation-perlito.md
@@ -4,5 +4,9 @@ The key difference between PerlOnJava and Perlito (https://github.com/fglock/Per
 
 From an architectural standpoint, PerlOnJava is more mature. However, Perlito is currently more feature-rich due to its longer development history. PerlOnJava, however, doesn't support JavaScript like Perlito does.
 
-Both compilers share certain limitations imposed by the JVM, such as the lack of support for XS modules and auto-closing filehandles, among others. PerlOnJava implements `DESTROY` via selective reference counting.
-
+Both compilers inherit constraints from the JVM, but PerlOnJava's current
+limitations are narrower than a blanket “no XS or automatic close” statement.
+Native C/XS binaries cannot run, while documented modules use Java replacements
+or pure-Perl fallbacks. Lexical filehandle cleanup, including descriptor closure,
+works on the JVM backend; the interpreter backend's descriptor closure remains
+incomplete. PerlOnJava implements `DESTROY` via selective reference counting.

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -84,7 +84,10 @@ Work currently in progress:
 
 - ~~**`DESTROY` Support**~~ — Implemented with selective reference counting. Supports cascading destruction, closure capture tracking, and global destruction phase.
 - ~~**Weak References**~~ — Implemented: `Scalar::Util::weaken`/`isweak`/`unweaken` with external WeakRefRegistry.
-- **Taint Mode (`-T`)** — Track external data provenance using a `TAINTED` wrapper type (no extra storage for untainted scalars). Required for security-sensitive Perl applications. See `dev/design/TAINT_MODE.md`.
+- ~~**Taint Mode (`-T`)**~~ — Implemented on both backends. External input is
+  marked tainted, taint propagates through supported operations, capture-based
+  untainting works, and security-sensitive operations reject tainted values.
+  Warning-mode `-t` semantics remain incomplete. See `dev/design/TAINT_MODE.md`.
 - **Dynamically-Scoped Regex Variables** — `$1`, `$2`, etc. should be localized per regex match in the dynamic scope.
 
 ### Missing Regex Features
@@ -112,9 +115,12 @@ Work currently in progress:
 
 ### Compiler Flags and Special Variables
 
-- **`$^H` and `%^H`** — Compile-time hint variables (needed for many pragmas).
-- **`${^WARNING_BITS}`** — Warning category bitmask.
-- **Extended `caller` info** — Full 11-element return from `caller($level)`.
+- ~~**`$^H`, `%^H`, and `${^WARNING_BITS}` snapshots**~~ — Lexical
+  compile-time state and extended `caller` fields are implemented on both
+  backends. Exact compatibility for every pragma-specific mutation and warning
+  bit remains ongoing.
+- ~~**Extended `caller` info**~~ — The full 11-element return from
+  `caller($level)` is implemented on both backends.
 
 ---
 
@@ -342,5 +348,8 @@ These features are unlikely to be implemented due to fundamental JVM constraints
 - **Perl XS (C code)** — C extensions cannot run on JVM. Java XS fallback mechanism is the replacement strategy.
 - **`dump` operator** — Core dump functionality has no JVM equivalent.
 - **DBM file support** — `dbmclose`/`dbmopen` not implemented; use DBI instead.
-- **Source filters** — `Filter::Util::Call` style source manipulation is not planned.
+- **Source filters beyond the supported subset** — Closure filters installed
+  through `Filter::Util::Call`, `Filter::Simple::FILTER`, and `FILTER_ONLY`
+  work. Object/method filters and Perl-compatible incremental streaming remain
+  deferred; see `dev/design/source_filters.md`.
 - **`Opcode.pm`** — Requires Perl opcode tree internals that don't exist in PerlOnJava's compilation model.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,10 +2,7 @@
 
 ## Table of Contents
 1. [Prerequisites](#prerequisites)
-2. [Build Options](#build-options)
-   - [Using Make](#using-make)
-   - [Using Maven](#using-maven)
-   - [Using Gradle](#using-gradle)
+2. [Building from Source](#building-from-source)
 3. [Package Installation](#package-installation)
    - [Debian Package](#debian-package)
 4. [Dependencies](#dependencies)
@@ -25,13 +22,13 @@
 
 ## Prerequisites
 - JDK 24 or later
-- Maven, or the included Gradle wrapper (recommended)
+- Make and the included Gradle wrapper
 - Optional: JDBC drivers for database connectivity
 
-## Build Options
+## Building from Source
 
-### Using Make
-The project includes a Makefile that wraps Gradle commands for a familiar build experience:
+Use the project Makefile for source builds. It applies the repository's tested
+Gradle configuration consistently:
 
 ```bash
 make          # same as 'make build'
@@ -39,16 +36,6 @@ make build    # builds the project and runs unit tests
 make test     # runs fast unit tests
 make clean    # cleans build artifacts
 make deb      # creates a Debian package (Linux only)
-```
-
-### Using Maven
-```bash
-mvn clean package
-```
-
-### Using Gradle
-```bash
-./gradlew clean build
 ```
 
 ## Package Installation

--- a/docs/guides/database-access.md
+++ b/docs/guides/database-access.md
@@ -30,9 +30,7 @@ Examples:
 
 Then build with the drivers included:
 ```bash
-mvn clean package
-# or
-./gradlew clean build
+make
 ```
 
 2. Using Java classpath:

--- a/docs/guides/java-integration.md
+++ b/docs/guides/java-integration.md
@@ -23,46 +23,29 @@ public class PerlExample {
 }
 ```
 
-### Passing Variables
-
-```java
-ScriptEngine engine = manager.getEngineByName("perl");
-
-// Set variables
-engine.put("name", "World");
-engine.put("count", 42);
-
-// Access in Perl
-engine.eval("say \"Hello, $name! Count: $count\"");
-```
-
 ### Getting Results
 
 ```java
 // Evaluate and get result
 Object result = engine.eval("2 + 2");
 System.out.println("Result: " + result);  // Output: Result: 4
-
-// Use variables
-engine.put("x", 10);
-engine.put("y", 20);
-Object sum = engine.eval("$x + $y");
-System.out.println("Sum: " + sum);  // Output: Sum: 30
 ```
 
-### Using Perl Subroutines
+`ScriptEngine.put()` and other Java `Bindings` are not yet bridged to Perl
+globals. Put values into the Perl source explicitly (with appropriate quoting
+or serialization), or expose a purpose-built Java-backed Perl module through
+the documented `XSLoader` integration. Binding bridging is tracked as remaining
+JSR-223 work in the [roadmap](../about/roadmap.md#jsr-223-compliance-improvements).
+
+### Compiling Once and Running Repeatedly
 
 ```java
-ScriptEngine engine = manager.getEngineByName("perl");
+import javax.script.Compilable;
+import javax.script.CompiledScript;
 
-// Define subroutine
-engine.eval("sub multiply { my ($a, $b) = @_; return $a * $b; }");
-
-// Call it
-engine.put("x", 5);
-engine.put("y", 7);
-Object result = engine.eval("multiply($x, $y)");
-System.out.println("Result: " + result);  // Output: Result: 35
+CompiledScript script = ((Compilable) engine).compile("40 + 2");
+System.out.println(script.eval());  // Output: 42
+System.out.println(script.eval());  // Reuses the compiled script
 ```
 
 ### Error Handling
@@ -123,58 +106,17 @@ try {
 }
 ```
 
-## Using PerlOnJava Directly
-
-For more control, you can use PerlOnJava's internal API directly.
-
-### Compiling Perl Code
-
-```java
-import org.perlonjava.runtime.runtimetypes.PerlCompiler;
-
-public class DirectExample {
-    public static void main(String[] args) {
-        PerlCompiler compiler = new PerlCompiler();
-        compiler.compile("say 'Hello World';");
-        compiler.run();
-    }
-}
-```
-
 ## Building with PerlOnJava
 
 PerlOnJava is not yet published to Maven Central. You can use the runnable JAR
-directly, or install the artifact into your local Maven repository:
+directly. When embedding a source checkout, build and test it with the project
+Makefile:
 
 ```bash
-mvn clean install
+make
 ```
 
-### Maven
-
-After installing it locally, add PerlOnJava as a dependency:
-
-```xml
-<dependency>
-    <groupId>org.perlonjava</groupId>
-    <artifactId>perlonjava</artifactId>
-    <version>5.44.0</version>
-</dependency>
-```
-
-### Gradle
-
-```gradle
-repositories {
-    mavenLocal()
-}
-
-dependencies {
-    implementation 'org.perlonjava:perlonjava:5.44.0'
-}
-```
-
-### Manual JAR
+### Runnable JAR from a source build
 
 1. Build PerlOnJava:
    ```bash
@@ -197,9 +139,11 @@ Use Perl for flexible configuration:
 
 ```java
 ScriptEngine engine = manager.getEngineByName("perl");
-engine.eval(Files.readString(Path.of("config.pl")));
-Object config = engine.get("config");
+Object configText = engine.eval(Files.readString(Path.of("config.pl")));
 ```
+
+Have the script return a string value (for example JSON) and decode it in Java;
+`engine.get()` does not currently read Perl globals.
 
 ### Data Processing
 

--- a/docs/reference/bundled-modules.md
+++ b/docs/reference/bundled-modules.md
@@ -447,8 +447,8 @@ These are loaded automatically or via `use`:
 | `Sys::Hostname` | Java | |
 | `I18N::Langinfo` | Java | |
 | `Benchmark` | Perl | |
-| `Filter::Simple` | Perl | |
-| `Filter::Util::Call` | Java | |
+| `Filter::Simple` | Perl | `FILTER` and `FILTER_ONLY` closure filters; method filters and true incremental streaming remain unsupported |
+| `Filter::Util::Call` | Java | Closure-based `filter_add`/`filter_read`/`filter_del`; buffered line-oriented emulation, without object/method filters |
 | `Tie::Hash` / `Tie::Array` / `Tie::Scalar` | Perl | |
 | `Tie::RefHash` | Perl | |
 | `Tie::Hash::Indexed` | Java XS bridge | Ordered tied-hash and object APIs, iterators, arithmetic helpers, and Storable hooks; no native C compiler required |

--- a/docs/reference/cli-options.md
+++ b/docs/reference/cli-options.md
@@ -110,6 +110,13 @@ jperl [options] [program | -e 'command'] [arguments]
 
 ### Warnings and Strictness
 
+- **`-T`** - Enable taint mode. External input is marked tainted, taint is
+  propagated, and security-sensitive operations reject unsafe values on both
+  execution backends.
+
+- **`-t`** - Accepted for compatibility, but warning-mode taint semantics are
+  not yet implemented.
+
 - **`-w`** - Enable warnings
   ```bash
   ./jperl -w script.pl

--- a/docs/reference/configure.md
+++ b/docs/reference/configure.md
@@ -178,7 +178,7 @@ When you add a dependency with `--search` or `--direct`:
    - Adds `<dependency>` entry with groupId, artifactId, version
 
 3. **Requires rebuild**:
-   - Run `make` or `./gradlew build` to download and bundle the dependency
+   - Run `make` to download, bundle, and test the dependency
 
 ### Search Ranking
 

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -55,10 +55,10 @@ PerlOnJava implements most core Perl features with some key differences:
 - Some core modules and pragmas
 - File operations and I/O
 - Overload
-- `format` operator
+- Source filters: closure filters work; method filters and true streaming remain incomplete
 
 ❌ Not Supported:
-- XS modules and C integration
+- Native C/XS binaries (documented Java replacements and pure-Perl fallbacks are supported)
 - `fork`
 
 ---
@@ -602,7 +602,10 @@ The `:encoding()` layer supports all encodings provided by Java's `Charset.forNa
 - ✅  **`reset("A-Z")`** resetting global variables is implemented.
 - ✅  **Single-quote as package separator**: Legacy `$a'b` style package separator is supported.
 - ✅  **Runtime-owned `@_`, `$_`, and regex state**: Each ithread receives an isolated runtime snapshot.
-- ❌  **Compiler flags**:  The special variables `$^H`, `%^H`, `${^WARNING_BITS}` are not implemented.
+- 🟡  **Compiler hints and warning bits**: `$^H`, `%^H`, and
+  `${^WARNING_BITS}` are tracked as lexical compile-time state and snapshots
+  are exposed through the extended `caller` tuple on both backends. Some
+  pragma-specific mutation and exact bitmask compatibility remain incomplete.
 - ✅  **`caller` operator**: `caller` returns `($package, $filename, $line)`.
   - ✅  **Extended call stack information**: the full 11-field `caller($level)` tuple and key subroutine metadata are supported on both backends. See the [caller audit probe](../../dev/tools/feature-audit/caller_fields.t).<br>
     Exact hint and bitmask values remain runtime- and pragma-dependent.
@@ -709,14 +712,20 @@ The `:encoding()` layer supports all encodings provided by Java's `Charset.forNa
 - ✅  **ExtUtils::MakeMaker** module: PerlOnJava version installs pure Perl modules directly.
 - ✅  **Fcntl** module
 - ✅  **FileHandle** module
-- ✅  **Filter::Simple** module: `FILTER` and `FILTER_ONLY` for source code filtering.
+- 🟡  **Filter::Simple and Filter::Util::Call**: closure filters installed by
+  `use`, `FILTER`, and `FILTER_ONLY` are supported. Object/method filters are
+  not yet applied, and `filter_read` uses buffered line-oriented emulation
+  rather than Perl's incremental source stream. See the
+  [source-filter design notes](../../dev/design/source_filters.md).
 - ✅  **File::Basename** use the same version as Perl.
 - ✅  **File::Find** use the same version as Perl.
 - ✅  **File::Spec::Functions** module.
 - ✅  **File::Spec** module.
 - ✅  **Getopt::Long** module.
 - ✅  **HTTP::Date** module.
-- ✅  **Internals**: `Internals::SvREADONLY` is implemented as a no-op.
+- 🟡  **Internals**: `Internals::SvREADONLY` enforces read-only writes.
+  `Scalar::Util::readonly` recognizes compile-time read-only values but does
+  not yet recognize every scalar marked read-only at runtime.
 - ✅  **IO::File** module.
 - ✅  **IO::Seekable** module.
 - ✅  **IO::Socket** module.
@@ -891,7 +900,9 @@ maintenance contract.
 
 - ❌  **`fork` operator**: `fork` is not implemented. Calling `fork` will always fail and return `undef`.
 - ✅  **`DESTROY`**: Implemented with selective reference counting on top of JVM GC. Supports cascading destruction, closure capture tracking, `weaken`/`isweak`/`unweaken`, global destruction phase, and `Internals::SvREFCNT` introspection.
-- ❌  **Perl `XS` code**: XS code interfacing with C is not supported on the JVM.
+- 🟡  **Perl `XS` ecosystem**: native C/XS binaries cannot run on the JVM.
+  PerlOnJava supports a documented set of Java replacements loaded through
+  `XSLoader` and pure-Perl fallbacks; see [XS Compatibility](xs-compatibility.md).
 - 🚧  **Auto-close files**: Lexical buffered writes and fd closure pass on the JVM backend, but the interpreter backend still permits reopening the fd after the lexical handle goes out of scope. Explicit close and program-end cleanup remain supported. See the [scope probe](../../dev/tools/feature-audit/autoclose_scope.t) and [fd probe](../../dev/tools/feature-audit/autoclose_fd.t).
 - ❌  **Keywords related to the control flow of the Perl program**: `dump` operator.
 - ❌  **DBM file support**: `dbmclose`, `dbmopen` are not implemented.

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -166,21 +166,16 @@ Result: PASS
 
 `jprove` is useful when you want standard Perl `prove` behavior and options, while `perl_test_runner.pl` provides additional features like JSON reporting and feature impact analysis.
 
-### 3. JUnit/Gradle Testing (For CI/CD)
+### 3. JUnit Testing (For CI/CD)
 
 Uses JUnit 5 with tags for test filtering:
 
 ```bash
-# Fast unit tests via Gradle
+# Fast unit tests
 make test-gradle-unit
 
-# All tests via Gradle
+# All tests
 make test-gradle-all
-
-# Direct Gradle commands
-./gradlew testUnit    # Only unit tests
-./gradlew testAll     # All tests
-./gradlew test        # Default test task
 ```
 
 **Use Cases:**
@@ -412,15 +407,12 @@ jq '.feature_impact' test_results.json
 3. Select "Run tests"
 4. Or run specific tags: `@Tag("unit")` or `@Tag("full")`
 
-### Command Line with Gradle
+### Command Line
 
 ```bash
-# Run specific test class
-./gradlew test --tests PerlScriptExecutionTest
-
 # Run with tags
-./gradlew testUnit    # @Tag("unit")
-./gradlew testAll     # @Tag("full")
+make test-gradle-unit  # @Tag("unit")
+make test-gradle-all   # @Tag("full")
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- reconcile documented status for taint mode, threads, source filters, read-only values, compiler hints, formats, XS replacements, and filehandle cleanup
- replace unsupported JSR-223 bindings and nonexistent direct-API examples with tested `eval` and `Compilable` behavior
- standardize source-build guidance on `make`, qualify compatibility claims, repair the design index, and label obsolete plans historical or superseded

## Validation

- `make check-links` — 599 links checked, 0 errors
- `git diff --check`
- stale-claim scan across public Markdown documentation
- full `make` intentionally skipped because this PR changes documentation only

Fixes #998

Generated with [Codex](https://openai.com/codex/)
