### PR TITLE
fix: keep Joni syntax errors fatal

### DIFF
--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -443,6 +443,10 @@ matcher-specific timeouts on both execution backends.
     byte semantics and fatal malformed-UTF-8 diagnostics. The focused oracle
     passes 7/7 on system Perl, JVM, interpreter, and the direct JVM eval
     compiler.
+  - [x] Kept Joni syntax/value exceptions fatal for ordinary user-source
+    compilation while preserving executable-source validation deferral. The
+    focused oracle passes 7/7 and unchanged forced-Joni `reg_mesg.t` gains 259
+    raw passing assertions; 197 parser-acceptance differences remain classified.
 - [ ] Phase 5: Remove the Java matching backend
   - [x] Retired the unreachable top-level `(*PRUNE)` text rewrite after native
     Joni control-verb gates passed under default and forced-Java policy
@@ -451,9 +455,9 @@ matcher-specific timeouts on both execution backends.
 
 ### Next Steps
 
-1. Finalize PR #1019 after its tracker correction, then integrate the validated
-   fatal-Joni-syntax commit `d2fd88096` (+259 raw `reg_mesg.t` passes; warning-
-   free `make`) and publish it as the next stacked slice.
+1. Publish the integrated fatal-Joni-syntax slice after combined-stack focused
+   gates and warning-free `make`, then integrate the validated PRUNE
+   preprocessor retirement commit `5760874e4` as the next stacked slice.
 2. Fix lexical `use bytes` substitution when an upgraded marker regex matches a
    byte subject, without patching generated fixtures. Regenerate the lossless
    corpus and prove that chunks 05–10 no longer match literal boundary markers

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -1,5 +1,6 @@
 package org.perlonjava.runtime.regex;
 
+import org.joni.exception.SyntaxException;
 import org.perlonjava.backend.bytecode.InterpreterState;
 import org.perlonjava.runtime.WarningBitsRegistry;
 import org.perlonjava.runtime.operators.PerlUtfString;
@@ -501,7 +502,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         RegexFlags preloadFlags = fromModifiers(modifiers, patternString);
         UnicodeResolver.preloadUserDefinedProperties(
                 patternString, preloadFlags.isCaseInsensitive());
-        return compileSynchronized(patternString, modifiers, lexicalDebugMode, trustedCalloutCount);
+        return compileSynchronized(patternString, modifiers, lexicalDebugMode,
+                trustedCalloutCount, false);
     }
 
     /** User properties execute Perl code and therefore cannot be validated while compiling a CV. */
@@ -522,7 +524,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
      */
     public static void validateLiteralSyntax(String patternString, String modifiers) {
         try {
-            compileSynchronized(patternString, stripDebugMarkers(modifiers), debugMode(modifiers), 0);
+            compileSynchronized(patternString, stripDebugMarkers(modifiers),
+                    debugMode(modifiers), 0, true);
         } catch (PerlJavaUnimplementedException unsupported) {
             String message = unsupported.getMessage();
             if (message != null && (message.contains("premature end of char-class")
@@ -541,7 +544,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
 
     private static synchronized RuntimeRegex compileSynchronized(
             String patternString, String modifiers, int lexicalDebugMode,
-            int trustedCalloutCount) {
+            int trustedCalloutCount, boolean literalSyntaxValidation) {
         // Debug logging
         if (DEBUG_REGEX) {
             System.err.println("RuntimeRegex.compile: pattern=" + patternString + " modifiers=" + modifiers);
@@ -746,6 +749,22 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                     }
                     throw new PerlCompilerException(
                             "Can't find Unicode property definition \"" + invalidProperty + "\"");
+                }
+                // Joni reports malformed patterns with SyntaxException (including its
+                // ValueException subclass). These are real compile errors, not missing
+                // PerlOnJava features, so JPERL_UNIMPLEMENTED=warn must not downgrade them.
+                boolean validatesExecutableSource = literalSyntaxValidation
+                        && containsExecutableSource(originalPatternString,
+                                regex.regexFlags.isExtended());
+                if (e instanceof SyntaxException && !validatesExecutableSource) {
+                    String message = e.getMessage();
+                    if (literalSyntaxValidation && message != null
+                            && (message.contains("premature end of char-class")
+                                    || message.contains("Unclosed character class"))) {
+                        throw new PerlCompilerException("Unmatched [ in regex m/"
+                                + originalPatternString + "/");
+                    }
+                    throw new PerlCompilerException(message);
                 }
                 // PerlJavaUnimplementedException extends PerlCompilerException, so check
                 // the more specific type first. Real syntax errors (PerlCompilerException

--- a/src/test/resources/unit/regex/joni_syntax_errors_are_fatal.t
+++ b/src/test/resources/unit/regex/joni_syntax_errors_are_fatal.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More tests => 7;
+
+local $ENV{JPERL_UNIMPLEMENTED} = 'warn';
+my @warnings;
+local $SIG{__WARN__} = sub { push @warnings, @_ };
+
+for my $case (
+    [ 'qr/(?;x/',          'invalid group introducer' ],
+    [ 'qr/[z-a]/',         'invalid character range' ],
+    [ 'qr/x{2147483648}/', 'oversized quantifier' ],
+) {
+    my ($source, $description) = @$case;
+    my $ok = eval "$source; 1";
+    ok(!$ok, "$description is rejected");
+    ok(length($@), "$description populates the compile error");
+}
+
+is(scalar @warnings, 0, 'syntax errors are not downgraded to warnings');


### PR DESCRIPTION
## Summary

- keep malformed Joni syntax/value failures fatal even when `JPERL_UNIMPLEMENTED=warn`
- retain deferred validation only for executable-source patterns that require runtime compilation
- preserve Perl's contextual unmatched-character-class diagnostics
- add a 7-assertion standard-Perl/JVM/interpreter fatal-syntax oracle

## Validation

- system Perl focused set: 16/16 across four files
- JVM focused set: 16/16
- interpreter focused set: 16/16
- PerlOnJava4 warning-free full `make`: passed in 4m21s
- combined-stack warning-free full `make`: passed in 4m11s
- unchanged forced-Joni `reg_mesg.t`: +259 passing assertions on the source branch; 197 residual parser-acceptance differences classified

## Stack

Draft stacked on #1020.
