### PR TITLE
WIP: Preserve deferred Unicode property provenance

### DIFF
--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -394,7 +394,8 @@ matcher-specific timeouts on both execution backends.
    both to PR 958 with the regression exit gate.
 4. Integrate PR #1011 and the deferred-property provenance slice, then finish
    PerlOnJava4's built-in Unicode aliases against the 1,065/1,110 diagnostics
-   baseline; its alias-complete target is 1,094/1,110.
+   baseline. Fixing the 29 executed alias failures also unlocks 16 gated match
+   assertions, so the alias-complete target is 1,110/1,110.
 5. Keep the warning-free whole-unit-suite gate green with Joni as the default;
    use explicit Java mode only to classify corpus regressions before Phase 5
    removes the legacy backend and selector.

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -233,9 +233,12 @@ user-property-definition diagnostic assertions as separate work.
 Direct user-property definitions now report Perl-compatible overflow, reversed
 range, invalid component, callback death, recursion-chain, and package-name
 diagnostics. The focused 12-assertion oracle passes on both execution backends;
-`regexp_unicode_prop.t` gains two more assertions. Four deferred bare-name
-assertions retain correct diagnostic content but still need literal source-order
-provenance to add the canonical `main::` prefix.
+`regexp_unicode_prop.t` gains two more assertions. Deferred property provenance
+now survives implicit Unicode-flag regex copies and remains associated with the
+property name for later source-literal reuse. The focused 8-assertion oracle
+passes on both execution backends; unchanged upstream coverage gains nine more
+assertions to reach 1,065/1,110, and all user-property diagnostic assertions
+through test 1,094 pass.
 
 Executable callback source and literal trailing `/x` comments survive canonical
 regex-object stringification on both execution backends. Recursive Joni call
@@ -359,9 +362,12 @@ matcher-specific timeouts on both execution backends.
   - [x] Matched user-property definition validation, deterministic recursion
     chains, callback-death wrapping, and direct package-name policy.
     The focused oracle passes 12/12 on system Perl, JVM, and interpreter;
-    unchanged upstream coverage gains two assertions, with four source-order
-    provenance assertions tracked separately.
-  - [ ] Complete the remaining Unicode aliases and diagnostic parity inventory.
+    unchanged upstream coverage gains two assertions.
+  - [x] Preserved deferred user-property package provenance through implicit
+    Unicode-flag copies and later literal reuse. The focused oracle passes 8/8
+    on system Perl, JVM, and interpreter; `regexp_unicode_prop.t` gains nine
+    assertions to 1,065/1,110 on both execution backends.
+  - [ ] Complete the remaining built-in Unicode aliases.
 - [x] Phase 4: Runtime source and diagnostics (2026-08-17; semantic gate
   complete at 550/555)
   - [x] Preserved mixed executable-source provenance, nested dynamic callback
@@ -386,9 +392,9 @@ matcher-specific timeouts on both execution backends.
    slices, then rerun the forced-Joni corpus from the new combined head.
 3. Capture the clean-branch JVM and interpreter 80-file baselines and compare
    both to PR 958 with the regression exit gate.
-4. Integrate the invalid-property and definition-diagnostic slices, then finish
-   PerlOnJava4's built-in Unicode aliases and preserve compile-time source-order
-   provenance for the four deferred bare-name diagnostics.
+4. Integrate PR #1011 and the deferred-property provenance slice, then finish
+   PerlOnJava4's built-in Unicode aliases against the 1,065/1,110 diagnostics
+   baseline; its alias-complete target is 1,094/1,110.
 5. Keep the warning-free whole-unit-suite gate green with Joni as the default;
    use explicit Java mode only to classify corpus regressions before Phase 5
    removes the legacy backend and selector.

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -1351,6 +1351,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             regex.patternNoInternalMarkers = originalRegex.patternNoInternalMarkers;
             regex.patternUnicodeNoInternalMarkers = originalRegex.patternUnicodeNoInternalMarkers;
             regex.patternString = originalRegex.patternString;
+            regex.deferredUserDefinedUnicodeProperties =
+                    originalRegex.deferredUserDefinedUnicodeProperties;
             regex.hasPreservesMatch = originalRegex.hasPreservesMatch;
             regex.quoteConstruction = originalRegex.quoteConstruction;
             regex.warningsOnUse = new ArrayList<>(originalRegex.warningsOnUse);
@@ -1391,6 +1393,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                     regex.patternNoInternalMarkers = originalRegex.patternNoInternalMarkers;
                     regex.patternUnicodeNoInternalMarkers = originalRegex.patternUnicodeNoInternalMarkers;
                     regex.patternString = originalRegex.patternString;
+                    regex.deferredUserDefinedUnicodeProperties =
+                            originalRegex.deferredUserDefinedUnicodeProperties;
                     regex.hasPreservesMatch = originalRegex.hasPreservesMatch;
                     regex.quoteConstruction = originalRegex.quoteConstruction;
                     regex.warningsOnUse = new ArrayList<>(originalRegex.warningsOnUse);
@@ -1591,6 +1595,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         regex.patternNoInternalMarkers = resolvedRegex.patternNoInternalMarkers;
         regex.patternUnicodeNoInternalMarkers = resolvedRegex.patternUnicodeNoInternalMarkers;
         regex.patternString = resolvedRegex.patternString;
+        regex.deferredUserDefinedUnicodeProperties =
+                resolvedRegex.deferredUserDefinedUnicodeProperties;
         regex.regexFlags = resolvedRegex.regexFlags;
         regex.hasPreservesMatch = resolvedRegex.hasPreservesMatch;
         regex.quoteConstruction = resolvedRegex.quoteConstruction;

--- a/src/main/java/org/perlonjava/runtime/regex/UnicodeResolver.java
+++ b/src/main/java/org/perlonjava/runtime/regex/UnicodeResolver.java
@@ -34,6 +34,10 @@ public class UnicodeResolver {
         return PerlRuntime.current().regexState().userUnicodePropertyCache;
     }
 
+    private static Set<String> deferredUserProperties() {
+        return PerlRuntime.current().regexState().deferredUserUnicodeProperties;
+    }
+
     private static String userPropertyCacheKey(String subName, boolean caseInsensitive) {
         return subName + (caseInsensitive ? "\u0000i" : "\u0000s");
     }
@@ -537,7 +541,8 @@ public class UnicodeResolver {
         RuntimeScalar codeRef = GlobalVariable.getGlobalCodeRef(subName);
 
         final String resolvedSubName = subName;
-        final String diagnosticName = qualifyBareDiagnosticName
+        final String diagnosticName = (qualifyBareDiagnosticName
+                || deferredUserProperties().contains(subName))
                 && !property.contains("::") ? subName : property;
         final String coordinationKey = cacheKey;
         try {
@@ -649,6 +654,9 @@ public class UnicodeResolver {
             String property = pattern.substring(slash + 3, end).trim();
             if (property.startsWith("^")) property = property.substring(1).trim();
             if (isUserDefinedPropertyName(property)) {
+                if (qualifyBareDiagnosticName && !property.contains("::")) {
+                    deferredUserProperties().add("main::" + property);
+                }
                 // Preloading is an optimization for callbacks that are already
                 // available. Perl permits qr// to contain a forward reference
                 // to a user property; RegexPreprocessor represents that with a

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeRegexState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeRegexState.java
@@ -4,9 +4,11 @@ import org.perlonjava.runtime.regex.RegexMatcher;
 import org.perlonjava.runtime.regex.RuntimeRegex;
 
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Mutable regular-expression state owned by one {@link PerlRuntime}.
@@ -46,6 +48,7 @@ public final class RuntimeRegexState {
     /** Stable scalar identities for literal regex targets, keyed by compiled call site. */
     public final Map<Integer, RuntimeScalar> literalRegexTargets = new LinkedHashMap<>();
     public final Map<String, String> userUnicodePropertyCache = new LinkedHashMap<>();
+    public final Set<String> deferredUserUnicodeProperties = new LinkedHashSet<>();
 
     /**
      * Per-runtime compiled templates. Some templates support deferred runtime
@@ -101,5 +104,6 @@ public final class RuntimeRegexState {
     /** Copy immutable regex metadata that Perl ithreads inherit at creation. */
     void snapshotInto(RuntimeRegexState target) {
         target.userUnicodePropertyCache.putAll(userUnicodePropertyCache);
+        target.deferredUserUnicodeProperties.addAll(deferredUserUnicodeProperties);
     }
 }

--- a/src/test/resources/unit/regex/user_property_source_provenance.t
+++ b/src/test/resources/unit/regex/user_property_source_provenance.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use feature 'unicode_strings';
+use Test::More tests => 8;
+
+our @deferred;
+BEGIN {
+    for my $name (qw(IsP36Overflow IsP36Reverse IsP36NonHex IsP36Death)) {
+        push @deferred, qr/\p{$name}/;
+    }
+}
+
+my @expected = (
+    qr/Code point too large .* expansion of main::IsP36Overflow/s,
+    qr/Illegal range .* expansion of main::IsP36Reverse/s,
+    qr/Can't find Unicode property definition .* expansion of main::IsP36NonHex/s,
+    qr/P36 callback death.* expansion of main::IsP36Death/s,
+);
+
+my @names = qw(IsP36Overflow IsP36Reverse IsP36NonHex IsP36Death);
+for my $index (0 .. $#deferred) {
+    undef $@;
+    eval { "A" =~ $deferred[$index] };
+    like($@, $expected[$index],
+            "deferred literal records canonical user-property package provenance");
+}
+
+for my $index (0 .. $#names) {
+    undef $@;
+    my $name = $names[$index];
+    eval { "A" =~ /\p{$name}/ };
+    like($@, $expected[$index],
+            "source literal retains canonical user-property package provenance");
+}
+
+sub IsP36Overflow { "0 80000000000000000\n" }
+sub IsP36Reverse  { "200 100\n" }
+sub IsP36NonHex   { "BEEF CAGED\n" }
+sub IsP36Death    { die "P36 callback death\n" }


### PR DESCRIPTION
## Summary

- preserve deferred user-property state when compiled regexes gain implicit Unicode flags
- remember canonical deferred property names for later source-literal diagnostic reuse
- keep fresh direct user properties unqualified, matching Perl's distinct diagnostic path
- copy deferred-property provenance into child Perl runtimes
- close the remaining user-property diagnostic assertions in `regexp_unicode_prop.t`

## Validation

- `user_property_source_provenance.t`: 8/8 on system Perl, JVM, and interpreter
- `user_property_definition_diagnostics.t`: 12/12 on JVM and interpreter
- unchanged `regexp_unicode_prop.t`: 1,065/1,110 on JVM and interpreter, up from 1,056
- deferred tests 1-5 and diagnostics 1088-1094 all pass on both execution backends
- warning-free exact-commit `make`: PASS in 3m31s at `6b3c77a2a`
- warning-free tracker-correction `make`: PASS in 3m15s at `9eae6b895`

## Remaining boundary

The remaining 29 executed failures in `regexp_unicode_prop.t` are the built-in
Unicode alias surface owned by PerlOnJava4. Sixteen additional match assertions
are gated behind those failed alias compilations, so the alias-complete target
is 1,110/1,110.
