### PR TITLE
fix: execute inline p modifiers through Joni

### DIFF
--- a/src/main/java/org/perlonjava/runtime/regex/RegexFlags.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexFlags.java
@@ -75,6 +75,52 @@ public record RegexFlags(boolean isGlobalMatch, boolean keepCurrentPosition, boo
         }
     }
 
+    /**
+     * Finds a positive inline Perl {@code p} modifier without treating escaped
+     * text or character-class contents as modifier groups. Match-variable
+     * retention is PerlOnJava source policy rather than a Joni matcher option.
+     */
+    static boolean hasInlinePreserveModifier(String pattern) {
+        if (pattern == null || pattern.length() < 4) return false;
+
+        boolean escaped = false;
+        boolean inClass = false;
+        for (int i = 0; i + 3 < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (c == '\\') {
+                escaped = true;
+                continue;
+            }
+            if (c == '[') {
+                inClass = true;
+                continue;
+            }
+            if (c == ']' && inClass) {
+                inClass = false;
+                continue;
+            }
+            if (inClass || c != '(' || pattern.charAt(i + 1) != '?') continue;
+
+            boolean negative = false;
+            for (int j = i + 2; j < pattern.length(); j++) {
+                char modifier = pattern.charAt(j);
+                if (modifier == ':' || modifier == ')') break;
+                if (modifier == '-') {
+                    negative = true;
+                    continue;
+                }
+                if (modifier == '^') continue;
+                if (modifier < 'a' || modifier > 'z') break;
+                if (modifier == 'p' && !negative) return true;
+            }
+        }
+        return false;
+    }
+
     public int toPatternFlags() {
         int flags = 0;
         

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -653,12 +653,15 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                             regex.recursivePattern.hasDeferredUserDefinedUnicodeProperty()
                                     || regex.recursivePatternUnicode
                                             .hasDeferredUserDefinedUnicodeProperty();
-                    regex.hasPreservesMatch = regex.regexFlags.preservesMatch();
+                    regex.hasPreservesMatch = regex.regexFlags.preservesMatch()
+                            || RegexFlags.hasInlinePreserveModifier(compilePatternString);
                     regex.hasBranchReset = false;
                     regex.hasBackslashK = false;
                 } else {
                     regex.deferredUserDefinedUnicodeProperties = RegexPreprocessor.hadDeferredUnicodePropertyEncountered();
-                    regex.hasPreservesMatch = regex.regexFlags.preservesMatch() || RegexPreprocessor.hadInlinePFlag();
+                    regex.hasPreservesMatch = regex.regexFlags.preservesMatch()
+                            || RegexFlags.hasInlinePreserveModifier(compilePatternString)
+                            || RegexPreprocessor.hadInlinePFlag();
                     regex.hasBranchReset = RegexPreprocessor.hadBranchReset();
                     regex.hasBackslashK = RegexPreprocessor.hadBackslashK();
                     regex.warningsOnUse.addAll(RegexPreprocessor.getWarningsOnUse());
@@ -2053,6 +2056,11 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         int capture = 1;
         int previousPos = startPos; // Track the previous position  
         int previousMatchEnd = -1;  // Track end of previous match
+        boolean previousMatchUsedPFlag = regexState.lastMatchUsedPFlag;
+        // Inline /p is Perl match-variable policy rather than a Joni option.
+        // Publish it while callouts execute; restore the preceding successful
+        // match's policy if this matcher ultimately fails.
+        regexState.lastMatchUsedPFlag = regex.hasPreservesMatch;
         // NOTE: Do NOT clear global match variables here.
         //
         // Perl preserves $1, @-, @+, $&, etc. from the last *successful* match even if a
@@ -2182,6 +2190,10 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             // recursion ceiling is reached; do not let the JVM error abort the
             // whole program for the equivalent pathological failure case.
             found = false;
+        }
+
+        if (!found) {
+            regexState.lastMatchUsedPFlag = previousMatchUsedPFlag;
         }
 
         // Reset pos() on failed match with /g, unless /c is set
@@ -2799,6 +2811,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         // The result string after substitutions
         StringBuilder resultBuffer = new StringBuilder();
         int found = 0;
+        boolean previousMatchUsedPFlag = state().lastMatchUsedPFlag;
+        state().lastMatchUsedPFlag = regex.hasPreservesMatch;
 
         // Unwrap readonly scalar
         if (replacement.type == RuntimeScalarType.READONLY_SCALAR) replacement = (RuntimeScalar) replacement.value;
@@ -2963,6 +2977,9 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         } catch (RegexTimeoutException e) {
             WarnDie.warn(new RuntimeScalar(e.getMessage() + "\n"), RuntimeScalarCache.scalarEmptyString);
             found = 0;
+        }
+        if (found == 0) {
+            state().lastMatchUsedPFlag = previousMatchUsedPFlag;
         }
         // Append the remaining text after the last match to the result buffer
         resultBuffer.append(inputStr, lastAppendEnd, inputStr.length());

--- a/src/test/resources/unit/regex/regex_inline_p_modifier.t
+++ b/src/test/resources/unit/regex/regex_inline_p_modifier.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+use Test::More tests => 15;
+
+{
+    my $subject = '012-345-6789';
+    ok($subject =~ /(?p)345/, 'standalone inline p matches');
+    is(${^PREMATCH}, '012-', 'standalone inline p exposes prematch');
+    is(${^MATCH}, '345', 'standalone inline p exposes match');
+    is(${^POSTMATCH}, '-6789', 'standalone inline p exposes postmatch');
+}
+
+{
+    my $subject = '012-345-6789';
+    ok($subject =~ /(?p:345)/, 'scoped inline p matches');
+    is(${^MATCH}, '345', 'scoped inline p exposes match');
+}
+
+{
+    my $subject = '012-AbC-6789';
+    ok($subject =~ /(?ip:abc)/, 'inline p composes with matcher modifiers');
+    is(${^MATCH}, 'AbC', 'combined inline modifiers expose exact match');
+}
+
+{
+    my $literal = '(?p)';
+    ok($literal =~ /\(\?p\)/, 'escaped modifier spelling remains literal');
+    ok(!defined ${^MATCH}, 'escaped modifier spelling does not enable p');
+}
+
+{
+    my $literal = 'p';
+    ok($literal =~ /[(?p)]/, 'modifier spelling in a class remains literal');
+    ok(!defined ${^MATCH}, 'character-class spelling does not enable p');
+}
+
+{
+    my $callback_match;
+    my $subject = 'a';
+    is($subject =~ s/(?p:a(?{ $callback_match = ${^MATCH} }))/b/, 1,
+        'inline p substitution callback executes');
+    is($callback_match, 'a', 'inline p is visible to substitution callback');
+    is($subject, 'b', 'inline p substitution retains normal replacement behavior');
+}

--- a/third_party/joni/src/org/joni/Parser.java
+++ b/third_party/joni/src/org/joni/Parser.java
@@ -629,13 +629,13 @@ class Parser extends Lexer {
                     newSyntaxException(UNDEFINED_GROUP_OPTION);
                 }
 
-            // case 'p': #ifdef USE_POSIXLINE_OPTION
             case '-':
             case 'i':
             case 'm':
             case 's':
             case 'x':
             case 'n':
+            case 'p':
             case 'a':
             case 'd':
             case 'l':
@@ -680,9 +680,14 @@ class Parser extends Lexer {
                             newSyntaxException(UNDEFINED_GROUP_OPTION);
                         }
                         break;
-                    // case 'p': #ifdef USE_POSIXLINE_OPTION // not defined
-                    // option = bsOnOff(option, Option.MULTILINE|Option.SINGLELINE, neg);
-                    // break;
+                    case 'p':
+                        // Perl's /p controls ${^PREMATCH}, ${^MATCH}, and
+                        // ${^POSTMATCH} retention in the host runtime. It has
+                        // no matcher option bit, but is valid inline syntax.
+                        if (!syntax.op2OptionPerl()) {
+                            newSyntaxException(UNDEFINED_GROUP_OPTION);
+                        }
+                        break;
 
                     case 'a':     /* limits \d, \s, \w and POSIX brackets to ASCII range */
                         if ((syntax.op2OptionPerl() || syntax.op2OptionRuby()) && !neg) {

--- a/third_party/joni/test/org/joni/test/TestPerlPreserveModifier.java
+++ b/third_party/joni/test/org/joni/test/TestPerlPreserveModifier.java
@@ -1,0 +1,48 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.joni.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.jcodings.specific.UTF8Encoding;
+import org.joni.Option;
+import org.joni.Regex;
+import org.joni.Syntax;
+import org.junit.Test;
+
+public class TestPerlPreserveModifier {
+    private static int search(String pattern, String input) {
+        byte[] patternBytes = pattern.getBytes(StandardCharsets.UTF_8);
+        byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+        Regex regex = new Regex(patternBytes, 0, patternBytes.length,
+                Option.NONE, UTF8Encoding.INSTANCE, Syntax.PerlNG);
+        return regex.matcher(inputBytes).search(0, inputBytes.length, Option.NONE);
+    }
+
+    @Test
+    public void acceptsPerlPreserveModifierAsMatcherNoOp() {
+        assertEquals(0, search("(?p)abc", "abc"));
+        assertEquals(0, search("(?p:abc)", "abc"));
+        assertEquals(0, search("(?ip:abc)", "ABC"));
+        assertEquals(0, search("(?-p:abc)", "abc"));
+    }
+}


### PR DESCRIPTION
## Summary

- accept Perl's inline `p` modifier in the vendored Joni parser as matcher-neutral syntax
- retain `${^PREMATCH}`, `${^MATCH}`, and `${^POSTMATCH}` in PerlOnJava source policy, including provisional callback state
- reject false preserve-policy detection for escaped text and character-class contents
- retain the vendored Joni copyright and license notices in the new fork test

## Phase 36 impact

- unchanged `perl5_t/t/re/reg_pmod.t`: 81/88 to 88/88 on both JVM and interpreter
- focused inline-`p` oracle: 15/15 on system Perl, JVM, and interpreter
- adds direct Joni coverage for standalone, scoped, combined, and negative inline `p`

## Validation

- `prove src/test/resources/unit/regex/regex_inline_p_modifier.t`
- bounded focused oracle on JVM and interpreter
- bounded unchanged `reg_pmod.t` on JVM and interpreter
- warning-free `make` (`BUILD SUCCESSFUL` in 5m24s), including Joni tests and packaging verification

## Stack

Base: PR #1013 (`wip/phase36-source-property-provenance`, exact prerequisite head `9eae6b8958a5355580bc756f7c3644672736399e`).

Generated with [OpenAI Codex](https://openai.com/codex)
