### PR TITLE
fix: preserve properties inside extended regex sets

### DIFF
--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -117,6 +117,7 @@ final class JoniRegexPattern {
             String pattern, RegexFlags flags) {
         StringBuilder translated = new StringBuilder(pattern.length());
         boolean deferred = false;
+        int extendedClassBracketDepth = 0;
         for (int i = 0; i < pattern.length(); i++) {
             char ch = pattern.charAt(i);
             if (ch == '\\' && i + 1 < pattern.length() && pattern.charAt(i + 1) == '\\') {
@@ -124,10 +125,31 @@ final class JoniRegexPattern {
                 i++;
                 continue;
             }
+            if (extendedClassBracketDepth == 0 && pattern.startsWith("(?[", i)) {
+                translated.append("(?[");
+                extendedClassBracketDepth = 1;
+                i += 2;
+                continue;
+            }
+            if (extendedClassBracketDepth > 0 && ch == '[') {
+                extendedClassBracketDepth++;
+                translated.append(ch);
+                continue;
+            }
+            if (extendedClassBracketDepth > 0 && ch == ']') {
+                extendedClassBracketDepth--;
+                translated.append(ch);
+                continue;
+            }
             if (ch != '\\' || i + 3 >= pattern.length()
                     || (pattern.charAt(i + 1) != 'p' && pattern.charAt(i + 1) != 'P')
                     || pattern.charAt(i + 2) != '{') {
-                translated.append(ch);
+                if (ch == '\\' && i + 1 < pattern.length()) {
+                    translated.append(pattern, i, i + 2);
+                    i++;
+                } else {
+                    translated.append(ch);
+                }
                 continue;
             }
             int end = pattern.indexOf('}', i + 3);
@@ -143,6 +165,11 @@ final class JoniRegexPattern {
                     "(?i)^(?:scx|script[_ ]?extensions)\\s*=.*");
             boolean frontendProperty = unnegated.matches(
                     "(?i)^(?:script|block|blk|age|in|present[_ ]?in)\\s*=.*");
+            if (frontendProperty && extendedClassBracketDepth > 0) {
+                translated.append(pattern, i, end + 1);
+                i = end;
+                continue;
+            }
             if (!userDefined && !scriptExtensions && !frontendProperty) {
                 translated.append(pattern, i, end + 1);
                 i = end;

--- a/src/test/java/org/perlonjava/runtime/regex/JoniRegexPatternTest.java
+++ b/src/test/java/org/perlonjava/runtime/regex/JoniRegexPatternTest.java
@@ -119,4 +119,15 @@ class JoniRegexPatternTest {
         assertEquals(0, matcher.start(1));
         assertEquals(2, matcher.end(1));
     }
+
+    @Test
+    void resolvesBlockPropertiesInsideExtendedClassesBeforeJoniCompilation() {
+        JoniRegexPattern pattern = new JoniRegexPattern(
+                "(?[ [k] + \\p{Blk=ASCII} ])",
+                RegexFlags.fromModifiers("i", "(?[ [k] + \\p{Blk=ASCII} ])"));
+
+        assertTrue(pattern.matcher("k", java.util.List.of()).find());
+        assertTrue(pattern.matcher("A", java.util.List.of()).find());
+        assertFalse(pattern.matcher("\u017F", java.util.List.of()).find());
+    }
 }

--- a/src/test/resources/unit/regex/regex_sets_ascii_property.t
+++ b/src/test/resources/unit/regex/regex_sets_ascii_property.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+my $pattern = qr/(?[ [k] + \p{Blk=ASCII} ])/i;
+
+ok("k" =~ $pattern, 'case-folded literal remains in the set');
+ok("A" =~ $pattern, 'ASCII block property remains in the set');
+ok("\x{17f}" !~ $pattern, '/i does not expand the ASCII block property');


### PR DESCRIPTION
## Summary

- preserve frontend Unicode properties while scanning Perl `(?[...])` sets
- let the existing extended-class evaluator apply property semantics before Joni compilation
- cover `\p{Blk=ASCII}` under `/i` on JVM and interpreter backends

## Upstream progress

`perl5_t/t/re/regex_sets.t` previously failed before TAP. It now completes all
88 tests, with 81 passing and seven later independent failures.

## Validation

- focused system Perl oracle — 3/3
- forced-Joni JVM oracle — 3/3
- forced-Joni interpreter oracle — 3/3
- bounded `regex_sets.t` — 81/88, complete
- full `make` — passed warning-free in 4m13s

Generated with [Codex](https://openai.com/codex)
