### PR TITLE
perf: reuse Joni subject offset tables

### DIFF
--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.List;
+import java.util.WeakHashMap;
 
 import org.perlonjava.runtime.operators.WarnDie;
 import org.perlonjava.runtime.runtimetypes.*;
@@ -30,6 +31,8 @@ import org.perlonjava.runtime.runtimetypes.*;
  * beyond the Java Pattern fast path.
  */
 final class JoniRegexPattern {
+    private static final Map<String, InputEncoding> INPUT_ENCODINGS = new WeakHashMap<>();
+
     // Ruby syntax defaults \w to ASCII even for a Unicode encoding. Perl's
     // default and /u modes use Unicode character classes; /a adds ASCII_RANGE
     // explicitly in toJoniOptions(). Keep the richer Ruby parser surface used
@@ -79,6 +82,21 @@ final class JoniRegexPattern {
                          RuntimeScalar subject) {
         return new JoniRegexMatcher(regex, sourcePattern, namedGroups, flags,
                 hasControlVerbState, input, callbacks, subject);
+    }
+
+    record InputEncoding(byte[] bytes, int[] charToByte, int[] byteToChar) {}
+
+    static InputEncoding inputEncoding(String input) {
+        synchronized (INPUT_ENCODINGS) {
+            return INPUT_ENCODINGS.computeIfAbsent(input, JoniRegexPattern::buildInputEncoding);
+        }
+    }
+
+    private static InputEncoding buildInputEncoding(String input) {
+        byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
+        int[] charToByte = JoniRegexMatcher.buildCharToByte(input);
+        int[] byteToChar = JoniRegexMatcher.buildByteToChar(input, bytes.length, charToByte);
+        return new InputEncoding(bytes, charToByte, byteToChar);
     }
 
     String patternDescription() {
@@ -602,9 +620,10 @@ final class JoniRegexPattern {
             this.input = input;
             this.callbacks = callbacks;
             this.subject = subject;
-            this.bytes = input.getBytes(StandardCharsets.UTF_8);
-            this.charToByte = buildCharToByte(input);
-            this.byteToChar = buildByteToChar(input, bytes.length, charToByte);
+            InputEncoding encoding = inputEncoding(input);
+            this.bytes = encoding.bytes();
+            this.charToByte = encoding.charToByte();
+            this.byteToChar = encoding.byteToChar();
             region(0, input.length());
         }
 
@@ -772,12 +791,16 @@ final class JoniRegexPattern {
 
         private static int[] buildByteToChar(String input, int byteLength, int[] charToByte) {
             int[] offsets = new int[byteLength + 1];
-            int charOffset = 0;
-            for (int b = 0; b <= byteLength; b++) {
-                while (charOffset + 1 < charToByte.length && charToByte[charOffset + 1] <= b) {
-                    charOffset++;
+            for (int charOffset = 0; charOffset < input.length();) {
+                int chars = Character.charCount(input.codePointAt(charOffset));
+                int nextCharOffset = charOffset + chars;
+                int nextByteOffset = charToByte[nextCharOffset];
+                for (int byteOffset = charToByte[charOffset];
+                     byteOffset < nextByteOffset; byteOffset++) {
+                    offsets[byteOffset] = charOffset;
                 }
-                offsets[b] = charOffset;
+                offsets[nextByteOffset] = nextCharOffset;
+                charOffset = nextCharOffset;
             }
             return offsets;
         }

--- a/src/test/java/org/perlonjava/runtime/regex/JoniRegexPatternTest.java
+++ b/src/test/java/org/perlonjava/runtime/regex/JoniRegexPatternTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("unit")
@@ -93,5 +95,28 @@ class JoniRegexPatternTest {
                 .matcher("aa", java.util.List.of()).find());
         assertTrue(new JoniRegexPattern("\\p{Latin}{ , 2 }", FLAGS)
                 .matcher("a", java.util.List.of()).find());
+    }
+
+    @Test
+    void reusesImmutableInputEncodingAndPreservesSupplementaryOffsets() {
+        String input = new String("A\u00E9\uD83D\uDE42Z");
+
+        JoniRegexPattern.InputEncoding first = JoniRegexPattern.inputEncoding(input);
+        JoniRegexPattern.InputEncoding second = JoniRegexPattern.inputEncoding(input);
+
+        assertSame(first, second);
+        assertArrayEquals(new int[] {0, 1, 3, 3, 7, 8}, first.charToByte());
+        assertArrayEquals(new int[] {0, 1, 1, 2, 2, 2, 2, 4, 5}, first.byteToChar());
+    }
+
+    @Test
+    void supplementaryCaptureUsesTheHighSurrogateBoundary() {
+        RegexMatcher matcher = new JoniRegexPattern("(.)", FLAGS)
+                .matcher("\uD83D\uDE42", java.util.List.of());
+
+        assertTrue(matcher.find());
+        assertEquals("\uD83D\uDE42", matcher.group(1));
+        assertEquals(0, matcher.start(1));
+        assertEquals(2, matcher.end(1));
     }
 }

--- a/src/test/resources/unit/regex/joni_global_offset_reuse.t
+++ b/src/test/resources/unit/regex/joni_global_offset_reuse.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+my $repetitions = 2_000;
+my $subject = "A\x{E9}\x{1F642}" x $repetitions;
+my ($matches, $last) = (0, '');
+
+while ($subject =~ /(.)/g) {
+    $matches++;
+    $last = $1;
+}
+
+is($matches, 3 * $repetitions, 'global match visits every Unicode code point');
+is($last, "\x{1F642}", 'last capture retains a supplementary code point');
+ok(!defined(pos($subject)), 'failed terminal global match resets pos');


### PR DESCRIPTION
## Summary

- cache immutable Joni UTF-8 subject encodings and char/byte offset tables
- preserve high-surrogate boundaries in reverse byte-to-character mappings
- add deterministic reuse, supplementary-capture, and large Unicode `/g` coverage

## Performance

The forced-Joni scalar `/g` reproducer previously timed out after 15 seconds at
100,000 characters. It now completes 1,000,000 matches in 1.07 seconds on the
JVM backend and 1.41 seconds on the interpreter backend.

## Validation

- `prove src/test/resources/unit/regex/joni_global_offset_reuse.t` — 3/3
- forced-Joni JVM oracle — 3/3
- forced-Joni interpreter oracle — 3/3
- full `make` — passed warning-free in 4m19s

Generated with [Codex](https://openai.com/codex)
