### PR TITLE
fix: preserve overloaded regex callback provenance

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/StringParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringParser.java
@@ -366,8 +366,14 @@ public class StringParser {
         Node parsed;
 
         if (rawStr.startDelim == '\'') {
-            // single quote delimiter, use the string as-is
-            parsed = new StringNode(rawStr.buffers.getFirst(), rawStr.index);
+            // An apostrophe delimiter suppresses ordinary interpolation, but
+            // literal (?{...}) and (??{...}) blocks are still compiled as regex
+            // callbacks. Keep variable interpolation disabled while using the
+            // regex-aware parser so executable source retains its provenance.
+            parsed = StringDoubleQuoted.parseDoubleQuotedString(
+                    ctx, rawStr, false, false, true,
+                    parser != null ? parser.getHeredocNodes() : null,
+                    null, true, isRegexQuoteConstruction);
         } else {
             // Check if /x modifier is present
             boolean hasXModifier = modifiers != null && modifiers.contains("x");

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegexTemplate.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegexTemplate.java
@@ -1,6 +1,10 @@
 package org.perlonjava.runtime.regex;
 
 import org.perlonjava.runtime.operators.StringOperators;
+import org.perlonjava.runtime.runtimetypes.Overload;
+import org.perlonjava.runtime.runtimetypes.OverloadContext;
+import org.perlonjava.runtime.runtimetypes.PerlCompilerException;
+import org.perlonjava.runtime.runtimetypes.RuntimeArray;
 import org.perlonjava.runtime.runtimetypes.RuntimeBase;
 import org.perlonjava.runtime.runtimetypes.RuntimeList;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
@@ -10,6 +14,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarUndef;
 
 /** Runtime interpolation result that keeps executable regex callbacks out of strings. */
 public final class RuntimeRegexTemplate {
@@ -58,7 +64,10 @@ public final class RuntimeRegexTemplate {
             // A lone interpolation must retain its runtime type so qr
             // overloading and an already-compiled regex remain observable.
             // Only a parser-created callback needs a new template skeleton.
-            if (!(only.value instanceof RuntimeRegexCallback)) return only;
+            if (!(only.value instanceof RuntimeRegexCallback)) {
+                RuntimeScalar overloaded = resolveLoneRegexOverload(only);
+                return overloaded == null ? only : overloaded;
+            }
         }
         boolean hasBlessedPart = false;
         for (RuntimeBase part : parts.elements) {
@@ -68,15 +77,10 @@ public final class RuntimeRegexTemplate {
             }
         }
         if (hasBlessedPart) {
-            RuntimeScalar concatenated = new RuntimeScalar("");
-            for (RuntimeBase part : parts.elements) {
-                RuntimeScalar scalar = part.scalar();
-                if (scalar.value instanceof RuntimeRegexCallback callback) {
-                    scalar = new RuntimeScalar(callback.source == null ? "" : callback.source);
-                }
-                concatenated = StringOperators.stringConcat(concatenated, scalar);
-            }
-            return concatenated;
+            // Overload dispatch is complete after this pass. A dot overload is
+            // allowed to return another blessed value; assemble that result
+            // without dispatching the same interpolation a second time.
+            parts = resolveBlessedParts(parts);
         }
         StringBuilder pattern = new StringBuilder();
         List<RuntimeRegexCallback> callbacks = new ArrayList<>();
@@ -113,6 +117,101 @@ public final class RuntimeRegexTemplate {
                 : new RuntimeScalar(new RuntimeRegexTemplate(pattern.toString(), callbacks));
         result.tainted = tainted;
         return result;
+    }
+
+    private static RuntimeScalar resolveLoneRegexOverload(RuntimeScalar scalar) {
+        int blessId = RuntimeScalarType.blessedId(scalar);
+        if (blessId >= 0) return null;
+        OverloadContext overload = OverloadContext.prepare(blessId);
+        if (overload == null) return null;
+
+        RuntimeScalar qr = resolveQrOverload(overload, scalar);
+        if (qr != null) return qr;
+        RuntimeScalar stringified = overload.tryOverload("(\"\"", unaryOverloadArguments(scalar));
+        if (stringified != null) return resolveStringificationResult(stringified);
+        if (!overload.allowsFallbackAutogen()) {
+            throw new PerlCompilerException("Operation \"qr\": no method found,");
+        }
+        return null;
+    }
+
+    private static RuntimeList resolveBlessedParts(RuntimeList parts) {
+        RuntimeList resolved = new RuntimeList();
+        resolved.add(new RuntimeScalar(""));
+
+        for (RuntimeBase part : parts.elements) {
+            RuntimeScalar scalar = part.scalar();
+            int blessId = RuntimeScalarType.blessedId(scalar);
+            if (blessId >= 0) {
+                resolved.add(scalar);
+                continue;
+            }
+
+            OverloadContext overload = OverloadContext.prepare(blessId);
+            RuntimeScalar qr = overload == null ? null : resolveQrOverload(overload, scalar);
+            if (qr != null) {
+                resolved.add(qr);
+                continue;
+            }
+
+            RuntimeScalar left = concatenateForOverload(resolved);
+            RuntimeScalar concatenated = OverloadContext.tryTwoArgumentOverloadDirect(
+                    left, scalar, RuntimeScalarType.blessedId(left), blessId, "(.");
+            if (concatenated != null) {
+                resolved = new RuntimeList(concatenated);
+                continue;
+            }
+
+            RuntimeScalar stringified = overload == null ? null
+                    : overload.tryOverload("(\"\"", unaryOverloadArguments(scalar));
+            if (stringified != null) {
+                resolved.add(resolveStringificationResult(stringified));
+                continue;
+            }
+
+            resolved = new RuntimeList(StringOperators.stringConcat(left, scalar));
+        }
+        return resolved;
+    }
+
+    /**
+     * A dot overload receives the textual pattern assembled so far. Executable
+     * callbacks on that side consequently become runtime source; only a qr or
+     * stringification overload that directly returns REGEXP keeps provenance.
+     */
+    private static RuntimeScalar concatenateForOverload(RuntimeList parts) {
+        RuntimeScalar concatenated = new RuntimeScalar("");
+        for (RuntimeBase part : parts.elements) {
+            RuntimeScalar scalar = part.scalar();
+            if (scalar.value instanceof RuntimeRegexCallback callback) {
+                scalar = new RuntimeScalar(callback.source == null ? "" : callback.source);
+            }
+            concatenated = StringOperators.stringConcat(concatenated, scalar);
+        }
+        return concatenated;
+    }
+
+    private static RuntimeScalar resolveQrOverload(OverloadContext overload,
+                                                    RuntimeScalar scalar) {
+        RuntimeScalar qr = overload.tryOverload("(qr", new RuntimeArray(scalar));
+        if (qr != null && qr.type != RuntimeScalarType.REGEX) {
+            throw new PerlCompilerException("Overloaded qr did not return a REGEXP");
+        }
+        return qr;
+    }
+
+    private static RuntimeScalar resolveStringificationResult(RuntimeScalar result) {
+        RuntimeScalar current = result;
+        for (int depth = 0; depth < 10 && RuntimeScalarType.blessedId(current) < 0; depth++) {
+            RuntimeScalar next = Overload.stringify(current);
+            if (next == current) break;
+            current = next;
+        }
+        return current;
+    }
+
+    private static RuntimeArray unaryOverloadArguments(RuntimeScalar scalar) {
+        return new RuntimeArray(scalar, scalarUndef, new RuntimeScalar(""));
     }
 
     /** Preserve callback-bearing qr values while an array is joined for interpolation. */

--- a/src/test/resources/unit/regex/overloaded_qr_provenance.t
+++ b/src/test/resources/unit/regex/overloaded_qr_provenance.t
@@ -1,0 +1,74 @@
+use strict;
+use warnings;
+use Test::More tests => 13;
+
+{
+    package Local::QrOverload;
+    use overload 'qr' => sub { qr/(??{50})/ };
+}
+
+{
+    package Local::StringOverload;
+    use overload '""' => sub { qr/(??{51})/ };
+}
+
+{
+    package Local::QrAndConcatOverload;
+    use overload
+        'qr' => sub { qr/(??{50})/ },
+        '.'  => sub { $_[1] . qr/(??{60})/ };
+}
+
+{
+    package Local::ConcatOverload;
+    use overload '.' => sub { $_[1] . qr/(??{52})/ };
+}
+
+{
+    package Local::StringAndConcatOverload;
+    use overload
+        '""' => sub { qr/(??{7})/ },
+        '.'  => sub { $_[1] . qr/(??{53})/ };
+}
+
+{
+    package Local::IndirectStringOverload;
+    use overload '""' => sub { $_[0][0] };
+}
+
+package main;
+
+my $qr_object = bless [], 'Local::QrOverload';
+ok('A50' =~ /^A$qr_object$/, 'embedded qr overload retains executable provenance');
+ok('50' =~ /$qr_object/, 'bare qr overload retains executable provenance');
+
+my $string_object = bless [], 'Local::StringOverload';
+ok('A51' =~ /^A$string_object$/, 'embedded string overload returning qr retains provenance');
+ok('51' =~ /$string_object/, 'bare string overload returning qr retains provenance');
+
+my $both_object = bless [], 'Local::QrAndConcatOverload';
+ok('A50' =~ /^A$both_object$/, 'embedded interpolation prefers qr overload to concat overload');
+
+my $concat_object = bless [], 'Local::ConcatOverload';
+my $concat_error = eval { 'A52' =~ /^A$concat_object$/; 1 } ? '' : $@;
+like($concat_error, qr/Eval-group not allowed/, 'concat overload source remains runtime source');
+my $bare_concat_error = eval { '52' =~ /$concat_object/; 1 } ? '' : $@;
+like($bare_concat_error, qr/no method found/, 'bare interpolation does not use concat overload');
+{
+    use re 'eval';
+    ok('A52' =~ /^A$concat_object$/, 'use re eval permits concat overload source');
+}
+
+my $string_concat_object = bless [], 'Local::StringAndConcatOverload';
+my $string_concat_error = eval { 'A53' =~ /^A$string_concat_object$/; 1 } ? '' : $@;
+like($string_concat_error, qr/Eval-group not allowed/, 'concat overload precedes string overload');
+my $bare_string_error = eval { '7' =~ /$string_concat_object/; 1 } ? '' : $@;
+is($bare_string_error, '', 'bare interpolation uses string overload without concat');
+{
+    use re 'eval';
+    ok('A53' =~ /^A$string_concat_object$/, 'use re eval permits preferred concat overload source');
+}
+
+my $indirect_object = bless [ $string_object ], 'Local::IndirectStringOverload';
+ok('A51' =~ /^A$indirect_object/, 'indirect string overload retains executable provenance');
+ok('51' =~ /$indirect_object/, 'bare indirect string overload retains provenance');

--- a/src/test/resources/unit/regex/single_quote_literal_callback.t
+++ b/src/test/resources/unit/regex/single_quote_literal_callback.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+use Test::More tests => 10;
+
+our $out = 1;
+ok('abc' =~ m'a(?{ $out = 2 })b', 'literal callback pattern matches');
+is($out, 2, 'literal callback executes without use re eval');
+
+$out = 1;
+ok(!('abc' =~ m'a(?{ $out = 3 })c'), 'failed literal callback branch does not match');
+is($out, 1, 'failed literal callback branch unwinds state');
+
+my $name = 'expanded';
+ok('expanded' !~ m'^$name$', 'single-quote regex delimiter does not interpolate variables');
+
+$out = 4;
+ok('a' =~ m'a(?{ $out++ })', 'callback code still resolves variables');
+is($out, 5, 'callback variable update is visible');
+
+ok('abc' =~ m'^a(??{"b"})c$', 'single-quote delimiter retains literal recursive callback');
+
+my $quoted = qr'^$name$';
+ok('expanded' !~ $quoted, 'single-quote qr delimiter does not interpolate variables');
+
+my ($search, $subject) = ('x', 'x');
+$subject =~ s'$search'y';
+is($subject, 'x', 'single-quote substitution pattern does not interpolate variables');


### PR DESCRIPTION
## Summary

- resolve embedded regex interpolation overloads in Perl order: `qr`, dot, then stringification
- preserve executable callback provenance when `qr` or stringification returns a REGEXP, including indirect stringification
- retain runtime-source behavior for dot overloads and Perl-compatible bare-interpolation diagnostics
- add a 13-assertion system-Perl oracle

## Validation

- `make` — passed on the exact committed tree
- system Perl oracle — 13/13
- Java/Joni x JVM/interpreter overload oracle — 13/13 on all four paths
- deferred-array regression oracle — 28/28 on all four paths
- stringified-callback regression oracle — 5/5 on all four paths
- direct `re/pat.t` — 1301/1302 TAP on all four paths, exit 0, no timeout
- wrapped `re/pat_thr.t` — identical 1301/1302 TAP on all four paths, exit 0, no lost TAP or timeout

## Stack

This targets PR #1005 (`wip/phase36-post-phase4`) and carries the rebased PR #1007 apostrophe-callback commit beneath this commit so the direct corpus can pass the earlier TAP 239 blocker. PR #1007 remains independently reviewable.

Design: `dev/design/phase36-regex-parity.md`
