### PR TITLE
WIP: Match user Unicode property diagnostics

### DIFF
--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -377,9 +377,11 @@ matcher-specific timeouts on both execution backends.
 
 ### Next Steps
 
-1. Remediate the seven reduced forced-Joni failure causes, starting with the
-   catastrophic `regexp*` cluster and the now-profiled `pat_psycho*` matcher
-   reconstruction path; keep per-child hard limits throughout.
+1. Remediate the remaining forced-Joni failure causes, starting with the
+   catastrophic `regexp*` cluster and absent generated Unicode fixtures; keep
+   per-child hard limits throughout. PR #1008 has removed the release-blocking
+   `pat_psycho*` offset-map reconstruction and bounded profiling confirms that
+   matcher-wrapper reuse is no longer on the critical path.
 2. Integrate the stacked Joni offset-map, regex-set property, and CEC timeout
    slices, then rerun the forced-Joni corpus from the new combined head.
 3. Capture the clean-branch JVM and interpreter 80-file baselines and compare

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -230,6 +230,12 @@ Perl's user-property callback path. A 39-assertion standard-Perl oracle passes
 on JVM and interpreter; the unchanged `regexp_unicode_prop.t` runner improves
 from 1,039/1,110 to 1,054/1,110, leaving built-in aliases and six
 user-property-definition diagnostic assertions as separate work.
+Direct user-property definitions now report Perl-compatible overflow, reversed
+range, invalid component, callback death, recursion-chain, and package-name
+diagnostics. The focused 12-assertion oracle passes on both execution backends;
+`regexp_unicode_prop.t` gains two more assertions. Four deferred bare-name
+assertions retain correct diagnostic content but still need literal source-order
+provenance to add the canonical `main::` prefix.
 
 Executable callback source and literal trailing `/x` comments survive canonical
 regex-object stringification on both execution backends. Recursive Joni call
@@ -350,6 +356,11 @@ matcher-specific timeouts on both execution backends.
     naming convention and made unknown-property diagnostics fatal even in
     compatibility warning mode. The focused oracle passes 39/39 on system
     Perl, JVM, and interpreter; `regexp_unicode_prop.t` gains 15 assertions.
+  - [x] Matched user-property definition validation, deterministic recursion
+    chains, callback-death wrapping, and direct package-name policy.
+    The focused oracle passes 12/12 on system Perl, JVM, and interpreter;
+    unchanged upstream coverage gains two assertions, with four source-order
+    provenance assertions tracked separately.
   - [ ] Complete the remaining Unicode aliases and diagnostic parity inventory.
 - [x] Phase 4: Runtime source and diagnostics (2026-08-17; semantic gate
   complete at 550/555)
@@ -373,9 +384,9 @@ matcher-specific timeouts on both execution backends.
    slices, then rerun the forced-Joni corpus from the new combined head.
 3. Capture the clean-branch JVM and interpreter 80-file baselines and compare
    both to PR 958 with the regression exit gate.
-4. Integrate the exact invalid-property dispatch/diagnostic slice, then finish
-   PerlOnJava4's built-in Unicode-alias slice and the six residual
-   user-property-definition diagnostic assertions against Perl 5.44 behavior.
+4. Integrate the invalid-property and definition-diagnostic slices, then finish
+   PerlOnJava4's built-in Unicode aliases and preserve compile-time source-order
+   provenance for the four deferred bare-name diagnostics.
 5. Keep the warning-free whole-unit-suite gate green with Joni as the default;
    use explicit Java mode only to classify corpus regressions before Phase 5
    removes the legacy backend and selector.

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -901,7 +901,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         // User property subs can execute arbitrary Perl and block. Resolve them
         // before compile() takes its process-wide monitor; only simultaneous
         // definitions of the same property coordinate in PerlThreadRegistry.
-        UnicodeResolver.preloadUserDefinedProperties(regex.patternString,
+        UnicodeResolver.preloadDeferredUserDefinedProperties(regex.patternString,
                 regex.regexFlags != null && regex.regexFlags.isCaseInsensitive());
         RuntimeRegex recompiled = compile(regex.patternString,
                 regex.regexFlags == null ? "" : regex.regexFlags.toFlagString(),

--- a/src/main/java/org/perlonjava/runtime/regex/UnicodeResolver.java
+++ b/src/main/java/org/perlonjava/runtime/regex/UnicodeResolver.java
@@ -6,7 +6,10 @@ import com.ibm.icu.text.UnicodeSet;
 import org.perlonjava.app.scriptengine.PerlLanguageProvider;
 import org.perlonjava.runtime.runtimetypes.*;
 
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -199,15 +202,16 @@ public class UnicodeResolver {
                 }
             } else {
                 // Parse hex range - extract the hex part before any comments
-                String hexPart = line.split("#")[0].trim();
-                // Split by tabs or multiple spaces
-                String[] parts = hexPart.split("\\t+|\\s{2,}");
+                String hexPart = stripDefinitionComment(line);
+                String[] parts = hexPart.split("\\s+");
                 if (parts.length == 1 && !parts[0].isEmpty()) {
                     // Single character
                     String hexStr = parts[0].trim();
                     // Check if it's a valid hex string
                     if (!hexStr.matches("[0-9A-Fa-f]+")) {
-                        throw new IllegalArgumentException("Can't find Unicode property definition \"" + line.trim() + "\" in expansion of " + propertyName);
+                        throw new IllegalArgumentException(
+                                "Can't find Unicode property definition \"" + hexPart
+                                        + "\" in expansion of " + propertyName);
                     }
                     try {
                         long codePoint = Long.parseLong(hexStr, 16);
@@ -218,7 +222,9 @@ public class UnicodeResolver {
                         }
                         resultSet.add((int) codePoint);
                     } catch (NumberFormatException e) {
-                        throw new IllegalArgumentException("Can't find Unicode property definition \"" + line.trim() + "\" in expansion of " + propertyName);
+                        throw new IllegalArgumentException(
+                                "Code point too large in \"" + line
+                                        + "\" in expansion of " + propertyName);
                     }
                 } else if (parts.length >= 2) {
                     // Range
@@ -227,7 +233,9 @@ public class UnicodeResolver {
 
                     // Check if they're valid hex strings
                     if (!startHex.matches("[0-9A-Fa-f]+") || !endHex.matches("[0-9A-Fa-f]+")) {
-                        throw new IllegalArgumentException("Can't find Unicode property definition \"" + line.trim() + "\" in expansion of " + propertyName);
+                        throw new IllegalArgumentException(
+                                "Can't find Unicode property definition \"" + hexPart
+                                        + "\" in expansion of " + propertyName);
                     }
 
                     try {
@@ -249,7 +257,9 @@ public class UnicodeResolver {
 
                         resultSet.add((int) start, (int) end);
                     } catch (NumberFormatException e) {
-                        throw new IllegalArgumentException("Can't find Unicode property definition \"" + line.trim() + "\" in expansion of " + propertyName);
+                        throw new IllegalArgumentException(
+                                "Code point too large in \"" + line
+                                        + "\" in expansion of " + propertyName);
                     }
                 }
             }
@@ -287,6 +297,16 @@ public class UnicodeResolver {
         }
     }
 
+    private static IllegalArgumentException recursivePropertyError(
+            String property, Set<String> recursionSet) {
+        List<String> expansionChain = new ArrayList<>(recursionSet);
+        Collections.reverse(expansionChain);
+        return new IllegalArgumentException(
+                "Infinite recursion in user-defined property \"" + property
+                        + "\" in expansion of "
+                        + String.join(" in expansion of ", expansionChain));
+    }
+
     /**
      * Resolves a property reference to a UnicodeSet (like utf8::InHiragana or main::IsMyProp).
      * Returns a UnicodeSet directly instead of a Java regex pattern string, so the result
@@ -301,18 +321,7 @@ public class UnicodeResolver {
         // Check for recursion
         if (recursionSet.contains(propRef)) {
             // Build recursion chain for error message
-            StringBuilder chain = new StringBuilder();
-            for (String prop : recursionSet) {
-                if (chain.length() > 0) {
-                    chain.append(" in expansion of ");
-                }
-                chain.append(prop);
-            }
-            if (chain.length() > 0) {
-                chain.append(" in expansion of ");
-            }
-            chain.append(propRef);
-            throw new IllegalArgumentException("Infinite recursion in user-defined property \"" + propRef + "\" in expansion of " + chain);
+            throw recursivePropertyError(propRef, recursionSet);
         }
 
         // Remove utf8:: prefix if present
@@ -483,6 +492,12 @@ public class UnicodeResolver {
      */
     private static String tryUserDefinedProperty(
             String property, Set<String> recursionSet, boolean caseInsensitive) {
+        return tryUserDefinedProperty(property, recursionSet, caseInsensitive, false);
+    }
+
+    private static String tryUserDefinedProperty(
+            String property, Set<String> recursionSet, boolean caseInsensitive,
+            boolean qualifyBareDiagnosticName) {
         // Build the full subroutine name
         String subName = property;
         if (!subName.contains("::")) {
@@ -495,18 +510,9 @@ public class UnicodeResolver {
         // namespace; otherwise InFoo -> main::InFoo can wait on its own active
         // future instead of reporting recursive expansion.
         if (recursionSet.contains(subName)) {
-            StringBuilder chain = new StringBuilder();
-            for (String recursiveProperty : recursionSet) {
-                if (chain.length() > 0) chain.append(" in expansion of ");
-                chain.append(recursiveProperty);
-            }
-            if (chain.length() > 0) chain.append(" in expansion of ");
-            chain.append(subName);
-            throw new IllegalArgumentException(
-                    "Infinite recursion in user-defined property \"" + subName
-                            + "\" in expansion of " + chain);
+            throw recursivePropertyError(subName, recursionSet);
         }
-        Set<String> newRecursionSet = new HashSet<>(recursionSet);
+        Set<String> newRecursionSet = new LinkedHashSet<>(recursionSet);
         newRecursionSet.add(subName);
 
         // Check cache first — Perl only calls user-defined property subs once
@@ -531,20 +537,26 @@ public class UnicodeResolver {
         RuntimeScalar codeRef = GlobalVariable.getGlobalCodeRef(subName);
 
         final String resolvedSubName = subName;
+        final String diagnosticName = qualifyBareDiagnosticName
+                && !property.contains("::") ? subName : property;
         final String coordinationKey = cacheKey;
         try {
             String parsed = PerlRuntime.current().threadRegistry()
                     .resolveUserUnicodeProperty(coordinationKey,
                             () -> resolveUserDefinedProperty(
-                                    codeRef, resolvedSubName, newRecursionSet,
+                                    codeRef, resolvedSubName, diagnosticName,
+                                    newRecursionSet,
                                     caseInsensitive));
             userPropertyCache().put(cacheKey, parsed);
             return parsed;
+        } catch (PerlDieException e) {
+            throw propertyDefinitionDie(e, diagnosticName);
         } catch (PerlCompilerException e) {
             // Re-throw Perl exceptions (like die in IsDeath)
             String msg = e.getMessage();
             if (msg != null && !msg.contains("in expansion of")) {
-                throw new IllegalArgumentException("Died" + (msg.isEmpty() ? "" : ": " + msg) + " in expansion of " + subName, e);
+                throw new IllegalArgumentException("Died" + (msg.isEmpty() ? "" : ": " + msg)
+                        + " in expansion of " + diagnosticName, e);
             }
             throw e;
         } catch (IllegalArgumentException e) {
@@ -556,9 +568,9 @@ public class UnicodeResolver {
         }
     }
 
-    private static String resolveUserDefinedProperty(RuntimeScalar codeRef, String subName,
-                                                     Set<String> recursionSet,
-                                                     boolean caseInsensitive) {
+    private static String resolveUserDefinedProperty(
+            RuntimeScalar codeRef, String subName, String diagnosticName,
+            Set<String> recursionSet, boolean caseInsensitive) {
         try {
             // Perl passes one false/true argument for case-sensitive/folded
             // expansion. A user property may intentionally return distinct
@@ -573,13 +585,16 @@ public class UnicodeResolver {
             String definition = result.elements.getFirst().toString();
 
             // Parse and cache the property definition
-            return parseUserDefinedProperty(definition, recursionSet, subName);
+            return parseUserDefinedProperty(definition, recursionSet, diagnosticName);
 
+        } catch (PerlDieException e) {
+            throw propertyDefinitionDie(e, diagnosticName);
         } catch (PerlCompilerException e) {
             // Re-throw Perl exceptions (like die in IsDeath)
             String msg = e.getMessage();
             if (msg != null && !msg.contains("in expansion of")) {
-                throw new IllegalArgumentException("Died" + (msg.isEmpty() ? "" : ": " + msg) + " in expansion of " + subName, e);
+                throw new IllegalArgumentException("Died" + (msg.isEmpty() ? "" : ": " + msg)
+                        + " in expansion of " + diagnosticName, e);
             }
             throw e;
         } catch (IllegalArgumentException e) {
@@ -591,12 +606,31 @@ public class UnicodeResolver {
         }
     }
 
+    private static IllegalArgumentException propertyDefinitionDie(
+            PerlDieException failure, String propertyName) {
+        String message = failure.getMessage();
+        return new IllegalArgumentException(
+                "Error \"" + (message == null ? "" : message)
+                        + "\" in expansion of " + propertyName);
+    }
+
     /**
      * Resolve deferred top-level user properties before entering the synchronized
      * regex compiler. Property subs are arbitrary Perl and may block; keeping
      * them outside that compiler monitor lets unrelated property names proceed.
      */
     static void preloadUserDefinedProperties(String pattern, boolean caseInsensitive) {
+        preloadUserDefinedProperties(pattern, caseInsensitive, false);
+    }
+
+    static void preloadDeferredUserDefinedProperties(
+            String pattern, boolean caseInsensitive) {
+        preloadUserDefinedProperties(pattern, caseInsensitive, true);
+    }
+
+    private static void preloadUserDefinedProperties(
+            String pattern, boolean caseInsensitive,
+            boolean qualifyBareDiagnosticName) {
         if (pattern == null || pattern.isEmpty()) return;
 
         for (int slash = pattern.indexOf('\\'); slash >= 0;
@@ -622,19 +656,20 @@ public class UnicodeResolver {
                 // translator here would turn that intentional forward reference
                 // into an early "unsupported property" fatal before the
                 // placeholder path can run.
-                tryUserDefinedProperty(property, new HashSet<>(), caseInsensitive);
+                tryUserDefinedProperty(property, new LinkedHashSet<>(), caseInsensitive,
+                        qualifyBareDiagnosticName);
             }
             slash = end;
         }
     }
 
     public static String translateUnicodeProperty(String property, boolean negated) {
-        return translateUnicodeProperty(property, negated, new HashSet<>(), false);
+        return translateUnicodeProperty(property, negated, new LinkedHashSet<>(), false);
     }
 
     static String translateUnicodeProperty(
             String property, boolean negated, boolean caseInsensitive) {
-        return translateUnicodeProperty(property, negated, new HashSet<>(), caseInsensitive);
+        return translateUnicodeProperty(property, negated, new LinkedHashSet<>(), caseInsensitive);
     }
 
     private static String translateUnicodeProperty(String property, boolean negated, Set<String> recursionSet) {

--- a/src/test/resources/unit/regex/user_property_definition_diagnostics.t
+++ b/src/test/resources/unit/regex/user_property_definition_diagnostics.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More tests => 12;
+
+sub IsOverflow { return "0\t80000000000000000#ネ" }
+sub IsRangeReversed { return "200 100#ネ" }
+sub IsNonHex { return "BEEF CAGED#ネ" }
+sub IsDeath { die "intentional property death\n" }
+sub InRecursedA { return "+main::InRecursedB\n" }
+sub InRecursedB { return "+main::InRecursedC\n" }
+sub InRecursedC { return "+main::InRecursedA\n" }
+sub InOneBadApple { return "0100\t0110\n10000\t10010\nF000\\tF010\n0400\t0410" }
+
+my @cases = (
+    [ IsOverflow => qr/^Code point too large in "0\t80000000000000000#ネ" in expansion of main::IsOverflow/ ],
+    [ IsRangeReversed => qr/^Illegal range in "200 100#ネ" in expansion of main::IsRangeReversed/ ],
+    [ IsNonHex => qr/^Can't find Unicode property definition "BEEF CAGED" in expansion of main::IsNonHex/ ],
+    [ IsDeath => qr/^Error "intentional property death\n" in expansion of main::IsDeath/s ],
+    [ InRecursedA => qr/^Infinite recursion in user-defined property "main::InRecursedA" in expansion of main::InRecursedC in expansion of main::InRecursedB in expansion of main::InRecursedA/ ],
+);
+
+for my $case (@cases) {
+    my ($property, $diagnostic) = @$case;
+    my $source = 'qr/\p{main::' . $property . '}/';
+    my $ok = eval "$source; 1";
+    ok(!$ok, "$property definition is rejected");
+    like($@, $diagnostic, "$property reports the Perl expansion diagnostic");
+}
+
+my $nested_ok = eval q{qr/\p{InOneBadApple}/; 1};
+ok(!$nested_ok, 'a bad nested component rejects the user property');
+like($@, qr/^Can't find Unicode property definition "F000\\tF010" in expansion of InOneBadApple/,
+    'a bad nested component reports the unqualified expansion name');


### PR DESCRIPTION
## Summary

- match Perl diagnostics for oversized code points, reversed ranges, and invalid definition components
- preserve deterministic recursive user-property expansion order
- wrap callback `die` payloads as property expansion errors without eval unwrapping them
- retain canonical names for deferred recompilation and bare names for direct properties
- track the four remaining literal source-order provenance assertions in the Phase 36 design
- record that PR #1008 removed `pat_psycho*` offset reconstruction from the critical path

## Validation

- `user_property_definition_diagnostics.t`: 12/12 on system Perl, JVM, and interpreter
- unchanged `regexp_unicode_prop.t`: 1,056/1,110 on JVM and interpreter, up from 1,054
- warning-free exact-tree `make`: PASS in 3m23s at `7410cabcf`

## Remaining boundary

Four upstream assertions have correct diagnostic content but render `IsName` instead of `main::IsName` because literal source order is not yet carried into runtime regex construction. That provenance work remains separate from PerlOnJava4's built-in alias slice.
