### PR TITLE
fix: honor utf8 in byte-backed eval source

### DIFF
--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -438,7 +438,15 @@ matcher-specific timeouts on both execution backends.
     the final owning regex scope exits (test 307).
   - [x] Resolved failed-path `$^N`/`$+` tests 85-86 on JVM and interpreter.
   - [x] Classified tests 444-448 as optimizer/debug-transcript exclusions.
+  - [x] Decoded byte-backed eval source according to lexical `use utf8`,
+    including pragmas activated inside the source, while preserving `no utf8`
+    byte semantics and fatal malformed-UTF-8 diagnostics. The focused oracle
+    passes 7/7 on system Perl, JVM, interpreter, and the direct JVM eval
+    compiler.
 - [ ] Phase 5: Remove the Java matching backend
+  - [x] Retired the unreachable top-level `(*PRUNE)` text rewrite after native
+    Joni control-verb gates passed under default and forced-Java policy
+    (`5760874e4`; 316 preprocessor lines removed).
 - [ ] Phase 6: Integration and release
 
 ### Next Steps
@@ -449,13 +457,16 @@ matcher-specific timeouts on both execution backends.
 2. Fix lexical `use bytes` substitution when an upgraded marker regex matches a
    byte subject, without patching generated fixtures. Regenerate the lossless
    corpus and prove that chunks 05–10 no longer match literal boundary markers
-   before treating any boundary or folding result as evidence. Keep the
-   separately reduced eval byte-source UTF-8 decoding fix as an independent
-   runtime parity slice.
+   before treating any boundary or folding result as evidence. Retain the now-
+   completed eval byte-source UTF-8 oracle as an independent runtime regression
+   gate; it is not the generated-corpus marker fix.
 3. Implement the remaining property clusters in measured order: Block,
    Script/Script_Extensions, Numeric_Value, Joining_Group, General_Category,
    break-property values, and Age/In/Present_In. Preserve pinned Perl 5.44
    acceptance and rejection semantics rather than inheriting host ICU breadth.
+   Close the independently reduced Joni syntax gaps for Python-style named
+   groups, alpha assertion aliases, underscored numeric escapes, and braced
+   octal parsing with focused standard-Perl gates.
 4. Rerun the forced-Joni 80-file corpus on JVM and interpreter from the combined
    head. Save complete JSON and logs, publish the missing differential report,
    and compare every file with both the Phase 0 result and PR 958 under the

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -371,19 +371,22 @@ my @copy = @{$z};         # ERROR
 - ✅  **Inline comments**: `(?#comment)` in regex is implemented.
 - ✅  **caret modifier**: `(?^` embedded pattern-match modifier, shorthand equivalent to "d-imnsx".
 - ✅  **\b inside character class**: `[\b]` is supported in regex.
-- ✅  **\b{gcb} \B{gcb}**: Boundary assertions.
+- 🟡  **Unicode boundary assertions**: `\b{gcb}`, `\B{gcb}`, and the `wb`/`lb`/`sb` forms are recognized, but the genuine hand-written generated-corpus preamble still has 25 semantic failures; comprehensive generated coverage is blocked by byte-mode marker normalization.
 - ✅  **Variable Interpolation in Regex**: Features like `${var}` for embedding variables.
 - ✅  **Non-capturing groups**: `(?:...)` is implemented.
 - ✅  **Named Capture Groups**: Defining named capture groups using `(?<name>...)` or `(?'name'...)` is supported.
 - ✅  **Backreferences to Named Groups**: Using `\k<name>` or `\g{name}` for backreferences to named groups is supported.
 - ✅  **Relative Backreferences**: Using `\g{-n}` for relative backreferences.
-- ✅  **Unicode Properties**: Matching with `\p{...}` and `\P{...}` (e.g., `\p{L}` for letters).
-- ✅  **Unicode Properties**: Add regex properties supported by Perl but missing in Java regex.
+- ✅  **Basic Unicode Properties**: Common `\p{...}` and `\P{...}` forms such as `\p{L}` execute through Joni.
+- 🟡  **Perl Unicode Property Syntax**: Perl-specific properties and focused Script/Block/Age aliases execute through Joni, but the generated corpus still exposes loose property/value aliases and pinned acceptance/rejection gaps.
 - ✅  **Possessive Quantifiers**: Quantifiers like `*+`, `++`, `?+`, and `{n,m}+`, which disable backtracking, are supported.
 - ✅  **Atomic Grouping**: Use of `(?>...)` for atomic groups is supported.
 - ✅  **`\K` assertion**: Keep left — in `s///`, text before `\K` is preserved; match variables reflect only the portion after `\K`.
 - ✅  **Preprocessor**: `\Q`, `\L`, `\U`, `\l`, `\u`, `\E` are preprocessed in regex.
 - ✅  **Overloading**: `qr` overloading is implemented. See also [overload pragma](#pragmas).
+- ❌  **Python-style named groups**: `(?P<name>...)` and `(?P=name)` are accepted by Perl but are not yet parsed by Joni.
+- ❌  **Alpha assertion aliases**: `(*pla:...)`, `(*plb:...)`, `(*nla:...)`, `(*nlb:...)`, and `(*atomic:...)` are not yet parsed by Joni.
+- ❌  **Underscored numeric regex escapes**: Perl spellings such as `\x{0_0_4_1}` and `\o{0_0_1_0_1}` are not yet parsed by Joni; braced octal syntax also needs complete validation and diagnostics.
 
 - ✅  **Dynamically-scoped regex variables**: Provisional captures, `$^R`, `$^N`, match positions, and callback locals follow matcher paths and unwind on backtracking.
 - ✅  **Recursive and Dynamic Patterns**: `(?R)`, `(?0)`, and runtime `(??{ code })` execute through Joni. Dynamic expressions may return strings or `qr//` values, nested alternatives participate in outer backtracking without changing outer grouping or capture numbering, and callback and pure-pattern recursion have engine-owned depth ceilings.
@@ -395,7 +398,7 @@ my @copy = @{$z};         # ERROR
 - ✅  **Advanced Subroutine Calls**: Sub-pattern calls with numbered or named references like `(?1)` and `(?&name)` execute through Joni.
 - ✅  **Conditional Expressions**: Numbered and named capture conditions, positive and negative assertion conditions, recursion conditions `(?(R))`, `(?(R1))`, and `(?(R&name))`, executable callback conditions, and optimistic predicates execute through Joni.
 - 🟡  **Extended Unicode Regex Features**: Focused Script, Block, Script Extensions, `Extended_Pictographic`, `Age`, `In`/`Present_In`, and invalid-property gates execute through Joni, and `regexp_unicode_prop.t` passes 1,110/1,110. The lossless generated `uniprops*.t` matrix currently passes 220,712/290,912 identically on JVM and interpreter, but chunks 01–04 still expose broad loose property/value alias gaps and chunks 05–10 are not yet valid boundary evidence because byte-mode substitution does not normalize upgraded boundary-marker regexes against byte subjects.
-- ✅  **Extended Grapheme Clusters**: `\X` matches combining sequences and emoji ZWJ grapheme clusters.
+- 🟡  **Extended Grapheme Clusters**: Focused `\X` combining-sequence and emoji-ZWJ cases pass, but comprehensive generated UAX verification remains blocked by byte-mode boundary-marker normalization.
 - ✅  **Embedded Code in Regex**: `(?{ code })`, optimistic callbacks `(*{ code })`, executable callback conditions, and `(??{ code })` run as lexical closures in Joni with provisional captures and backtracking unwind. Callback `local` frames follow matcher paths, and escaped loop control or `goto` stops at the callback pseudo-block boundary. `$^N` follows capture-close order independently of `$+`.
 - ✅  **Regex Debugging**: Lexically scoped `use/no re 'debug'` and `debugcolor` are supported, including runtime snapshot ownership.
 - ✅  **Runtime Regex Evaluation**: `use re 'eval'` controls whether interpolated patterns containing eval groups may compile. Admitted runtime source is compiled into lexical callback closures and preserves its package, visible lexical cells, Unicode or byte source type, default regex modifiers, and match-once state. Literal callbacks, interpolated `qr//` values (including local, referenced, and tied arrays), raw runtime eval groups, callback conditions, and standalone `(?(DEFINE)...)` containers may be composed in one Joni pattern; dynamic callbacks may return further admitted executable source.

--- a/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
@@ -13,6 +13,7 @@ import org.perlonjava.frontend.parser.SpecialBlockParser;
 import org.perlonjava.frontend.semantic.ScopedSymbolTable;
 import org.perlonjava.runtime.operators.WarnDie;
 import org.perlonjava.runtime.perlmodule.BHooksEndOfScope;
+import org.perlonjava.runtime.perlmodule.Strict;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import java.util.ArrayList;
@@ -236,7 +237,14 @@ public class EvalStringHandler {
             // Step 1: Clear $@ at start of eval
             GlobalVariable.setGlobalVariable("main::@", "");
 
-            if (isEvalbytes && RuntimeCode.shouldDecodeEvalbytesUtf8Source(perlCode)) {
+            int inheritedStrictOptions = siteStrictOptions >= 0
+                    ? siteStrictOptions
+                    : currentCode != null ? currentCode.strictOptions : 0;
+            boolean byteStringUtf8Source = !isEvalbytes
+                    && sourceType == RuntimeScalarType.BYTE_STRING
+                    && (inheritedStrictOptions & Strict.HINT_UTF8) != 0;
+            if ((isEvalbytes && RuntimeCode.shouldDecodeEvalbytesUtf8Source(perlCode))
+                    || byteStringUtf8Source) {
                 perlCode = RuntimeCode.decodeEvalbytesUtf8Source(perlCode);
             }
 
@@ -254,7 +262,9 @@ public class EvalStringHandler {
 
             CompilerOptions opts = new CompilerOptions();
             opts.fileName = evalFileName;
-            configureEvalSourceOptions(opts, perlCode, sourceType, isEvalbytes);
+            configureEvalSourceOptions(opts, perlCode,
+                    byteStringUtf8Source ? RuntimeScalarType.STRING : sourceType,
+                    isEvalbytes);
             ScopedSymbolTable symbolTable = new ScopedSymbolTable();
 
             // Add standard variables that are always available in eval context.

--- a/src/main/java/org/perlonjava/frontend/parser/StringParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringParser.java
@@ -240,8 +240,13 @@ public class StringParser {
 
         if (ctx.symbolTable.isStrictOptionEnabled(HINT_UTF8)
                 || ctx.compilerOptions.isUnicodeSource) {
-            // utf8 source code is true - keep Unicode string as-is
-            buffers.add(buffer.toString());
+            // A byte-backed eval can activate `use utf8` inside its own source.
+            // Decode only after the parser has applied that lexical pragma;
+            // whole-source substring detection would misclassify comments and
+            // quoted text containing the words "use utf8".
+            buffers.add(ctx.compilerOptions.isByteStringSource
+                    ? decodeUtf8ByteSource(buffer.toString())
+                    : buffer.toString());
 
             // System.out.println("buffers utf8: " + buffer.toString().length() + " " + buffer.toString());
         } else if (ctx.compilerOptions.isEvalbytes) {
@@ -315,6 +320,22 @@ public class StringParser {
                 secondBufferStartDelim, secondBufferEndDelim);
         parsed.sourceLine = parser != null ? parser.sourceLineAt(index) : 1;
         return parsed;
+    }
+
+    private static String decodeUtf8ByteSource(String source) {
+        byte[] bytes = new byte[source.length()];
+        for (int i = 0; i < source.length(); i++) {
+            bytes[i] = (byte) (source.charAt(i) & 0xFF);
+        }
+        try {
+            return java.nio.charset.StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(java.nio.charset.CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(java.nio.charset.CodingErrorAction.REPORT)
+                    .decode(java.nio.ByteBuffer.wrap(bytes))
+                    .toString();
+        } catch (java.nio.charset.CharacterCodingException e) {
+            throw new IllegalArgumentException("Malformed UTF-8 character (fatal)", e);
+        }
     }
 
     public static ParsedString parseRawStrings(Parser parser, EmitterContext ctx, List<LexerToken> tokens, int tokenIndex, int stringCount) {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeCode.java
@@ -27,6 +27,7 @@ import org.perlonjava.runtime.debugger.DebugState;
 import org.perlonjava.runtime.operators.ModuleOperators;
 import org.perlonjava.runtime.operators.WarnDie;
 import org.perlonjava.runtime.perlmodule.BHooksEndOfScope;
+import org.perlonjava.runtime.perlmodule.Strict;
 import org.perlonjava.runtime.CoreSubroutineGenerator;
 
 import java.lang.invoke.MethodHandle;
@@ -2065,7 +2066,15 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         for (int i = 0; i < source.length(); i++) {
             bytes[i] = (byte) (source.charAt(i) & 0xFF);
         }
-        return new String(bytes, StandardCharsets.UTF_8);
+        try {
+            return StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(java.nio.charset.CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(java.nio.charset.CodingErrorAction.REPORT)
+                    .decode(java.nio.ByteBuffer.wrap(bytes))
+                    .toString();
+        } catch (java.nio.charset.CharacterCodingException e) {
+            throw new IllegalArgumentException("Malformed UTF-8 character (fatal)", e);
+        }
     }
 
     /**
@@ -2146,11 +2155,14 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             // EXCEPT for evalbytes, which must treat everything as bytes
             String evalString = code.toString();
             boolean evalbytesUtf8Source = ctx.isEvalbytes && shouldDecodeEvalbytesUtf8Source(evalString);
-            if (evalbytesUtf8Source) {
+            boolean byteStringUtf8Source = !ctx.isEvalbytes
+                    && code.type == RuntimeScalarType.BYTE_STRING
+                    && (ctx.symbolTable.strictOptionsStack.peek() & Strict.HINT_UTF8) != 0;
+            if (evalbytesUtf8Source || byteStringUtf8Source) {
                 evalString = decodeEvalbytesUtf8Source(evalString);
             }
             boolean hasUnicode = false;
-            if (evalbytesUtf8Source) {
+            if (evalbytesUtf8Source || byteStringUtf8Source) {
                 hasUnicode = true;
             } else if (!ctx.isEvalbytes && code.type != RuntimeScalarType.BYTE_STRING) {
                 for (int i = 0; i < evalString.length(); i++) {
@@ -2168,7 +2180,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             // The eval string can originate from either a Perl STRING or BYTE_STRING scalar.
             // For BYTE_STRING source we must treat the source as raw bytes (latin-1-ish) and
             // NOT re-encode characters to UTF-8 when simulating 'non-unicode source'.
-            boolean isByteStringSource = !ctx.isEvalbytes && code.type == RuntimeScalarType.BYTE_STRING;
+            boolean isByteStringSource = !ctx.isEvalbytes
+                    && code.type == RuntimeScalarType.BYTE_STRING
+                    && !byteStringUtf8Source;
             if (hasUnicode) {
                 evalCompilerOptions.isUnicodeSource = true;
             }
@@ -2176,6 +2190,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 evalCompilerOptions.isEvalbytes = true;
             }
             if (isByteStringSource) {
+                evalCompilerOptions.isUnicodeSource = false;
                 evalCompilerOptions.isByteStringSource = true;
             }
 
@@ -2197,7 +2212,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             // Include package name in cache key to ensure source location info is correct per-package
             int featureFlags = ctx.symbolTable.featureFlagsStack.peek();
             String currentPackage = ctx.symbolTable.getCurrentPackage();
-            String cacheKey = evalString + '\0' + evalTag + '\0' + hasUnicode + '\0' + ctx.isEvalbytes + '\0' + evalbytesUtf8Source + '\0' + isByteStringSource + '\0' + featureFlags + '\0' + currentPackage;
+            String cacheKey = evalString + '\0' + evalTag + '\0' + hasUnicode + '\0' + ctx.isEvalbytes + '\0' + evalbytesUtf8Source + '\0' + byteStringUtf8Source + '\0' + isByteStringSource + '\0' + featureFlags + '\0' + currentPackage;
             Class<?> cachedClass = null;
             if (!isDebugging) {
                 Map<String, Class<?>> runtimeEvalCache = evalCache();
@@ -2689,14 +2704,17 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
         try {
             String evalString = code.toString();
             boolean evalbytesUtf8Source = ctx.isEvalbytes && shouldDecodeEvalbytesUtf8Source(evalString);
-            if (evalbytesUtf8Source) {
+            boolean byteStringUtf8Source = !ctx.isEvalbytes
+                    && code.type == RuntimeScalarType.BYTE_STRING
+                    && (ctx.symbolTable.strictOptionsStack.peek() & Strict.HINT_UTF8) != 0;
+            if (evalbytesUtf8Source || byteStringUtf8Source) {
                 evalString = decodeEvalbytesUtf8Source(evalString);
             }
             evalTrace("evalStringWithInterpreter parse start tag=" + evalTag + " ctx=" + callContext +
                     " fileName=" + ctx.compilerOptions.fileName);
             // Handle Unicode source detection (same logic as evalStringHelper)
             boolean hasUnicode = false;
-            if (evalbytesUtf8Source) {
+            if (evalbytesUtf8Source || byteStringUtf8Source) {
                 hasUnicode = true;
             } else if (!ctx.isEvalbytes && code.type != RuntimeScalarType.BYTE_STRING) {
                 for (int i = 0; i < evalString.length(); i++) {
@@ -2710,7 +2728,9 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
             // Clone compiler options and set isUnicodeSource if needed
             // Always clone to avoid modifying the original and to set a unique filename
             CompilerOptions evalCompilerOptions = ctx.compilerOptions.clone();
-            boolean isByteStringSource = !ctx.isEvalbytes && code.type == RuntimeScalarType.BYTE_STRING;
+            boolean isByteStringSource = !ctx.isEvalbytes
+                    && code.type == RuntimeScalarType.BYTE_STRING
+                    && !byteStringUtf8Source;
             if (hasUnicode) {
                 evalCompilerOptions.isUnicodeSource = true;
             }
@@ -2718,6 +2738,7 @@ public class RuntimeCode extends RuntimeBase implements RuntimeScalarReference {
                 evalCompilerOptions.isEvalbytes = true;
             }
             if (isByteStringSource) {
+                evalCompilerOptions.isUnicodeSource = false;
                 evalCompilerOptions.isByteStringSource = true;
             }
             // Always generate a unique filename for each eval to prevent source location collisions

--- a/src/test/resources/unit/regex/eval_byte_source_utf8.t
+++ b/src/test/resources/unit/regex/eval_byte_source_utf8.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+use Test::More tests => 7;
+
+# Keep this compilation unit Unicode-sourced while individual eval sites
+# independently enable or disable the utf8 pragma: é.
+
+my $quoted_divide = pack('C*', 0x22, 0xC3, 0xB7, 0x22);
+ok(!utf8::is_utf8($quoted_divide), 'fixture is an octet string');
+
+{
+    use utf8;
+    my $value = eval $quoted_divide;
+    is($@, '', 'UTF-8 byte source compiles under lexical use utf8');
+    is(ord($value), 0xF7, 'lexical use utf8 decodes eval byte source');
+}
+
+{
+    no utf8;
+    my $value = eval $quoted_divide;
+    is(ord($value), 0xC3, 'no utf8 retains byte-source interpretation');
+}
+
+{
+    no utf8;
+    my $source = pack('C*', unpack('C*', "use utf8; \"\x{C3}\x{B7}\""));
+    my $value = eval $source;
+    is(ord($value), 0xF7, 'use utf8 inside byte source decodes following text');
+}
+
+{
+    no utf8;
+    my @prefix = unpack('C*', 'my $text = "use utf8"; "');
+    my $source = pack('C*', @prefix, 0xC3, 0xB7, 0x22);
+    my $value = eval $source;
+    is(ord($value), 0xC3, 'quoted use utf8 text does not activate the pragma');
+}
+
+{
+    use utf8;
+    my $malformed = pack('C*', 0x22, 0xFF, 0x22);
+    local $SIG{__WARN__} = sub { };
+    my $value = eval $malformed;
+    ok(!defined($value) && $@ =~ /Malformed UTF-8 character/,
+       'malformed UTF-8 byte source is fatal');
+}


### PR DESCRIPTION
## Summary

- decode byte-backed eval source when lexical `use utf8` is active
- activate decoding at the real parser boundary for `use utf8` inside evaluated source, without substring false positives
- preserve `no utf8` byte interpretation even in Unicode-sourced compilation units
- reject malformed UTF-8 source consistently across eval execution paths
- update the Phase 36 tracker and expose missing Joni syntax in the feature matrix

## Validation

- system Perl focused oracle: 7/7
- JVM focused oracle: 7/7
- interpreter focused oracle: 7/7
- direct JVM eval compiler (`JPERL_EVAL_NO_INTERPRETER=1`): 7/7
- warning-free full `make`: passed in 5m08s

## Stack

Draft stacked on #1019. This runtime parity fix is independent of the generated
boundary-corpus blocker, which is byte-mode regex marker substitution.
