### PR TITLE
Complete runtime regex callback state semantics

### DIFF
--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -222,7 +222,7 @@ compatibility contract.
 
 ## Progress Tracking
 
-### Current Status: Joni default; Phase 4 callback values at 434/555
+### Current Status: Joni default; Phase 4 callback values at 463/555
 
 Executable callback source and literal trailing `/x` comments survive canonical
 regex-object stringification on both execution backends. Recursive Joni call
@@ -230,7 +230,9 @@ frames now preserve the Perl-visible caller capture view for optimistic
 callbacks and committed matches, including `$1`, `$^N`, and `$+`. Tied scalar
 values returned by dynamic callbacks are materialized before callee regex state
 teardown. Joni invalid-backreference errors use Perl's nonexistent-group
-diagnostic. The focused `pat_re_eval.t` gate executes all 555 assertions with 434
+diagnostic. Reopened repeated groups expose their preceding closed capture to
+dynamic callbacks without altering matching registers. The focused
+`pat_re_eval.t` gate executes all 555 assertions with 463
 passing.
 
 ### Completed Phases
@@ -245,8 +247,9 @@ passing.
 
 ### Next Steps
 
-1. Correct repeated dynamic-program matching and capture propagation, beginning
-   with the Bug 56194 block in `pat_re_eval.t` (tests 87-143).
+1. Complete the remaining Bug 56194 nested compiled-regex cases (tests 116-143),
+   including capture numbering across dynamically returned `qr//` objects and
+   `$^R` preservation.
 2. Capture forced-Java and forced-Joni results for the full 80-file direct regex
    corpus, compare both against PR 958, and classify any newly exposed gaps.
 3. Run the applicable `pat_advanced.t` control-verb and condition sections,

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -222,7 +222,7 @@ compatibility contract.
 
 ## Progress Tracking
 
-### Current Status: Joni default; Phase 4 callback values at 542/555
+### Current Status: Joni default; Phase 4 semantic gate complete at 550/555
 
 Executable callback source and literal trailing `/x` comments survive canonical
 regex-object stringification on both execution backends. Recursive Joni call
@@ -238,37 +238,72 @@ double-quote case modifiers are deferred until after interpolation and obey
 runtime `re 'eval'` permission. Foreach aliases refresh the active lexical-cell
 registry on both execution backends, so runtime-compiled callbacks capture each
 iteration's cell and retain it after scope exit. Executable runtime pattern
-compilation uses independent `(eval N)` source identities for diagnostics. The
-focused `pat_re_eval.t` gate executes all 555 assertions with 542 passing.
+compilation uses independent `(eval N)` source identities for diagnostics.
+Runtime source now inherits exact lexical warning masks and reports Unicode
+parser names and undefined match operands at the original call site. Failed
+callback branches preserve the preceding successful `$&`, `$1`, and related
+match state. Dynamic regex-state restoration releases discarded temporary
+callback patterns, so captured values stay alive through the enclosing scope
+and are destroyed when that scope exits. Recursive callback unwind preserves
+the failed nested `$^N` and `$+` state without clobbering numbered captures or
+one-level failed callback state. The focused `pat_re_eval.t` gate executes all
+555 assertions with 550 semantic assertions passing on both execution backends;
+the remaining five inspect Perl's optimizer/debug transcript.
 
 ### Completed Phases
 
-- [ ] Phase 0: Reproducible differential baseline
-- [ ] Phase 1: Joni ordinary-pattern parity
-- [ ] Phase 2: Conditions and backtracking-visible state
-- [ ] Phase 3: Unicode and pattern syntax completion
-- [ ] Phase 4: Runtime source and diagnostics
+- [x] Phase 0: Reproducible differential baseline (2026-08-17)
+  - Captured the 80-file regex differential with complete output and JSON.
+  - Compared every file with the PR 958 baseline at
+    `../PerlOnJava/logs/test_20260815_080000_958.log`.
+  - Recorded 51,002/94,829 passing assertions, a net gain of 729 passing and
+    58 planned assertions, with no per-file pass-count regressions.
+  - Added separate parallel handling for CPU-heavy `pat_psycho*` and `speed*`
+    tests while retaining per-child timeouts.
+- [ ] Phase 1: Joni ordinary-pattern parity (implementation substantially
+  complete; forced Java/Joni corpus comparison remains)
+  - [x] Added the temporary backend selector and made Joni the default.
+  - [x] Routed ordinary matching, substitution, and split through the selected
+    backend without per-operation fallback.
+  - [ ] Re-run the complete forced-backend matrix and prove the exit criterion.
+- [ ] Phase 2: Conditions and backtracking-visible state (in progress)
+  - [x] Implemented executable callback conditions, control verbs including
+    `(*MARK:NAME)`, and callback-visible recursive capture state in Joni.
+  - [x] Closed runtime callback capture ownership at final scope teardown.
+  - [x] Closed failed-path `$^N` and `$+` restoration through recursive
+    callback unwind.
+- [ ] Phase 3: Unicode and pattern syntax completion (in progress)
+  - [x] Added Perl escape syntax, Unicode-property resolution, scoped ASCII
+    folds, possessive intervals, and bounded lookbehind support to Joni.
+  - [ ] Complete the remaining Unicode aliases and diagnostic parity inventory.
+- [x] Phase 4: Runtime source and diagnostics (2026-08-17; semantic gate
+  complete at 550/555)
+  - [x] Preserved mixed executable-source provenance, nested dynamic callback
+    values, foreach lexical cells, and independent `(eval N)` source names.
+  - [x] Restored lexical warning masks, Unicode source diagnostics, undefined
+    operand warnings, and prior successful match state across failed callbacks.
+  - [x] Released callback captures when temporary match state is discarded and
+    the final owning regex scope exits (test 307).
+  - [x] Resolved failed-path `$^N`/`$+` tests 85-86 on JVM and interpreter.
+  - [x] Classified tests 444-448 as optimizer/debug-transcript exclusions.
 - [ ] Phase 5: Remove the Java matching backend
 - [ ] Phase 6: Integration and release
 
 ### Next Steps
 
-1. Complete failed-path capture restoration (tests 85-86 and 441-442), callback
-   scope teardown (test 306), and runtime warning/source diagnostics (tests 412,
-   430 and 434; test 412 also requires interpreter warning-bit parity).
-2. Capture forced-Java and forced-Joni results for the full 80-file direct regex
+1. Capture forced-Java and forced-Joni results for the full 80-file direct regex
    corpus, compare both against PR 958, and classify any newly exposed gaps.
-3. Run the applicable `pat_advanced.t` control-verb and condition sections,
+2. Run the applicable `pat_advanced.t` control-verb and condition sections,
    then close Phase 2 if their direct and interpreter results agree.
-4. Map each remaining `pat.t.patch` hunk to its semantic blocker. As each blocker
+3. Map each remaining `pat.t.patch` hunk to its semantic blocker. As each blocker
    closes, remove its hunk and rerun the targeted importer so validation uses
    the original Perl 5.44 assertions.
-5. Capture the clean-branch JVM and interpreter 80-file baselines and compare
+4. Capture the clean-branch JVM and interpreter 80-file baselines and compare
    both to PR 958 with the regression exit gate.
-6. Inventory the remaining uncommon Unicode aliases and invalid-property
+5. Inventory the remaining uncommon Unicode aliases and invalid-property
    diagnostics against Perl 5.44's bundled tables, then move the next
    matcher-semantic preprocessor slice into Joni.
-7. Keep the warning-free whole-unit-suite gate green with Joni as the default;
+6. Keep the warning-free whole-unit-suite gate green with Joni as the default;
    use explicit Java mode only to classify corpus regressions before Phase 5
    removes the legacy backend and selector.
 

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -222,7 +222,7 @@ compatibility contract.
 
 ## Progress Tracking
 
-### Current Status: Joni default; Phase 4 callback values at 479/555
+### Current Status: Joni default; Phase 4 callback values at 483/555
 
 Executable callback source and literal trailing `/x` comments survive canonical
 regex-object stringification on both execution backends. Recursive Joni call
@@ -233,8 +233,10 @@ teardown. Joni invalid-backreference errors use Perl's nonexistent-group
 diagnostic. Reopened repeated groups expose their preceding closed capture to
 dynamic callbacks without altering matching registers. Nested dynamic matcher
 completion preserves the last successful block result in `$^R`, including a
-runtime `qr` returned by an outer `(??{...})`. The focused `pat_re_eval.t` gate
-executes all 555 assertions with 479 passing.
+runtime `qr` returned by an outer `(??{...})`. Executable-looking groups inside
+double-quote case modifiers are deferred until after interpolation and obey
+runtime `re 'eval'` permission. The focused `pat_re_eval.t` gate executes all
+555 assertions with 483 passing.
 
 ### Completed Phases
 
@@ -248,7 +250,8 @@ executes all 555 assertions with 479 passing.
 
 ### Next Steps
 
-1. Complete the failed-path terminal capture view (tests 85-86).
+1. Complete the failed-path terminal capture view (tests 85-86), then the
+   runtime-source closure matrix beginning at test 159.
 2. Capture forced-Java and forced-Joni results for the full 80-file direct regex
    corpus, compare both against PR 958, and classify any newly exposed gaps.
 3. Run the applicable `pat_advanced.t` control-verb and condition sections,

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -222,11 +222,13 @@ compatibility contract.
 
 ## Progress Tracking
 
-### Current Status: Joni default; Phase 4 source preservation at 423/555
+### Current Status: Joni default; Phase 4 recursive captures at 432/555
 
 Executable callback source and literal trailing `/x` comments survive canonical
-regex-object stringification on both execution backends. The focused
-`pat_re_eval.t` gate currently executes all 555 assertions with 423 passing.
+regex-object stringification on both execution backends. Recursive Joni call
+frames now preserve the Perl-visible caller capture view for optimistic
+callbacks and committed matches, including `$1`, `$^N`, and `$+`. The focused
+`pat_re_eval.t` gate executes all 555 assertions with 432 passing.
 
 ### Completed Phases
 
@@ -240,22 +242,24 @@ regex-object stringification on both execution backends. The focused
 
 ### Next Steps
 
-1. Correct recursion-visible capture restoration so `$^N` and `$+` expose the
-   selected Perl capture state after optimistic callbacks and nested dynamic
-   programs; use the first failing `pat_re_eval.t` block as the focused oracle.
-2. Capture forced-Java and forced-Joni results for the full 80-file direct regex
+1. Fix the next executable-pattern capture boundary: tied/interpolated dynamic
+   programs must observe the current outer capture while resolving their value
+   (`pat_re_eval.t` test 511), without caching magic or reference stringification.
+2. Normalize dynamic-program compilation diagnostics, beginning with the
+   nonexistent-group wording exercised by `pat_re_eval.t` test 515.
+3. Capture forced-Java and forced-Joni results for the full 80-file direct regex
    corpus, compare both against PR 958, and classify any newly exposed gaps.
-3. Run the applicable `pat_advanced.t` control-verb and condition sections,
+4. Run the applicable `pat_advanced.t` control-verb and condition sections,
    then close Phase 2 if their direct and interpreter results agree.
-4. Map each remaining `pat.t.patch` hunk to its semantic blocker. As each blocker
+5. Map each remaining `pat.t.patch` hunk to its semantic blocker. As each blocker
    closes, remove its hunk and rerun the targeted importer so validation uses
    the original Perl 5.44 assertions.
-5. Capture the clean-branch JVM and interpreter 80-file baselines and compare
+6. Capture the clean-branch JVM and interpreter 80-file baselines and compare
    both to PR 958 with the regression exit gate.
-6. Inventory the remaining uncommon Unicode aliases and invalid-property
+7. Inventory the remaining uncommon Unicode aliases and invalid-property
    diagnostics against Perl 5.44's bundled tables, then move the next
    matcher-semantic preprocessor slice into Joni.
-7. Keep the warning-free whole-unit-suite gate green with Joni as the default;
+8. Keep the warning-free whole-unit-suite gate green with Joni as the default;
    use explicit Java mode only to classify corpus regressions before Phase 5
    removes the legacy backend and selector.
 

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -222,7 +222,7 @@ compatibility contract.
 
 ## Progress Tracking
 
-### Current Status: Joni default; Phase 4 callback values at 540/555
+### Current Status: Joni default; Phase 4 callback values at 542/555
 
 Executable callback source and literal trailing `/x` comments survive canonical
 regex-object stringification on both execution backends. Recursive Joni call
@@ -237,8 +237,9 @@ runtime `qr` returned by an outer `(??{...})`. Executable-looking groups inside
 double-quote case modifiers are deferred until after interpolation and obey
 runtime `re 'eval'` permission. Foreach aliases refresh the active lexical-cell
 registry on both execution backends, so runtime-compiled callbacks capture each
-iteration's cell and retain it after scope exit. The focused `pat_re_eval.t`
-gate executes all 555 assertions with 540 passing.
+iteration's cell and retain it after scope exit. Executable runtime pattern
+compilation uses independent `(eval N)` source identities for diagnostics. The
+focused `pat_re_eval.t` gate executes all 555 assertions with 542 passing.
 
 ### Completed Phases
 
@@ -254,7 +255,7 @@ gate executes all 555 assertions with 540 passing.
 
 1. Complete failed-path capture restoration (tests 85-86 and 441-442), callback
    scope teardown (test 306), and runtime warning/source diagnostics (tests 412,
-   428-430, and 434).
+   430 and 434; test 412 also requires interpreter warning-bit parity).
 2. Capture forced-Java and forced-Joni results for the full 80-file direct regex
    corpus, compare both against PR 958, and classify any newly exposed gaps.
 3. Run the applicable `pat_advanced.t` control-verb and condition sections,

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -222,7 +222,7 @@ compatibility contract.
 
 ## Progress Tracking
 
-### Current Status: Joni default; Phase 4 callback values at 463/555
+### Current Status: Joni default; Phase 4 callback values at 478/555
 
 Executable callback source and literal trailing `/x` comments survive canonical
 regex-object stringification on both execution backends. Recursive Joni call
@@ -232,7 +232,7 @@ values returned by dynamic callbacks are materialized before callee regex state
 teardown. Joni invalid-backreference errors use Perl's nonexistent-group
 diagnostic. Reopened repeated groups expose their preceding closed capture to
 dynamic callbacks without altering matching registers. The focused
-`pat_re_eval.t` gate executes all 555 assertions with 463
+`pat_re_eval.t` gate executes all 555 assertions with 478
 passing.
 
 ### Completed Phases
@@ -247,9 +247,8 @@ passing.
 
 ### Next Steps
 
-1. Complete the remaining Bug 56194 nested compiled-regex cases (tests 116-143),
-   including capture numbering across dynamically returned `qr//` objects and
-   `$^R` preservation.
+1. Complete the remaining Bug 56194 `$^R` preservation assertion (test 143) and
+   the failed-path terminal capture view (tests 85-86).
 2. Capture forced-Java and forced-Joni results for the full 80-file direct regex
    corpus, compare both against PR 958, and classify any newly exposed gaps.
 3. Run the applicable `pat_advanced.t` control-verb and condition sections,

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -222,13 +222,15 @@ compatibility contract.
 
 ## Progress Tracking
 
-### Current Status: Joni default; Phase 4 recursive captures at 432/555
+### Current Status: Joni default; Phase 4 callback values at 433/555
 
 Executable callback source and literal trailing `/x` comments survive canonical
 regex-object stringification on both execution backends. Recursive Joni call
 frames now preserve the Perl-visible caller capture view for optimistic
-callbacks and committed matches, including `$1`, `$^N`, and `$+`. The focused
-`pat_re_eval.t` gate executes all 555 assertions with 432 passing.
+callbacks and committed matches, including `$1`, `$^N`, and `$+`. Tied scalar
+values returned by dynamic callbacks are materialized before callee regex state
+teardown. The focused `pat_re_eval.t` gate executes all 555 assertions with 433
+passing.
 
 ### Completed Phases
 
@@ -242,24 +244,21 @@ callbacks and committed matches, including `$1`, `$^N`, and `$+`. The focused
 
 ### Next Steps
 
-1. Fix the next executable-pattern capture boundary: tied/interpolated dynamic
-   programs must observe the current outer capture while resolving their value
-   (`pat_re_eval.t` test 511), without caching magic or reference stringification.
-2. Normalize dynamic-program compilation diagnostics, beginning with the
+1. Normalize dynamic-program compilation diagnostics, beginning with the
    nonexistent-group wording exercised by `pat_re_eval.t` test 515.
-3. Capture forced-Java and forced-Joni results for the full 80-file direct regex
+2. Capture forced-Java and forced-Joni results for the full 80-file direct regex
    corpus, compare both against PR 958, and classify any newly exposed gaps.
-4. Run the applicable `pat_advanced.t` control-verb and condition sections,
+3. Run the applicable `pat_advanced.t` control-verb and condition sections,
    then close Phase 2 if their direct and interpreter results agree.
-5. Map each remaining `pat.t.patch` hunk to its semantic blocker. As each blocker
+4. Map each remaining `pat.t.patch` hunk to its semantic blocker. As each blocker
    closes, remove its hunk and rerun the targeted importer so validation uses
    the original Perl 5.44 assertions.
-6. Capture the clean-branch JVM and interpreter 80-file baselines and compare
+5. Capture the clean-branch JVM and interpreter 80-file baselines and compare
    both to PR 958 with the regression exit gate.
-7. Inventory the remaining uncommon Unicode aliases and invalid-property
+6. Inventory the remaining uncommon Unicode aliases and invalid-property
    diagnostics against Perl 5.44's bundled tables, then move the next
    matcher-semantic preprocessor slice into Joni.
-8. Keep the warning-free whole-unit-suite gate green with Joni as the default;
+7. Keep the warning-free whole-unit-suite gate green with Joni as the default;
    use explicit Java mode only to classify corpus regressions before Phase 5
    removes the legacy backend and selector.
 

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -222,7 +222,7 @@ compatibility contract.
 
 ## Progress Tracking
 
-### Current Status: Joni default; Phase 4 callback values at 478/555
+### Current Status: Joni default; Phase 4 callback values at 479/555
 
 Executable callback source and literal trailing `/x` comments survive canonical
 regex-object stringification on both execution backends. Recursive Joni call
@@ -231,9 +231,10 @@ callbacks and committed matches, including `$1`, `$^N`, and `$+`. Tied scalar
 values returned by dynamic callbacks are materialized before callee regex state
 teardown. Joni invalid-backreference errors use Perl's nonexistent-group
 diagnostic. Reopened repeated groups expose their preceding closed capture to
-dynamic callbacks without altering matching registers. The focused
-`pat_re_eval.t` gate executes all 555 assertions with 478
-passing.
+dynamic callbacks without altering matching registers. Nested dynamic matcher
+completion preserves the last successful block result in `$^R`, including a
+runtime `qr` returned by an outer `(??{...})`. The focused `pat_re_eval.t` gate
+executes all 555 assertions with 479 passing.
 
 ### Completed Phases
 
@@ -247,8 +248,7 @@ passing.
 
 ### Next Steps
 
-1. Complete the remaining Bug 56194 `$^R` preservation assertion (test 143) and
-   the failed-path terminal capture view (tests 85-86).
+1. Complete the failed-path terminal capture view (tests 85-86).
 2. Capture forced-Java and forced-Joni results for the full 80-file direct regex
    corpus, compare both against PR 958, and classify any newly exposed gaps.
 3. Run the applicable `pat_advanced.t` control-verb and condition sections,

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -222,7 +222,7 @@ compatibility contract.
 
 ## Progress Tracking
 
-### Current Status: Joni default; Phase 4 callback values at 483/555
+### Current Status: Joni default; Phase 4 callback values at 540/555
 
 Executable callback source and literal trailing `/x` comments survive canonical
 regex-object stringification on both execution backends. Recursive Joni call
@@ -235,8 +235,10 @@ dynamic callbacks without altering matching registers. Nested dynamic matcher
 completion preserves the last successful block result in `$^R`, including a
 runtime `qr` returned by an outer `(??{...})`. Executable-looking groups inside
 double-quote case modifiers are deferred until after interpolation and obey
-runtime `re 'eval'` permission. The focused `pat_re_eval.t` gate executes all
-555 assertions with 483 passing.
+runtime `re 'eval'` permission. Foreach aliases refresh the active lexical-cell
+registry on both execution backends, so runtime-compiled callbacks capture each
+iteration's cell and retain it after scope exit. The focused `pat_re_eval.t`
+gate executes all 555 assertions with 540 passing.
 
 ### Completed Phases
 
@@ -250,8 +252,9 @@ runtime `re 'eval'` permission. The focused `pat_re_eval.t` gate executes all
 
 ### Next Steps
 
-1. Complete the failed-path terminal capture view (tests 85-86), then the
-   runtime-source closure matrix beginning at test 159.
+1. Complete failed-path capture restoration (tests 85-86 and 441-442), callback
+   scope teardown (test 306), and runtime warning/source diagnostics (tests 412,
+   428-430, and 434).
 2. Capture forced-Java and forced-Joni results for the full 80-file direct regex
    corpus, compare both against PR 958, and classify any newly exposed gaps.
 3. Run the applicable `pat_advanced.t` control-verb and condition sections,

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -222,14 +222,15 @@ compatibility contract.
 
 ## Progress Tracking
 
-### Current Status: Joni default; Phase 4 callback values at 433/555
+### Current Status: Joni default; Phase 4 callback values at 434/555
 
 Executable callback source and literal trailing `/x` comments survive canonical
 regex-object stringification on both execution backends. Recursive Joni call
 frames now preserve the Perl-visible caller capture view for optimistic
 callbacks and committed matches, including `$1`, `$^N`, and `$+`. Tied scalar
 values returned by dynamic callbacks are materialized before callee regex state
-teardown. The focused `pat_re_eval.t` gate executes all 555 assertions with 433
+teardown. Joni invalid-backreference errors use Perl's nonexistent-group
+diagnostic. The focused `pat_re_eval.t` gate executes all 555 assertions with 434
 passing.
 
 ### Completed Phases
@@ -244,8 +245,8 @@ passing.
 
 ### Next Steps
 
-1. Normalize dynamic-program compilation diagnostics, beginning with the
-   nonexistent-group wording exercised by `pat_re_eval.t` test 515.
+1. Correct repeated dynamic-program matching and capture propagation, beginning
+   with the Bug 56194 block in `pat_re_eval.t` (tests 87-143).
 2. Capture forced-Java and forced-Joni results for the full 80-file direct regex
    corpus, compare both against PR 958, and classify any newly exposed gaps.
 3. Run the applicable `pat_advanced.t` control-verb and condition sections,

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -6339,6 +6339,16 @@ public class BytecodeCompiler implements Visitor {
 
         // Step 7: Body start (redo jumps here)
         int bodyStartPc = bytecode.size();
+        if (lexicalLoopVarName != null) {
+            emit(Opcodes.BIND_ACTIVE_LEXICAL);
+            emitReg(varReg);
+            emit(addToStringPool(lexicalLoopVarName));
+        }
+        for (int i = 0; i < lexicalLoopVarNames.size(); i++) {
+            emit(Opcodes.BIND_ACTIVE_LEXICAL);
+            emitReg(multiVarRegs.get(i));
+            emit(addToStringPool(lexicalLoopVarNames.get(i)));
+        }
         LoopInfo loopInfo = new LoopInfo(node.labelName, bodyStartPc, true);
         loopStack.push(loopInfo);
         loopInfo.cleanupScopeIndex = symbolTable.currentScopeIndex() + 1;

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -2096,8 +2096,8 @@ public class BytecodeInterpreter {
 
                             case Opcodes.MATCH_REGEX -> {
                                 // Match regex
-                                // Format: MATCH_REGEX rd stringReg regexReg ctx bytesMode
-                                pc = OpcodeHandlerExtended.executeMatchRegex(bytecode, pc, registers);
+                                // Format: MATCH_REGEX rd stringReg regexReg ctx bytesMode targetNameIndex
+                                pc = OpcodeHandlerExtended.executeMatchRegex(bytecode, pc, registers, code);
                             }
 
                             case Opcodes.MATCH_REGEX_NOT -> {
@@ -3384,12 +3384,15 @@ public class BytecodeInterpreter {
                 int flagsReg = bytecode[pc++];
                 int implicitU = bytecode[pc++];
                 int warningState = bytecode[pc++];
+                int warningBitsIndex = bytecode[pc++];
                 int quoteConstruction = bytecode[pc++];
                 RuntimeScalar flags = registers[flagsReg].scalar();
                 if (implicitU != 0) {
                     flags = RuntimeRegex.applyUnicodeStringsFeatureToModifiers(flags);
                 }
                 RegexQuoteMeta.setCallSiteWarningState(warningState);
+                RegexQuoteMeta.setCallSiteWarningBits(warningBitsIndex >= 0
+                        ? code.stringPool[warningBitsIndex] : null);
                 registers[rd] = RuntimeRegex.getQuotedRegex(registers[patternReg].scalar(), flags);
                 if (quoteConstruction != 0) {
                     registers[rd] = RuntimeRegex.markQuoteConstruction(registers[rd].scalar());
@@ -3403,12 +3406,15 @@ public class BytecodeInterpreter {
                 int callsiteId = bytecode[pc++];
                 int implicitU = bytecode[pc++];
                 int warningState = bytecode[pc++];
+                int warningBitsIndex = bytecode[pc++];
                 int quoteConstruction = bytecode[pc++];
                 RuntimeScalar flags = registers[flagsReg].scalar();
                 if (implicitU != 0) {
                     flags = RuntimeRegex.applyUnicodeStringsFeatureToModifiers(flags);
                 }
                 RegexQuoteMeta.setCallSiteWarningState(warningState);
+                RegexQuoteMeta.setCallSiteWarningBits(warningBitsIndex >= 0
+                        ? code.stringPool[warningBitsIndex] : null);
                 registers[rd] = RuntimeRegex.getQuotedRegex(registers[patternReg].scalar(), flags, callsiteId);
                 if (quoteConstruction != 0) {
                     registers[rd] = RuntimeRegex.markQuoteConstruction(registers[rd].scalar());

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -839,6 +839,13 @@ public class BytecodeInterpreter {
                                         code.stringPool[nameIdx], registers[reg]);
                             }
 
+                            case Opcodes.BIND_ACTIVE_LEXICAL -> {
+                                int reg = bytecode[pc++];
+                                int nameIdx = bytecode[pc++];
+                                registers[reg] = code.bindActiveLexical(
+                                        code.stringPool[nameIdx], registers[reg]);
+                            }
+
                             // =================================================================
                             // VARIABLE ACCESS - GLOBAL
                             // =================================================================

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperatorHelper.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperatorHelper.java
@@ -381,6 +381,7 @@ public class CompileBinaryOperatorHelper {
                 bytecodeCompiler.emitReg(rs2);
                 bytecodeCompiler.emit(bytecodeCompiler.currentCallContext);
                 bytecodeCompiler.emit(0);
+                bytecodeCompiler.emit(-1);
             }
             case "!~" -> {
                 // $string !~ /pattern/ - negated regex match

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -287,6 +287,20 @@ public class CompileOperator {
         return Boolean.TRUE.equals(node.getAnnotation("regexWarningsEnabled")) ? 1 : 0;
     }
 
+    private static int regexWarningBitsIndex(BytecodeCompiler bc, OperatorNode node) {
+        Object bits = node.getAnnotation("regexWarningBits");
+        return bits instanceof String string ? bc.addToStringPool(string) : -1;
+    }
+
+    private static int regexTargetNameIndex(BytecodeCompiler bc, Node node) {
+        if (node instanceof OperatorNode operator
+                && operator.operator.equals("$")
+                && operator.operand instanceof IdentifierNode identifier) {
+            return bc.addToStringPool("$" + identifier.name);
+        }
+        return -1;
+    }
+
     private static void visitMatchRegex(BytecodeCompiler bc, OperatorNode node) {
         if (node.operand == null || !(node.operand instanceof ListNode args) || args.elements.size() < 2) {
             bc.throwCompilerException("matchRegex requires pattern and flags");
@@ -312,6 +326,7 @@ public class CompileOperator {
             bc.emitReg(callsiteId);
             bc.emit(unicodeStringsImplicitUFlag(bc));
             bc.emit(regexWarningState(node));
+            bc.emit(regexWarningBitsIndex(bc, node));
             bc.emit(0);
         } else {
             bc.emit(Opcodes.QUOTE_REGEX);
@@ -320,6 +335,7 @@ public class CompileOperator {
             bc.emitReg(flagsReg);
             bc.emit(unicodeStringsImplicitUFlag(bc));
             bc.emit(regexWarningState(node));
+            bc.emit(regexWarningBitsIndex(bc, node));
             bc.emit(0);
         }
         int stringReg;
@@ -341,6 +357,8 @@ public class CompileOperator {
         bc.emitReg(regexReg);
         bc.emit(bc.currentCallContext);
         bc.emit(bc.isBytesEnabled() ? 1 : 0);
+        bc.emit(regexTargetNameIndex(bc,
+                args.elements.size() > 2 ? args.elements.get(2) : null));
         bc.lastResultReg = rd;
     }
 
@@ -382,6 +400,8 @@ public class CompileOperator {
         bc.emitReg(regexReg);
         bc.emit(bc.currentCallContext);
         bc.emit(bc.isBytesEnabled() ? 1 : 0);
+        bc.emit(regexTargetNameIndex(bc,
+                args.elements.size() > 3 ? args.elements.get(3) : null));
         bc.lastResultReg = rd;
     }
 
@@ -1130,6 +1150,7 @@ public class CompileOperator {
                     bytecodeCompiler.emitReg(callsiteId);
                     bytecodeCompiler.emit(unicodeStringsImplicitUFlag(bytecodeCompiler));
                     bytecodeCompiler.emit(regexWarningState(node));
+                    bytecodeCompiler.emit(regexWarningBitsIndex(bytecodeCompiler, node));
                     bytecodeCompiler.emit(1);
                 } else {
                     bytecodeCompiler.emit(Opcodes.QUOTE_REGEX);
@@ -1138,6 +1159,7 @@ public class CompileOperator {
                     bytecodeCompiler.emitReg(flagsReg);
                     bytecodeCompiler.emit(unicodeStringsImplicitUFlag(bytecodeCompiler));
                     bytecodeCompiler.emit(regexWarningState(node));
+                    bytecodeCompiler.emit(regexWarningBitsIndex(bytecodeCompiler, node));
                     bytecodeCompiler.emit(1);
                 }
                 bytecodeCompiler.lastResultReg = rd;
@@ -1356,7 +1378,9 @@ public class CompileOperator {
                     bytecodeCompiler.evalSitePragmaFlags.add(new int[]{
                             bytecodeCompiler.symbolTable.strictOptionsStack.peek(),
                             bytecodeCompiler.symbolTable.featureFlagsStack.peek(),
-                            op.equals("evalbytes") ? 1 : 0
+                            op.equals("evalbytes") ? 1 : 0,
+                            bytecodeCompiler.addToStringPool(
+                                    bytecodeCompiler.symbolTable.getWarningBitsString())
                     });
                     bytecodeCompiler.emitWithToken(Opcodes.EVAL_STRING, node.getIndex());
                     bytecodeCompiler.emitReg(rd);

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -209,6 +209,12 @@ public class Disassemble {
                         sb.append("APPLY_LEXICAL_ALIAS r").append(rd)
                                 .append(" ").append(interpretedCode.stringPool[aliasNameIdx]).append("\n");
                         break;
+                    case Opcodes.BIND_ACTIVE_LEXICAL:
+                        rd = interpretedCode.bytecode[pc++];
+                        int bindingNameIdx = interpretedCode.bytecode[pc++];
+                        sb.append("BIND_ACTIVE_LEXICAL r").append(rd)
+                                .append(" ").append(interpretedCode.stringPool[bindingNameIdx]).append("\n");
+                        break;
                     case Opcodes.ALIAS_LVALUE_REFERENCE:
                         rd = interpretedCode.bytecode[pc++];
                         src = interpretedCode.bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -844,7 +844,8 @@ public class Disassemble {
                         int regReg = interpretedCode.bytecode[pc++];
                         int matchCtx = interpretedCode.bytecode[pc++];
                         int bytesMode = interpretedCode.bytecode[pc++];
-                        sb.append("MATCH_REGEX r").append(rd).append(" = r").append(strReg).append(" =~ r").append(regReg).append(" (ctx=").append(matchCtx).append(", bytes=").append(bytesMode).append(")\n");
+                        int targetNameIndex = interpretedCode.bytecode[pc++];
+                        sb.append("MATCH_REGEX r").append(rd).append(" = r").append(strReg).append(" =~ r").append(regReg).append(" (ctx=").append(matchCtx).append(", bytes=").append(bytesMode).append(", targetName=").append(targetNameIndex).append(")\n");
                         break;
                     case Opcodes.MATCH_REGEX_NOT:
                         rd = interpretedCode.bytecode[pc++];
@@ -1331,10 +1332,12 @@ public class Disassemble {
                         int flagsReg = interpretedCode.bytecode[pc++];
                         int implicitU = interpretedCode.bytecode[pc++];
                         int warningState = interpretedCode.bytecode[pc++];
+                        int warningBitsIndex = interpretedCode.bytecode[pc++];
                         int quoteConstruction = interpretedCode.bytecode[pc++];
                         sb.append("QUOTE_REGEX r").append(rd).append(" = qr{r").append(patternReg)
                                 .append("}r").append(flagsReg).append(" implicitU=").append(implicitU)
                                 .append(" warningState=").append(warningState)
+                                .append(" warningBits=").append(warningBitsIndex)
                                 .append(" quoteConstruction=").append(quoteConstruction).append("\n");
                         break;
                     case Opcodes.QUOTE_REGEX_O:
@@ -1344,11 +1347,13 @@ public class Disassemble {
                         int callsiteId = interpretedCode.bytecode[pc++];
                         implicitU = interpretedCode.bytecode[pc++];
                         warningState = interpretedCode.bytecode[pc++];
+                        warningBitsIndex = interpretedCode.bytecode[pc++];
                         quoteConstruction = interpretedCode.bytecode[pc++];
                         sb.append("QUOTE_REGEX_O r").append(rd).append(" = qr{r").append(patternReg)
                                 .append("}r").append(flagsReg).append(" callsite=").append(callsiteId)
                                 .append(" implicitU=").append(implicitU)
                                 .append(" warningState=").append(warningState)
+                                .append(" warningBits=").append(warningBitsIndex)
                                 .append(" quoteConstruction=").append(quoteConstruction).append("\n");
                         break;
                     case Opcodes.ITERATOR_CREATE:

--- a/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
@@ -159,7 +159,8 @@ public class EvalStringHandler {
                                              int siteFeatureFlags,
                                              boolean isEvalbytes) {
         return evalStringList(perlCode, RuntimeScalarType.STRING, currentCode, registers,
-                sourceName, sourceLine, callContext, siteRegistry, siteStrictOptions, siteFeatureFlags, isEvalbytes);
+                sourceName, sourceLine, callContext, siteRegistry, siteStrictOptions,
+                siteFeatureFlags, isEvalbytes, null);
     }
 
     public static RuntimeList evalStringList(RuntimeScalar codeScalar,
@@ -189,7 +190,25 @@ public class EvalStringHandler {
         // Let an enclosing eval block handle it, matching the JVM backend and Perl.
         RuntimeCode.rejectTaintedEval(codeScalar);
         return evalStringList(codeScalar.toString(), codeScalar.type, currentCode, registers,
-                sourceName, sourceLine, callContext, siteRegistry, siteStrictOptions, siteFeatureFlags, isEvalbytes);
+                sourceName, sourceLine, callContext, siteRegistry, siteStrictOptions,
+                siteFeatureFlags, isEvalbytes, null);
+    }
+
+    public static RuntimeList evalStringList(RuntimeScalar codeScalar,
+                                             InterpretedCode currentCode,
+                                             RuntimeBase[] registers,
+                                             String sourceName,
+                                             int sourceLine,
+                                             int callContext,
+                                             Map<String, Integer> siteRegistry,
+                                             int siteStrictOptions,
+                                             int siteFeatureFlags,
+                                             boolean isEvalbytes,
+                                             String siteWarningBits) {
+        RuntimeCode.rejectTaintedEval(codeScalar);
+        return evalStringList(codeScalar.toString(), codeScalar.type, currentCode, registers,
+                sourceName, sourceLine, callContext, siteRegistry, siteStrictOptions,
+                siteFeatureFlags, isEvalbytes, siteWarningBits);
     }
 
     private static RuntimeList evalStringList(String perlCode,
@@ -202,7 +221,8 @@ public class EvalStringHandler {
                                              Map<String, Integer> siteRegistry,
                                              int siteStrictOptions,
                                              int siteFeatureFlags,
-                                             boolean isEvalbytes) {
+                                             boolean isEvalbytes,
+                                             String siteWarningBits) {
         try (PerlRuntime.Binding runtimeBinding = PerlRuntime.current().bind()) {
         PerlLanguageProvider.CompilationLockGuard compilationLock =
                 PerlLanguageProvider.acquireCompilationLock();
@@ -383,6 +403,7 @@ public class EvalStringHandler {
                 symbolTable.featureFlagsStack.push(featFlags);
                 symbolTable.warningFlagsStack.pop();
                 symbolTable.warningFlagsStack.push((java.util.BitSet) currentCode.warningFlags.clone());
+                WarningFlags.setWarningBitsFromString(symbolTable, siteWarningBits);
             }
 
             // Use runtime package (maintained by PUSH_PACKAGE/SET_PACKAGE opcodes).

--- a/src/main/java/org/perlonjava/backend/bytecode/InterpretedCode.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InterpretedCode.java
@@ -34,7 +34,7 @@ public class InterpretedCode extends RuntimeCode implements PerlSubroutine {
     public final RuntimeBase[] capturedVars; // Closure support (captured from outer scope)
     public final Map<String, Integer> variableRegistry; // Variable name → register index (for eval STRING)
     public final List<Map<String, Integer>> evalSiteRegistries; // Per-eval-site variable registries
-    public final List<int[]> evalSitePragmaFlags; // Per-eval-site [strictOptions, featureFlags]
+    public final List<int[]> evalSitePragmaFlags; // Per-eval-site [strict, features, evalbytes, warningBitsPoolIndex]
 
     // Optimization flags (set by compiler after construction)
     // If false, we can skip DynamicVariableManager.getLocalLevel/popToLocalLevel calls

--- a/src/main/java/org/perlonjava/backend/bytecode/OpcodeHandlerExtended.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/OpcodeHandlerExtended.java
@@ -908,14 +908,20 @@ public class OpcodeHandlerExtended {
 
     /**
      * Execute match regex operation.
-     * Format: MATCH_REGEX rd stringReg regexReg ctx bytesMode
+     * Format: MATCH_REGEX rd stringReg regexReg ctx bytesMode targetNameIndex
      */
-    public static int executeMatchRegex(int[] bytecode, int pc, RuntimeBase[] registers) {
+    public static int executeMatchRegex(int[] bytecode, int pc, RuntimeBase[] registers,
+                                        InterpretedCode code) {
         int rd = bytecode[pc++];
         int stringReg = bytecode[pc++];
         int regexReg = bytecode[pc++];
         int ctx = bytecode[pc++];
         boolean bytesMode = bytecode[pc++] != 0;
+        int targetNameIndex = bytecode[pc++];
+
+        RegexQuoteMeta.setMatchTargetName(targetNameIndex >= 0
+                && targetNameIndex < code.stringPool.length
+                ? code.stringPool[targetNameIndex] : null);
 
         if (ctx == RuntimeContextType.RUNTIME) ctx = ((RuntimeScalar) registers[2]).getInt();
         RuntimeScalar regex = registers[regexReg].scalar();
@@ -944,6 +950,7 @@ public class OpcodeHandlerExtended {
         int regexReg = bytecode[pc++];
         int ctx = bytecode[pc++];
 
+        RegexQuoteMeta.setMatchTargetName(null);
         if (ctx == RuntimeContextType.RUNTIME) ctx = ((RuntimeScalar) registers[2]).getInt();
         RuntimeBase matchResult = RuntimeRegex.matchRegex(
                 (RuntimeScalar) registers[regexReg],

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -935,7 +935,7 @@ public class Opcodes {
 
     /**
      * Quote regex operator: rd = RuntimeRegex.getQuotedRegex(pattern_reg, flags_reg)
-     * Format: QUOTE_REGEX rd pattern_reg flags_reg implicit_unicode_strings_u warning_state quote_construction
+     * Format: QUOTE_REGEX rd pattern_reg flags_reg implicit_unicode_strings_u warning_state warning_bits_index quote_construction
      */
     public static final short QUOTE_REGEX = 159;
 
@@ -1003,7 +1003,7 @@ public class Opcodes {
 
     /**
      * Match regex: rd = RuntimeRegex.matchRegex(string, regex, ctx)
-     * Format: MATCH_REGEX rd stringReg regexReg ctx bytesMode
+     * Format: MATCH_REGEX rd stringReg regexReg ctx bytesMode target_name_index
      */
     public static final short MATCH_REGEX = 167;
 
@@ -1834,7 +1834,7 @@ public class Opcodes {
 
     /**
      * Quote regex with /o modifier support: rd = RuntimeRegex.getQuotedRegex(pattern_reg, flags_reg, callsite_id)
-     * Format: QUOTE_REGEX_O rd pattern_reg flags_reg callsite_id implicit_unicode_strings_u warning_state quote_construction
+     * Format: QUOTE_REGEX_O rd pattern_reg flags_reg callsite_id implicit_unicode_strings_u warning_state warning_bits_index quote_construction
      */
     public static final short QUOTE_REGEX_O = 374;
 

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -2477,6 +2477,9 @@ public class Opcodes {
     /** Logical negation using raw Perl truth without overload dispatch. Format: rd rs. */
     public static final short NOT_NO_OVERLOAD = 524;
 
+    /** Refresh an active foreach lexical alias. Format: reg nameStringIdx. */
+    public static final short BIND_ACTIVE_LEXICAL = 525;
+
     /** Return the mutable {@code $#array} cell. Format: ARRAY_LAST_INDEX_LVALUE rd arrayReg. */
     public static final short ARRAY_LAST_INDEX_LVALUE = 518;
 

--- a/src/main/java/org/perlonjava/backend/bytecode/SlowOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/SlowOpcodeHandler.java
@@ -293,12 +293,17 @@ public class SlowOpcodeHandler {
         int siteStrictOptions = -1;
         int siteFeatureFlags = -1;
         boolean siteIsEvalbytes = false;
+        String siteWarningBits = null;
         if (evalSiteIndex >= 0 && code.evalSitePragmaFlags != null
                 && evalSiteIndex < code.evalSitePragmaFlags.size()) {
             int[] pragmaFlags = code.evalSitePragmaFlags.get(evalSiteIndex);
             siteStrictOptions = pragmaFlags[0];
             siteFeatureFlags = pragmaFlags[1];
             siteIsEvalbytes = pragmaFlags.length > 2 && pragmaFlags[2] != 0;
+            if (pragmaFlags.length > 3 && pragmaFlags[3] >= 0
+                    && pragmaFlags[3] < code.stringPool.length) {
+                siteWarningBits = code.stringPool[pragmaFlags[3]];
+            }
         }
 
         RuntimeBase codeValue = registers[stringReg];
@@ -336,7 +341,8 @@ public class SlowOpcodeHandler {
                     siteRegistry,
                     siteStrictOptions,
                     siteFeatureFlags,
-                    siteIsEvalbytes
+                    siteIsEvalbytes,
+                    siteWarningBits
             );
             registers[rd] = result;
             evalTrace("EVAL_STRING opcode exit LIST stored=" + (registers[rd] != null ? registers[rd].getClass().getSimpleName() : "null") +
@@ -352,7 +358,8 @@ public class SlowOpcodeHandler {
                     siteRegistry,
                     siteStrictOptions,
                     siteFeatureFlags,
-                    siteIsEvalbytes
+                    siteIsEvalbytes,
+                    siteWarningBits
             ).scalar();
             registers[rd] = result;
             evalTrace("EVAL_STRING opcode exit SCALAR/VOID stored=" + (registers[rd] != null ? registers[rd].getClass().getSimpleName() : "null") +

--- a/src/main/java/org/perlonjava/backend/jvm/EmitForeach.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitForeach.java
@@ -570,6 +570,18 @@ public class EmitForeach {
                     loopVarIndex = emitterVisitor.ctx.symbolTable.getVariableIndex(varName);
                     if (CompilerOptions.DEBUG_ENABLED) emitterVisitor.ctx.logDebug("FOR1 single var name:" + varName + " index:" + loopVarIndex);
                     mv.visitVarInsn(Opcodes.ASTORE, loopVarIndex);
+                    mv.visitVarInsn(Opcodes.ALOAD, loopVarIndex);
+                    Node codeRef = new OperatorNode("__SUB__", null, operatorNode.tokenIndex);
+                    codeRef.accept(emitterVisitor.with(RuntimeContextType.SCALAR));
+                    mv.visitLdcInsn(varName);
+                    mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                            "org/perlonjava/runtime/runtimetypes/RuntimeCode",
+                            "bindActiveLexical",
+                            "(Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;Ljava/lang/String;)Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;",
+                            false);
+                    mv.visitTypeInsn(Opcodes.CHECKCAST,
+                            "org/perlonjava/runtime/runtimetypes/RuntimeScalar");
+                    mv.visitVarInsn(Opcodes.ASTORE, loopVarIndex);
                 }
             }
         }

--- a/src/main/java/org/perlonjava/backend/jvm/EmitRegex.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitRegex.java
@@ -69,6 +69,15 @@ public class EmitRegex {
         emitterVisitor.ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                 "org/perlonjava/runtime/regex/RegexQuoteMeta",
                 "setCallSiteWarningState", "(I)V", false);
+        Object warningBits = node.getAnnotation("regexWarningBits");
+        if (warningBits instanceof String bits) {
+            emitterVisitor.ctx.mv.visitLdcInsn(bits);
+        } else {
+            emitterVisitor.ctx.mv.visitInsn(Opcodes.ACONST_NULL);
+        }
+        emitterVisitor.ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                "org/perlonjava/runtime/regex/RegexQuoteMeta",
+                "setCallSiteWarningBits", "(Ljava/lang/String;)V", false);
     }
 
     /**
@@ -461,6 +470,15 @@ public class EmitRegex {
 
         // Generate bytecode for the variable access
         variable.accept(scalarVisitor);
+        String targetName = regexTargetName(variable);
+        if (targetName == null) {
+            scalarVisitor.ctx.mv.visitInsn(Opcodes.ACONST_NULL);
+        } else {
+            scalarVisitor.ctx.mv.visitLdcInsn(targetName);
+        }
+        scalarVisitor.ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
+                "org/perlonjava/runtime/regex/RegexQuoteMeta", "setMatchTargetName",
+                "(Ljava/lang/String;)V", false);
         if (stabilizeLiteral && variable instanceof StringNode) {
             scalarVisitor.ctx.mv.visitLdcInsn(nextCallsiteId.getAndIncrement());
             scalarVisitor.ctx.mv.visitMethodInsn(Opcodes.INVOKESTATIC,
@@ -468,5 +486,14 @@ public class EmitRegex {
                     "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;I)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;",
                     false);
         }
+    }
+
+    private static String regexTargetName(Node node) {
+        if (node instanceof OperatorNode operator
+                && operator.operator.equals("$")
+                && operator.operand instanceof IdentifierNode identifier) {
+            return "$" + identifier.name;
+        }
+        return null;
     }
 }

--- a/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
@@ -694,7 +694,9 @@ public class IdentifierParser {
                         token.type != LexerTokenType.NEWLINE && token.type != LexerTokenType.WHITESPACE &&
                         !(token.type == LexerTokenType.OPERATOR && (token.text.equals("(") || token.text.equals("}") || token.text.equals(";") || token.text.equals("=") || token.text.equals(")") || token.text.equals(",") || token.text.equals("]")))) {
                     // Bad name after ::
-                    parser.throwCleanError("Bad name after " + variableName + "::");
+                    // The separator was appended before validation.  Reusing it
+                    // here avoids reporting Foo:::: for the source Foo::$bar.
+                    parser.throwCleanError("Bad name after " + variableName);
                 }
                 continue;
             }

--- a/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
@@ -167,12 +167,14 @@ public class ParseInfix {
                     OperatorNode quoted = new OperatorNode("quoteRegex", operatorNode.operand, operatorNode.tokenIndex);
                     quoted.setAnnotation("regexWarningsEnabled", operatorNode.getAnnotation("regexWarningsEnabled"));
                     quoted.setAnnotation("regexWarningsFatal", operatorNode.getAnnotation("regexWarningsFatal"));
+                    quoted.setAnnotation("regexWarningBits", operatorNode.getAnnotation("regexWarningBits"));
                     left = quoted;
                 }
                 if (right instanceof OperatorNode operatorNode && operatorNode.operator.equals("matchRegex")) {
                     OperatorNode quoted = new OperatorNode("quoteRegex", operatorNode.operand, operatorNode.tokenIndex);
                     quoted.setAnnotation("regexWarningsEnabled", operatorNode.getAnnotation("regexWarningsEnabled"));
                     quoted.setAnnotation("regexWarningsFatal", operatorNode.getAnnotation("regexWarningsFatal"));
+                    quoted.setAnnotation("regexWarningBits", operatorNode.getAnnotation("regexWarningBits"));
                     right = quoted;
                 }
             }

--- a/src/main/java/org/perlonjava/frontend/parser/StringDoubleQuoted.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringDoubleQuoted.java
@@ -58,7 +58,11 @@ public class StringDoubleQuoted extends StringSegmentParser {
 
     @Override
     protected boolean regexCodeBlocksAreActive() {
-        return caseModifiers.stream().noneMatch(modifier -> "Q".equals(modifier.type));
+        // Text inside \Q, \U, \L, and the other interpolation modifiers is
+        // transformed before it becomes regex source. Perl therefore treats an
+        // executable-looking group there as runtime-generated source, not as a
+        // literal callback visible to the quote lexer.
+        return caseModifiers.isEmpty();
     }
 
     /**

--- a/src/main/java/org/perlonjava/frontend/parser/StringParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringParser.java
@@ -605,6 +605,8 @@ public class StringParser {
                 ctx.symbolTable != null && ctx.symbolTable.isWarningCategoryEnabled("regexp"));
         node.setAnnotation("regexWarningsFatal",
                 ctx.symbolTable != null && ctx.symbolTable.isFatalWarningCategory("regexp"));
+        node.setAnnotation("regexWarningBits",
+                ctx.symbolTable == null ? null : ctx.symbolTable.getWarningBitsString());
         return node;
     }
 
@@ -640,6 +642,8 @@ public class StringParser {
                 ctx.symbolTable != null && ctx.symbolTable.isWarningCategoryEnabled("regexp"));
         node.setAnnotation("regexWarningsFatal",
                 ctx.symbolTable != null && ctx.symbolTable.isFatalWarningCategory("regexp"));
+        node.setAnnotation("regexWarningBits",
+                ctx.symbolTable == null ? null : ctx.symbolTable.getWarningBitsString());
         return node;
     }
 

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -579,6 +579,7 @@ final class JoniRegexPattern {
         private int regionEnd;
         private int nextStart;
         private boolean matched;
+        private int committedLastClosedCapture = -1;
         private final boolean hasControlVerbState;
         private final List<RuntimeRegexCallback> callbacks;
         private PerlCalloutHandler calloutHandler;
@@ -612,6 +613,7 @@ final class JoniRegexPattern {
         private boolean find(int option, boolean anchored) {
             if (nextStart > regionEnd) {
                 matched = false;
+                committedLastClosedCapture = -1;
                 if (hasControlVerbState) RuntimeRegex.updateControlVerbVariables(null, null);
                 return false;
             }
@@ -635,8 +637,21 @@ final class JoniRegexPattern {
                         matcher.getControlMark(), matcher.getControlError());
             }
             if (calloutHandler != null) calloutHandler.finish(matched);
-            if (!matched) return false;
-            captures = matcher.getEagerRegion();
+            if (!matched) {
+                committedLastClosedCapture = -1;
+                return false;
+            }
+            captures = Region.newRegion(regex.numberOfCaptures() + 1);
+            for (int group = 0; group <= regex.numberOfCaptures(); group++) {
+                captures.setBeg(group, matcher.captureBegin(group));
+                captures.setEnd(group, matcher.captureEnd(group));
+            }
+            committedLastClosedCapture = matcher.lastClosedCapture();
+            if (committedLastClosedCapture <= 0
+                    || captures.getBeg(committedLastClosedCapture) < 0
+                    || captures.getEnd(committedLastClosedCapture) < 0) {
+                committedLastClosedCapture = deriveCommittedLastClosedCapture(captures);
+            }
             int start = start();
             int end = end();
             nextStart = end > start ? end : advanceCodePoint(end);
@@ -676,11 +691,24 @@ final class JoniRegexPattern {
         }
 
         @Override public int groupCount() { return regex.numberOfCaptures(); }
-        @Override public int lastClosedCapture() { return matcher.lastClosedCapture(); }
+        @Override public int lastClosedCapture() { return committedLastClosedCapture; }
         @Override public String controlMark() { return matcher.getControlMark(); }
         @Override public String controlError() { return matcher.getControlError(); }
         @Override public Map<String, Integer> namedGroups() { return namedGroups; }
         @Override public String patternDescription() { return sourcePattern; }
+
+        private static int deriveCommittedLastClosedCapture(Region region) {
+            int latestCapture = -1;
+            int latestEnd = -1;
+            for (int group = 1; group < region.getNumRegs(); group++) {
+                int end = region.getEnd(group);
+                if (region.getBeg(group) >= 0 && end > latestEnd) {
+                    latestCapture = group;
+                    latestEnd = end;
+                }
+            }
+            return latestCapture;
+        }
 
         private int groupOffset(String name, boolean begin) {
             requireMatch();

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -776,7 +776,29 @@ final class JoniRegexPattern {
 
     private static final class PerlCalloutHandler implements CalloutHandler {
         private record Token(int localLevel, RegexState regexState, RuntimeScalar previousR,
-                             RuntimeScalar result, boolean block) {}
+                             RuntimeScalar result, boolean block,
+                             CaptureSnapshot previousDynamicView) {}
+
+        private record CaptureSnapshot(int position, int[] begins, int[] ends,
+                                       int lastClosed, String controlMark) implements MatchView {
+            static CaptureSnapshot of(MatchView match) {
+                int count = match.captureCount();
+                int[] begins = new int[count + 1];
+                int[] ends = new int[count + 1];
+                for (int capture = 0; capture <= count; capture++) {
+                    begins[capture] = match.captureBegin(capture);
+                    ends[capture] = match.captureEnd(capture);
+                }
+                return new CaptureSnapshot(match.currentBytePosition(), begins, ends,
+                        match.lastClosedCapture(), match.controlMark());
+            }
+
+            @Override public int currentBytePosition() { return position; }
+            @Override public int captureCount() { return begins.length - 1; }
+            @Override public int captureBegin(int capture) { return begins[capture]; }
+            @Override public int captureEnd(int capture) { return ends[capture]; }
+            @Override public int lastClosedCapture() { return lastClosed; }
+        }
 
         private final String input;
         private final int[] byteToChar;
@@ -784,6 +806,7 @@ final class JoniRegexPattern {
         private final RegexFlags outerFlags;
         private final int initialLocalLevel;
         private RuntimeScalar completedResult;
+        private CaptureSnapshot previousDynamicView;
 
         PerlCalloutHandler(String input, int[] byteToChar, List<RuntimeRegexCallback> callbacks,
                            RegexFlags outerFlags) {
@@ -879,7 +902,13 @@ final class JoniRegexPattern {
                             new RuntimeScalar(callback.code), enclosingSelf);
                 }
             }
-            publishProvisional(match);
+            CaptureSnapshot priorDynamicView = previousDynamicView;
+            MatchView provisional = callback.kind == RuntimeRegexCallback.Kind.DYNAMIC
+                    ? dynamicCaptureView(match, priorDynamicView) : match;
+            publishProvisional(provisional);
+            if (callback.kind == RuntimeRegexCallback.Kind.DYNAMIC) {
+                previousDynamicView = CaptureSnapshot.of(match);
+            }
             var callbackLocations = PerlRuntime.current().executionState()
                     .activeRegexCallbackLocations;
             callbackLocations.push(callback.sourceLocation == null ? "" : callback.sourceLocation);
@@ -902,13 +931,14 @@ final class JoniRegexPattern {
                 boolean block = callback.kind == RuntimeRegexCallback.Kind.BLOCK;
                 if (block) rVariable.set(result);
                 Token token = new Token(localLevel, savedRegex, previousR,
-                        result.clone(), block);
+                        result.clone(), block, priorDynamicView);
                 return new Evaluation(result, token);
             } catch (RuntimeException | Error failure) {
                 // The matcher cannot register an unwind token when the callout
                 // itself throws. Restore the provisional match and dynamic
                 // scope here before the exception crosses an eval boundary.
                 restoreCallbackScope(localLevel, savedRegex, previousR);
+                previousDynamicView = priorDynamicView;
                 throw failure;
             } finally {
                 if (!callbackLocations.isEmpty()) callbackLocations.pop();
@@ -948,6 +978,7 @@ final class JoniRegexPattern {
         private void restore(Token token, boolean completed) {
             if (!completed) {
                 DynamicVariableManager.popToLocalLevel(token.localLevel());
+                previousDynamicView = token.previousDynamicView();
             }
             token.regexState().restore();
             GlobalVariable.getGlobalVariable(GlobalContext.encodeSpecialVar("R"))
@@ -955,6 +986,23 @@ final class JoniRegexPattern {
             if (completed && token.block() && completedResult == null) {
                 completedResult = token.result();
             }
+        }
+
+        private static MatchView dynamicCaptureView(
+                MatchView current, CaptureSnapshot previous) {
+            CaptureSnapshot adjusted = CaptureSnapshot.of(current);
+            if (previous == null || previous.position() >= adjusted.position()) return adjusted;
+            for (int capture = 1; capture <= adjusted.captureCount(); capture++) {
+                if (adjusted.begins()[capture] == adjusted.position()
+                        && adjusted.ends()[capture] == adjusted.position()
+                        && previous.begins()[capture] == previous.position()
+                        && (previous.ends()[capture] < 0
+                        || previous.ends()[capture] == previous.position())) {
+                    adjusted.begins()[capture] = previous.position();
+                    adjusted.ends()[capture] = adjusted.position();
+                }
+            }
+            return adjusted;
         }
 
         private static void restoreCallbackScope(int localLevel, RegexState regexState,

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -776,7 +776,7 @@ final class JoniRegexPattern {
 
     private static final class PerlCalloutHandler implements CalloutHandler {
         private record Token(int localLevel, RegexState regexState, RuntimeScalar previousR,
-                             RuntimeScalar result, boolean block,
+                             RuntimeScalar result, boolean block, boolean dynamic,
                              CaptureSnapshot previousDynamicView) {}
 
         private record CaptureSnapshot(int position, int[] begins, int[] ends,
@@ -931,7 +931,9 @@ final class JoniRegexPattern {
                 boolean block = callback.kind == RuntimeRegexCallback.Kind.BLOCK;
                 if (block) rVariable.set(result);
                 Token token = new Token(localLevel, savedRegex, previousR,
-                        result.clone(), block, priorDynamicView);
+                        result.clone(), block,
+                        callback.kind == RuntimeRegexCallback.Kind.DYNAMIC,
+                        priorDynamicView);
                 return new Evaluation(result, token);
             } catch (RuntimeException | Error failure) {
                 // The matcher cannot register an unwind token when the callout
@@ -960,7 +962,8 @@ final class JoniRegexPattern {
             restore((Token) value, true);
         }
 
-        void finish(boolean matched) {
+        @Override
+        public void finish(boolean matched) {
             try {
                 if (matched && completedResult != null) {
                     GlobalVariable.getGlobalVariable(GlobalContext.encodeSpecialVar("R"))
@@ -981,8 +984,10 @@ final class JoniRegexPattern {
                 previousDynamicView = token.previousDynamicView();
             }
             token.regexState().restore();
-            GlobalVariable.getGlobalVariable(GlobalContext.encodeSpecialVar("R"))
-                    .set(token.previousR());
+            if (!completed || !token.dynamic()) {
+                GlobalVariable.getGlobalVariable(GlobalContext.encodeSpecialVar("R"))
+                        .set(token.previousR());
+            }
             if (completed && token.block() && completedResult == null) {
                 completedResult = token.result();
             }

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.List;
 
+import org.perlonjava.runtime.operators.WarnDie;
 import org.perlonjava.runtime.runtimetypes.*;
 
 /**
@@ -805,16 +806,32 @@ final class JoniRegexPattern {
         private final List<RuntimeRegexCallback> callbacks;
         private final RegexFlags outerFlags;
         private final int initialLocalLevel;
+        private final RegexState initialRegexState;
+        private final PerlCalloutHandler parent;
+        private final int nestedDepth;
         private RuntimeScalar completedResult;
         private CaptureSnapshot previousDynamicView;
+        private boolean hasFailedNestedCaptureState;
+        private boolean executedNestedCallbackPattern;
+        private String failedNestedLastClosedCapture;
+        private String failedNestedLastParenMatch;
 
         PerlCalloutHandler(String input, int[] byteToChar, List<RuntimeRegexCallback> callbacks,
                            RegexFlags outerFlags) {
+            this(input, byteToChar, callbacks, outerFlags, null);
+        }
+
+        private PerlCalloutHandler(
+                String input, int[] byteToChar, List<RuntimeRegexCallback> callbacks,
+                RegexFlags outerFlags, PerlCalloutHandler parent) {
             this.input = input;
             this.byteToChar = byteToChar;
             this.callbacks = callbacks;
             this.outerFlags = outerFlags;
+            this.parent = parent;
+            this.nestedDepth = parent == null ? 0 : parent.nestedDepth + 1;
             this.initialLocalLevel = DynamicVariableManager.getLocalLevel();
+            this.initialRegexState = new RegexState();
         }
 
         @Override
@@ -838,6 +855,11 @@ final class JoniRegexPattern {
             }
             Evaluation evaluation = evaluate(callback, match);
             RuntimeScalar value = evaluation.result();
+            if (value.type == RuntimeScalarType.UNDEF) {
+                WarnDie.warnWithCategory(
+                        new RuntimeScalar("Use of uninitialized value"),
+                        RuntimeScalarCache.scalarEmptyString, "uninitialized");
+            }
             JoniRegexPattern nestedPattern;
             List<RuntimeRegexCallback> nestedCallbacks = List.of();
             if (value.value instanceof RuntimeRegex runtimeRegex) {
@@ -874,7 +896,9 @@ final class JoniRegexPattern {
                     : new PerlCalloutHandler(input, byteToChar, nestedCallbacks,
                             value.value instanceof RuntimeRegex runtimeRegex
                                     && runtimeRegex.getRegexFlags() != null
-                                    ? runtimeRegex.getRegexFlags() : outerFlags);
+                                    ? runtimeRegex.getRegexFlags() : outerFlags,
+                            this);
+            if (nestedHandler != null) executedNestedCallbackPattern = true;
             return new DynamicPatternResult(nestedPattern.engineRegex(), nestedHandler,
                     evaluation.token());
         }
@@ -965,13 +989,35 @@ final class JoniRegexPattern {
         @Override
         public void finish(boolean matched) {
             try {
+                RuntimeRegexState state = PerlRuntime.current().regexState;
+                if (!matched && parent != null
+                        && (nestedDepth >= 2 || executedNestedCallbackPattern)) {
+                    parent.recordFailedNestedCaptureState(
+                            state.lastClosedCapture, RuntimeRegex.lastCaptureString());
+                } else if (hasFailedNestedCaptureState && parent != null) {
+                    parent.recordFailedNestedCaptureState(
+                            failedNestedLastClosedCapture, failedNestedLastParenMatch);
+                }
                 if (matched && completedResult != null) {
                     GlobalVariable.getGlobalVariable(GlobalContext.encodeSpecialVar("R"))
                             .set(completedResult);
+                } else if (!matched) {
+                    initialRegexState.restore();
+                    if (hasFailedNestedCaptureState) {
+                        state.lastClosedCapture = failedNestedLastClosedCapture;
+                        state.lastParenMatchOverrideActive = true;
+                        state.lastParenMatchOverride = failedNestedLastParenMatch;
+                    }
                 }
             } finally {
                 DynamicVariableManager.popToLocalLevel(initialLocalLevel);
             }
+        }
+
+        private void recordFailedNestedCaptureState(String lastClosed, String lastParen) {
+            hasFailedNestedCaptureState = true;
+            failedNestedLastClosedCapture = lastClosed;
+            failedNestedLastParenMatch = lastParen;
         }
 
         void abort() {
@@ -1041,6 +1087,8 @@ final class JoniRegexPattern {
 
         private void publishProvisional(MatchView match) {
             RuntimeRegexState state = PerlRuntime.current().regexState;
+            state.lastParenMatchOverrideActive = false;
+            state.lastParenMatchOverride = null;
             int count = match.captureCount();
             state.globalMatchString = input;
             state.lastMatchedString = input;

--- a/src/main/java/org/perlonjava/runtime/regex/RegexQuoteMeta.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexQuoteMeta.java
@@ -9,9 +9,27 @@ import java.util.List;
 public class RegexQuoteMeta {
     private static final ThreadLocal<List<String>> WARNINGS_ON_USE = ThreadLocal.withInitial(ArrayList::new);
     private static final ThreadLocal<Integer> CALL_SITE_WARNING_STATE = new ThreadLocal<>();
+    private static final ThreadLocal<String> CALL_SITE_WARNING_BITS = new ThreadLocal<>();
+    private static final ThreadLocal<String> MATCH_TARGET_NAME = new ThreadLocal<>();
 
     public static void setCallSiteWarningState(int state) {
         CALL_SITE_WARNING_STATE.set(state);
+    }
+
+    public static void setCallSiteWarningBits(String bits) {
+        CALL_SITE_WARNING_BITS.set(bits);
+    }
+
+    public static String getCallSiteWarningBits() {
+        return CALL_SITE_WARNING_BITS.get();
+    }
+
+    public static void setMatchTargetName(String name) {
+        MATCH_TARGET_NAME.set(name);
+    }
+
+    public static String getMatchTargetName() {
+        return MATCH_TARGET_NAME.get();
     }
 
     public static String escapeQ(String s) {

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -185,6 +185,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
     JoniRegexPattern recursivePattern;
     JoniRegexPattern recursivePatternUnicode;
     List<RuntimeRegexCallback> executableCallbacks = List.of();
+    private boolean executableCallbacksReleased;
     int[] branchResetCaptureMap;
     int patternFlags;
     int patternFlagsUnicode;
@@ -238,7 +239,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         copy.notemptyPatternUnicode = this.notemptyPatternUnicode;
         copy.recursivePattern = this.recursivePattern;
         copy.recursivePatternUnicode = this.recursivePatternUnicode;
-        copy.executableCallbacks = this.executableCallbacks;
+        copy.setExecutableCallbacks(this.executableCallbacks);
         copy.branchResetCaptureMap = this.branchResetCaptureMap;
         copy.patternFlags = this.patternFlags;
         copy.patternFlagsUnicode = this.patternFlagsUnicode;
@@ -264,6 +265,20 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
     /** Returns the regex flags for this compiled pattern. */
     public RegexFlags getRegexFlags() {
         return regexFlags;
+    }
+
+    private void setExecutableCallbacks(List<RuntimeRegexCallback> callbacks) {
+        List<RuntimeRegexCallback> retained = List.copyOf(callbacks);
+        for (RuntimeRegexCallback callback : retained) callback.retainOwner();
+        executableCallbacks = retained;
+        executableCallbacksReleased = false;
+    }
+
+    /** Release closure captures owned by this tracked qr// value. */
+    public void releaseExecutableCallbacks() {
+        if (executableCallbacksReleased || executableCallbacks.isEmpty()) return;
+        executableCallbacksReleased = true;
+        for (RuntimeRegexCallback callback : executableCallbacks) callback.releaseOwner();
     }
 
     /** Select the byte or Unicode compiled pattern for a particular target scalar. */
@@ -1292,7 +1307,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         if (patternString.value instanceof RuntimeRegexTemplate template) {
             RuntimeRegex regex = compile(template.pattern(), modifierStr, callSiteDebugMode,
                     template.callbacks().size()).cloneTracked();
-            regex.executableCallbacks = template.callbacks();
+            regex.setExecutableCallbacks(template.callbacks());
             return new RuntimeScalar(regex).propagateTaint(patternString);
         }
 
@@ -1311,7 +1326,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             regex.patternUnicode = originalRegex.patternUnicode;
             regex.recursivePattern = originalRegex.recursivePattern;
             regex.recursivePatternUnicode = originalRegex.recursivePatternUnicode;
-            regex.executableCallbacks = originalRegex.executableCallbacks;
+            regex.setExecutableCallbacks(originalRegex.executableCallbacks);
             regex.branchResetCaptureMap = originalRegex.branchResetCaptureMap;
             regex.patternNoInternalMarkers = originalRegex.patternNoInternalMarkers;
             regex.patternUnicodeNoInternalMarkers = originalRegex.patternUnicodeNoInternalMarkers;
@@ -1351,7 +1366,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                     regex.patternUnicode = originalRegex.patternUnicode;
                     regex.recursivePattern = originalRegex.recursivePattern;
                     regex.recursivePatternUnicode = originalRegex.recursivePatternUnicode;
-                    regex.executableCallbacks = originalRegex.executableCallbacks;
+                    regex.setExecutableCallbacks(originalRegex.executableCallbacks);
                     regex.branchResetCaptureMap = originalRegex.branchResetCaptureMap;
                     regex.patternNoInternalMarkers = originalRegex.patternNoInternalMarkers;
                     regex.patternUnicodeNoInternalMarkers = originalRegex.patternUnicodeNoInternalMarkers;
@@ -1456,7 +1471,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         int lexicalDebugMode = debugMode(modifiers);
         RuntimeRegex regex = compile(executablePattern, stripDebugMarkers(modifiers),
                 lexicalDebugMode, callbacks.size()).cloneTracked();
-        regex.executableCallbacks = List.copyOf(callbacks);
+        regex.setExecutableCallbacks(callbacks);
         return new RuntimeScalar(regex).propagateTaint(original);
     }
 
@@ -1656,6 +1671,17 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
      * @return A RuntimeScalar or RuntimeList.
      */
     public static RuntimeBase matchRegex(RuntimeScalar quotedRegex, RuntimeScalar string, int ctx) {
+        if (string.type == RuntimeScalarType.UNDEF) {
+            String lexicalName = RegexQuoteMeta.getMatchTargetName();
+            if (lexicalName == null) {
+                lexicalName = RuntimeCode.findActiveLexicalName(string);
+            }
+            String message = "Use of uninitialized value"
+                    + (lexicalName == null ? "" : " " + lexicalName)
+                    + " in pattern match (m//)";
+            WarnDie.warnWithCategory(new RuntimeScalar(message),
+                    RuntimeScalarCache.scalarEmptyString, "uninitialized");
+        }
         RuntimeRegex regex = resolveRegex(quotedRegex);
         regex = ensureCompiledForRuntime(regex);
         if (regex.replacement != null) {
@@ -1752,6 +1778,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
     /** Populate Perl's numbered capture state from the backend-neutral view. */
     private static void updateNumberedCaptureGroups(RuntimeRegex regex, RegexMatcher matcher) {
         RuntimeRegexState regexState = state();
+        regexState.lastParenMatchOverrideActive = false;
+        regexState.lastParenMatchOverride = null;
         regexState.manualCaptureStarts = null;
         regexState.manualCaptureEnds = null;
         int captureCount = matcher.groupCount();
@@ -2131,16 +2159,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             System.err.println("  match result: found=" + found);
         }
 
-        if (!found) {
-            // No match: scalar match vars ($`, $&, $') should become undef.
-            // Keep lastSuccessful* and the previous regexState.globalMatcher intact so @-/@+ do not get clobbered
-            // by internal regex checks that fail (e.g. in test libraries).
-            regexState.globalMatchString = null;
-            regexState.lastMatchedString = null;
-            regexState.lastMatchStart = -1;
-            regexState.lastMatchEnd = -1;
-            // Don't clear regexState.lastCaptureGroups - Perl preserves $1 across failed matches
-        }
+        // A failed match preserves all match variables from the preceding
+        // successful match, including $&, $`, $', and numbered captures.
 
         if (found) {
             fixPerl16894AlternateCaptureInLookahead(regex, inputStr);
@@ -2259,6 +2279,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         state().lastMatchUsedBackslashK = false;
         state().lastNamedCaptureGroups = new LinkedHashMap<>();
         state().lastCaptureGroups = new String[]{group1, group2, group3, group4};
+        state().lastParenMatchOverrideActive = false;
+        state().lastParenMatchOverride = null;
         state().manualCaptureStarts = new int[]{
                 closing ? tagStart + 1 : literalStart,
                 nameEnd,
@@ -2339,6 +2361,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         state().lastMatchUsedBackslashK = false;
         state().lastNamedCaptureGroups = new LinkedHashMap<>();
         state().lastCaptureGroups = new String[]{group1, group2, group3};
+        state().lastParenMatchOverrideActive = false;
+        state().lastParenMatchOverride = null;
         state().manualCaptureStarts = new int[]{match.group1Start, match.group2Start, match.group3Start};
         state().manualCaptureEnds = new int[]{match.group1End, match.group2End, match.group3End};
         state().lastMatchedString = inputStr.substring(match.matchStart, match.matchEnd);

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -715,6 +715,10 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                     }
                 }
             } catch (Exception e) {
+                if ("invalid backref number/name".equals(e.getMessage())
+                        || "invalid backref number".equals(e.getMessage())) {
+                    throw new PerlCompilerException("Reference to nonexistent group");
+                }
                 // PerlJavaUnimplementedException extends PerlCompilerException, so check
                 // the more specific type first. Real syntax errors (PerlCompilerException
                 // but NOT PerlJavaUnimplementedException) are always fatal.

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegexCallback.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegexCallback.java
@@ -13,6 +13,7 @@ public final class RuntimeRegexCallback {
     final String sourceLocation;
     final String lexicalPackage;
     final String source;
+    private int ownerCount;
 
     private RuntimeRegexCallback(
             RuntimeCode code, Kind kind, String sourceLocation, String lexicalPackage,
@@ -22,6 +23,24 @@ public final class RuntimeRegexCallback {
         this.sourceLocation = sourceLocation;
         this.lexicalPackage = lexicalPackage;
         this.source = source;
+    }
+
+    synchronized void retainOwner() {
+        if (code.refCount < 0) return;
+        if (ownerCount++ == 0) {
+            code.refCount++;
+        }
+    }
+
+    synchronized void releaseOwner() {
+        if (code.refCount < 0) return;
+        if (ownerCount <= 0) return;
+        ownerCount--;
+        if (ownerCount != 0) return;
+        if (code.refCount > 0) code.refCount--;
+        if (code.refCount == 0 && code.stashRefCount <= 0) {
+            code.releaseCaptures();
+        }
     }
 
     public static RuntimeScalar wrap(RuntimeScalar codeRef, String kindName) {

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegexSourceCompiler.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegexSourceCompiler.java
@@ -2,6 +2,7 @@ package org.perlonjava.runtime.regex;
 
 import org.perlonjava.app.cli.CompilerOptions;
 import org.perlonjava.app.scriptengine.PerlLanguageProvider;
+import org.perlonjava.runtime.WarningBitsRegistry;
 import org.perlonjava.backend.bytecode.BytecodeCompiler;
 import org.perlonjava.backend.bytecode.InterpretedCode;
 import org.perlonjava.backend.bytecode.InterpreterState;
@@ -20,6 +21,7 @@ import org.perlonjava.runtime.runtimetypes.RuntimeCode;
 import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
 import org.perlonjava.runtime.runtimetypes.RuntimeList;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
+import org.perlonjava.runtime.runtimetypes.WarningFlags;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -75,6 +77,17 @@ final class RuntimeRegexSourceCompiler {
             symbolTable.enableStrictOption(HINT_RE_EVAL);
             symbolTable.enableLexicalRegexModifiers(
                     publicModifiers.replaceAll("[^imsx]", ""));
+            String warningBits = RegexQuoteMeta.getCallSiteWarningBits();
+            if (warningBits == null) {
+                warningBits = WarningBitsRegistry.getCallSiteBits();
+            }
+            if (warningBits == null) {
+                warningBits = WarningBitsRegistry.getCurrent();
+            }
+            if (warningBits == null && owner != null) {
+                warningBits = RuntimeCode.getWarningBitsForCode(owner);
+            }
+            WarningFlags.setWarningBitsFromString(symbolTable, warningBits);
             symbolTable.setCurrentPackage(
                     InterpreterState.currentPackage.get().toString(), false);
 
@@ -112,8 +125,13 @@ final class RuntimeRegexSourceCompiler {
             RuntimeList result = code.apply(new RuntimeArray(), RuntimeContextType.SCALAR);
             RuntimeScalar compiled = result.scalar().propagateTaint(pattern);
             if (compiled.value instanceof RuntimeRegex && !modifiers.isEmpty()) {
+                RuntimeScalar unmodified = compiled;
                 compiled = RuntimeRegex.getQuotedRegex(
-                        compiled, new RuntimeScalar(modifiers)).propagateTaint(pattern);
+                        unmodified, new RuntimeScalar(modifiers)).propagateTaint(pattern);
+                if (compiled.value != unmodified.value
+                        && unmodified.value instanceof RuntimeRegex temporary) {
+                    temporary.releaseExecutableCallbacks();
+                }
             }
             return compiled;
         } finally {
@@ -137,7 +155,11 @@ final class RuntimeRegexSourceCompiler {
 
         List<RuntimeRegexCallback> callbacks = new ArrayList<>(template.callbacks());
         callbacks.addAll(sourceRegex.executableCallbacks);
-        return RuntimeRegex.compileExecutableTemplate(executablePattern, modifiers,
-                callbacks, original);
+        RuntimeScalar result = RuntimeRegex.compileExecutableTemplate(
+                executablePattern, modifiers, callbacks, original);
+        if (result.value != sourceRegex) {
+            sourceRegex.releaseExecutableCallbacks();
+        }
+        return result;
     }
 }

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegexSourceCompiler.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegexSourceCompiler.java
@@ -57,9 +57,10 @@ final class RuntimeRegexSourceCompiler {
         String sourceModifiers = publicModifiers.replaceAll("[gcr?op]", "");
         String source = "qr~" + pattern.toString().replace("~", "\\~")
                 + "~" + sourceModifiers;
-        String sourceName = owner != null && owner.cvStartFile != null
-                ? owner.cvStartFile : "(runtime regex)";
-        int sourceLine = owner != null && owner.cvStartLine > 0 ? owner.cvStartLine : 1;
+        // Perl compiles each executable runtime pattern as a distinct eval,
+        // so diagnostics and warnings use an independent (eval N) filename.
+        String sourceName = RuntimeCode.getNextEvalFilename();
+        int sourceLine = 1;
 
         ScopedSymbolTable savedScope = SpecialBlockParser.getCurrentScope();
         try (PerlLanguageProvider.CompilationLockGuard ignored =

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/DestroyDispatch.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/DestroyDispatch.java
@@ -268,6 +268,8 @@ public class DestroyDispatch {
                 }
                 code.releaseCaptures();
             }
+        } else if (referent instanceof org.perlonjava.runtime.regex.RuntimeRegex regex) {
+            regex.releaseExecutableCallbacks();
         }
 
         String className = NameNormalizer.getBlessStr(referent.blessId);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RegexState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RegexState.java
@@ -23,6 +23,8 @@ public class RegexState implements DynamicState {
     private final boolean lastMatchUsedBackslashK;
     private final String[] lastCaptureGroups;
     private final String lastClosedCapture;
+    private final boolean lastParenMatchOverrideActive;
+    private final String lastParenMatchOverride;
     private final Map<String, List<String>> lastNamedCaptureGroups;
     private final boolean lastMatchWasByteString;
     private final boolean lastMatchResultsTainted;
@@ -46,6 +48,8 @@ public class RegexState implements DynamicState {
         lastMatchUsedBackslashK = state.lastMatchUsedBackslashK;
         lastCaptureGroups = state.lastCaptureGroups;
         lastClosedCapture = state.lastClosedCapture;
+        lastParenMatchOverrideActive = state.lastParenMatchOverrideActive;
+        lastParenMatchOverride = state.lastParenMatchOverride;
         lastNamedCaptureGroups = state.lastNamedCaptureGroups;
         lastMatchWasByteString = state.lastMatchWasByteString;
         lastMatchResultsTainted = state.lastMatchResultsTainted;
@@ -71,6 +75,12 @@ public class RegexState implements DynamicState {
             throw new IllegalStateException("Regex state must be restored in its owning PerlRuntime");
         }
         RuntimeRegexState state = owner.regexState;
+        RuntimeRegex discardedPattern = state.lastSuccessfulPattern;
+        if (discardedPattern != null
+                && discardedPattern != lastSuccessfulPattern
+                && discardedPattern.refCount <= 0) {
+            discardedPattern.releaseExecutableCallbacks();
+        }
         state.globalMatcher = globalMatcher;
         state.globalMatchString = globalMatchString;
         state.lastMatchedString = lastMatchedString;
@@ -85,6 +95,8 @@ public class RegexState implements DynamicState {
         state.lastMatchUsedBackslashK = lastMatchUsedBackslashK;
         state.lastCaptureGroups = lastCaptureGroups;
         state.lastClosedCapture = lastClosedCapture;
+        state.lastParenMatchOverrideActive = lastParenMatchOverrideActive;
+        state.lastParenMatchOverride = lastParenMatchOverride;
         state.lastNamedCaptureGroups = lastNamedCaptureGroups;
         state.lastMatchWasByteString = lastMatchWasByteString;
         state.lastMatchResultsTainted = lastMatchResultsTainted;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -381,6 +381,19 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         return null;
     }
 
+    /** Find the Perl lexical name for a live cell, for value-specific diagnostics. */
+    public static String findActiveLexicalName(RuntimeBase cell) {
+        if (cell == null) return null;
+        PerlRuntime runtime = PerlRuntime.current();
+        if (!runtime.runtimeCodeState().lexicalAliasSupportEnabled) return null;
+        for (ActiveLexicalFrame frame : activeLexicalFrames(runtime.executionState())) {
+            for (Map.Entry<String, RuntimeBase> entry : frame.cells().entrySet()) {
+                if (entry.getValue() == cell) return entry.getKey();
+            }
+        }
+        return null;
+    }
+
     /** Return a stable snapshot of the live lexical cells for an active CV. */
     public static Map<String, RuntimeBase> snapshotActiveLexicals(RuntimeCode code) {
         if (code == null) return Collections.emptyMap();
@@ -2776,7 +2789,17 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 // reconstruct this state later, so seed the parser scope from
                 // the saved caller frame before BEGIN blocks are compiled.
                 String callerWarningBits = WarningBitsRegistry.getCallerBitsAtFrame(0);
-                if (callerWarningBits != null) {
+                if (callerWarningBits == null || callerWarningBits.isEmpty()) {
+                    callerWarningBits = WarningBitsRegistry.getCallSiteBits();
+                }
+                if (callerWarningBits == null || callerWarningBits.isEmpty()) {
+                    callerWarningBits = WarningBitsRegistry.getCurrent();
+                }
+                // An empty caller-stack entry means the interpreter had no
+                // more precise runtime value.  Do not let that erase the
+                // compile-time warning mask already present in the eval
+                // call site's captured symbol table.
+                if (callerWarningBits != null && !callerWarningBits.isEmpty()) {
                     WarningFlags.setWarningBitsFromString(parseSymbolTable, callerWarningBits);
                 }
                 // BEGIN blocks execute while the eval string is being parsed.

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -1195,6 +1195,21 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         return cell;
     }
 
+    /** Refresh a live lexical binding after foreach replaces its alias cell. */
+    public RuntimeBase bindActiveLexical(String variableName, RuntimeBase cell) {
+        registerActiveLexical(this, variableName, cell);
+        return cell;
+    }
+
+    public static RuntimeBase bindActiveLexical(
+            RuntimeBase cell, RuntimeScalar codeRef, String variableName) {
+        if (codeRef != null && codeRef.value instanceof RuntimeCode code) {
+            return code.bindActiveLexical(variableName, cell);
+        }
+        RuntimeCode active = getActiveCodeAt(0);
+        return active == null ? cell : active.bindActiveLexical(variableName, cell);
+    }
+
     public static RuntimeBase resolveLexicalAlias(
             RuntimeBase defaultValue, RuntimeScalar codeRef, String variableName) {
         if (codeRef != null && codeRef.value instanceof RuntimeCode code) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -5632,6 +5632,15 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             if (elem instanceof ScalarSpecialVariable ssv) {
                 RuntimeScalar resolved = ssv.getValueAsScalar();
                 elems.set(i, new RuntimeScalar(resolved));
+            } else if (callContext != RuntimeContextType.LVALUE
+                    && callContext != RuntimeContextType.LVALUE_LIST
+                    && elem instanceof RuntimeScalar scalar
+                    && scalar.type == RuntimeScalarType.TIED_SCALAR) {
+                // FETCH before RegexState/local teardown. A tied return can
+                // depend on captures produced inside the callee; deferring its
+                // magic until the caller consumes the value exposes the
+                // restored caller capture state instead.
+                elems.set(i, new RuntimeScalar(scalar));
             } else if (!preserveAggregateLvalues && elem instanceof RuntimeArray arr) {
                 // Copy array elements to ensure independence from local restoration.
                 // For tied arrays, use getList() which dispatches through FETCHSIZE/FETCH,

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeRegexState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeRegexState.java
@@ -33,6 +33,8 @@ public final class RuntimeRegexState {
     public boolean lastMatchUsedBackslashK;
     public String[] lastCaptureGroups;
     public String lastClosedCapture;
+    public boolean lastParenMatchOverrideActive;
+    public String lastParenMatchOverride;
     public Map<String, List<String>> lastNamedCaptureGroups;
     public boolean lastMatchWasByteString;
     public boolean lastMatchResultsTainted;
@@ -87,6 +89,8 @@ public final class RuntimeRegexState {
         lastMatchUsedBackslashK = false;
         lastCaptureGroups = null;
         lastClosedCapture = null;
+        lastParenMatchOverrideActive = false;
+        lastParenMatchOverride = null;
         lastNamedCaptureGroups = null;
         lastMatchWasByteString = false;
         lastMatchResultsTainted = false;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarSpecialVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ScalarSpecialVariable.java
@@ -224,6 +224,10 @@ public class ScalarSpecialVariable extends RuntimeBaseProxy {
                     yield getScalarInt(RuntimeIO.getLastAccessedHandle().currentLineNumber);
                 }
                 case LAST_PAREN_MATCH -> {
+                    if (PerlRuntime.current().regexState.lastParenMatchOverrideActive) {
+                        String override = PerlRuntime.current().regexState.lastParenMatchOverride;
+                        yield override != null ? makeRegexResultScalar(override) : scalarUndef;
+                    }
                     String lastCapture = RuntimeRegex.lastCaptureString();
                     yield lastCapture != null ? makeRegexResultScalar(lastCapture) : scalarUndef;
                 }

--- a/src/test/resources/unit/regex/case_modifier_dynamic_eval.t
+++ b/src/test/resources/unit/regex/case_modifier_dynamic_eval.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+local our $lower = 'i';
+local our $upper = 'J';
+
+eval { 'Ia' =~ /^\U(??{"$lower\Ea"})$/ };
+like($@, qr/Eval-group not allowed at runtime/,
+    'uppercase interpolation requires runtime eval permission');
+
+eval { 'ja' =~ /^\L(??{"$upper\Ea"})$/ };
+like($@, qr/Eval-group not allowed at runtime/,
+    'lowercase interpolation requires runtime eval permission');
+
+{
+    use re 'eval';
+    ok('Ia' =~ /^\U(??{"$lower\Ea"})$/,
+        'uppercase interpolation executes after runtime permission');
+    ok('ja' =~ /^\L(??{"$upper\Ea"})$/,
+        'lowercase interpolation executes after runtime permission');
+}

--- a/src/test/resources/unit/regex/dynamic_invalid_backref_diagnostic.t
+++ b/src/test/resources/unit/regex/dynamic_invalid_backref_diagnostic.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+use Test::More tests => 1;
+use re 'eval';
+
+eval 'qr/(?{})\6/';
+like($@, qr/Reference to nonexistent group/,
+    'dynamic regex reports Perl nonexistent-group diagnostic');

--- a/src/test/resources/unit/regex/dynamic_tied_capture.t
+++ b/src/test/resources/unit/regex/dynamic_tied_capture.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+use re 'eval';
+
+{
+    package DynamicTieCapture::Overloaded;
+    use overload '""' => sub { 'abc' };
+}
+
+{
+    package DynamicTieCapture::Scalar;
+    sub TIESCALAR { bless [], __PACKAGE__ }
+    sub STORE { }
+    sub FETCH { "$1" }
+}
+
+package main;
+
+tie my $dynamic, 'DynamicTieCapture::Scalar';
+$dynamic = bless [], 'DynamicTieCapture::Overloaded';
+
+my $matched = 'aab' =~ /(a)((??{ 'b' =~ m|(.)|; $dynamic }))/;
+ok($matched, 'dynamic tied pattern matches');
+is("[$1 $2]", '[a b]', 'dynamic tied FETCH sees nested capture');

--- a/src/test/resources/unit/regex/embedded_dynamic_qr_capture.t
+++ b/src/test/resources/unit/regex/embedded_dynamic_qr_capture.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+use Test::More tests => 7;
+use re 'eval';
+
+our @seen;
+my $inner = qr{
+    (1)
+    ((??{
+        push @seen, defined $^N ? $^N : 'undef';
+        1 + $^N;
+    })){2}
+    (?{ $^N })
+    (|a(b)c|def)
+    (??{ "$^R" })
+}x;
+
+my $matched = '123abc3' =~ /^($inner)$/;
+ok($matched, 'embedded executable qr matches');
+is(join(',', @seen), '1,2', 'embedded callbacks see shifted captures');
+is($1, '123abc3', 'outer capture spans the embedded qr');
+is($2, '1', 'first embedded capture is renumbered');
+is($3, '3', 'repeated embedded capture publishes its final value');
+is($4, 'abc', 'embedded alternation capture is renumbered');
+is($5, 'b', 'nested embedded capture is renumbered');

--- a/src/test/resources/unit/regex/embedded_dynamic_qr_capture.t
+++ b/src/test/resources/unit/regex/embedded_dynamic_qr_capture.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 7;
+use Test::More tests => 10;
 use re 'eval';
 
 our @seen;
@@ -15,6 +15,7 @@ my $inner = qr{
     (??{ "$^R" })
 }x;
 
+undef $^R;
 my $matched = '123abc3' =~ /^($inner)$/;
 ok($matched, 'embedded executable qr matches');
 is(join(',', @seen), '1,2', 'embedded callbacks see shifted captures');
@@ -23,3 +24,10 @@ is($2, '1', 'first embedded capture is renumbered');
 is($3, '3', 'repeated embedded capture publishes its final value');
 is($4, 'abc', 'embedded alternation capture is renumbered');
 is($5, 'b', 'nested embedded capture is renumbered');
+is($^R, '3', 'embedded block result survives the nested matcher');
+
+our $runtime_qr = $inner;
+undef $^R;
+ok('123abc3' =~ /^(??{$runtime_qr})$/,
+    'runtime qr containing callbacks matches through a dynamic group');
+is($^R, '3', 'runtime qr block result survives its outer dynamic callback');

--- a/src/test/resources/unit/regex/failed_dynamic_callback_state.t
+++ b/src/test/resources/unit/regex/failed_dynamic_callback_state.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use re 'eval';
+use Test::More tests => 4;
+
+my $nested = qr/(a)(?{ 1 })/;
+'old' =~ /(old)/;
+
+ok(!('a' =~ /^(??{$nested})(?!)$/),
+    'outer failure unwinds a successful dynamic callback pattern');
+is($1, 'old', 'failed dynamic callback preserves the preceding numbered capture');
+is($^N, 'old', 'one-level dynamic callback failure preserves the last closed capture');
+is($+, 'old', 'one-level dynamic callback failure preserves the last participating capture');

--- a/src/test/resources/unit/regex/mixed_runtime_source.t
+++ b/src/test/resources/unit/regex/mixed_runtime_source.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 18;
+use Test::More tests => 23;
 
 {
     my $seen = 0;
@@ -103,6 +103,48 @@ use Test::More tests => 18;
     use re 'eval';
     ok("\x{100}" =~ /^$runtime$/,
         'runtime callback source retains Unicode characters');
+}
+
+{
+    use re 'eval';
+    use utf8;
+    my $runtime = '(?{Ｆｏｏ::$bar})';
+    eval { "a" =~ /^a$runtime/ };
+    like($@, qr/Bad name after Ｆｏｏ:: at \(eval \d+\) line \d+/,
+        'runtime source preserves Unicode parser diagnostics');
+}
+
+{
+    use warnings;
+    my ($source, $target, $warning) = ('s');
+    local $SIG{__WARN__} = sub { $warning .= "@_" };
+    eval q[
+        use re 'eval';
+        my $runtime = '(?{$target=$source+1})';
+        "a" =~ /a$runtime/;
+        1;
+    ];
+    like($warning, qr/ at \(eval \d+\) line 1/,
+        'runtime source inherits lexical warning bits');
+}
+
+{
+    use warnings;
+    my ($target, $returned);
+    my $warning = '';
+    local $SIG{__WARN__} = sub { $warning .= $_[0] };
+    $target =~ /(??{$returned})/ or die;
+    like($warning,
+        qr/value \$target in pattern match.*\n.*uninitialized value at/s,
+        'undefined match target and dynamic source retain warning context');
+}
+
+{
+    use re 'eval';
+    "foo" =~ /f(o)o/;
+    "bar" =~ /(?{})baz/;
+    is($&, 'foo', 'failed callback branch preserves the prior whole match');
+    is($1, 'o', 'failed callback branch preserves the prior capture');
 }
 
 {

--- a/src/test/resources/unit/regex/mixed_runtime_source.t
+++ b/src/test/resources/unit/regex/mixed_runtime_source.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 16;
+use Test::More tests => 18;
 
 {
     my $seen = 0;
@@ -112,4 +112,18 @@ use Test::More tests => 16;
     use re 'eval';
     ok("AQ2R2" =~ /^A$embedded$runtime$/,
         'runtime callbacks retain lexical cells');
+}
+
+{
+    use re 'eval';
+    my (@immediate, @patterns);
+    for my $value (qw(a b c)) {
+        my $runtime = '(??{$value})';
+        push @immediate, $value if $value =~ /^$runtime$/;
+        push @patterns, qr/^$runtime$/;
+    }
+    is(join('', @immediate), 'abc',
+        'runtime callbacks see the active foreach lexical alias');
+    ok('a' =~ $patterns[0] && 'b' =~ $patterns[1] && 'c' =~ $patterns[2],
+        'runtime callbacks retain distinct foreach iteration cells');
 }

--- a/src/test/resources/unit/regex/recursive_capture_restore.t
+++ b/src/test/resources/unit/regex/recursive_capture_restore.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+our @seen;
+my $matched = 'ab' =~ /\A
+    (?<recursive>
+        (.)
+        (?:(?&recursive))?
+        (*{
+            push @seen,
+                (defined $^N ? $^N : 'undef') . ':' .
+                (defined $+  ? $+  : 'undef');
+        })
+    )
+\z/x;
+my $committed = (defined $1  ? $1  : 'undef') . ':' .
+                (defined $^N ? $^N : 'undef') . ':' .
+                (defined $+  ? $+  : 'undef');
+
+ok($matched, 'recursive subpattern matches');
+is(join(',', @seen), 'b:b,a:a',
+    'return from recursion restores caller captures for optimistic callback');
+is($committed, 'ab:ab:a', 'committed match publishes outer capture state');

--- a/src/test/resources/unit/regex/repeated_dynamic_capture.t
+++ b/src/test/resources/unit/regex/repeated_dynamic_capture.t
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+use Test::More tests => 5;
+use re 'eval';
+
+our @seen;
+my $matched = '123' =~ /^(\d)(((??{
+    push @seen, defined $^N ? $^N : 'undef';
+    1 + $^N;
+})))+$/;
+ok($matched, 'repeated dynamic pattern matches');
+is(join(',', @seen), '1,2,3', 'each dynamic program sees the preceding capture');
+is($1, '1', 'first capture is preserved');
+is($2, '3', 'repeated enclosing capture publishes its final value');
+is($3, '3', 'nested repeated capture publishes its final value');

--- a/src/test/resources/unit/regex/runtime_callback_destroy_lifetime.t
+++ b/src/test/resources/unit/regex/runtime_callback_destroy_lifetime.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+{
+    package RuntimeCallbackDestroyLifetime;
+    our $destroyed = 0;
+    sub DESTROY { $destroyed++ }
+}
+
+{
+    my $r1;
+    {
+        my $value = bless [1], 'RuntimeCallbackDestroyLifetime';
+        $r1 = eval 'qr/(??{$value->[0]})/';
+    }
+    my $r2 = eval 'qr/a$r1/';
+    my $value = 2;
+    ok(eval '"a1" =~ qr/^$r2$/', 'runtime callback remains executable');
+    "a" =~ /a(?{1})/;
+    is($RuntimeCallbackDestroyLifetime::destroyed, 0,
+        'captured callback value remains alive in the enclosing scope');
+}
+
+is($RuntimeCallbackDestroyLifetime::destroyed, 1,
+    'captured callback value is released after scope exit');

--- a/third_party/joni/src/org/joni/ArrayCompiler.java
+++ b/third_party/joni/src/org/joni/ArrayCompiler.java
@@ -417,7 +417,9 @@ final class ArrayCompiler extends Compiler {
         addOpcode(OPCode.CALL);
         node.unsetAddrList.add(codeLength, node.target);
         addAbsAddr(0); /*dummy addr.*/
-        addMemNum(node.groupNum);
+        // Preserve analyser recursion knowledge for the matcher without adding
+        // an opcode operand. -1 remains reserved for compiler-internal calls.
+        addMemNum(node.isRecursion() ? -(node.groupNum + 1) : node.groupNum);
     }
 
     @Override

--- a/third_party/joni/src/org/joni/ByteCodeMachine.java
+++ b/third_party/joni/src/org/joni/ByteCodeMachine.java
@@ -19,6 +19,8 @@
  */
 package org.joni;
 
+import java.util.ArrayDeque;
+
 import static org.joni.BitStatus.bsAt;
 import static org.joni.Config.USE_CEC;
 import static org.joni.Option.isFindCondition;
@@ -2013,8 +2015,11 @@ class ByteCodeMachine extends StackMachine implements MatchView {
             throw new ValueException("subpattern recursion limit exceeded");
         }
         int addr = code[ip++];
-        int groupNum = code[ip++];
-        pushCallFrame(ip, groupNum);
+        int encodedGroupNum = code[ip++];
+        boolean recursive = encodedGroupNum <= -2;
+        int groupNum = recursive ? -encodedGroupNum - 1 : encodedGroupNum;
+        recursive |= isInsideSubexpCall(groupNum);
+        pushCallFrame(ip, groupNum, recursive);
         ip = addr; // absolute address
     }
 
@@ -2204,7 +2209,7 @@ class ByteCodeMachine extends StackMachine implements MatchView {
     public int captureBegin(int capture) {
         checkCapture(capture);
         if (capture == 0) return sstart - str;
-        int value = repeatStk[memStartStk + capture];
+        int value = visibleCapturePointer(capture, true);
         if (value == INVALID_INDEX) return Region.REGION_NOTPOS;
         return (bsAt(regex.btMemStart, capture) ? stack[value].getMemPStr() : value) - str;
     }
@@ -2213,20 +2218,110 @@ class ByteCodeMachine extends StackMachine implements MatchView {
     public int captureEnd(int capture) {
         checkCapture(capture);
         if (capture == 0) return s - str;
-        int value = repeatStk[memEndStk + capture];
+        int value = visibleCapturePointer(capture, false);
         if (value == INVALID_INDEX) return Region.REGION_NOTPOS;
         return (bsAt(regex.btMemEnd, capture) ? stack[value].getMemPStr() : value) - str;
     }
 
     @Override
     public int lastClosedCapture() {
+        CompletedRecursiveCall completed = completedRecursiveCall();
         for (int i = stk - 1; i >= 0; i--) {
             StackEntry entry = stack[i];
-            if (entry.type != MEM_END) continue;
+            if (entry.type != MEM_END && entry.type != MEM_END_MARK) continue;
             int mem = entry.getMemNum();
-            if (repeatStk[memEndStk + mem] == i) return mem;
+            boolean active = entry.type == MEM_END
+                    ? repeatStk[memEndStk + mem] == i
+                    : repeatStk[memEndStk + mem] != INVALID_INDEX;
+            if (active && (completed == null || i > completed.returnIndex)) return mem;
         }
-        return -1;
+        if (completed != null) {
+            int[] snapshot = completed.frame.getCallFrameCaptureSnapshot();
+            int count = regex.numMem + 1;
+            int latest = INVALID_INDEX;
+            int latestCapture = -1;
+            for (int mem = 1; mem <= regex.numMem; mem++) {
+                int end = snapshot[count + mem];
+                if (end > latest) {
+                    latest = end;
+                    latestCapture = mem;
+                }
+            }
+            return latestCapture;
+        }
+        // Recursive memory-end opcodes may retain only direct offsets after a
+        // successful candidate commits. In that representation there is no
+        // active MEM_END stack entry to identify, so recover Perl's outermost
+        // last close from the visible capture ends. Ties keep the lower-numbered
+        // (and therefore enclosing) capture, which closes after its child.
+        int latestEnd = Region.REGION_NOTPOS;
+        int latestCapture = -1;
+        for (int mem = 1; mem <= regex.numMem; mem++) {
+            int end = captureEnd(mem);
+            if (end > latestEnd) {
+                latestEnd = end;
+                latestCapture = mem;
+            }
+        }
+        return latestCapture;
+    }
+
+    private int visibleCapturePointer(int capture, boolean begin) {
+        int current = repeatStk[(begin ? memStartStk : memEndStk) + capture];
+        CompletedRecursiveCall completed = completedRecursiveCall();
+        if (completed == null) return current;
+        int[] snapshot = completed.frame.getCallFrameCaptureSnapshot();
+        int count = regex.numMem + 1;
+        int currentEnd = repeatStk[memEndStk + capture];
+        if (currentEnd != INVALID_INDEX && captureClosedAfterReturn(
+                capture, completed.returnIndex)) {
+            if (begin && snapshot[capture] != INVALID_INDEX
+                    && snapshot[count + capture] == INVALID_INDEX) {
+                // The caller had opened this enclosing capture before making
+                // the recursive call and closed it after return. Its start is
+                // from the caller snapshot; its end is the committed current end.
+                return snapshot[capture];
+            }
+            return current;
+        }
+        return snapshot[(begin ? 0 : count) + capture];
+    }
+
+    private boolean captureClosedAfterReturn(int capture, int returnIndex) {
+        for (int i = stk - 1; i > returnIndex; i--) {
+            StackEntry entry = stack[i];
+            if ((entry.type == MEM_END || entry.type == MEM_END_MARK)
+                    && entry.getMemNum() == capture) return true;
+        }
+        return false;
+    }
+
+    private CompletedRecursiveCall completedRecursiveCall() {
+        ArrayDeque<Integer> returns = new ArrayDeque<>();
+        CompletedRecursiveCall visible = null;
+        for (int i = stk - 1; i >= 0; i--) {
+            StackEntry entry = stack[i];
+            if (entry.type == RETURN) {
+                returns.push(i);
+            } else if (entry.type == CALL_FRAME && !returns.isEmpty()) {
+                int returnIndex = returns.pop();
+                if (entry.getCallFrameCaptureSnapshot() != null
+                        && (visible == null || returnIndex > visible.returnIndex)) {
+                    visible = new CompletedRecursiveCall(entry, returnIndex);
+                }
+            }
+        }
+        return visible;
+    }
+
+    private static final class CompletedRecursiveCall {
+        final StackEntry frame;
+        final int returnIndex;
+
+        CompletedRecursiveCall(StackEntry frame, int returnIndex) {
+            this.frame = frame;
+            this.returnIndex = returnIndex;
+        }
     }
 
     @Override
@@ -2241,7 +2336,8 @@ class ByteCodeMachine extends StackMachine implements MatchView {
     }
 
     private void opReturn() {
-        ip = sreturn();
+        StackEntry frame = returnFrame();
+        ip = frame.getCallFrameRetAddr();
         pushReturn();
     }
 

--- a/third_party/joni/src/org/joni/ByteCodeMachine.java
+++ b/third_party/joni/src/org/joni/ByteCodeMachine.java
@@ -2068,8 +2068,10 @@ class ByteCodeMachine extends StackMachine implements MatchView {
             throw new IllegalStateException("dynamic regex requires the bytecode matcher");
         }
         nested.useIndependentStack();
-        nested.setCalloutHandler(result.getCalloutHandler());
-        DynamicContinuation continuation = new DynamicContinuation(nested, s, range);
+        CalloutHandler nestedHandler = result.getCalloutHandler();
+        nested.setCalloutHandler(nestedHandler);
+        DynamicContinuation continuation = new DynamicContinuation(
+                nested, nestedHandler, s, range);
         int nestedEnd = continuation.first();
         if (nestedEnd < 0) {
             continuation.abort();
@@ -2408,13 +2410,16 @@ class ByteCodeMachine extends StackMachine implements MatchView {
     /** Lazy nested matcher whose remaining alternatives belong to its caller. */
     static final class DynamicContinuation {
         private final ByteCodeMachine machine;
+        private final CalloutHandler handler;
         private final int start;
         private final int range;
         private boolean started;
         private boolean closed;
 
-        DynamicContinuation(ByteCodeMachine machine, int start, int range) {
+        DynamicContinuation(ByteCodeMachine machine, CalloutHandler handler,
+                int start, int range) {
             this.machine = machine;
+            this.handler = handler;
             this.start = start;
             this.range = range;
         }
@@ -2464,12 +2469,14 @@ class ByteCodeMachine extends StackMachine implements MatchView {
             if (closed) return;
             closed = true;
             machine.completeActiveCallouts();
+            if (handler != null) handler.finish(true);
         }
 
         void abort() {
             if (closed) return;
             closed = true;
             machine.unwindActiveCallouts();
+            if (handler != null) handler.finish(false);
         }
     }
 

--- a/third_party/joni/src/org/joni/ByteCodeMachine.java
+++ b/third_party/joni/src/org/joni/ByteCodeMachine.java
@@ -2233,6 +2233,11 @@ class ByteCodeMachine extends StackMachine implements MatchView {
             boolean active = entry.type == MEM_END
                     ? repeatStk[memEndStk + mem] == i
                     : repeatStk[memEndStk + mem] != INVALID_INDEX;
+            if (!active && entry.type == MEM_END
+                    && repeatStk[memEndStk + mem] == INVALID_INDEX
+                    && repeatStk[memStartStk + mem] != INVALID_INDEX) {
+                active = true;
+            }
             if (active && (completed == null || i > completed.returnIndex)) return mem;
         }
         if (completed != null) {
@@ -2269,7 +2274,10 @@ class ByteCodeMachine extends StackMachine implements MatchView {
     private int visibleCapturePointer(int capture, boolean begin) {
         int current = repeatStk[(begin ? memStartStk : memEndStk) + capture];
         CompletedRecursiveCall completed = completedRecursiveCall();
-        if (completed == null) return current;
+        if (completed == null) {
+            int previous = previousClosedCapturePointer(capture, begin);
+            return previous != INVALID_INDEX ? previous : current;
+        }
         int[] snapshot = completed.frame.getCallFrameCaptureSnapshot();
         int count = regex.numMem + 1;
         int currentEnd = repeatStk[memEndStk + capture];
@@ -2285,6 +2293,26 @@ class ByteCodeMachine extends StackMachine implements MatchView {
             return current;
         }
         return snapshot[(begin ? 0 : count) + capture];
+    }
+
+    private int previousClosedCapturePointer(int capture, boolean begin) {
+        if (repeatStk[memEndStk + capture] != INVALID_INDEX
+                || repeatStk[memStartStk + capture] == INVALID_INDEX) {
+            return INVALID_INDEX;
+        }
+        int endPointer = INVALID_INDEX;
+        for (int i = stk - 1; i >= 0; i--) {
+            StackEntry entry = stack[i];
+            if (endPointer == INVALID_INDEX) {
+                if (entry.type == MEM_END && entry.getMemNum() == capture) {
+                    if (!begin) return i;
+                    endPointer = i;
+                }
+            } else if (entry.type == MEM_START && entry.getMemNum() == capture) {
+                return i;
+            }
+        }
+        return INVALID_INDEX;
     }
 
     private boolean captureClosedAfterReturn(int capture, int returnIndex) {

--- a/third_party/joni/src/org/joni/CalloutHandler.java
+++ b/third_party/joni/src/org/joni/CalloutHandler.java
@@ -37,4 +37,8 @@ public interface CalloutHandler {
     default void complete(Object backtrackToken) {
         unwind(backtrackToken);
     }
+
+    /** Finish one matcher invocation after its active tokens have been resolved. */
+    default void finish(boolean matched) {
+    }
 }

--- a/third_party/joni/src/org/joni/Matcher.java
+++ b/third_party/joni/src/org/joni/Matcher.java
@@ -116,6 +116,19 @@ public abstract class Matcher extends IntHolder {
         return msaEnd;
     }
 
+    /** Capture offsets exposed after a match; bytecode matchers may provide a language view. */
+    public int captureBegin(int capture) {
+        if (capture == 0) return msaBegin;
+        Region region = getEagerRegion();
+        return capture < region.getNumRegs() ? region.getBeg(capture) : Region.REGION_NOTPOS;
+    }
+
+    public int captureEnd(int capture) {
+        if (capture == 0) return msaEnd;
+        Region region = getEagerRegion();
+        return capture < region.getNumRegs() ? region.getEnd(capture) : Region.REGION_NOTPOS;
+    }
+
     /** Most recently closed active capture; engines without this view return -1. */
     public int lastClosedCapture() {
         return -1;

--- a/third_party/joni/src/org/joni/StackEntry.java
+++ b/third_party/joni/src/org/joni/StackEntry.java
@@ -26,6 +26,7 @@ class StackEntry {
     private ByteCodeMachine.DynamicContinuation dynamicContinuation;
     private String previousControlMarkName;
     private String controlMarkLabel;
+    private int[] callFrameCaptureSnapshot;
 
     // first union member
     /* byte code position */
@@ -164,6 +165,12 @@ class StackEntry {
     }
     int getCallFramePStr() {
         return E3;
+    }
+    void setCallFrameCaptureSnapshot(int[] snapshot) {
+        callFrameCaptureSnapshot = snapshot;
+    }
+    int[] getCallFrameCaptureSnapshot() {
+        return callFrameCaptureSnapshot;
     }
 
     /* absent position */

--- a/third_party/joni/src/org/joni/StackMachine.java
+++ b/third_party/joni/src/org/joni/StackMachine.java
@@ -306,12 +306,21 @@ abstract class StackMachine extends Matcher implements StackType {
         stk++;
     }
 
-    protected final void pushCallFrame(int pat, int groupNum) {
+    protected final void pushCallFrame(int pat, int groupNum, boolean recursive) {
         StackEntry e = ensure1();
         e.type = CALL_FRAME;
         e.setCallFrameRetAddr(pat);
         e.setCallFrameNum(groupNum);
+        e.setCallFrameCaptureSnapshot(recursive ? captureSnapshot() : null);
         stk++;
+    }
+
+    private int[] captureSnapshot() {
+        int count = regex.numMem + 1;
+        int[] snapshot = new int[count << 1];
+        System.arraycopy(repeatStk, memStartStk, snapshot, 0, count);
+        System.arraycopy(repeatStk, memEndStk, snapshot, count, count);
+        return snapshot;
     }
 
     protected final boolean isInsideSubexpCall(int groupNum) {
@@ -778,6 +787,10 @@ abstract class StackMachine extends Matcher implements StackType {
     }
 
     protected final int sreturn() {
+        return returnFrame().getCallFrameRetAddr();
+    }
+
+    protected final StackEntry returnFrame() {
         int level = 0;
         int k = stk;
         while (true) {
@@ -786,7 +799,7 @@ abstract class StackMachine extends Matcher implements StackType {
 
             if (e.type == CALL_FRAME) {
                 if (level == 0) {
-                    return e.getCallFrameRetAddr();
+                    return e;
                 } else {
                     level--;
                 }

--- a/third_party/joni/test/org/joni/test/TestCallout.java
+++ b/third_party/joni/test/org/joni/test/TestCallout.java
@@ -330,6 +330,41 @@ public class TestCallout {
         assertEquals(3, matcher.captureEnd(2));
     }
 
+    @Test
+    public void repeatedDynamicProgramSeesPreviouslyClosedCapture() {
+        List<String> events = new ArrayList<>();
+        Regex outer = regex("\\A(?<digit>\\d)(?<repeat>(?<step>(?{=DYNAMIC:1})))+\\z");
+        byte[] input = "123".getBytes(StandardCharsets.US_ASCII);
+        Matcher matcher = outer.matcher(input);
+        matcher.setCalloutHandler(new CalloutHandler() {
+            @Override
+            public CalloutResult execute(int id, MatchView match) {
+                throw new AssertionError("plain callback not expected");
+            }
+
+            @Override
+            public DynamicPatternResult executeDynamic(int id, MatchView match) {
+                int capture = match.lastClosedCapture();
+                int begin = match.captureBegin(capture);
+                int end = match.captureEnd(capture);
+                events.add(begin + "-" + end);
+                char next = (char) (input[end - 1] + 1);
+                return new DynamicPatternResult(regex(String.valueOf(next)), null, null);
+            }
+
+            @Override
+            public void unwind(Object token) {
+            }
+        });
+
+        assertEquals(0, matcher.search(0, input.length, Option.NONE));
+        assertEquals(Arrays.asList("0-1", "1-2", "2-3"), events);
+        assertEquals(2, matcher.captureBegin(2));
+        assertEquals(3, matcher.captureEnd(2));
+        assertEquals(2, matcher.captureBegin(3));
+        assertEquals(3, matcher.captureEnd(3));
+    }
+
     private static CalloutHandler recordingHandler(List<String> events, boolean fail) {
         return new CalloutHandler() {
             @Override

--- a/third_party/joni/test/org/joni/test/TestCallout.java
+++ b/third_party/joni/test/org/joni/test/TestCallout.java
@@ -301,6 +301,35 @@ public class TestCallout {
                 "outer-unwind:dynamic-token"), events);
     }
 
+    @Test
+    public void enclosingCaptureClosesAfterDynamicProgram() {
+        Regex outer = regex("(a)((?{=DYNAMIC:1}))");
+        Regex nested = regex("b");
+        byte[] input = "aab".getBytes(StandardCharsets.US_ASCII);
+        Matcher matcher = outer.matcher(input);
+        matcher.setCalloutHandler(new CalloutHandler() {
+            @Override
+            public CalloutResult execute(int id, MatchView match) {
+                throw new AssertionError("plain callback not expected");
+            }
+
+            @Override
+            public DynamicPatternResult executeDynamic(int id, MatchView match) {
+                return new DynamicPatternResult(nested, null, null);
+            }
+
+            @Override
+            public void unwind(Object token) {
+            }
+        });
+
+        assertEquals(1, matcher.search(0, input.length, Option.NONE));
+        assertEquals(1, matcher.captureBegin(1));
+        assertEquals(2, matcher.captureEnd(1));
+        assertEquals(2, matcher.captureBegin(2));
+        assertEquals(3, matcher.captureEnd(2));
+    }
+
     private static CalloutHandler recordingHandler(List<String> events, boolean fail) {
         return new CalloutHandler() {
             @Override

--- a/third_party/joni/test/org/joni/test/TestCallout.java
+++ b/third_party/joni/test/org/joni/test/TestCallout.java
@@ -101,6 +101,27 @@ public class TestCallout {
     }
 
     @Test
+    public void recursiveSubpatternReturnRestoresCallerCaptures() {
+        List<String> events = new ArrayList<>();
+        Regex regex = regex("(?<r>(?<letter>a)(?:\\g<r>)?(?{=CALL:4}))");
+        CalloutHandler handler = new CalloutHandler() {
+            @Override
+            public CalloutResult execute(int id, MatchView match) {
+                events.add(id + ":" + match.lastClosedCapture() + ":"
+                        + match.captureBegin(2) + "-" + match.captureEnd(2));
+                return CalloutResult.CONTINUE;
+            }
+
+            @Override
+            public void unwind(Object token) {
+            }
+        };
+
+        assertEquals(0, search(regex, "aa", handler));
+        assertEquals(Arrays.asList("4:2:1-2", "4:2:0-1"), events);
+    }
+
+    @Test
     public void unwindsBacktrackedAndSuccessfulPathsExactlyOnce() {
         List<String> events = new ArrayList<>();
         Regex regex = regex("(a(?{=CALL:1})b|a(?{=CALL:2})c)");


### PR DESCRIPTION
## Summary

- complete Joni recursive and dynamic callback capture-state restoration
- preserve runtime regex source locations, warning masks, Unicode diagnostics,
  foreach lexical cells, and nested callback values on both execution backends
- retain callback captures through owning `qr//` values and release them when
  discarded match state or the final regex scope is torn down
- complete the semantic `pat_re_eval.t` gate at 550/555; tests 444-448 are
  documented Perl optimizer/debug-transcript exclusions
- update the Phase 36 progress tracker and focused regression coverage

## Validation

- `make` — PASS after rebase onto current master; no warning lines
- `pat_re_eval.t` JVM — 550/555
- `pat_re_eval.t` interpreter — 550/555
- callback destruction lifetime oracle — PASS on system Perl, JVM, interpreter
- one-level failed dynamic callback state oracle — PASS on system Perl, JVM,
  interpreter
- mixed runtime source oracle — 23/23 on JVM and interpreter
