### PR TITLE
feat(test): add weighted semantic test scheduling

### DIFF
--- a/dev/design/README.md
+++ b/dev/design/README.md
@@ -126,6 +126,8 @@ These represent major architectural directions for the project.
 
 Also notable for performance work:
 
+- **weighted-test-scheduler.md** - Resource-budget scheduling for semantic TAP
+  validation, including long-running-first admission and tuning constraints
 - **dbixclass-timeout-jit-analysis.md** - Root-cause analysis of the DBIx::Class JIT timeout (C1 register-allocator failure under CPU pressure); feeds into **reduce-apply-bytecode.md**
 - **reduce-apply-bytecode.md** - Three-phase plan to shrink generated `apply()` bytecode (Phase 1: fix `TempLocalCountVisitor`; Phases 2–3: extract trampoline/eval helpers)
 - **perf-dbic-safe-port.md** - DBIx::Class safe-porting performance analysis

--- a/dev/design/weighted-test-scheduler.md
+++ b/dev/design/weighted-test-scheduler.md
@@ -1,0 +1,103 @@
+# Weighted Semantic Test Scheduling
+
+**Status:** Implemented and locally validated
+
+**Date:** 2026-08-17
+
+**Issue:** [#1001](https://github.com/fglock/PerlOnJava/issues/1001)
+
+## Scope
+
+`dev/tools/perl_test_runner.pl` validates TAP results and Perl semantics. It is
+not an authoritative timing harness. Performance comparisons use a separate,
+controlled procedure, so benchmark elapsed time and benchmark ratios do not
+affect this scheduler's resource profiles.
+
+The previous scheduler split the corpus into a normal parallel phase followed
+by an exclusive serial phase. Long regex stress tests therefore started only
+after the ordinary corpus drained, leaving a long serial tail.
+
+## Policy
+
+The caller's `--jobs` value is a scheduling-unit budget:
+
+- ordinary tests consume one unit;
+- known CPU-, memory-, or subprocess-heavy semantic tests consume three units;
+- a heavy weight is clamped to the caller's budget, allowing all tests to run
+  with `--jobs 1` or `--jobs 2`;
+- no current test has an exclusive semantic profile.
+
+The scheduler retains an explicit isolation mechanism in case a future test
+demonstrably cannot share a process environment. Such a profile is a barrier:
+it waits for active work to finish and cannot be bypassed. Timing sensitivity
+alone is not sufficient evidence for isolation.
+
+## Admission Order
+
+All input is known before execution, so the scheduler uses a stable
+longest-processing-time heuristic:
+
+1. future exclusive barriers, if any;
+2. known heavy tests;
+3. ordinary tests.
+
+Original order is preserved within each class, and original test indices remain
+attached to results. If the next heavy test cannot fit the remaining budget, a
+lighter test may use that capacity. For example, a ten-unit budget admits three
+weight-three tests and one ordinary test. Starting long-running work early
+reduces the straggler tail while the more uniform short files fill gaps.
+
+## Safety Invariants
+
+- Active scheduling weight never exceeds `--jobs`.
+- A positive `--jobs` value is required.
+- Capacity is released only after the parent reaps the child.
+- Per-test hard timeouts, kill grace, output capture, JSON reporting, and final
+  process-group cleanup are unchanged.
+- Resource profiles match both Unix and Windows path separators.
+
+Profiles and admission helpers live in
+`dev/tools/lib/PerlTestRunner/Scheduler.pm`; focused tests live in
+`dev/tools/tests/perl_test_runner_scheduler.t`.
+
+## Tuning
+
+Adjust weights only from semantic-result parity, timeout behavior, peak memory,
+CPU pressure, and orphan-process checks on supported platforms. Do not use
+`perl_test_runner.pl` elapsed times to make performance claims. A weight change
+must retain identical per-file TAP results and must not weaken deadlines or
+cleanup behavior.
+
+## Progress Tracking
+
+### Current Status: Implementation complete and locally validated
+
+### Completed Phases
+
+- [x] Scheduler design and implementation (2026-08-17)
+  - Replaced normal/exclusive phases with one weighted budget.
+  - Added stable long-running-first admission with lighter gap filling.
+  - Removed timing-only benchmark scheduling and timeout accommodations.
+  - Added policy, capacity, isolation-barrier, low-budget, and Windows-path
+    tests.
+- [x] Local validation (2026-08-17)
+  - `make test-thread-tooling`: 4 files, 35 assertions passed.
+  - Weighted runner smoke test: 3 files, 81 assertions passed at `--jobs 1`.
+  - `make check-links`: 603 links checked, zero errors.
+  - Full `make`: passed all five unit shards and Joni tests.
+
+### Next Steps
+
+1. Verify Linux and Windows CI semantic-result parity and cleanup behavior.
+2. Revisit weight three only if cross-platform memory or timeout evidence
+   requires adjustment.
+
+### Open Questions
+
+- None. Timing measurement is explicitly owned by a separate procedure.
+
+## Related Documentation
+
+- [Testing guide](../../docs/reference/testing.md)
+- [Concurrency and runtime isolation](concurrency.md)
+- [PerlOnJava agent test-safety rules](../../AGENTS.md)

--- a/dev/tools/lib/PerlTestRunner/Scheduler.pm
+++ b/dev/tools/lib/PerlTestRunner/Scheduler.pm
@@ -1,0 +1,100 @@
+package PerlTestRunner::Scheduler;
+
+use strict;
+use warnings;
+use Exporter qw(import);
+
+our @EXPORT_OK = qw(
+    effective_weight
+    next_runnable_index
+    profile_for_test
+    scheduling_priority
+    test_can_start
+);
+
+sub profile_for_test {
+    my ($test_file) = @_;
+    (my $normalized_file = $test_file) =~ tr{\\}{/};
+
+    # These fixtures create sustained CPU, memory, or subprocess pressure.
+    # Weight three permits three such files within a --jobs 10 budget while
+    # leaving one unit available for an ordinary test.
+    if ($normalized_file =~ m{
+          (?:^|/)perl5/dist/threads/t/join\.t$
+        | (?:^|/)perl5_t/t/op/gv\.t$
+        | (?:^|/)perl5_t/t/re/pat(?:_thr)?\.t$
+        | (?:^|/)perl5_t/t/re/pat_psycho(?:_thr)?\.t$
+        | (?:^|/)perl5_t/t/re/pat_advanced(?:_thr)?\.t$
+        | (?:^|/)perl5_t/t/re/regexp_qr_embed_thr\.t$
+        | (?:^|/)perl5_t/t/re/speed(?:_thr)?\.t$
+        | (?:^|/)perl5_t/t/japh/abigail\.t$
+    }x) {
+        return {
+            class => 'heavy',
+            weight => 3,
+            exclusive => 0,
+        };
+    }
+
+    # No current test requires exclusive semantic isolation. The runner
+    # validates TAP semantics, so timing-only benchmarks deliberately receive
+    # no scheduling privilege; authoritative timings use a separate,
+    # controlled benchmark procedure.
+    return {
+        class => 'normal',
+        weight => 1,
+        exclusive => 0,
+    };
+}
+
+sub effective_weight {
+    my ($profile, $budget) = @_;
+    die "Scheduling budget must be positive\n"
+        unless defined($budget) && $budget > 0;
+
+    my $weight = $profile->{weight} || 1;
+    return $weight > $budget ? $budget : $weight;
+}
+
+sub scheduling_priority {
+    my ($profile) = @_;
+    return 0 if $profile->{exclusive};
+    return 1 if ($profile->{weight} || 1) > 1;
+    return 2;
+}
+
+sub test_can_start {
+    my ($profile, $budget, $active_weight, $active_count, $exclusive_active) = @_;
+
+    return 0 if $exclusive_active;
+    return $active_count == 0 if $profile->{exclusive};
+
+    my $weight = effective_weight($profile, $budget);
+    return $active_weight + $weight <= $budget;
+}
+
+sub next_runnable_index {
+    my ($tests, $budget, $active_weight, $active_count, $exclusive_active) = @_;
+
+    return if $exclusive_active;
+    for my $index (0 .. $#$tests) {
+        my $profile = $tests->[$index]{profile};
+
+        # An isolation case is a barrier: it may start only when the runner is
+        # idle, and later work must never leapfrog it.
+        if ($profile->{exclusive}) {
+            return $active_count == 0 ? $index : undef;
+        }
+
+        return $index if test_can_start(
+            $profile,
+            $budget,
+            $active_weight,
+            $active_count,
+            $exclusive_active,
+        );
+    }
+    return;
+}
+
+1;

--- a/dev/tools/perl_test_runner.pl
+++ b/dev/tools/perl_test_runner.pl
@@ -9,6 +9,14 @@ use JSON::PP;
 use Data::Dumper;
 use POSIX qw(WNOHANG WIFEXITED WEXITSTATUS WIFSIGNALED WTERMSIG setsid);
 use Config ();
+use FindBin qw($Bin);
+use lib "$Bin/lib";
+use PerlTestRunner::Scheduler qw(
+    effective_weight
+    next_runnable_index
+    profile_for_test
+    scheduling_priority
+);
 
 # PerlOnJava Test Runner
 # Runs standard Perl tests against PerlOnJava and analyzes results
@@ -33,6 +41,8 @@ if ($help || @ARGV < 1) {
     print_usage();
     exit($help ? 0 : 1);
 }
+
+die "Error: --jobs must be a positive integer\n" unless $jobs > 0;
 
 # Accept either a directory or a specific .t file, or multiple directories
 my $test_dir = '.';
@@ -88,24 +98,30 @@ my %feature_patterns = (
 
 my $total_files = @test_files;
 my @indexed_tests = map {
-    +{ test_file => $test_files[$_], test_index => $_ + 1 }
+    +{
+        test_file => $test_files[$_],
+        test_index => $_ + 1,
+        profile => profile_for_test($test_files[$_]),
+    }
 } 0 .. $#test_files;
-my (@parallel_tests, @exclusive_tests);
-for my $test (@indexed_tests) {
-    push @{ requires_exclusive_slot($test->{test_file})
-        ? \@exclusive_tests : \@parallel_tests }, $test;
-}
+my $heavy_count = grep { $_->{profile}{class} eq 'heavy' } @indexed_tests;
+my $exclusive_count = grep { $_->{profile}{exclusive} } @indexed_tests;
+@indexed_tests = sort {
+       scheduling_priority($a->{profile}) <=> scheduling_priority($b->{profile})
+    || $a->{test_index} <=> $b->{test_index}
+} @indexed_tests;
 
 print "Found $total_files test files\n";
-print "Running tests with $jperl_path (${jobs} parallel jobs, ${timeout}s base timeout; "
-    . scalar(@exclusive_tests) . " resource-sensitive tests run serially)\n";
+print "Running tests with $jperl_path (${jobs}-unit resource budget, "
+    . "${timeout}s base timeout; $heavy_count weighted heavy, "
+    . "$exclusive_count exclusive)\n";
 print "-" x 60, "\n";
 
-# Run the normal corpus in parallel, then give known CPU-heavy tests an
-# exclusive slot. Their upstream watchdogs and TAP totals are load-sensitive,
-# so merely increasing the outer timeout is not sufficient under contention.
-run_tests_parallel(\@parallel_tests, $test_dir, $jobs, $total_files);
-run_tests_parallel(\@exclusive_tests, $test_dir, 1, $total_files);
+# Use one scheduling budget for the complete corpus. Ordinary tests consume one
+# unit, heavy semantic fixtures consume more, and true isolation cases wait for
+# an idle runner. Stable longest-first classes start known slow work early, then
+# use the more uniform ordinary files to fill the remaining resource budget.
+run_tests_weighted(\@indexed_tests, $test_dir, $jobs, $total_files);
 
 print "-" x 60, "\n";
 print_summary();
@@ -134,22 +150,44 @@ sub find_test_files {
     return sort @files;
 }
 
-sub run_tests_parallel {
-    my ($test_files, $test_dir, $max_jobs, $total_files) = @_;
-    my $completed = 0;
+sub run_tests_weighted {
+    my ($test_files, $test_dir, $budget, $total_files) = @_;
     my %children;
     my @test_queue = @$test_files;
+    my $active_weight = 0;
+    my $exclusive_active = 0;
 
     # Don't use SIGCHLD handler - we'll poll instead
     local $SIG{CHLD} = 'DEFAULT';
 
-    # Start initial batch of jobs
-    while (@test_queue && keys(%children) < $max_jobs) {
-        start_test_job(\@test_queue, \%children, $total_files, $completed);
-    }
-
-    # Wait for jobs to complete and start new ones
     while (%children || @test_queue) {
+        while (@test_queue) {
+            my $queue_index = next_runnable_index(
+                \@test_queue,
+                $budget,
+                $active_weight,
+                scalar(keys %children),
+                $exclusive_active,
+            );
+            last unless defined $queue_index;
+
+            my $test = $test_queue[$queue_index];
+            my $profile = $test->{profile};
+            my $weight = effective_weight($profile, $budget);
+            $test->{scheduler_weight} = $weight;
+            start_test_job(
+                \@test_queue,
+                \%children,
+                $total_files,
+                $queue_index,
+            );
+            $active_weight += $weight;
+            if ($profile->{exclusive}) {
+                $exclusive_active = 1;
+                last;
+            }
+        }
+
         # Check for completed children
         my @pids = keys %children;
         for my $pid (@pids) {
@@ -157,17 +195,15 @@ sub run_tests_parallel {
             if ($res > 0) {
                 # Child has exited
                 my $test_info = delete $children{$pid};
+                $active_weight -= $test_info->{scheduler_weight};
+                $exclusive_active = 0 if $test_info->{exclusive};
                 process_test_result($test_info, $test_dir);
-                $completed++;
-
-                # Start a new job if queue has items
-                if (@test_queue && keys(%children) < $max_jobs) {
-                    start_test_job(\@test_queue, \%children, $total_files, $completed);
-                }
             } elsif ($res < 0) {
                 # Error - child doesn't exist
                 warn "Warning: Lost track of child $pid\n";
-                delete $children{$pid};
+                my $test_info = delete $children{$pid};
+                $active_weight -= $test_info->{scheduler_weight};
+                $exclusive_active = 0 if $test_info->{exclusive};
             }
         }
 
@@ -407,13 +443,6 @@ sub run_single_test {
     # Use absolute path for jperl
     my $abs_jperl = File::Spec->rel2abs($jperl_path, $old_dir);
     my $test_name = File::Spec->abs2rel($test_file, $local_test_dir || '.');
-    # Benchmark.pm's default three-CPU-second sample is too noisy while other
-    # JVM builds or CPAN testers are active. A five-second sample still fits
-    # the resource-sensitive test's 600-second runner allowance and makes its
-    # relative global/lexical hash comparisons substantially more stable.
-    my @test_args = $test_file =~ m{
-        (?:^|/)perl5_t/t/benchmark/gh7094-speed-up-keys-on-empty-hash\.t$
-    }x ? ('-5') : ();
 
     # Try to use system timeout command if available.
     # Use --kill-after (-k) so a SIGTERM that the JVM ignores is followed
@@ -462,7 +491,7 @@ sub run_single_test {
             exec {
                 $timeout_program
             } $timeout_program, '--foreground', '-k', "${kill_after}s",
-                "${test_timeout}s", $abs_jperl, $test_name, @test_args;
+                "${test_timeout}s", $abs_jperl, $test_name;
             die "Cannot execute $timeout_program: $!";
         }
 
@@ -490,7 +519,7 @@ sub run_single_test {
         $output_captured = 1;
     } else {
         # Fallback to alarm-based timeout
-        my $cmd = join(' ', $abs_jperl, $test_name, @test_args)
+        my $cmd = join(' ', $abs_jperl, $test_name)
             . " < $devnull 2>&1";
         eval {
             local $SIG{ALRM} = sub { die "timeout\n" };
@@ -554,34 +583,18 @@ sub timeout_for_test {
         | (?:^|/)perl5_t/t/re/pat_advanced(?:_thr)?\.t$
         | (?:^|/)perl5_t/t/re/regexp_qr_embed_thr\.t$
         | (?:^|/)perl5_t/t/re/speed(?:_thr)?\.t$
-        | (?:^|/)perl5_t/t/benchmark/gh7094-speed-up-keys-on-empty-hash\.t$
         | (?:^|/)perl5_t/t/japh/abigail\.t$
     }x && $timeout < 600;
     return $timeout;
 }
 
-sub requires_exclusive_slot {
-    my ($test_file) = @_;
-    return $test_file =~ m{
-          (?:^|/)perl5/dist/threads/t/join\.t$
-        |
-          (?:^|/)perl5_t/t/op/gv\.t$
-        | (?:^|/)perl5_t/t/re/pat(?:_thr)?\.t$
-        | (?:^|/)perl5_t/t/re/pat_psycho(?:_thr)?\.t$
-        | (?:^|/)perl5_t/t/re/pat_advanced(?:_thr)?\.t$
-        | (?:^|/)perl5_t/t/re/regexp_qr_embed_thr\.t$
-        | (?:^|/)perl5_t/t/re/speed(?:_thr)?\.t$
-        | (?:^|/)perl5_t/t/benchmark/gh7094-speed-up-keys-on-empty-hash\.t$
-        | (?:^|/)perl5_t/t/japh/abigail\.t$
-    }x;
-}
-
 sub start_test_job {
-    my ($test_queue, $children, $total_files, $completed) = @_;
+    my ($test_queue, $children, $total_files, $queue_index) = @_;
 
     return unless @$test_queue;
 
-    my $test = shift @$test_queue;
+    $queue_index //= 0;
+    my ($test) = splice @$test_queue, $queue_index, 1;
     my $test_file = $test->{test_file};
     my $test_index = $test->{test_index};
 
@@ -612,6 +625,8 @@ sub start_test_job {
             test_index => $test_index,
             start_time => time(),
             child_pid => $pid,
+            scheduler_weight => $test->{scheduler_weight},
+            exclusive => $test->{profile}{exclusive},
         };
     }
 }
@@ -883,7 +898,7 @@ Options:
   --jperl PATH     Path to jperl executable (default: ./jperl)
   --timeout SEC    Base timeout per test in seconds (default: 300; selected
                    subprocess-heavy tests have a documented minimum)
-  --jobs|-j NUM    Number of parallel jobs (default: 5)
+  --jobs|-j NUM    Total scheduling-unit budget (default: 5)
   --output FILE    Save detailed results to JSON file
   --strict-exit    Exit nonzero if any file fails, errors, times out, or is incomplete
   --help           Show this help message

--- a/dev/tools/tests/perl_test_runner_scheduler.t
+++ b/dev/tools/tests/perl_test_runner_scheduler.t
@@ -1,0 +1,109 @@
+use strict;
+use warnings;
+
+use FindBin;
+use Test::More;
+use lib "$FindBin::Bin/../lib";
+use PerlTestRunner::Scheduler qw(
+    effective_weight
+    next_runnable_index
+    profile_for_test
+    scheduling_priority
+    test_can_start
+);
+
+sub profile_is {
+    my ($path, $class, $weight, $exclusive, $name) = @_;
+    my $profile = profile_for_test($path);
+    is_deeply(
+        $profile,
+        {
+            class => $class,
+            weight => $weight,
+            exclusive => $exclusive,
+        },
+        $name,
+    );
+}
+
+profile_is('src/test/resources/unit/array.t', 'normal', 1, 0,
+    'ordinary semantic test consumes one unit');
+profile_is('perl5_t/t/re/pat_psycho.t', 'heavy', 3, 0,
+    'regex stress test consumes three units');
+profile_is('perl5_t/t/re/pat_psycho_thr.t', 'heavy', 3, 0,
+    'threaded regex stress wrapper consumes three units');
+profile_is('/checkout/perl5_t/t/op/gv.t', 'heavy', 3, 0,
+    'absolute heavy-test path is recognized');
+profile_is('C:\\checkout\\perl5_t\\t\\re\\pat_psycho.t', 'heavy', 3, 0,
+    'Windows heavy-test path is recognized');
+profile_is('perl5/dist/threads/t/join.t', 'heavy', 3, 0,
+    'load-sensitive synchronization test uses weighted capacity');
+profile_is('perl5_t/t/benchmark/gh7094-speed-up-keys-on-empty-hash.t',
+    'normal', 1, 0, 'timing benchmark has no semantic scheduling privilege');
+
+my $heavy = profile_for_test('perl5_t/t/re/pat_psycho.t');
+my $normal = profile_for_test('unit/example.t');
+my $exclusive = {
+    class => 'exclusive',
+    weight => 1,
+    exclusive => 1,
+};
+
+is(scheduling_priority($exclusive), 0,
+    'future exclusive semantic work receives the earliest scheduling class');
+is(scheduling_priority($heavy), 1,
+    'known long-running work is scheduled before ordinary tests');
+is(scheduling_priority($normal), 2,
+    'uniform ordinary work fills the remaining budget');
+
+is(effective_weight($heavy, 2), 2,
+    'heavy weight is clamped to a small caller budget');
+is(effective_weight($heavy, 10), 3,
+    'heavy weight is retained within a larger caller budget');
+
+ok(test_can_start($heavy, 10, 6, 2, 0),
+    'third heavy test fits a ten-unit budget');
+ok(!test_can_start($heavy, 10, 9, 3, 0),
+    'fourth heavy test exceeds a ten-unit budget');
+ok(test_can_start($normal, 10, 9, 3, 0),
+    'normal test can use the final scheduling unit');
+ok(!test_can_start($exclusive, 10, 1, 1, 0),
+    'exclusive test waits for active work');
+ok(test_can_start($exclusive, 10, 0, 0, 0),
+    'exclusive test starts on an idle runner');
+ok(!test_can_start($normal, 10, 1, 1, 1),
+    'ordinary work waits while an exclusive test is active');
+
+my @weighted_queue = map { +{ profile => $_ } }
+    ($heavy, $heavy, $normal);
+is(next_runnable_index(\@weighted_queue, 10, 9, 3, 0), 2,
+    'light work may bypass a heavy test that does not fit remaining capacity');
+
+my @barrier_queue = map { +{ profile => $_ } }
+    ($exclusive, $normal);
+ok(!defined next_runnable_index(\@barrier_queue, 10, 3, 1, 0),
+    'work never bypasses a waiting exclusive barrier');
+is(next_runnable_index(\@barrier_queue, 10, 0, 0, 0), 0,
+    'exclusive barrier is selected once the runner is idle');
+
+my @initial_queue = map { +{ profile => $_ } }
+    ($heavy, $heavy, $heavy, $heavy, $normal, $normal);
+my ($initial_weight, @initial_classes) = (0);
+while (1) {
+    my $index = next_runnable_index(
+        \@initial_queue,
+        10,
+        $initial_weight,
+        scalar(@initial_classes),
+        0,
+    );
+    last unless defined $index;
+    my ($test) = splice @initial_queue, $index, 1;
+    $initial_weight += effective_weight($test->{profile}, 10);
+    push @initial_classes, $test->{profile}{class};
+}
+is_deeply(\@initial_classes, [qw(heavy heavy heavy normal)],
+    'longest-first admission fills spare capacity with ordinary work');
+is($initial_weight, 10, 'initial admission never exceeds caller budget');
+
+done_testing;

--- a/dev/tools/tests/perl_test_runner_weighted_integration.t
+++ b/dev/tools/tests/perl_test_runner_weighted_integration.t
@@ -1,0 +1,69 @@
+use strict;
+use warnings;
+
+use File::Path qw(make_path);
+use File::Spec;
+use File::Temp qw(tempdir);
+use FindBin;
+use Test::More;
+
+my $root = File::Spec->rel2abs(
+    File::Spec->catdir($FindBin::Bin, '..', '..', '..'));
+my $runner = File::Spec->catfile(
+    $root, 'dev', 'tools', 'perl_test_runner.pl');
+my $temporary = tempdir(CLEANUP => 1);
+my $fake_jperl = File::Spec->catfile($temporary, 'fake-jperl');
+my $order_file = File::Spec->catfile($temporary, 'launch-order.txt');
+my $normal_test = File::Spec->catfile($temporary, 'unit', 'short.t');
+my $heavy_test = File::Spec->catfile(
+    $temporary, 'perl5_t', 't', 're', 'pat_psycho.t');
+
+make_path(File::Spec->catdir($temporary, 'unit'));
+make_path(File::Spec->catdir($temporary, 'perl5_t', 't', 're'));
+write_file($normal_test, "# fake normal test\n");
+write_file($heavy_test, "# fake heavy test\n");
+write_file($fake_jperl, <<'FAKE_JPERL');
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+open my $fh, '>>', $ENV{RUNNER_ORDER_FILE}
+    or die "cannot open launch-order file: $!\n";
+print {$fh} "$ARGV[0]\n";
+close $fh;
+print "1..1\nok 1 - fake semantic result\n";
+FAKE_JPERL
+chmod 0755, $fake_jperl or die "chmod $fake_jperl failed: $!";
+
+local $ENV{RUNNER_ORDER_FILE} = $order_file;
+open my $command, '-|', $^X, $runner,
+    '--jperl', $fake_jperl,
+    '--strict-exit',
+    '--jobs', '1',
+    '--timeout', '10',
+    $normal_test,
+    $heavy_test
+    or die "cannot start test runner: $!";
+my $runner_output = do { local $/; <$command> };
+ok(close $command, 'weighted runner integration fixture passes')
+    or diag($runner_output // '');
+
+open my $order_fh, '<', $order_file
+    or die "cannot read $order_file: $!";
+chomp(my @launch_order = <$order_fh>);
+close $order_fh;
+
+is(scalar(@launch_order), 2, 'both fake files ran');
+like($launch_order[0], qr{pat_psycho\.t$},
+    'known long-running file launches before earlier ordinary input');
+like($launch_order[1], qr{short\.t$},
+    'ordinary file launches after the heavy file at budget one');
+
+done_testing;
+
+sub write_file {
+    my ($path, $contents) = @_;
+    open my $fh, '>', $path or die "cannot write $path: $!";
+    print {$fh} $contents;
+    close $fh or die "cannot close $path: $!";
+}

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -108,15 +108,32 @@ perl dev/tools/perl_test_runner.pl --jobs 4 --timeout 20 src/test/resources/unit
 
 **Features:**
 - TAP (Test Anything Protocol) output
-- Parallel test execution
+- Resource-weighted parallel test execution
 - Timeout protection
 - Feature impact analysis
 - Incomplete test detection
 - JSON reporting
 
+The runner is a semantic validator, not a performance benchmark harness.
+`--jobs` is a scheduling-unit budget shared by the whole run: ordinary files
+consume one unit, known CPU/memory-heavy semantic fixtures consume three, and
+any future test requiring demonstrated process isolation can run alone. No
+current test has an exclusive semantic profile. A heavy file's weight is
+clamped to the caller's budget, so it still runs with `--jobs 1` or `--jobs 2`.
+The runner starts known long-running heavy files before ordinary files,
+preserving input order within each class. Starting the long work early avoids a
+heavy-test tail; the more uniform ordinary files fill unused scheduling units
+as heavy tests complete.
+
+Resource profiles are defined in
+`dev/tools/lib/PerlTestRunner/Scheduler.pm`. Tune them from semantic stability,
+peak memory, and orphan-process checks across supported CI platforms. Do not
+tune them to preserve benchmark ratios or elapsed-time measurements; collect
+authoritative timings with a separate controlled benchmark procedure.
+
 **Options:**
 ```bash
---jobs|-j NUM      Number of parallel jobs (default: 5)
+--jobs|-j NUM      Total scheduling-unit budget (default: 5)
 --timeout SEC      Timeout per test in seconds
 --output FILE      Save detailed results to JSON file
 --jperl PATH       Path to jperl executable (default: ./jperl)
@@ -249,7 +266,7 @@ perl dev/tools/perl_test_runner.pl \
   terminate that exact PID only.
 - Do not recursively delete wildcard test directories as routine preparation.
   Remove an exact, verified stale path only when the failing test requires it.
-- `--jobs 10` - Run ten independent test files concurrently
+- `--jobs 10` - Allow ten scheduling units of concurrent test work
 - `--timeout 300` - Allow 5 minutes per test (for slower tests)
 - `logs/test_YYYYMMDD_HHMMSS.log` - Timestamped log for tracking history
 
@@ -386,7 +403,7 @@ jq '.feature_impact' test_results.json
 
 1. **Run `test-unit` frequently** during development for fast feedback
 2. **Run `test-all` before commits** to catch regressions
-3. **Use parallel jobs** (`--jobs 8`) to speed up test runs
+3. **Set a resource budget** (`--jobs 8`) to control concurrent test work
 4. **Set appropriate timeouts** - short for unit tests (10s), longer for module tests (30s)
 5. **Review incomplete tests** - they often indicate bugs that block many tests
 6. **Save JSON reports** for trend analysis and debugging
@@ -395,7 +412,8 @@ jq '.feature_impact' test_results.json
 
 - **Unit tests**: Should complete in < 5 minutes total
 - **All tests**: May take 10-30 minutes depending on system
-- **Parallel jobs**: Adjust `--jobs` based on CPU cores (typically 1-2x core count)
+- **Parallel work**: Adjust `--jobs` based on CPU capacity and available memory;
+  heavy semantic fixtures consume three units each
 - **Timeouts**: Increase for slow systems, decrease for fast feedback
 
 ## Integration with IDEs


### PR DESCRIPTION
## Summary

- replace the separate serial heavy-test lane with one weighted resource budget
- schedule known long-running tests before ordinary tests, while allowing lighter tests to fill unused capacity
- classify current resource-heavy semantic fixtures at weight 3 and keep the current exclusive-profile set empty
- treat `perl_test_runner.pl` as a semantic validator, with no special scheduling or timeout accommodations for timing benchmarks
- add scheduler policy, capacity, low-budget, Windows-path, and real runner-order integration tests
- document the scheduling policy and tuning constraints

## Scheduling behavior

`--jobs` is now the total scheduling-unit budget. Ordinary files consume one unit and known heavy files consume three. Heavy weights clamp to smaller caller budgets, so `--jobs 1` and `--jobs 2` cannot deadlock.

Known long-running files are ordered before ordinary files. When another heavy file does not fit the remaining budget, an ordinary file may fill the gap. With `--jobs 10`, the initial batch can therefore contain three weight-3 files plus one ordinary file.

No current semantic test is marked exclusive. The scheduler retains tested barrier support for a future test only if process isolation is demonstrated to be semantically necessary.

## Validation

- `make`: PASS, including all five unit shards and Joni tests
- `make test-thread-tooling`: PASS, 4 files / 35 assertions
- low-budget semantic runner smoke: PASS, 3 files / 81 assertions at `--jobs 1`
- `make check-links`: PASS, 603 links / 0 errors
- `git diff --check`: PASS
- no leftover PerlOnJava4 test JVMs

Closes #1001
