### PR TITLE
Preserve callbacks in apostrophe-delimited regexes

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/StringParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringParser.java
@@ -366,8 +366,14 @@ public class StringParser {
         Node parsed;
 
         if (rawStr.startDelim == '\'') {
-            // single quote delimiter, use the string as-is
-            parsed = new StringNode(rawStr.buffers.getFirst(), rawStr.index);
+            // An apostrophe delimiter suppresses ordinary interpolation, but
+            // literal (?{...}) and (??{...}) blocks are still compiled as regex
+            // callbacks. Keep variable interpolation disabled while using the
+            // regex-aware parser so executable source retains its provenance.
+            parsed = StringDoubleQuoted.parseDoubleQuotedString(
+                    ctx, rawStr, false, false, true,
+                    parser != null ? parser.getHeredocNodes() : null,
+                    null, true, isRegexQuoteConstruction);
         } else {
             // Check if /x modifier is present
             boolean hasXModifier = modifiers != null && modifiers.contains("x");

--- a/src/test/resources/unit/regex/single_quote_literal_callback.t
+++ b/src/test/resources/unit/regex/single_quote_literal_callback.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+use Test::More tests => 10;
+
+our $out = 1;
+ok('abc' =~ m'a(?{ $out = 2 })b', 'literal callback pattern matches');
+is($out, 2, 'literal callback executes without use re eval');
+
+$out = 1;
+ok(!('abc' =~ m'a(?{ $out = 3 })c'), 'failed literal callback branch does not match');
+is($out, 1, 'failed literal callback branch unwinds state');
+
+my $name = 'expanded';
+ok('expanded' !~ m'^$name$', 'single-quote regex delimiter does not interpolate variables');
+
+$out = 4;
+ok('a' =~ m'a(?{ $out++ })', 'callback code still resolves variables');
+is($out, 5, 'callback variable update is visible');
+
+ok('abc' =~ m'^a(??{"b"})c$', 'single-quote delimiter retains literal recursive callback');
+
+my $quoted = qr'^$name$';
+ok('expanded' !~ $quoted, 'single-quote qr delimiter does not interpolate variables');
+
+my ($search, $subject) = ('x', 'x');
+$subject =~ s'$search'y';
+is($subject, 'x', 'single-quote substitution pattern does not interpolate variables');


### PR DESCRIPTION
## Summary

- preserve literal `(?{})` and `(??{})` callback provenance in apostrophe-delimited `m`, `qr`, and substitution search patterns
- keep ordinary interpolation disabled, matching Perl's apostrophe-delimiter semantics
- add a focused 10-assertion Perl oracle for callback execution, unwind, dynamic callbacks, and non-interpolation

This closes the shared pre-routing abort that stopped `pat.t` after TAP 239 under both Java and Joni. The Java/Joni pairwise comparison in PR #1006 originally masked it because both matcher selections failed identically; PR #1006 now records the corrected classification.

## Validation

- checked-in oracle: 10/10 on system Perl
- checked-in oracle: 10/10 on Java/JVM, Java/interpreter, Joni/JVM, and Joni/interpreter
- direct `pat.t` first: all four selections advance from TAP 239 through TAP 689, then stop at the next independent runtime-eval provenance blocker near upstream line 1521
- `pat_thr.t` after direct runs: worker reaches TAP 689 on all four selections; wrapper's lost-TAP/exit-0 behavior is recorded separately in the shared handoff
- `make`: passed warning-free in 4m16s

Generated with [Codex](https://openai.com/codex/)
