### PR TITLE
fix(regex): enable safe Joni backtracking checks

### DIFF
--- a/third_party/joni/src/org/joni/Analyser.java
+++ b/third_party/joni/src/org/joni/Analyser.java
@@ -130,7 +130,9 @@ final class Analyser extends Parser {
         }
 
         if (Config.USE_CEC) {
-            if (env.backrefedMem == 0 || (Config.USE_SUBEXP_CALL && env.numCall == 0)) {
+            if (env.backrefedMem == 0 &&
+                    (!Config.USE_SUBEXP_CALL || env.numCall == 0) &&
+                    !env.hasCallout) {
                 setupCombExpCheck(root, 0);
 
                 if (Config.USE_SUBEXP_CALL && env.hasRecursion) {

--- a/third_party/joni/src/org/joni/ArrayCompiler.java
+++ b/third_party/joni/src/org/joni/ArrayCompiler.java
@@ -1355,10 +1355,11 @@ final class ArrayCompiler extends Compiler {
             break;
 
         case NodeType.QTFR:
-            if (Config.USE_CEC) {
-                len = compileCECLengthQuantifierNode((QuantifierNode)node);
+            QuantifierNode quantifier = (QuantifierNode)node;
+            if (Config.USE_CEC && regex.numCombExpCheck > 0 && quantifier.combExpCheckNum > 0) {
+                len = compileCECLengthQuantifierNode(quantifier);
             } else {
-                len = compileNonCECLengthQuantifierNode((QuantifierNode)node);
+                len = compileNonCECLengthQuantifierNode(quantifier);
             }
             break;
 

--- a/third_party/joni/src/org/joni/ByteCodeMachine.java
+++ b/third_party/joni/src/org/joni/ByteCodeMachine.java
@@ -1151,7 +1151,6 @@ class ByteCodeMachine extends StackMachine implements MatchView {
             sprev = s;
             s += n;
         }
-        sprev = sbegin; // break;
     }
 
     private void opStateCheckAnyCharStarSb() {
@@ -1165,7 +1164,6 @@ class ByteCodeMachine extends StackMachine implements MatchView {
             sprev = s;
             s++;
         }
-        sprev = sbegin; // break;
     }
 
     // CEC
@@ -1181,7 +1179,6 @@ class ByteCodeMachine extends StackMachine implements MatchView {
             sprev = s;
             s += n;
         }
-        sprev = sbegin; // break;
     }
 
     private void opStateCheckAnyCharMLStarSb() {
@@ -1193,7 +1190,6 @@ class ByteCodeMachine extends StackMachine implements MatchView {
             sprev = s;
             s++;
         }
-        sprev = sbegin; // break;
     }
 
     private void opWord() {

--- a/third_party/joni/src/org/joni/Compiler.java
+++ b/third_party/joni/src/org/joni/Compiler.java
@@ -162,10 +162,11 @@ abstract class Compiler implements ErrorMessages {
             break;
 
         case NodeType.QTFR:
-            if (Config.USE_CEC) {
-                compileCECQuantifierNode((QuantifierNode)node);
+            QuantifierNode quantifier = (QuantifierNode)node;
+            if (Config.USE_CEC && regex.numCombExpCheck > 0 && quantifier.combExpCheckNum > 0) {
+                compileCECQuantifierNode(quantifier);
             } else {
-                compileNonCECQuantifierNode((QuantifierNode)node);
+                compileNonCECQuantifierNode(quantifier);
             }
             break;
 

--- a/third_party/joni/src/org/joni/Config.java
+++ b/third_party/joni/src/org/joni/Config.java
@@ -44,7 +44,7 @@ public interface Config extends org.jcodings.Config {
     boolean USE_WORD_BEGIN_END = ConfigSupport.getBoolean("joni.use_word_begin_end", true); /* "\<": word-begin, "\>": word-end */
     boolean USE_FIND_LONGEST_SEARCH_ALL_OF_RANGE = ConfigSupport.getBoolean("joni.use_find_longest_search_all_of_range", true);
     boolean USE_SUNDAY_QUICK_SEARCH = ConfigSupport.getBoolean("joni.use_sunday_quick_search", true);
-    boolean USE_CEC = ConfigSupport.getBoolean("joni.use_cec", false);
+    boolean USE_CEC = ConfigSupport.getBoolean("joni.use_cec", true);
     boolean USE_DYNAMIC_OPTION = ConfigSupport.getBoolean("joni.use_dynamic_option", false);
     boolean USE_BYTE_MAP = ConfigSupport.getBoolean("joni.use_byte_map", OptExactInfo.OPT_EXACT_MAXLEN <= CHAR_TABLE_SIZE);
     boolean USE_INT_MAP_BACKWARD = ConfigSupport.getBoolean("joni.use_int_map_backward", false);

--- a/third_party/joni/src/org/joni/Matcher.java
+++ b/third_party/joni/src/org/joni/Matcher.java
@@ -192,7 +192,7 @@ public abstract class Matcher extends IntHolder {
         msaInit(option, at, at);
 
         if (Config.USE_CEC) {
-            int offset = at = str;
+            int offset = at - str;
             stateCheckBuffInit(end - str, offset, regex.numCombExpCheck); // move it to construction?
         } // USE_COMBINATION_EXPLOSION_CHECK
 

--- a/third_party/joni/src/org/joni/StackMachine.java
+++ b/third_party/joni/src/org/joni/StackMachine.java
@@ -150,7 +150,7 @@ abstract class StackMachine extends Matcher implements StackType {
                     // same impl, reduce...
                     stateCheckBuff = new byte[size];
                 }
-                Arrays.fill(stateCheckBuff, offset, (size - offset), (byte)0);
+                Arrays.fill(stateCheckBuff, offset, size, (byte)0);
                 stateCheckBuffSize = size;
             } else {
                 stateCheckBuff = null; // reduce

--- a/third_party/joni/test/org/joni/test/TestPerl.java
+++ b/third_party/joni/test/org/joni/test/TestPerl.java
@@ -44,4 +44,10 @@ public class TestPerl extends Test {
 	@Override
     public void test() throws Exception {
     }
+
+    @org.junit.Test(timeout = 5000)
+    public void testNestedQuantifierCombinationExplosion() throws Exception {
+        x2s(".X(.+)+X", "bXcXaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 0, 4);
+        org.junit.Assert.assertEquals(0, nfail + nerror);
+    }
 }


### PR DESCRIPTION
## Summary

- enable Joni's backtracking safeguard by default while retaining `-Djoni.use_cec=false`
- repair dormant state-buffer, offset, eligibility, compiler-selection, and boundary-tracking defects
- add a bounded Perl-syntax regression for the nested-quantifier slowdown

## Validation

- full `make` passed without warnings
- focused Joni callout, UTF-8, subexpression, zero-length, and nested-quantifier coverage passed
- the standalone reducer completed on JVM and interpreter backends
- all eight formerly timed-out compatibility files completed with per-process limits

This PR is stacked on `fix/phase36-regex-sets-ascii` to preserve PRs #1008 and #1009.
