### PR TITLE
test: generate lossless Unicode property corpus chunks

### DIFF
--- a/dev/import-perl5/README.md
+++ b/dev/import-perl5/README.md
@@ -66,6 +66,7 @@ Main synchronization script that imports files from perl5/ based on config.yaml.
 
 **Features:**
 - Copies individual files or entire directories
+- Generates pinned-source test artifacts such as `unicore/TestProp.pl`
 - Applies patches automatically
 - Creates necessary directories
 - Validates sources exist
@@ -79,6 +80,34 @@ perl dev/import-perl5/sync.pl --help
 ```
 
 Protected targets (`protected: true` in YAML) are always excluded from bulk directory rsync using the **full** config list, even when `--only` is used.
+
+#### Generated Unicode property fixture
+
+The upstream `uniprops01.t` through `uniprops10.t` wrappers load
+`perl5_t/lib/unicore/TestProp.pl`. Perl does not commit that file: its build
+generates it from `perl5/lib/unicore/mktables` and the pinned Unicode database.
+PerlOnJava therefore generates a losslessly split fixture explicitly:
+
+```bash
+perl dev/import-perl5/sync.pl --only TestProp.pl
+```
+
+Generation runs in a temporary copy of `perl5/lib/unicore`, so it does not
+modify the pinned source tree. The importer retains every canonical assertion,
+splits the ten existing `TESTCHUNK` sections into ignored `TestProp-01.pl`
+through `TestProp-10.pl` files, and installs a small `TestProp.pl` dispatcher.
+Each unchanged upstream wrapper consequently parses only its selected section
+instead of parsing the complete 12 MB corpus before applying its chunk guard.
+Running the dispatcher without `TESTCHUNK` still evaluates all sections in
+canonical order.
+
+The dispatcher embeds the canonical SHA-256 and per-chunk call counts. The
+dispatcher and all chunks remain ignored with the rest of `perl5_t/` and are
+not included in the JAR or distribution. A clean checkout obtains them by
+running the command above (a full unfiltered sync also runs this row). Unrelated
+filtered syncs neither generate nor remove them. Missing Unicode inputs or an
+incompatible host Perl make the sync fail with an actionable diagnostic rather
+than silently leaving the ten wrappers unavailable.
 
 ### add_module.pl
 

--- a/dev/import-perl5/config.yaml
+++ b/dev/import-perl5/config.yaml
@@ -3,7 +3,8 @@
 # Each entry specifies:
 #   source:    Path relative to project root (typically perl5/...)
 #   target:    Path relative to project root where file/dir should be copied
-#   type:      'file' (default) or 'directory' for bulk directory copies
+#   type:      'file' (default), 'directory' for bulk copies, or a documented
+#              generated type handled by sync.pl (currently TestProp.pl only)
 #   patch:     Optional patch file (relative to dev/import-perl5/patches/)
 #   protected: Optional boolean (true/false) - if true, existing file won't be overwritten
 #
@@ -94,9 +95,12 @@ imports:
     target: perl5_t/Porting
     type: directory
 
-  # NOTE: perl5_t/lib directory should exist (for opendir tests) but remain empty
-  # to avoid module loading conflicts. PerlOnJava uses src/main/perl/lib instead.
-  # The sync.pl script will create an empty perl5_t/lib directory if needed.
+  # perl5_t/lib otherwise remains empty to avoid module loading conflicts.
+  # TestProp.pl is generated from the pinned Unicode inputs because upstream
+  # does not store this build artifact in the perl5 source tree.
+  - source: perl5/lib/unicore/mktables
+    target: perl5_t/lib/unicore/TestProp.pl
+    type: generated_unicode_testprop
 
   # Bulk import all core test files from perl5/t/ to perl5_t/t/
   # This creates a complete Perl 5 test environment under perl5_t/

--- a/dev/import-perl5/sync.pl
+++ b/dev/import-perl5/sync.pl
@@ -16,7 +16,9 @@ use File::Basename qw(dirname);
 use File::Path qw(make_path);
 use File::Copy qw(copy);
 use File::Spec;
-use Cwd qw(abs_path);
+use File::Temp qw(tempdir tempfile);
+use Cwd qw(abs_path getcwd);
+use Digest::SHA qw(sha256_hex);
 
 # Simple YAML parser for our specific needs
 sub parse_yaml {
@@ -137,6 +139,249 @@ sub copy_directory {
         warn "  Warning: rsync failed with exit code $result\n";
         return 0;
     }
+    return 1;
+}
+
+# Split the canonical generated corpus without dropping or reordering a byte of
+# any TESTCHUNK section. The small dispatcher retains the canonical lexical
+# helper scope and evals only the selected section. Leading newlines in each
+# chunk preserve canonical caller line numbers in TAP diagnostics.
+sub split_unicode_testprop {
+    my ($canonical) = @_;
+    my @markers;
+    while ($canonical
+           =~ /^if \(!\$::TESTCHUNK or \$::TESTCHUNK == (\d+)\) \{\s*$/mg)
+    {
+        push @markers, { number => 0 + $1, start => $-[0] };
+    }
+    unless (join(',', map { $_->{number} } @markers) eq join(',', 1 .. 10)) {
+        die "Generated TestProp.pl has unexpected TESTCHUNK order: "
+            . (@markers ? join(',', map { $_->{number} } @markers) : '(none)')
+            . "\n";
+    }
+
+    pos($canonical) = $markers[-1]{start};
+    my $finished_start;
+    if ($canonical =~ /^Finished\(\);\s*$/mg) {
+        $finished_start = $-[0];
+    }
+    die "Generated TestProp.pl is missing Finished() after TESTCHUNK 10\n"
+        unless defined $finished_start;
+
+    my $preamble = substr($canonical, 0, $markers[0]{start});
+    my $finish = substr($canonical, $finished_start);
+    my @sections;
+    for my $index (0 .. $#markers) {
+        my $end = $index == $#markers
+            ? $finished_start
+            : $markers[$index + 1]{start};
+        my $section = substr($canonical, $markers[$index]{start},
+                             $end - $markers[$index]{start});
+        my $line_offset = substr($canonical, 0, $markers[$index]{start})
+            =~ tr/\n//;
+        my %counts;
+        $counts{$1}++ while $section
+            =~ /^\s+(Expect|Error|Test_GCB|Test_SB|Test_LB|Test_WB)\(/mg;
+        push @sections, {
+            number      => $markers[$index]{number},
+            source      => $section,
+            padded      => ("\n" x $line_offset) . $section,
+            line_offset => $line_offset,
+            counts      => \%counts,
+        };
+    }
+
+    my $reconstructed = $preamble . join('', map { $_->{source} } @sections)
+        . $finish;
+    die "Internal TestProp.pl split changed canonical content\n"
+        unless $reconstructed eq $canonical;
+
+    my $canonical_sha = sha256_hex($canonical);
+    my @manifest = (
+        "\n# PerlOnJava lossless TESTCHUNK dispatcher\n",
+        "# Canonical pinned mktables SHA-256: $canonical_sha\n",
+    );
+    for my $section (@sections) {
+        my @counts = map { "$_=$section->{counts}{$_}" }
+            sort keys %{$section->{counts}};
+        push @manifest, "# TESTCHUNK $section->{number}: "
+            . join(', ', @counts) . "\n";
+    }
+    push @manifest, <<'DISPATCHER';
+my $__poj_testprop_dir = __FILE__;
+$__poj_testprop_dir =~ s{[^/\\]+\z}{};
+my @__poj_testprop_chunks = !$::TESTCHUNK
+    ? (1 .. 10)
+    : ($::TESTCHUNK >= 1 && $::TESTCHUNK <= 10 ? ($::TESTCHUNK) : ());
+for my $__poj_testprop_chunk (@__poj_testprop_chunks) {
+    my $__poj_testprop_path = sprintf '%sTestProp-%02d.pl',
+        $__poj_testprop_dir, $__poj_testprop_chunk;
+    open my $__poj_testprop_fh, '<', $__poj_testprop_path
+        or die "Cannot load $__poj_testprop_path: $!\n";
+    local $/;
+    my $__poj_testprop_source = <$__poj_testprop_fh>;
+    close $__poj_testprop_fh
+        or die "Cannot close $__poj_testprop_path: $!\n";
+    my $__poj_testprop_completed = eval($__poj_testprop_source . "\n; 1;");
+    my $__poj_testprop_error = $@;
+    unless ($__poj_testprop_completed) {
+        $__poj_testprop_error = "section eval returned false without an error\n"
+            unless length $__poj_testprop_error;
+        die "Cannot evaluate $__poj_testprop_path: $__poj_testprop_error";
+    }
+}
+DISPATCHER
+    my $dispatcher = $preamble . join('', @manifest) . $finish;
+    return ($dispatcher, \@sections, $canonical_sha);
+}
+
+# Generate the Unicode property test fixture from a pristine copy of the
+# pinned source data. Upstream deliberately does not commit TestProp.pl; its
+# normal build creates it with lib/unicore/mktables -maketest.
+sub generate_unicode_testprop {
+    my ($generator_relative, $target, $project_root) = @_;
+    my $generator = File::Spec->catfile($project_root, $generator_relative);
+    my $unicode_source = dirname($generator);
+    my @required = (
+        $generator,
+        File::Spec->catfile($unicode_source, 'version'),
+        File::Spec->catfile($unicode_source, 'UnicodeData.txt'),
+    );
+    for my $required (@required) {
+        unless (-f $required) {
+            warn "  ERROR: Cannot generate Unicode TestProp.pl; missing pinned "
+                . "generation prerequisite: $required\n"
+                . "  Restore perl5/lib/unicore from the pinned perl5 source "
+                . "before running this sync.\n\n";
+            return 0;
+        }
+    }
+
+    my $temporary = tempdir('perlonjava-testprop-XXXXXX', TMPDIR => 1, CLEANUP => 1);
+    my $temporary_unicode = File::Spec->catdir($temporary, 'unicore');
+    make_path($temporary_unicode) or do {
+        warn "  ERROR: Cannot create temporary Unicode generation directory: $!\n\n";
+        return 0;
+    };
+    unless (copy_directory($unicode_source, $temporary_unicode,
+                           $project_root, [], [])) {
+        warn "  ERROR: Cannot copy pinned Unicode data for TestProp.pl generation.\n\n";
+        return 0;
+    }
+
+    my $generated = File::Spec->catfile($temporary_unicode, 'TestProp.pl');
+    my $original_dir = getcwd();
+    unless (chdir $project_root) {
+        warn "  ERROR: Cannot enter project root for TestProp.pl generation: $!\n\n";
+        return 0;
+    }
+    print "  Generating with pinned Unicode data: $generator_relative\n";
+    my $result = system($^X, $generator_relative,
+                        '-C', $temporary_unicode,
+                        '-T', $generated,
+                        '-q');
+    my $generation_error = $!;
+    unless (chdir $original_dir) {
+        die "sync.pl: cannot restore working directory '$original_dir': $!\n";
+    }
+    if ($result != 0) {
+        my $exit = $result == -1
+            ? "could not start: $generation_error"
+            : ($result & 127)
+                ? "terminated by signal " . ($result & 127)
+                : "exit code " . ($result >> 8);
+        warn "  ERROR: Unicode TestProp.pl generation failed ($exit).\n"
+            . "  Ensure the pinned perl5/lib/unicore data is complete and the "
+            . "host Perl can run mktables.\n\n";
+        return 0;
+    }
+    unless (-s $generated) {
+        warn "  ERROR: Unicode generator completed without producing TestProp.pl.\n\n";
+        return 0;
+    }
+
+    open my $generated_fh, '<', $generated or do {
+        warn "  ERROR: Cannot inspect generated TestProp.pl: $!\n\n";
+        return 0;
+    };
+    local $/;
+    my $contents = <$generated_fh>;
+    close $generated_fh;
+    my ($dispatcher, $sections, $canonical_sha);
+    eval {
+        ($dispatcher, $sections, $canonical_sha)
+            = split_unicode_testprop($contents);
+        1;
+    } or do {
+        my $error = $@ || 'unknown split error';
+        chomp $error;
+        warn "  ERROR: Cannot split generated TestProp.pl: $error\n\n";
+        return 0;
+    };
+
+    my $target_dir = dirname($target);
+    unless (-d $target_dir) {
+        make_path($target_dir) or do {
+            warn "  ERROR: Cannot create generated fixture directory: $!\n\n";
+            return 0;
+        };
+    }
+    my @outputs;
+    my ($volume, $directories, $base) = File::Spec->splitpath($target);
+    $base =~ s/\.pl\z//;
+    for my $section (@$sections) {
+        my $chunk_base = sprintf '%s-%02d.pl', $base, $section->{number};
+        my $chunk_target = File::Spec->catpath($volume, $directories,
+                                               $chunk_base);
+        push @outputs, [$chunk_target, $section->{padded}];
+    }
+    # Publish the dispatcher last so readers never see it before all ten chunk
+    # names exist. Stage every output completely before replacing any member of
+    # the current family; a write failure therefore leaves that family intact.
+    push @outputs, [$target, $dispatcher];
+    my @staged;
+    for my $output (@outputs) {
+        my ($path, $source) = @$output;
+        my ($output_fh, $staged_path);
+        eval {
+            ($output_fh, $staged_path) = tempfile(
+                '.TestProp-sync-XXXXXX', DIR => $target_dir, UNLINK => 0
+            );
+            1;
+        } or do {
+            my $error = $@ || 'unknown temporary-file error';
+            chomp $error;
+            warn "  ERROR: Cannot stage generated fixture $path: $error\n\n";
+            unlink $_->[0] for @staged;
+            return 0;
+        };
+        print {$output_fh} $source or do {
+            warn "  ERROR: Cannot stage generated fixture $path: $!\n\n";
+            close $output_fh;
+            unlink $staged_path;
+            unlink $_->[0] for @staged;
+            return 0;
+        };
+        close $output_fh or do {
+            warn "  ERROR: Cannot close staged generated fixture $path: $!\n\n";
+            unlink $staged_path;
+            unlink $_->[0] for @staged;
+            return 0;
+        };
+        push @staged, [$staged_path, $path];
+    }
+    while (my $staged = shift @staged) {
+        my ($staged_path, $path) = @$staged;
+        unless (rename $staged_path, $path) {
+            warn "  ERROR: Cannot publish generated fixture $path: $!\n\n";
+            unlink $staged_path;
+            unlink $_->[0] for @staged;
+            return 0;
+        }
+    }
+    print "  Installed lossless generated fixture dispatcher and 10 chunks: "
+        . File::Spec->abs2rel($target, $project_root)
+        . " (canonical SHA-256 $canonical_sha)\n";
     return 1;
 }
 
@@ -264,7 +509,13 @@ sub main {
         print "Processing: $import->{source}\n";
         
         # Check if source exists
-        if ($type eq 'directory') {
+        if ($type eq 'generated_unicode_testprop') {
+            unless (generate_unicode_testprop($import->{source}, $target, $project_root)) {
+                $error_count++;
+                next;
+            }
+        }
+        elsif ($type eq 'directory') {
             unless (-d $source) {
                 warn "  ERROR: Source directory not found: $source\n\n";
                 $error_count++;
@@ -342,7 +593,8 @@ sub main {
         $success_count++;
     }
     
-    # Create empty perl5_t/lib directory (needed for opendir tests but must stay empty)
+    # Create perl5_t/lib for opendir tests. It remains empty except for
+    # explicitly configured generated test fixtures such as unicore/TestProp.pl.
     my $lib_dir = File::Spec->catdir($project_root, 'perl5_t', 'lib');
     unless (-d $lib_dir) {
         print "Creating empty perl5_t/lib directory...\n";
@@ -362,4 +614,6 @@ sub main {
     }
 }
 
-main();
+main() unless caller;
+
+1;

--- a/dev/import-perl5/t/generated_unicode_testprop.t
+++ b/dev/import-perl5/t/generated_unicode_testprop.t
@@ -1,0 +1,203 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Path qw(make_path);
+use File::Spec;
+use File::Temp qw(tempdir);
+use Digest::SHA qw(sha256_hex);
+
+my $sync = File::Spec->catfile('dev', 'import-perl5', 'sync.pl');
+do "./$sync" or die "Could not load $sync: $@ $!";
+
+my $root = tempdir(CLEANUP => 1);
+my $unicode = File::Spec->catdir($root, 'perl5', 'lib', 'unicore');
+make_path($unicode);
+
+my $generator_relative = File::Spec->catfile('perl5', 'lib', 'unicore', 'mktables');
+my $generator = File::Spec->catfile($root, $generator_relative);
+open my $generator_fh, '>', $generator or die "Cannot create fake generator: $!";
+print {$generator_fh} <<'GENERATOR';
+use strict;
+use warnings;
+use File::Spec;
+my ($directory, $target);
+while (@ARGV) {
+    my $argument = shift;
+    $directory = shift if $argument eq '-C';
+    $target = shift if $argument eq '-T';
+}
+die "missing generation arguments\n" unless defined $directory && defined $target;
+open my $output, '>', $target or die "Cannot create $target: $!";
+print {$output} <<'PREAMBLE';
+# generated fixture
+my $helper_lexical = 1;
+sub Expect { $main::testprop_expects += $helper_lexical }
+sub Error { $main::testprop_errors += $helper_lexical }
+sub Test_GCB { $main::testprop_breaks += $helper_lexical }
+sub Test_SB { $main::testprop_breaks += $helper_lexical }
+sub Test_LB { $main::testprop_breaks += $helper_lexical }
+sub Test_WB { $main::testprop_breaks += $helper_lexical }
+sub Finished { $main::testprop_finished++ }
+PREAMBLE
+for my $chunk (1 .. 10) {
+    print {$output} "if (!\$::TESTCHUNK or \$::TESTCHUNK == $chunk) {\n";
+    print {$output} "    \$main::testprop_chunks .= '$chunk,';\n";
+    if ($chunk <= 4) {
+        for my $index (1 .. 600) {
+            my $suffix = " # chunk-$chunk-expect-$index";
+            $suffix .= " regression-$index"
+                if $chunk == 1 && $index <= 16;
+            print {$output} "    Expect();$suffix\n";
+        }
+        print {$output} "    Error(); # chunk-$chunk-error-$_\n" for 1 .. 300;
+    }
+    elsif ($chunk == 5) {
+        print {$output} "    Test_GCB();\n" for 1 .. 120;
+        print {$output} "    Test_SB();\n" for 1 .. 80;
+    }
+    elsif ($chunk <= 9) {
+        print {$output} "    Test_LB();\n" for 1 .. 80;
+    }
+    else {
+        print {$output} "    Test_WB();\n" for 1 .. 80;
+    }
+    print {$output} "}\n";
+}
+print {$output} "Finished();\n";
+close $output;
+GENERATOR
+close $generator_fh;
+
+for my $required (qw(version UnicodeData.txt)) {
+    my $path = File::Spec->catfile($unicode, $required);
+    open my $fh, '>', $path or die "Cannot create $path: $!";
+    print {$fh} $required eq 'version' ? "17.0.0\n" : "0041;LATIN CAPITAL LETTER A\n";
+    close $fh;
+}
+
+my $target = File::Spec->catfile($root, 'perl5_t', 'lib', 'unicore', 'TestProp.pl');
+my @family = ($target, map {
+    File::Spec->catfile($root, 'perl5_t', 'lib', 'unicore',
+                       sprintf('TestProp-%02d.pl', $_))
+} 1 .. 10);
+
+sub slurp {
+    my ($path) = @_;
+    open my $fh, '<', $path or die "Cannot read $path: $!";
+    local $/;
+    my $contents = <$fh>;
+    close $fh;
+    return $contents;
+}
+
+ok(generate_unicode_testprop($generator_relative, $target, $root),
+   'generated import succeeds from pinned inputs');
+ok(-s $_, "generated fixture is installed: $_") for @family;
+my %first_family = map { $_ => slurp($_) } @family;
+my $first = $first_family{$target};
+like($first, qr/^# Canonical pinned mktables SHA-256: ([0-9a-f]{64})$/m,
+     'dispatcher records its canonical generated-input hash');
+my ($recorded_canonical_sha) = $first
+    =~ /^# Canonical pinned mktables SHA-256: ([0-9a-f]{64})$/m;
+my @reconstructed_sections;
+for my $chunk (1 .. 10) {
+    like($first, qr/^# TESTCHUNK $chunk: /m,
+         "dispatcher records TESTCHUNK $chunk counts");
+    my $path = $family[$chunk];
+    my $source = $first_family{$path};
+    my $marker = "if (!\$::TESTCHUNK or \$::TESTCHUNK == $chunk) {";
+    my $start = index($source, $marker);
+    cmp_ok($start, '>=', 0, "chunk $chunk contains its canonical marker");
+    is(index($source, 'TESTCHUNK == ', $start + length $marker), -1,
+       "chunk $chunk contains no later TESTCHUNK section");
+    push @reconstructed_sections, substr($source, $start);
+}
+my ($canonical_preamble) = split /\n# PerlOnJava lossless TESTCHUNK dispatcher\n/,
+    $first, 2;
+my $reconstructed = $canonical_preamble
+    . join('', @reconstructed_sections) . "Finished();\n";
+is(sha256_hex($reconstructed), $recorded_canonical_sha,
+   'dispatcher and chunks reconstruct the canonical generated hash');
+my @expects = $reconstructed =~ /^\s+Expect\(/mg;
+my @errors = $reconstructed =~ /^\s+Error\(/mg;
+is(scalar @expects, 4 * 600, 'all canonical Expect calls are retained');
+is(scalar @errors, 4 * 300, 'all canonical Error calls are retained');
+like($reconstructed, qr/# chunk-2-expect-1$/m,
+     'first ordered Expect call is retained');
+like($reconstructed, qr/# chunk-2-expect-600$/m,
+     'last ordered Expect call is retained');
+like($reconstructed, qr/# chunk-2-error-1$/m,
+     'first ordered Error call is retained');
+like($reconstructed, qr/# chunk-2-error-300$/m,
+     'last ordered Error call is retained');
+
+{
+    local $::TESTCHUNK = 2;
+    local $::testprop_chunks = '';
+    local $::testprop_expects = 0;
+    local $::testprop_errors = 0;
+    local $::testprop_breaks = 0;
+    local $::testprop_finished = 0;
+    my $loaded = do $target;
+    ok(defined $loaded, 'dispatcher executes one selected generated chunk')
+        or diag "dispatcher error: $@ $!";
+    is($::testprop_chunks, '2,', 'dispatcher loads exactly the selected chunk');
+    is($::testprop_expects, 600,
+       'selected chunk eval sees canonical lexical helper scope');
+    is($::testprop_errors, 300, 'selected chunk retains every Error call');
+    is($::testprop_finished, 1, 'selected dispatch calls canonical Finished once');
+}
+{
+    local $::TESTCHUNK = 0;
+    local $::testprop_chunks = '';
+    local $::testprop_expects = 0;
+    local $::testprop_errors = 0;
+    local $::testprop_breaks = 0;
+    local $::testprop_finished = 0;
+    my $loaded = do $target;
+    ok(defined $loaded, 'dispatcher executes all chunks when none is selected')
+        or diag "dispatcher error: $@ $!";
+    is($::testprop_chunks, '1,2,3,4,5,6,7,8,9,10,',
+       'unselected dispatch preserves canonical chunk order');
+    is($::testprop_expects, 4 * 600, 'all-chunk dispatch retains all Expect calls');
+    is($::testprop_errors, 4 * 300, 'all-chunk dispatch retains all Error calls');
+    is($::testprop_breaks, 120 + 80 + 4 * 80 + 80,
+       'all-chunk dispatch retains all boundary calls');
+    is($::testprop_finished, 1, 'all-chunk dispatch calls canonical Finished once');
+}
+
+open my $damage_fh, '>', $target or die "Cannot alter $target: $!";
+print {$damage_fh} "damaged\n";
+close $damage_fh;
+open my $chunk_damage_fh, '>', $family[7]
+    or die "Cannot alter $family[7]: $!";
+print {$chunk_damage_fh} "damaged chunk\n";
+close $chunk_damage_fh;
+ok(generate_unicode_testprop($generator_relative, $target, $root),
+   'repeated generation succeeds');
+my %second_family = map { $_ => slurp($_) } @family;
+is_deeply(\%second_family, \%first_family,
+          'repeated generation installs a byte-identical dispatcher and chunks');
+
+unlink File::Spec->catfile($unicode, 'version')
+    or die "Cannot remove fake version prerequisite: $!";
+my $warning = '';
+{
+    local $SIG{__WARN__} = sub { $warning .= join '', @_ };
+    ok(!generate_unicode_testprop($generator_relative, $target, $root),
+       'missing generation prerequisite fails');
+}
+like($warning, qr/missing pinned generation prerequisite.*version/s,
+     'missing prerequisite diagnostic names the absent input');
+
+my $bad_order = join '',
+    "if (!\$::TESTCHUNK or \$::TESTCHUNK == 2) {\n}\n",
+    "if (!\$::TESTCHUNK or \$::TESTCHUNK == 1) {\n}\n",
+    (map { "if (!\$::TESTCHUNK or \$::TESTCHUNK == $_) {\n}\n" } 3 .. 10),
+    "Finished();\n";
+my $order_error = '';
+eval { split_unicode_testprop($bad_order); 1 } or $order_error = $@;
+like($order_error, qr/unexpected TESTCHUNK order: 2,1,3,4,5,6,7,8,9,10/,
+     'splitting rejects dropped or reordered canonical sections');
+
+done_testing;


### PR DESCRIPTION
## Summary

- generate upstream `unicore/TestProp.pl` from the pinned Perl 5.44 / Unicode
  data during importer sync, without requiring a previously built Perl tree
- losslessly split the ten canonical `TESTCHUNK` sections behind an ignored
  dispatcher so each unchanged `unipropsNN.t` wrapper parses only its section
- validate byte-exact canonical reconstruction and publish staged chunks before
  the dispatcher; preserve unrelated filtered-sync behavior and actionable
  prerequisite/signal diagnostics
- document the clean-checkout generation path and verify selected/all-chunk
  dispatch, lexical helper scope, ordering, counts, and family idempotence

All generated fixtures remain under ignored `perl5_t/lib/unicore/`; none are
committed, bundled into the JAR, or published in a distribution.

## Reproducibility

- canonical generated size: 12,636,303 bytes
- canonical SHA-256:
  `0d5499d20123b34bae3c3a23d22dcff2f0d266bfbf2883e5c575c76664368461`
- dispatcher SHA-256:
  `aaec3d34ec528dc0ae109eb251d8bc1fe8ed95789d35d68661fcaa72bcd78193`
- two isolated generations produced byte-identical dispatcher/chunk families
- an unrelated filtered sync preserved all eleven hashes

## Validation

- `prove dev/import-perl5/t/generated_unicode_testprop.t`: 66/66
- system Perl lossless wrappers: 503,197 TAP, zero timeouts
- JVM lossless wrappers: 290,912 TAP, 194,891 ok / 96,021 not ok, zero timeouts
- interpreter lossless wrappers: exact JVM totals and per-wrapper counts, zero
  timeouts
- full `make`: passed all unit shards, Joni tests, packaging verification, and
  shadow JAR in 4m45s with no warning/error output

The four property-heavy JVM chunks completed in 229.76-284.30 seconds under
individual 300-second bounds. This restores complete TAP but leaves a narrow
performance margin that should remain visible in the Phase 36 differential.
A subsequent warm chunk-4 rerun under concurrent build load timed out at
300.03 seconds after assertion 30,479, before its 41,806-test plan. That is
recorded as a Phase 1/6 performance-risk follow-up rather than hidden by
sampling or addressed speculatively in this importer-only PR.

Stacked on #1005.
