### PR TITLE
fix: reject invalid Perl inline regex options

### DIFF
--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -454,13 +454,17 @@ matcher-specific timeouts on both execution backends.
   - [x] Retired the unreachable top-level `(*PRUNE)` text rewrite after native
     Joni control-verb gates passed under default and forced-Java policy
     (`5760874e4`; 316 preprocessor lines removed).
+  - [x] Removed the disabled invalid-brace pass and its exclusive helpers
+    (`4be6a48e3`; 208 preprocessor lines removed), retaining active Perl/Joni
+    quantifier diagnostics as explicit focused hard/TODO gates.
 - [ ] Phase 6: Integration and release
 
 ### Next Steps
 
 1. Publish the integrated inline-option parser slice after combined-stack
    focused gates and warning-free `make`, then integrate the validated PRUNE
-   preprocessor retirement commit `5760874e4` as the next stacked slice.
+   and dead invalid-brace preprocessor retirement commits `5760874e4` and
+   `4be6a48e3` as the next stacked slice.
 2. Fix lexical `use bytes` substitution when an upgraded marker regex matches a
    byte subject, without patching generated fixtures. Regenerate the lossless
    corpus and prove that chunks 05–10 no longer match literal boundary markers

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -424,6 +424,9 @@ matcher-specific timeouts on both execution backends.
   - [x] Normalized explicit `Is_*` property/value assignments and the colon
     delimiter (PR #1019), gaining exactly 44,944 generated assertions on both
     execution backends without changing any plan.
+  - [x] Rejected 40 invalid Perl inline option/group-name forms in forked Joni
+    with exact JVM/interpreter `reg_mesg.t` parity, reducing residual Joni-only
+    acceptance differences from 198 to 158 (`028602adc`).
   - [ ] Fix byte-mode substitution of upgraded marker regexes so chunks 05–10
     exercise real boundary subjects, then close the property and boundary
     failures with exact JVM/interpreter plan and semantic parity before marking
@@ -455,8 +458,8 @@ matcher-specific timeouts on both execution backends.
 
 ### Next Steps
 
-1. Publish the integrated fatal-Joni-syntax slice after combined-stack focused
-   gates and warning-free `make`, then integrate the validated PRUNE
+1. Publish the integrated inline-option parser slice after combined-stack
+   focused gates and warning-free `make`, then integrate the validated PRUNE
    preprocessor retirement commit `5760874e4` as the next stacked slice.
 2. Fix lexical `use bytes` substitution when an upgraded marker regex matches a
    byte subject, without patching generated fixtures. Regenerate the lossless

--- a/src/test/resources/unit/regex/joni_inline_option_errors.t
+++ b/src/test/resources/unit/regex/joni_inline_option_errors.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use Test::More tests => 15;
+
+local $ENV{JPERL_UNIMPLEMENTED} = 'warn';
+my @warnings;
+local $SIG{__WARN__} = sub { push @warnings, @_ };
+
+for my $case (
+    [ 'qr/(?<;name>match)/', 'Group name must start with a non-digit word character' ],
+    [ 'qr/(?^-i:foo)/',      'Sequence (?^-...) not recognized' ],
+    [ 'qr/(?^d:foo)/',       'Sequence (?^d...) not recognized' ],
+    [ 'qr/(?^lu:foo)/',      'Regexp modifiers "l" and "u" are mutually exclusive' ],
+    [ 'qr/(?da:foo)/',       'Regexp modifiers "d" and "a" are mutually exclusive' ],
+    [ 'qr/(?lil:foo)/',      'Regexp modifier "l" may not appear twice' ],
+    [ 'qr/(?aaia:foo)/',     'Regexp modifier "a" may appear a maximum of twice' ],
+) {
+    my ($source, $expected) = @$case;
+    my $ok = eval "$source; 1";
+    ok(!$ok, "$source is rejected");
+    like($@, qr/^\Q$expected\E/, "$source reports the Perl diagnostic");
+}
+
+is(scalar @warnings, 0, 'fatal option diagnostics do not warn');

--- a/third_party/joni/src/org/joni/Parser.java
+++ b/third_party/joni/src/org/joni/Parser.java
@@ -625,6 +625,12 @@ class Parser extends Lexer {
                     option = bsOnOff(option, Option.CAPTURE_GROUP, false);
                     option = bsOnOff(option, Option.PERL_ASCII_STRICT, true);
                     fetch();
+                    if (c == '-') {
+                        newSyntaxException(PERL_CARET_MINUS_OPTION_NOT_RECOGNIZED);
+                    }
+                    if (c == 'd') {
+                        newSyntaxException(PERL_CARET_D_OPTION_NOT_RECOGNIZED);
+                    }
                 } else {
                     newSyntaxException(UNDEFINED_GROUP_OPTION);
                 }
@@ -642,6 +648,9 @@ class Parser extends Lexer {
             case 'u':
                 boolean neg = false;
                 int asciiModifierCount = 0;
+                boolean sawDefaultCharset = false;
+                boolean sawLocaleCharset = false;
+                boolean sawUnicodeCharset = false;
                 while (true) {
                     switch(c) {
                     case ':':
@@ -691,7 +700,13 @@ class Parser extends Lexer {
 
                     case 'a':     /* limits \d, \s, \w and POSIX brackets to ASCII range */
                         if ((syntax.op2OptionPerl() || syntax.op2OptionRuby()) && !neg) {
+                            if (syntax.op2OptionPerl() && sawDefaultCharset) {
+                                newSyntaxException(PERL_MODIFIERS_D_AND_A_MUTUALLY_EXCLUSIVE);
+                            }
                             asciiModifierCount++;
+                            if (syntax.op2OptionPerl() && asciiModifierCount > 2) {
+                                newSyntaxException(PERL_MODIFIER_A_MAXIMUM_TWICE);
+                            }
                             option = bsOnOff(option, Option.ASCII_RANGE, false);
                             option = bsOnOff(option, Option.POSIX_BRACKET_ALL_RANGE, true);
                             option = bsOnOff(option, Option.WORD_BOUND_ALL_RANGE, true);
@@ -704,6 +719,10 @@ class Parser extends Lexer {
                         }
                     case 'u':
                         if ((syntax.op2OptionPerl() || syntax.op2OptionRuby()) && !neg) {
+                            if (syntax.op2OptionPerl() && sawLocaleCharset) {
+                                newSyntaxException(PERL_MODIFIERS_L_AND_U_MUTUALLY_EXCLUSIVE);
+                            }
+                            sawUnicodeCharset = true;
                             option = bsOnOff(option, Option.ASCII_RANGE, true);
                             option = bsOnOff(option, Option.POSIX_BRACKET_ALL_RANGE, true);
                             option = bsOnOff(option, Option.WORD_BOUND_ALL_RANGE, true);
@@ -715,6 +734,10 @@ class Parser extends Lexer {
 
                     case 'd':
                         if (syntax.op2OptionPerl() && !neg) {
+                            if (asciiModifierCount > 0) {
+                                newSyntaxException(PERL_MODIFIERS_D_AND_A_MUTUALLY_EXCLUSIVE);
+                            }
+                            sawDefaultCharset = true;
                             option = bsOnOff(option, Option.ASCII_RANGE, true);
                             option = bsOnOff(option, Option.PERL_ASCII_STRICT, true);
                         } else if (syntax.op2OptionRuby() && !neg) {
@@ -728,6 +751,13 @@ class Parser extends Lexer {
 
                     case 'l':
                         if (syntax.op2OptionPerl() && !neg) {
+                            if (sawUnicodeCharset) {
+                                newSyntaxException(PERL_MODIFIERS_L_AND_U_MUTUALLY_EXCLUSIVE);
+                            }
+                            if (sawLocaleCharset) {
+                                newSyntaxException(PERL_MODIFIER_L_MAY_NOT_APPEAR_TWICE);
+                            }
+                            sawLocaleCharset = true;
                             option = bsOnOff(option, Option.ASCII_RANGE, true);
                             option = bsOnOff(option, Option.PERL_ASCII_STRICT, true);
                         } else {
@@ -905,6 +935,12 @@ class Parser extends Lexer {
     }
 
     private Node parseEncloseNamedGroup2(boolean listCapture) {
+        if (syntax.op2OptionPerl() && left()) {
+            int first = enc.mbcToCode(bytes, p, stop);
+            if (enc.isDigit(first) || !enc.isWord(first)) {
+                newValueException(PERL_GROUP_NAME_MUST_START_WITH_WORD);
+            }
+        }
         int nm = p;
         fetchName(c, false);
         int nameEnd = value;

--- a/third_party/joni/src/org/joni/exception/ErrorMessages.java
+++ b/third_party/joni/src/org/joni/exception/ErrorMessages.java
@@ -57,6 +57,20 @@ public interface ErrorMessages extends org.jcodings.exception.ErrorMessages {
     String INVALID_LOOK_BEHIND_PATTERN = "invalid pattern in look-behind";
     String INVALID_REPEAT_RANGE_PATTERN = "invalid repeat range {lower,upper}";
     String INVALID_CONDITION_PATTERN = "invalid conditional pattern";
+    String PERL_GROUP_NAME_MUST_START_WITH_WORD =
+            "Group name must start with a non-digit word character";
+    String PERL_CARET_MINUS_OPTION_NOT_RECOGNIZED =
+            "Sequence (?^-...) not recognized";
+    String PERL_CARET_D_OPTION_NOT_RECOGNIZED =
+            "Sequence (?^d...) not recognized";
+    String PERL_MODIFIERS_L_AND_U_MUTUALLY_EXCLUSIVE =
+            "Regexp modifiers \"l\" and \"u\" are mutually exclusive";
+    String PERL_MODIFIERS_D_AND_A_MUTUALLY_EXCLUSIVE =
+            "Regexp modifiers \"d\" and \"a\" are mutually exclusive";
+    String PERL_MODIFIER_L_MAY_NOT_APPEAR_TWICE =
+            "Regexp modifier \"l\" may not appear twice";
+    String PERL_MODIFIER_A_MAXIMUM_TWICE =
+            "Regexp modifier \"a\" may appear a maximum of twice";
 
     /* values error (syntax error) */
     String TOO_BIG_NUMBER = "too big number";

--- a/third_party/joni/test/org/joni/test/TestPerl.java
+++ b/third_party/joni/test/org/joni/test/TestPerl.java
@@ -21,6 +21,7 @@ package org.joni.test;
 
 import org.joni.Option;
 import org.joni.Syntax;
+import org.joni.exception.ErrorMessages;
 import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
 
@@ -43,6 +44,13 @@ public class TestPerl extends Test {
     }
 	@Override
     public void test() throws Exception {
+        xerrs("(?<;name>match)", ErrorMessages.PERL_GROUP_NAME_MUST_START_WITH_WORD);
+        xerrs("(?^-i:foo)", ErrorMessages.PERL_CARET_MINUS_OPTION_NOT_RECOGNIZED);
+        xerrs("(?^d:foo)", ErrorMessages.PERL_CARET_D_OPTION_NOT_RECOGNIZED);
+        xerrs("(?^lu:foo)", ErrorMessages.PERL_MODIFIERS_L_AND_U_MUTUALLY_EXCLUSIVE);
+        xerrs("(?da:foo)", ErrorMessages.PERL_MODIFIERS_D_AND_A_MUTUALLY_EXCLUSIVE);
+        xerrs("(?lil:foo)", ErrorMessages.PERL_MODIFIER_L_MAY_NOT_APPEAR_TWICE);
+        xerrs("(?aaia:foo)", ErrorMessages.PERL_MODIFIER_A_MAXIMUM_TWICE);
     }
 
     @org.junit.Test(timeout = 5000)


### PR DESCRIPTION
## Summary

- reject invalid Perl inline option and group-name forms in the forked Joni parser
- preserve Ruby parser behavior by gating validation to Perl syntax
- add exact Joni error constants and vendored parser assertions
- add a 15-assertion standard-Perl/JVM/interpreter language-level oracle

## Validation

- focused system Perl: 15/15
- focused JVM: 15/15
- focused interpreter: 15/15
- PerlOnJava4 warning-free full `make`: passed in 5m08s
- combined-stack warning-free full `make`: passed in 4m20s with the promoted language-level oracle
- unchanged forced-Joni `reg_mesg.t`: exact JVM/interpreter parity at 1,389/2,495, +40 passing with no plan change

## Stack

Draft stacked on #1021.
