### PR TITLE
fix: integrate Joni Unicode and G-position parity

### DIFF
--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -348,7 +348,7 @@ matcher-specific timeouts on both execution backends.
     system Perl, JVM, and interpreter.
   - [x] Removed the final `pat.t.patch` hunk, deleted the patch and its importer
     configuration, and resynchronized the unmodified Perl 5.44 `pat.t`.
-- [x] Phase 3: Unicode and pattern syntax completion (2026-08-17)
+- [ ] Phase 3: Unicode and pattern syntax completion (in progress)
   - [x] Added Perl escape syntax, Unicode-property resolution, scoped ASCII
     folds, possessive intervals, and bounded lookbehind support to Joni.
   - [x] Converted public regex `pos` values between Perl logical-character
@@ -367,10 +367,7 @@ matcher-specific timeouts on both execution backends.
     Unicode-flag copies and later literal reuse. The focused oracle passes 8/8
     on system Perl, JVM, and interpreter; `regexp_unicode_prop.t` gains nine
     assertions to 1,065/1,110 on both execution backends.
-  - [x] Completed Perl-compatible built-in Unicode alias normalization while
-    preserving deferred user-property precedence. The focused alias oracle
-    passes 16/16 on system Perl, JVM, and interpreter; unchanged
-    `regexp_unicode_prop.t` passes 1,110/1,110 on both execution backends.
+  - [ ] Complete the remaining built-in Unicode aliases.
 - [x] Phase 4: Runtime source and diagnostics (2026-08-17; semantic gate
   complete at 550/555)
   - [x] Preserved mixed executable-source provenance, nested dynamic callback
@@ -386,14 +383,20 @@ matcher-specific timeouts on both execution backends.
 
 ### Next Steps
 
-1. Integrate the stacked offset-map, regex-set, Joni safeguard, property
-   diagnostics, provenance, and Unicode-alias branches while retaining their
-   validated prerequisite heads.
-2. Rerun the forced-Joni corpus from the combined head and capture clean JVM
-   and interpreter 80-file baselines for comparison with PR 958.
-3. Classify residual generated-fixture and engine-introspection exclusions,
-   then queue the largest remaining semantic cluster as a focused slice.
-4. Keep the warning-free whole-unit-suite gate green with Joni as the default;
+1. Remediate the remaining forced-Joni failure causes, starting with the
+   catastrophic `regexp*` cluster and absent generated Unicode fixtures; keep
+   per-child hard limits throughout. PR #1008 has removed the release-blocking
+   `pat_psycho*` offset-map reconstruction and bounded profiling confirms that
+   matcher-wrapper reuse is no longer on the critical path.
+2. Integrate the stacked Joni offset-map, regex-set property, and CEC timeout
+   slices, then rerun the forced-Joni corpus from the new combined head.
+3. Capture the clean-branch JVM and interpreter 80-file baselines and compare
+   both to PR 958 with the regression exit gate.
+4. Integrate PR #1011 and the deferred-property provenance slice, then finish
+   PerlOnJava4's built-in Unicode aliases against the 1,065/1,110 diagnostics
+   baseline. Fixing the 29 executed alias failures also unlocks 16 gated match
+   assertions, so the alias-complete target is 1,110/1,110.
+5. Keep the warning-free whole-unit-suite gate green with Joni as the default;
    use explicit Java mode only to classify corpus regressions before Phase 5
    removes the legacy backend and selector.
 

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -250,6 +250,12 @@ before interpolation, so `\c@` cannot be mistaken for `@-`; the focused
 4-assertion oracle passes on all three runtimes and unchanged `subst.t` reaches
 250/281 on JVM and interpreter.
 
+The matcher adapter now carries Joni's search start and Perl `\G` position as
+independent cursors, including Unicode offset conversion. The focused
+12-assertion oracle passes on system Perl, JVM, and interpreter; unchanged
+`subst.t` reaches 275/281 on both execution backends with tests 165-188
+restored. The temporary Java backend retains its start-at-`pos` approximation.
+
 Executable callback source and literal trailing `/x` comments survive canonical
 regex-object stringification on both execution backends. Recursive Joni call
 frames now preserve the Perl-visible caller capture view for optimistic
@@ -322,6 +328,10 @@ matcher-specific timeouts on both execution backends.
     `/g` hot loop. The focused million-match oracle completes in 1.07 seconds
     on JVM and 1.41 seconds on interpreter (PR #1008), with exact map and
     supplementary-character capture-boundary coverage.
+  - [x] Separated Joni's search-start and `\G` cursors for ordinary matching
+    and substitution, including Unicode subjects and code replacements. The
+    focused oracle passes 12/12 and unchanged `subst.t` passes 275/281 on JVM
+    and interpreter.
 - [x] Phase 2: Conditions and backtracking-visible state (2026-08-17)
   - [x] Implemented executable callback conditions, control verbs including
     `(*MARK:NAME)`, and callback-visible recursive capture state in Joni.
@@ -358,7 +368,7 @@ matcher-specific timeouts on both execution backends.
     system Perl, JVM, and interpreter.
   - [x] Removed the final `pat.t.patch` hunk, deleted the patch and its importer
     configuration, and resynchronized the unmodified Perl 5.44 `pat.t`.
-- [ ] Phase 3: Unicode and pattern syntax completion (in progress)
+- [x] Phase 3: Unicode and pattern syntax completion (2026-08-17)
   - [x] Added Perl escape syntax, Unicode-property resolution, scoped ASCII
     folds, possessive intervals, and bounded lookbehind support to Joni.
   - [x] Converted public regex `pos` values between Perl logical-character
@@ -384,7 +394,10 @@ matcher-specific timeouts on both execution backends.
   - [x] Preserved `\c` control operands through regex source interpolation.
     The focused oracle passes 4/4 and unchanged `subst.t` gains test 154 on
     both execution backends.
-  - [ ] Complete the remaining built-in Unicode aliases.
+  - [x] Completed Perl-compatible built-in Unicode alias normalization while
+    preserving deferred user-property precedence. The focused alias oracle
+    passes 16/16 on system Perl, JVM, and interpreter; unchanged
+    `regexp_unicode_prop.t` passes 1,110/1,110 on both execution backends.
 - [x] Phase 4: Runtime source and diagnostics (2026-08-17; semantic gate
   complete at 550/555)
   - [x] Preserved mixed executable-source provenance, nested dynamic callback
@@ -400,26 +413,16 @@ matcher-specific timeouts on both execution backends.
 
 ### Next Steps
 
-1. Remediate the remaining forced-Joni failure causes, starting with the
-   catastrophic `regexp*` cluster and absent generated Unicode fixtures; keep
-   per-child hard limits throughout. PR #1008 has removed the release-blocking
-   `pat_psycho*` offset-map reconstruction and bounded profiling confirms that
-   matcher-wrapper reuse is no longer on the critical path.
-2. Integrate the stacked Joni offset-map, regex-set property, and CEC timeout
-   slices, then rerun the forced-Joni corpus from the new combined head.
-3. Capture the clean-branch JVM and interpreter 80-file baselines and compare
-   both to PR 958 with the regression exit gate.
-4. Integrate PR #1011, the deferred-property provenance slice, inline-`p`
-   syntax, and control-escape source handling. Finish PerlOnJava4's built-in
-   Unicode aliases against the 1,065/1,110 diagnostics baseline. Fixing the 29
-   executed alias failures also unlocks 16 gated match assertions, so the
-   alias-complete target is 1,110/1,110.
-5. Give the matcher adapter an independent Joni `gpos` cursor. Substitution
-   must search before `pos` when pattern atoms precede `\G`; the current
-   start-at-`pos` shortcut causes `subst.t` tests 165-188 to miss every match.
-   Keep Java's temporary approximation isolated and use Joni's existing
-   `Matcher.search(gpos, start, range, option)` API for final semantics.
-6. Keep the warning-free whole-unit-suite gate green with Joni as the default;
+1. Complete the combined offset-map, regex-set, Joni safeguard, property
+   diagnostics/provenance, Unicode-alias, inline-`p`, and control-escape
+   integration while retaining each validated prerequisite head.
+2. Integrate the lossless generated Unicode fixtures, then rerun the
+   forced-Joni corpus from the combined head with every child hard-bounded.
+3. Capture clean JVM and interpreter 80-file baselines and compare every file
+   with PR 958 under the no-regression gate.
+4. Classify residual engine-introspection exclusions, then queue the largest
+   remaining semantic cluster as a focused slice.
+5. Keep the warning-free whole-unit-suite gate green with Joni as the default;
    use explicit Java mode only to classify corpus regressions before Phase 5
    removes the legacy backend and selector.
 

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -348,7 +348,7 @@ matcher-specific timeouts on both execution backends.
     system Perl, JVM, and interpreter.
   - [x] Removed the final `pat.t.patch` hunk, deleted the patch and its importer
     configuration, and resynchronized the unmodified Perl 5.44 `pat.t`.
-- [ ] Phase 3: Unicode and pattern syntax completion (in progress)
+- [x] Phase 3: Unicode and pattern syntax completion (2026-08-17)
   - [x] Added Perl escape syntax, Unicode-property resolution, scoped ASCII
     folds, possessive intervals, and bounded lookbehind support to Joni.
   - [x] Converted public regex `pos` values between Perl logical-character
@@ -367,7 +367,10 @@ matcher-specific timeouts on both execution backends.
     Unicode-flag copies and later literal reuse. The focused oracle passes 8/8
     on system Perl, JVM, and interpreter; `regexp_unicode_prop.t` gains nine
     assertions to 1,065/1,110 on both execution backends.
-  - [ ] Complete the remaining built-in Unicode aliases.
+  - [x] Completed Perl-compatible built-in Unicode alias normalization while
+    preserving deferred user-property precedence. The focused alias oracle
+    passes 16/16 on system Perl, JVM, and interpreter; unchanged
+    `regexp_unicode_prop.t` passes 1,110/1,110 on both execution backends.
 - [x] Phase 4: Runtime source and diagnostics (2026-08-17; semantic gate
   complete at 550/555)
   - [x] Preserved mixed executable-source provenance, nested dynamic callback
@@ -383,20 +386,14 @@ matcher-specific timeouts on both execution backends.
 
 ### Next Steps
 
-1. Remediate the remaining forced-Joni failure causes, starting with the
-   catastrophic `regexp*` cluster and absent generated Unicode fixtures; keep
-   per-child hard limits throughout. PR #1008 has removed the release-blocking
-   `pat_psycho*` offset-map reconstruction and bounded profiling confirms that
-   matcher-wrapper reuse is no longer on the critical path.
-2. Integrate the stacked Joni offset-map, regex-set property, and CEC timeout
-   slices, then rerun the forced-Joni corpus from the new combined head.
-3. Capture the clean-branch JVM and interpreter 80-file baselines and compare
-   both to PR 958 with the regression exit gate.
-4. Integrate PR #1011 and the deferred-property provenance slice, then finish
-   PerlOnJava4's built-in Unicode aliases against the 1,065/1,110 diagnostics
-   baseline. Fixing the 29 executed alias failures also unlocks 16 gated match
-   assertions, so the alias-complete target is 1,110/1,110.
-5. Keep the warning-free whole-unit-suite gate green with Joni as the default;
+1. Integrate the stacked offset-map, regex-set, Joni safeguard, property
+   diagnostics, provenance, and Unicode-alias branches while retaining their
+   validated prerequisite heads.
+2. Rerun the forced-Joni corpus from the combined head and capture clean JVM
+   and interpreter 80-file baselines for comparison with PR 958.
+3. Classify residual generated-fixture and engine-introspection exclusions,
+   then queue the largest remaining semantic cluster as a focused slice.
+4. Keep the warning-free whole-unit-suite gate green with Joni as the default;
    use explicit Java mode only to classify corpus regressions before Phase 5
    removes the legacy backend and selector.
 

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -117,6 +117,7 @@ final class JoniRegexPattern {
             String pattern, RegexFlags flags) {
         StringBuilder translated = new StringBuilder(pattern.length());
         boolean deferred = false;
+        int extendedClassBracketDepth = 0;
         for (int i = 0; i < pattern.length(); i++) {
             char ch = pattern.charAt(i);
             if (ch == '\\' && i + 1 < pattern.length() && pattern.charAt(i + 1) == '\\') {
@@ -124,10 +125,31 @@ final class JoniRegexPattern {
                 i++;
                 continue;
             }
+            if (extendedClassBracketDepth == 0 && pattern.startsWith("(?[", i)) {
+                translated.append("(?[");
+                extendedClassBracketDepth = 1;
+                i += 2;
+                continue;
+            }
+            if (extendedClassBracketDepth > 0 && ch == '[') {
+                extendedClassBracketDepth++;
+                translated.append(ch);
+                continue;
+            }
+            if (extendedClassBracketDepth > 0 && ch == ']') {
+                extendedClassBracketDepth--;
+                translated.append(ch);
+                continue;
+            }
             if (ch != '\\' || i + 3 >= pattern.length()
                     || (pattern.charAt(i + 1) != 'p' && pattern.charAt(i + 1) != 'P')
                     || pattern.charAt(i + 2) != '{') {
-                translated.append(ch);
+                if (ch == '\\' && i + 1 < pattern.length()) {
+                    translated.append(pattern, i, i + 2);
+                    i++;
+                } else {
+                    translated.append(ch);
+                }
                 continue;
             }
             int end = pattern.indexOf('}', i + 3);
@@ -143,6 +165,11 @@ final class JoniRegexPattern {
                     "(?i)^(?:scx|script[_ ]?extensions)\\s*=.*");
             boolean frontendProperty = unnegated.matches(
                     "(?i)^(?:script|block|blk|age|in|present[_ ]?in)\\s*=.*");
+            if (frontendProperty && extendedClassBracketDepth > 0) {
+                translated.append(pattern, i, end + 1);
+                i = end;
+                continue;
+            }
             if (!userDefined && !scriptExtensions && !frontendProperty) {
                 translated.append(pattern, i, end + 1);
                 i = end;

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.List;
+import java.util.WeakHashMap;
 
 import org.perlonjava.runtime.operators.WarnDie;
 import org.perlonjava.runtime.runtimetypes.*;
@@ -30,6 +31,8 @@ import org.perlonjava.runtime.runtimetypes.*;
  * beyond the Java Pattern fast path.
  */
 final class JoniRegexPattern {
+    private static final Map<String, InputEncoding> INPUT_ENCODINGS = new WeakHashMap<>();
+
     // Ruby syntax defaults \w to ASCII even for a Unicode encoding. Perl's
     // default and /u modes use Unicode character classes; /a adds ASCII_RANGE
     // explicitly in toJoniOptions(). Keep the richer Ruby parser surface used
@@ -79,6 +82,21 @@ final class JoniRegexPattern {
                          RuntimeScalar subject) {
         return new JoniRegexMatcher(regex, sourcePattern, namedGroups, flags,
                 hasControlVerbState, input, callbacks, subject);
+    }
+
+    record InputEncoding(byte[] bytes, int[] charToByte, int[] byteToChar) {}
+
+    static InputEncoding inputEncoding(String input) {
+        synchronized (INPUT_ENCODINGS) {
+            return INPUT_ENCODINGS.computeIfAbsent(input, JoniRegexPattern::buildInputEncoding);
+        }
+    }
+
+    private static InputEncoding buildInputEncoding(String input) {
+        byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
+        int[] charToByte = JoniRegexMatcher.buildCharToByte(input);
+        int[] byteToChar = JoniRegexMatcher.buildByteToChar(input, bytes.length, charToByte);
+        return new InputEncoding(bytes, charToByte, byteToChar);
     }
 
     String patternDescription() {
@@ -602,9 +620,10 @@ final class JoniRegexPattern {
             this.input = input;
             this.callbacks = callbacks;
             this.subject = subject;
-            this.bytes = input.getBytes(StandardCharsets.UTF_8);
-            this.charToByte = buildCharToByte(input);
-            this.byteToChar = buildByteToChar(input, bytes.length, charToByte);
+            InputEncoding encoding = inputEncoding(input);
+            this.bytes = encoding.bytes();
+            this.charToByte = encoding.charToByte();
+            this.byteToChar = encoding.byteToChar();
             region(0, input.length());
         }
 
@@ -772,12 +791,16 @@ final class JoniRegexPattern {
 
         private static int[] buildByteToChar(String input, int byteLength, int[] charToByte) {
             int[] offsets = new int[byteLength + 1];
-            int charOffset = 0;
-            for (int b = 0; b <= byteLength; b++) {
-                while (charOffset + 1 < charToByte.length && charToByte[charOffset + 1] <= b) {
-                    charOffset++;
+            for (int charOffset = 0; charOffset < input.length();) {
+                int chars = Character.charCount(input.codePointAt(charOffset));
+                int nextCharOffset = charOffset + chars;
+                int nextByteOffset = charToByte[nextCharOffset];
+                for (int byteOffset = charToByte[charOffset];
+                     byteOffset < nextByteOffset; byteOffset++) {
+                    offsets[byteOffset] = charOffset;
                 }
-                offsets[b] = charOffset;
+                offsets[nextByteOffset] = nextCharOffset;
+                charOffset = nextCharOffset;
             }
             return offsets;
         }

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -165,12 +165,13 @@ final class JoniRegexPattern {
                     "(?i)^(?:scx|script[_ ]?extensions)\\s*=.*");
             boolean frontendProperty = unnegated.matches(
                     "(?i)^(?:script|block|blk|age|in|present[_ ]?in)\\s*=.*");
+            boolean perlBuiltInAlias = UnicodeResolver.isPerlBuiltInPropertyAlias(unnegated);
             if (frontendProperty && extendedClassBracketDepth > 0) {
                 translated.append(pattern, i, end + 1);
                 i = end;
                 continue;
             }
-            if (!userDefined && !scriptExtensions && !frontendProperty) {
+            if (!userDefined && !scriptExtensions && !frontendProperty && !perlBuiltInAlias) {
                 translated.append(pattern, i, end + 1);
                 i = end;
                 continue;

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -630,6 +630,7 @@ final class JoniRegexPattern {
         private int regionStart;
         private int regionEnd;
         private int nextStart;
+        private int globalPosition = -1;
         private boolean matched;
         private int committedLastClosedCapture = -1;
         private final boolean hasControlVerbState;
@@ -680,9 +681,15 @@ final class JoniRegexPattern {
             }
             int result;
             try {
-                result = anchored
-                        ? matcher.match(charToByte[nextStart], charToByte[regionEnd], option)
-                        : matcher.search(charToByte[nextStart], charToByte[regionEnd], option);
+                if (globalPosition >= 0) {
+                    result = matcher.search(charToByte[globalPosition], charToByte[nextStart],
+                            charToByte[regionEnd], option);
+                    if (anchored && result != charToByte[nextStart]) result = -1;
+                } else {
+                    result = anchored
+                            ? matcher.match(charToByte[nextStart], charToByte[regionEnd], option)
+                            : matcher.search(charToByte[nextStart], charToByte[regionEnd], option);
+                }
             } catch (RuntimeException | Error failure) {
                 if (calloutHandler != null) calloutHandler.abort();
                 throw failure;
@@ -724,6 +731,12 @@ final class JoniRegexPattern {
 
         @Override public void useAnchoringBounds(boolean enabled) { }
         @Override public void useTransparentBounds(boolean enabled) { }
+        @Override
+        public boolean setGlobalPosition(int position) {
+            if (position < 0 || position > input.length()) return false;
+            globalPosition = position;
+            return true;
+        }
         @Override public int start() { return toCharOffset(matcher.getBegin()); }
         @Override public int end() { return toCharOffset(matcher.getEnd()); }
         @Override public int start(int index) { return groupOffset(index, true); }

--- a/src/main/java/org/perlonjava/runtime/regex/RegexMatcher.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexMatcher.java
@@ -19,6 +19,12 @@ public interface RegexMatcher {
 
     void useTransparentBounds(boolean enabled);
 
+    /**
+     * Set an independent Perl {@code \G} anchor while retaining the current
+     * search start. Backends without a separate gpos cursor return false.
+     */
+    default boolean setGlobalPosition(int position) { return false; }
+
     int start();
 
     int end();

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -1937,6 +1937,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         RuntimeScalar posScalar = null;
         boolean isPosDefined = false;
         int startPos = 0;
+        boolean nativeGlobalPosition = false;
         // Flag to skip the first find() when the notempty variant already found a match
         boolean skipFirstFind = false;
         
@@ -2017,6 +2018,10 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             }
         }
 
+        if (regex.useGAssertion) {
+            nativeGlobalPosition = matcher.setGlobalPosition(startPos);
+        }
+
         if (regex.requiredLiteral != null && !inputStr.contains(regex.requiredLiteral)) {
             if (DEBUG_REGEX) {
                 System.err.println("  required literal prefilter failed: " + regex.requiredLiteral);
@@ -2040,7 +2045,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         // Start matching from the current position if defined
         // (skip if notempty variant already found a match - region() would reset the matcher)
         if (isPosDefined && !skipFirstFind) {
-            matcher.region(startPos, inputStr.length());
+            matcher.region(nativeGlobalPosition ? 0 : startPos, inputStr.length());
             // Disable anchoring bounds so ^ and $ in /m mode anchor only at real
             // line breaks in the input, not at the artificial region boundary.
             // Java's default useAnchoringBounds(true) would let ^ match at startPos
@@ -2074,7 +2079,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 skipFirstFind = false;
                 // If \G is used, ensure the match starts at the expected position.
                 // When pos() is undefined, \G anchors at 0 (the default startPos).
-                if (regex.useGAssertion && matcher.start() != startPos) {
+                if (regex.useGAssertion && !nativeGlobalPosition
+                        && matcher.start() != startPos) {
                     break;
                 }
 
@@ -2159,6 +2165,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                         break; // Break out of the loop after the first match in SCALAR context
                     } else {
                         startPos = matchEnd;
+                        if (nativeGlobalPosition) matcher.setGlobalPosition(startPos);
                         if (posScalar != null) {
                             posScalar.set(RuntimePosLvalue.fromMatcherOffset(
                                     string, inputStr, startPos));
@@ -2790,6 +2797,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 ? compileNonEmptySubstitutionPattern(pattern)
                 : null;
         int searchStart = 0;
+        int globalPosition = 0;
+        boolean nativeGlobalPosition = false;
 
         // Honor pos() when \G is used. `s/\G.../.../` should anchor at
         // pos($string) so a substitution inserted right after a previous /g
@@ -2803,9 +2812,11 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 int startPos = RuntimePosLvalue.toMatcherOffset(
                         string, inputStr, posScalar.getInt());
                 if (startPos >= 0 && startPos <= inputStr.length()) {
-                    searchStart = startPos;
+                    globalPosition = startPos;
                 }
             }
+            nativeGlobalPosition = matcher.setGlobalPosition(globalPosition);
+            if (!nativeGlobalPosition) searchStart = globalPosition;
         }
 
         // The result string after substitutions
@@ -2837,6 +2848,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         try {
             while (searchStart <= inputStr.length()) {
                 setSubstitutionRegion(matcher, searchStart, inputStr.length(), true);
+                if (nativeGlobalPosition) matcher.setGlobalPosition(globalPosition);
                 if (!matcher.find()) {
                     break;
                 }
@@ -2902,6 +2914,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
 
                 if (matcher.end() > matcher.start()) {
                     searchStart = matcher.end();
+                    globalPosition = searchStart;
                     continue;
                 }
 
@@ -2917,6 +2930,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                     // The synthetic (?<=[\s\S]) suffix relies on opaque bounds
                     // so a zero-length match at the region start is rejected.
                     setSubstitutionRegion(retryMatcher, zeroLengthOffset, inputStr.length(), false);
+                    if (nativeGlobalPosition) retryMatcher.setGlobalPosition(zeroLengthOffset);
                     boolean retryFound = nonEmptySubstitutionPattern != null
                             ? retryMatcher.find() : retryMatcher.findNotEmpty();
                     if (retryFound
@@ -2966,12 +2980,14 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                             }
                         }
                         searchStart = retryMatcher.end();
+                        globalPosition = searchStart;
                         consumedNonEmptyRetry = true;
                     }
                 }
 
                 if (!consumedNonEmptyRetry) {
                     searchStart = bumpGlobalMatchPosition(inputStr, zeroLengthOffset);
+                    globalPosition = searchStart;
                 }
             }
         } catch (RegexTimeoutException e) {

--- a/src/main/java/org/perlonjava/runtime/regex/UnicodeResolver.java
+++ b/src/main/java/org/perlonjava/runtime/regex/UnicodeResolver.java
@@ -360,6 +360,9 @@ public class UnicodeResolver {
      * @return A UnicodeSet, or null if the property cannot be resolved
      */
     private static UnicodeSet resolveStandardPropertyAsSet(String property, Set<String> recursionSet) {
+        UnicodeSet perlBuiltInAlias = resolvePerlBuiltInPropertyAlias(property);
+        if (perlBuiltInAlias != null) return perlBuiltInAlias;
+
         // Handle well-known Perl property aliases
         switch (property) {
             case "XPosixSpace": case "XPerlSpace": case "SpacePerl":
@@ -714,6 +717,11 @@ public class UnicodeResolver {
                 // Property not found - fall through to throw error below
             }
 
+            UnicodeSet perlBuiltInAlias = resolvePerlBuiltInPropertyAlias(property);
+            if (perlBuiltInAlias != null) {
+                return wrapCharClass(unicodeSetToJavaPattern(perlBuiltInAlias), negated);
+            }
+
             // Special cases - Perl XPosix properties not natively supported in Java
             switch (property) {
                 case "lb=cr":
@@ -922,6 +930,80 @@ public class UnicodeResolver {
 
     static boolean isUserDefinedPropertyName(String property) {
         return property != null && USER_DEFINED_PROPERTY_NAME.matcher(property).matches();
+    }
+
+    static boolean isPerlBuiltInPropertyAlias(String property) {
+        return resolvePerlBuiltInPropertyAlias(property) != null;
+    }
+
+    private static UnicodeSet resolvePerlBuiltInPropertyAlias(String property) {
+        if (property == null) return null;
+
+        String alias = property.trim();
+        if (alias.equalsIgnoreCase("L&")) {
+            UnicodeSet casedLetters = unicodePropertyValueSet(
+                    UProperty.GENERAL_CATEGORY, "UppercaseLetter");
+            casedLetters.addAll(unicodePropertyValueSet(
+                    UProperty.GENERAL_CATEGORY, "LowercaseLetter"));
+            casedLetters.addAll(unicodePropertyValueSet(
+                    UProperty.GENERAL_CATEGORY, "TitlecaseLetter"));
+            return casedLetters;
+        }
+
+        int equals = alias.indexOf('=');
+        if (equals > 0 && loosePropertyName(alias.substring(0, equals)).equals("category")) {
+            return unicodePropertyValueSet(
+                    UProperty.GENERAL_CATEGORY, alias.substring(equals + 1));
+        }
+
+        String blockAlias = alias;
+        if (alias.length() > 2 && alias.regionMatches(true, 0, "in", 0, 2)) {
+            int valueStart = 2;
+            while (valueStart < alias.length()) {
+                char separator = alias.charAt(valueStart);
+                if (!Character.isWhitespace(separator) && separator != '-' && separator != '_') break;
+                valueStart++;
+            }
+            if (valueStart >= alias.length()) return null;
+            blockAlias = alias.substring(valueStart);
+        } else if (equals >= 0 || unicodePropertyValue(UProperty.SCRIPT, alias) >= 0) {
+            return null;
+        }
+
+        int blockValue = unicodePropertyValue(UProperty.BLOCK, blockAlias);
+        if (blockValue < 0) return null;
+        String canonicalBlock = UCharacter.getPropertyValueName(
+                UProperty.BLOCK, blockValue, UProperty.NameChoice.LONG);
+        if (canonicalBlock == null || !loosePropertyName(blockAlias)
+                .equals(loosePropertyName(canonicalBlock))) {
+            return null;
+        }
+        return new UnicodeSet().applyIntPropertyValue(UProperty.BLOCK, blockValue);
+    }
+
+    private static String loosePropertyName(String value) {
+        StringBuilder normalized = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (!Character.isWhitespace(ch) && ch != '-' && ch != '_') {
+                normalized.append(Character.toLowerCase(ch));
+            }
+        }
+        return normalized.toString();
+    }
+
+    private static UnicodeSet unicodePropertyValueSet(int property, String alias) {
+        int value = unicodePropertyValue(property, alias);
+        if (value < 0) return null;
+        return new UnicodeSet().applyIntPropertyValue(property, value);
+    }
+
+    private static int unicodePropertyValue(int property, String alias) {
+        try {
+            return UCharacter.getPropertyValueEnum(property, alias);
+        } catch (IllegalArgumentException ignored) {
+            return -1;
+        }
     }
 
     private static String translatePerlAgeProperty(String property, boolean negated) {

--- a/src/test/java/org/perlonjava/runtime/regex/JoniRegexPatternTest.java
+++ b/src/test/java/org/perlonjava/runtime/regex/JoniRegexPatternTest.java
@@ -119,4 +119,15 @@ class JoniRegexPatternTest {
         assertEquals(0, matcher.start(1));
         assertEquals(2, matcher.end(1));
     }
+
+    @Test
+    void resolvesBlockPropertiesInsideExtendedClassesBeforeJoniCompilation() {
+        JoniRegexPattern pattern = new JoniRegexPattern(
+                "(?[ [k] + \\p{Blk=ASCII} ])",
+                RegexFlags.fromModifiers("i", "(?[ [k] + \\p{Blk=ASCII} ])"));
+
+        assertTrue(pattern.matcher("k", java.util.List.of()).find());
+        assertTrue(pattern.matcher("A", java.util.List.of()).find());
+        assertFalse(pattern.matcher("\u017F", java.util.List.of()).find());
+    }
 }

--- a/src/test/java/org/perlonjava/runtime/regex/JoniRegexPatternTest.java
+++ b/src/test/java/org/perlonjava/runtime/regex/JoniRegexPatternTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("unit")
@@ -93,5 +95,28 @@ class JoniRegexPatternTest {
                 .matcher("aa", java.util.List.of()).find());
         assertTrue(new JoniRegexPattern("\\p{Latin}{ , 2 }", FLAGS)
                 .matcher("a", java.util.List.of()).find());
+    }
+
+    @Test
+    void reusesImmutableInputEncodingAndPreservesSupplementaryOffsets() {
+        String input = new String("A\u00E9\uD83D\uDE42Z");
+
+        JoniRegexPattern.InputEncoding first = JoniRegexPattern.inputEncoding(input);
+        JoniRegexPattern.InputEncoding second = JoniRegexPattern.inputEncoding(input);
+
+        assertSame(first, second);
+        assertArrayEquals(new int[] {0, 1, 3, 3, 7, 8}, first.charToByte());
+        assertArrayEquals(new int[] {0, 1, 1, 2, 2, 2, 2, 4, 5}, first.byteToChar());
+    }
+
+    @Test
+    void supplementaryCaptureUsesTheHighSurrogateBoundary() {
+        RegexMatcher matcher = new JoniRegexPattern("(.)", FLAGS)
+                .matcher("\uD83D\uDE42", java.util.List.of());
+
+        assertTrue(matcher.find());
+        assertEquals("\uD83D\uDE42", matcher.group(1));
+        assertEquals(0, matcher.start(1));
+        assertEquals(2, matcher.end(1));
     }
 }

--- a/src/test/resources/unit/regex/joni_global_offset_reuse.t
+++ b/src/test/resources/unit/regex/joni_global_offset_reuse.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+my $repetitions = 2_000;
+my $subject = "A\x{E9}\x{1F642}" x $repetitions;
+my ($matches, $last) = (0, '');
+
+while ($subject =~ /(.)/g) {
+    $matches++;
+    $last = $1;
+}
+
+is($matches, 3 * $repetitions, 'global match visits every Unicode code point');
+is($last, "\x{1F642}", 'last capture retains a supplementary code point');
+ok(!defined(pos($subject)), 'failed terminal global match resets pos');

--- a/src/test/resources/unit/regex/regex_gpos_independent_search.t
+++ b/src/test/resources/unit/regex/regex_gpos_independent_search.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+use Test::More tests => 12;
+
+my $subject = '123456';
+pos($subject) = 4;
+is($subject =~ s/\d\d\G/7/g, 1, 'atoms before G match once');
+is($subject, '12756', 'short replacement after atoms before G');
+
+$subject = '123456';
+pos($subject) = 4;
+is($subject =~ s/\d\d\G/789/g, 1, 'long replacement matches once');
+is($subject, '1278956', 'long replacement does not move the input anchor');
+
+$subject = '123456';
+pos($subject) = 4;
+is($subject =~ s/\d\d(?=\d\G)/7/g, 1, 'lookahead observes independent G');
+is($subject, '17456', 'lookahead replacement uses the earlier match start');
+
+$subject = '123456';
+pos($subject) = 4;
+my $replacement = sub { '78' };
+is($subject =~ s/\d\d\G/$replacement->()/eg, 1,
+   'code replacement preserves independent G');
+is($subject, '127856', 'code replacement result is applied once');
+
+$subject = '123456';
+pos($subject) = 4;
+ok($subject =~ /\d\d\G/g, 'ordinary global match can begin before G');
+is($&, '34', 'ordinary match ends at the external position');
+
+$subject = "\x{3b1}12";
+pos($subject) = 2;
+ok($subject =~ /\d\G/g, 'G uses Perl character offsets on Unicode input');
+is($&, '1', 'Unicode match begins before the independent G position');

--- a/src/test/resources/unit/regex/regex_sets_ascii_property.t
+++ b/src/test/resources/unit/regex/regex_sets_ascii_property.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More tests => 3;
+
+my $pattern = qr/(?[ [k] + \p{Blk=ASCII} ])/i;
+
+ok("k" =~ $pattern, 'case-folded literal remains in the set');
+ok("A" =~ $pattern, 'ASCII block property remains in the set');
+ok("\x{17f}" !~ $pattern, '/i does not expand the ASCII block property');

--- a/src/test/resources/unit/regex/unicode_property_aliases.t
+++ b/src/test/resources/unit/regex/unicode_property_aliases.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More tests => 16;
+
+ok('A' =~ /^\p{L&}$/, 'L& matches a cased letter');
+ok('1' !~ /^\p{L&}$/, 'L& rejects a digit');
+ok(chr(0xAC00) =~ /^\p{HangulSyllables}$/, 'bare Hangul block alias matches');
+ok('A' !~ /^\p{HangulSyllables}$/, 'bare Hangul block alias rejects Latin');
+ok('A' =~ /^\p{Category=UppercaseLetter}$/, 'Category long value matches');
+ok('a' !~ /^\p{Category=UppercaseLetter}$/, 'Category long value rejects lowercase');
+ok(chr(0xFF) =~ /^\p{latin-1   supplement}$/, 'loose bare block alias matches');
+ok(chr(0x100) !~ /^\p{latin-1   supplement}$/, 'loose bare block alias rejects next block');
+ok('A' =~ /^\p{InBasicLatin}$/, 'InBasicLatin matches its block');
+ok(chr(0x80) !~ /^\p{InBasicLatin}$/, 'InBasicLatin rejects next block');
+ok(chr(0x80) =~ /^\p{InLatin1Supplement}$/, 'InLatin1Supplement matches');
+ok('A' !~ /^\p{InLatin1Supplement}$/, 'InLatin1Supplement rejects Basic Latin');
+ok(chr(0x100) =~ /^\p{InLatinExtendedA}$/, 'InLatinExtendedA matches');
+ok(chr(0xFF) !~ /^\p{InLatinExtendedA}$/, 'InLatinExtendedA rejects prior block');
+ok(chr(0x30A1) =~ /^\p{InKatakana}$/, 'InKatakana matches');
+ok(chr(0x3041) !~ /^\p{InKatakana}$/, 'InKatakana rejects Hiragana');

--- a/third_party/joni/src/org/joni/Analyser.java
+++ b/third_party/joni/src/org/joni/Analyser.java
@@ -130,7 +130,9 @@ final class Analyser extends Parser {
         }
 
         if (Config.USE_CEC) {
-            if (env.backrefedMem == 0 || (Config.USE_SUBEXP_CALL && env.numCall == 0)) {
+            if (env.backrefedMem == 0 &&
+                    (!Config.USE_SUBEXP_CALL || env.numCall == 0) &&
+                    !env.hasCallout) {
                 setupCombExpCheck(root, 0);
 
                 if (Config.USE_SUBEXP_CALL && env.hasRecursion) {

--- a/third_party/joni/src/org/joni/ArrayCompiler.java
+++ b/third_party/joni/src/org/joni/ArrayCompiler.java
@@ -1355,10 +1355,11 @@ final class ArrayCompiler extends Compiler {
             break;
 
         case NodeType.QTFR:
-            if (Config.USE_CEC) {
-                len = compileCECLengthQuantifierNode((QuantifierNode)node);
+            QuantifierNode quantifier = (QuantifierNode)node;
+            if (Config.USE_CEC && regex.numCombExpCheck > 0 && quantifier.combExpCheckNum > 0) {
+                len = compileCECLengthQuantifierNode(quantifier);
             } else {
-                len = compileNonCECLengthQuantifierNode((QuantifierNode)node);
+                len = compileNonCECLengthQuantifierNode(quantifier);
             }
             break;
 

--- a/third_party/joni/src/org/joni/ByteCodeMachine.java
+++ b/third_party/joni/src/org/joni/ByteCodeMachine.java
@@ -1151,7 +1151,6 @@ class ByteCodeMachine extends StackMachine implements MatchView {
             sprev = s;
             s += n;
         }
-        sprev = sbegin; // break;
     }
 
     private void opStateCheckAnyCharStarSb() {
@@ -1165,7 +1164,6 @@ class ByteCodeMachine extends StackMachine implements MatchView {
             sprev = s;
             s++;
         }
-        sprev = sbegin; // break;
     }
 
     // CEC
@@ -1181,7 +1179,6 @@ class ByteCodeMachine extends StackMachine implements MatchView {
             sprev = s;
             s += n;
         }
-        sprev = sbegin; // break;
     }
 
     private void opStateCheckAnyCharMLStarSb() {
@@ -1193,7 +1190,6 @@ class ByteCodeMachine extends StackMachine implements MatchView {
             sprev = s;
             s++;
         }
-        sprev = sbegin; // break;
     }
 
     private void opWord() {

--- a/third_party/joni/src/org/joni/Compiler.java
+++ b/third_party/joni/src/org/joni/Compiler.java
@@ -162,10 +162,11 @@ abstract class Compiler implements ErrorMessages {
             break;
 
         case NodeType.QTFR:
-            if (Config.USE_CEC) {
-                compileCECQuantifierNode((QuantifierNode)node);
+            QuantifierNode quantifier = (QuantifierNode)node;
+            if (Config.USE_CEC && regex.numCombExpCheck > 0 && quantifier.combExpCheckNum > 0) {
+                compileCECQuantifierNode(quantifier);
             } else {
-                compileNonCECQuantifierNode((QuantifierNode)node);
+                compileNonCECQuantifierNode(quantifier);
             }
             break;
 

--- a/third_party/joni/src/org/joni/Config.java
+++ b/third_party/joni/src/org/joni/Config.java
@@ -44,7 +44,7 @@ public interface Config extends org.jcodings.Config {
     boolean USE_WORD_BEGIN_END = ConfigSupport.getBoolean("joni.use_word_begin_end", true); /* "\<": word-begin, "\>": word-end */
     boolean USE_FIND_LONGEST_SEARCH_ALL_OF_RANGE = ConfigSupport.getBoolean("joni.use_find_longest_search_all_of_range", true);
     boolean USE_SUNDAY_QUICK_SEARCH = ConfigSupport.getBoolean("joni.use_sunday_quick_search", true);
-    boolean USE_CEC = ConfigSupport.getBoolean("joni.use_cec", false);
+    boolean USE_CEC = ConfigSupport.getBoolean("joni.use_cec", true);
     boolean USE_DYNAMIC_OPTION = ConfigSupport.getBoolean("joni.use_dynamic_option", false);
     boolean USE_BYTE_MAP = ConfigSupport.getBoolean("joni.use_byte_map", OptExactInfo.OPT_EXACT_MAXLEN <= CHAR_TABLE_SIZE);
     boolean USE_INT_MAP_BACKWARD = ConfigSupport.getBoolean("joni.use_int_map_backward", false);

--- a/third_party/joni/src/org/joni/Matcher.java
+++ b/third_party/joni/src/org/joni/Matcher.java
@@ -192,7 +192,7 @@ public abstract class Matcher extends IntHolder {
         msaInit(option, at, at);
 
         if (Config.USE_CEC) {
-            int offset = at = str;
+            int offset = at - str;
             stateCheckBuffInit(end - str, offset, regex.numCombExpCheck); // move it to construction?
         } // USE_COMBINATION_EXPLOSION_CHECK
 

--- a/third_party/joni/src/org/joni/StackMachine.java
+++ b/third_party/joni/src/org/joni/StackMachine.java
@@ -150,7 +150,7 @@ abstract class StackMachine extends Matcher implements StackType {
                     // same impl, reduce...
                     stateCheckBuff = new byte[size];
                 }
-                Arrays.fill(stateCheckBuff, offset, (size - offset), (byte)0);
+                Arrays.fill(stateCheckBuff, offset, size, (byte)0);
                 stateCheckBuffSize = size;
             } else {
                 stateCheckBuff = null; // reduce

--- a/third_party/joni/test/org/joni/test/TestPerl.java
+++ b/third_party/joni/test/org/joni/test/TestPerl.java
@@ -44,4 +44,10 @@ public class TestPerl extends Test {
 	@Override
     public void test() throws Exception {
     }
+
+    @org.junit.Test(timeout = 5000)
+    public void testNestedQuantifierCombinationExplosion() throws Exception {
+        x2s(".X(.+)+X", "bXcXaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 0, 4);
+        org.junit.Assert.assertEquals(0, nfail + nerror);
+    }
 }


### PR DESCRIPTION
## Summary

- integrate the validated Joni offset-map reuse, regex-set property, recursion safeguard, and Perl Unicode-property alias slices
- separate Joni's search-start cursor from Perl `\G`/`pos` for ordinary matching and substitution
- preserve character offsets for Unicode subjects and code replacements while retaining the temporary Java backend approximation
- update the Phase 36 tracker with completed Unicode aliases and the independent-`gpos` gate

## Validation

- standard Perl, JVM, and interpreter focused `gpos` oracle: 12/12
- unchanged `perl5_t/t/re/subst.t`: 275/281 on JVM and interpreter (tests 165–188 restored)
- unchanged `perl5_t/t/re/regexp_unicode_prop.t`: 1,110/1,110 on JVM and interpreter
- focused alias/diagnostic/provenance gates: 16/16, 39/39, 12/12, and 8/8 on both execution backends
- source tree is byte-for-byte identical to the previously validated recovery branch
- warning-free full `make` on the corrected integration history (result added before publication)

## Stack

- base: #1015
- retains corrected PerlOnJava4 alias head `4ef73a3c7c31568c40b34954cf3a309f28fc6c5c`
- retains validated integration merge `98d4c02315e99ce5473649f3edd58724584dd391`

Generated with [OpenAI Codex](https://openai.com/codex)
