### PR TITLE
fix: preserve regex control escape operands

### DIFF
--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -240,6 +240,16 @@ passes on both execution backends; unchanged upstream coverage gains nine more
 assertions to reach 1,065/1,110, and all user-property diagnostic assertions
 through test 1,094 pass.
 
+Joni now accepts Perl's top-level, scoped, combined, and negative inline `p`
+syntax as matcher-neutral policy. PerlOnJava publishes that policy while
+ordinary and substitution callbacks execute, without misclassifying escaped or
+character-class text. The focused 15-assertion oracle passes on system Perl,
+JVM, and interpreter, and unchanged `reg_pmod.t` reaches 88/88 on both
+execution backends. Regex source scanning also consumes each `\c` operand
+before interpolation, so `\c@` cannot be mistaken for `@-`; the focused
+4-assertion oracle passes on all three runtimes and unchanged `subst.t` reaches
+250/281 on JVM and interpreter.
+
 Executable callback source and literal trailing `/x` comments survive canonical
 regex-object stringification on both execution backends. Recursive Joni call
 frames now preserve the Perl-visible caller capture view for optimistic
@@ -367,6 +377,13 @@ matcher-specific timeouts on both execution backends.
     Unicode-flag copies and later literal reuse. The focused oracle passes 8/8
     on system Perl, JVM, and interpreter; `regexp_unicode_prop.t` gains nine
     assertions to 1,065/1,110 on both execution backends.
+  - [x] Accepted inline `p` directly in Joni while retaining match-variable
+    policy in PerlOnJava, including provisional callback state. The focused
+    oracle passes 15/15 and unchanged `reg_pmod.t` passes 88/88 on JVM and
+    interpreter.
+  - [x] Preserved `\c` control operands through regex source interpolation.
+    The focused oracle passes 4/4 and unchanged `subst.t` gains test 154 on
+    both execution backends.
   - [ ] Complete the remaining built-in Unicode aliases.
 - [x] Phase 4: Runtime source and diagnostics (2026-08-17; semantic gate
   complete at 550/555)
@@ -392,11 +409,17 @@ matcher-specific timeouts on both execution backends.
    slices, then rerun the forced-Joni corpus from the new combined head.
 3. Capture the clean-branch JVM and interpreter 80-file baselines and compare
    both to PR 958 with the regression exit gate.
-4. Integrate PR #1011 and the deferred-property provenance slice, then finish
-   PerlOnJava4's built-in Unicode aliases against the 1,065/1,110 diagnostics
-   baseline. Fixing the 29 executed alias failures also unlocks 16 gated match
-   assertions, so the alias-complete target is 1,110/1,110.
-5. Keep the warning-free whole-unit-suite gate green with Joni as the default;
+4. Integrate PR #1011, the deferred-property provenance slice, inline-`p`
+   syntax, and control-escape source handling. Finish PerlOnJava4's built-in
+   Unicode aliases against the 1,065/1,110 diagnostics baseline. Fixing the 29
+   executed alias failures also unlocks 16 gated match assertions, so the
+   alias-complete target is 1,110/1,110.
+5. Give the matcher adapter an independent Joni `gpos` cursor. Substitution
+   must search before `pos` when pattern atoms precede `\G`; the current
+   start-at-`pos` shortcut causes `subst.t` tests 165-188 to miss every match.
+   Keep Java's temporary approximation isolated and use Joni's existing
+   `Matcher.search(gpos, start, range, option)` API for final semantics.
+6. Keep the warning-free whole-unit-suite gate green with Joni as the default;
    use explicit Java mode only to classify corpus regressions before Phase 5
    removes the legacy backend and selector.
 

--- a/src/main/java/org/perlonjava/frontend/parser/StringDoubleQuoted.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringDoubleQuoted.java
@@ -499,6 +499,11 @@ public class StringDoubleQuoted extends StringSegmentParser {
                 caseModifiers.push(new CaseModifier("Q", false));
             }
 
+            // A regex control escape consumes its operand before normal string
+            // interpolation sees it. In particular, the '@' in \c@ is not the
+            // start of @- when used in a range such as [\c@-\c_].
+            case "c" -> appendToCurrentSegment("\\c" + TokenUtils.consumeChar(parser));
+
             // Unknown escape - treat as literal character
             default -> appendToCurrentSegment("\\" + escape);
         }

--- a/src/test/resources/unit/regex/regex_control_character_range.t
+++ b/src/test/resources/unit/regex/regex_control_character_range.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+ok("\x00" =~ /[\c@-\c_]/, 'NUL is in the control-character range');
+ok("\x1f" =~ /[\c@-\c_]/, 'unit separator is in the control-character range');
+ok("\x20" !~ /[\c@-\c_]/, 'space is outside the control-character range');
+
+my $controls = "\x20\x00\x30\x01\x40\x1a\x50\x1f\x60";
+is($controls =~ s/[\c@-\c_]//gr, "\x20\x30\x40\x50\x60",
+   'substitution removes the complete control-character range');


### PR DESCRIPTION
## Summary

- consume a regex `\c` operand atomically before double-quote interpolation
- prevent the `@` in `\c@` from being parsed as the `@-` match-offset array
- preserve the original regex spelling for Joni to execute
- update the Phase 36 tracker with both completed slices and the reduced Joni `gpos` follow-up

## Phase 36 impact

- focused control-character range oracle: 4/4 on system Perl, JVM, and interpreter
- unchanged `perl5_t/t/re/subst.t`: 249/281 to 250/281 on JVM and interpreter, restoring test 154

## Validation

- `prove src/test/resources/unit/regex/regex_control_character_range.t`
- bounded focused oracle on JVM and interpreter
- bounded unchanged `subst.t` on JVM and interpreter
- warning-free `make` (`BUILD SUCCESSFUL` in 4m59s), including Joni tests and packaging verification

## Stack

Base: PR #1014 (`wip/phase36-joni-inline-p`, exact prerequisite head `785aa06a629ca2bf3129b195b23b352601fd68f4`).

Generated with [OpenAI Codex](https://openai.com/codex)
