### PR TITLE
fix(regex): preserve Joni byte-mode pattern semantics

### DIFF
--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -224,35 +224,30 @@ compatibility contract.
 
 ### Current Status: Phases 0, 2, and 4 complete; Phases 1 and 3 corpus gates active
 
-The combined integration stack now includes immutable Joni offset-map reuse,
-regex-set property preservation, bounded catastrophic-backtracking safeguards,
-user-property diagnostics and provenance, and focused built-in Unicode alias
-normalization. The focused property gates pass 39/39, 12/12, 8/8, and 16/16;
-unchanged `regexp_unicode_prop.t` passes 1,110/1,110 on JVM and interpreter.
-Draft PR #1016 preserves each validated prerequisite head and passed a
-warning-free full `make` on its corrected integration history.
+The current integration stack is preserved through draft PR #1023. It includes
+the completed callback/runtime slices, lossless generated Unicode fixtures,
+explicit `Is_*` property/value normalization, fatal Joni syntax diagnostics,
+and the first 524 lines of retired Java-only preprocessor code. Every published
+slice has a warning-free combined `make` checkpoint.
 
-The lossless generated `TestProp.pl` fixture now exposes ten previously gated
-`uniprops*.t` files. The exact-history JVM run executes all 290,912 planned
-assertions with zero timeouts or incomplete files, at 175,768 passing and
-115,144 failing. PR 958 recorded zero plan for all ten files, so this is new
-coverage rather than a regression, but it reopens Phase 3's full-corpus exit
-gate. The interpreter produces the exact same 175,768/290,912 split, with
-identical per-file plans and no timeout or incomplete file. Semantic-key
-validation found that all 123,411 generated records
-in chunks 05–10 retain literal UTF-8 boundary markers in both subjects and
-patterns. Their 122,620 apparent passing assertions are therefore vacuous,
-not evidence of boundary or folding parity. Chunks 01–04 contain the genuine
-property and hand-written boundary evidence. An exact upstream-stage reducer
-shows that lexical `use bytes` fails to replace the upgraded marker regex in a
-byte subject (system Perl 4/4, JVM/interpreter 2/4); that byte-mode substitution
-gap must be fixed before chunks 05–10 can become an authoritative boundary gate.
+Lexical `use bytes` now compiles non-ASCII substitution patterns with a
+single-byte Joni encoding while preserving upgraded, byte-backed, and compiled
+`qr//` source provenance. The focused oracle passes 12/12 on system Perl, JVM,
+and interpreter, and the exact upstream marker-stage reducer improves from 2/4
+to 4/4 on both execution backends. Generated chunks 05–10 consequently execute
+239,843 genuine boundary assertions rather than matching literal UTF-8 marker
+text. JVM and interpreter have exact per-file parity at 2,192/239,843 with every
+plan complete, exit 0, and no child timeout; all current passes are in the GCB
+chunk (2,192/14,953), while the line, sentence, and word boundary chunks expose
+zero passing assertions. The runner classifies zero-pass files as `error`, but
+their recorded plans, actual counts, and process exits are complete.
 
-Explicit `Is_*` property/value assignments now normalize before built-in
-routing, including Perl's colon delimiter. The focused 12-assertion oracle
-passes on system Perl, JVM, and interpreter. The generated corpus rises by
-exactly 44,944 assertions to 220,712/290,912 on both execution backends, with
-identical per-file counts and zero errors, timeouts, or incomplete files.
+The most recent exact property chunks 01–04 remain 98,092/167,501 on both
+execution backends. Combined with the newly authoritative boundary chunks, the
+current generated evidence is 100,284/407,344. A current-head refresh of chunks
+01–04 is running in a reduced resource lane because an oversubscribed first
+attempt reached the runner's no-output deadline; retain the prior exact counts
+until that refresh completes.
 
 Joni now accepts Perl's top-level, scoped, combined, and negative inline `p`
 syntax as matcher-neutral policy. PerlOnJava publishes that policy while
@@ -346,6 +341,10 @@ matcher-specific timeouts on both execution backends.
     and substitution, including Unicode subjects and code replacements. The
     focused oracle passes 12/12 and unchanged `subst.t` passes 275/281 on JVM
     and interpreter.
+  - [x] Added a provenance-aware single-byte Joni pattern/input path for
+    non-ASCII substitutions under lexical `use bytes`. Upgraded, byte-backed,
+    and compiled byte-backed patterns pass 12/12 on all runtimes, and the
+    generated Unicode marker stage passes 4/4 on JVM and interpreter.
 - [x] Phase 2: Conditions and backtracking-visible state (2026-08-17)
   - [x] Implemented executable callback conditions, control verbs including
     `(*MARK:NAME)`, and callback-visible recursive capture state in Joni.
@@ -427,9 +426,10 @@ matcher-specific timeouts on both execution backends.
   - [x] Rejected 40 invalid Perl inline option/group-name forms in forked Joni
     with exact JVM/interpreter `reg_mesg.t` parity, reducing residual Joni-only
     acceptance differences from 198 to 158 (`028602adc`).
-  - [ ] Fix byte-mode substitution of upgraded marker regexes so chunks 05–10
-    exercise real boundary subjects, then close the property and boundary
-    failures with exact JVM/interpreter plan and semantic parity before marking
+  - [x] Fixed byte-mode substitution of upgraded marker regexes so chunks 05–10
+    exercise real boundary subjects with exact JVM/interpreter plans.
+  - [ ] Implement native Joni GCB, line, sentence, and word boundary algorithms,
+    then close the remaining property and boundary failures before marking
     Phase 3 complete.
 - [x] Phase 4: Runtime source and diagnostics (2026-08-17; semantic gate
   complete at 550/555)
@@ -457,20 +457,23 @@ matcher-specific timeouts on both execution backends.
   - [x] Removed the disabled invalid-brace pass and its exclusive helpers
     (`4be6a48e3`; 208 preprocessor lines removed), retaining active Perl/Joni
     quantifier diagnostics as explicit focused hard/TODO gates.
+  - [x] Removed the Java-only terminated-whitespace possessification pass
+    (`c5343aca2`; 80 preprocessor lines removed) after greedy backtracking and
+    20,000-character gates passed default and forced-Java policy on both
+    execution backends.
 - [ ] Phase 6: Integration and release
 
 ### Next Steps
 
-1. Publish the integrated PRUNE and dead invalid-brace preprocessor retirement
-   slice after its warning-free combined `make`, then integrate the validated
-   forked-Joni braced-octal diagnostics/tokenization slice. Continue retiring
-   independently proven Java-only preprocessor rewrites as they complete.
-2. Fix lexical `use bytes` substitution when an upgraded marker regex matches a
-   byte subject, without patching generated fixtures. Regenerate the lossless
-   corpus and prove that chunks 05–10 no longer match literal boundary markers
-   before treating any boundary or folding result as evidence. Retain the now-
-   completed eval byte-source UTF-8 oracle as an independent runtime regression
-   gate; it is not the generated-corpus marker fix.
+1. Publish the byte-mode Joni pattern slice after its warning-free `make` and
+   authoritative boundary-corpus measurement. Then integrate the validated
+   braced-octal, braced-hex, and terminated-whitespace slices as focused
+   stacked PRs; add lazy-negated-class retirement after its validation completes.
+2. Implement boundary semantics natively in Joni in measured order: GCB first
+   (2,192/14,953 currently pass), followed by line, sentence, and word breaks
+   (currently 0/224,890). Use bundled Perl 5.44 Unicode data and the generated
+   chunks as the release oracle; remove the simplified Java boundary rewrites
+   only after native parity.
 3. Implement the remaining property clusters in measured order: Block,
    Script/Script_Extensions, Numeric_Value, Joining_Group, General_Category,
    break-property values, and Age/In/Present_In. Preserve pinned Perl 5.44

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -371,7 +371,7 @@ my @copy = @{$z};         # ERROR
 - ✅  **Inline comments**: `(?#comment)` in regex is implemented.
 - ✅  **caret modifier**: `(?^` embedded pattern-match modifier, shorthand equivalent to "d-imnsx".
 - ✅  **\b inside character class**: `[\b]` is supported in regex.
-- 🟡  **Unicode boundary assertions**: `\b{gcb}`, `\B{gcb}`, and the `wb`/`lb`/`sb` forms are recognized, but the genuine hand-written generated-corpus preamble still has 25 semantic failures; comprehensive generated coverage is blocked by byte-mode marker normalization.
+- 🟡  **Unicode boundary assertions**: `\b{gcb}`, `\B{gcb}`, and the `wb`/`lb`/`sb` forms are recognized. Byte-mode marker normalization is fixed, so the generated boundary corpus is authoritative: GCB passes 2,192/14,953, while line, sentence, and word boundary chunks currently pass 0/224,890 on both execution backends.
 - ✅  **Variable Interpolation in Regex**: Features like `${var}` for embedding variables.
 - ✅  **Non-capturing groups**: `(?:...)` is implemented.
 - ✅  **Named Capture Groups**: Defining named capture groups using `(?<name>...)` or `(?'name'...)` is supported.
@@ -386,7 +386,7 @@ my @copy = @{$z};         # ERROR
 - ✅  **Overloading**: `qr` overloading is implemented. See also [overload pragma](#pragmas).
 - ❌  **Python-style named groups**: `(?P<name>...)` and `(?P=name)` are accepted by Perl but are not yet parsed by Joni.
 - ❌  **Alpha assertion aliases**: `(*pla:...)`, `(*plb:...)`, `(*nla:...)`, `(*nlb:...)`, and `(*atomic:...)` are not yet parsed by Joni.
-- ❌  **Underscored numeric regex escapes**: Perl spellings such as `\x{0_0_4_1}` and `\o{0_0_1_0_1}` are not yet parsed by Joni; braced octal syntax also needs complete validation and diagnostics.
+- ❌  **Underscored numeric regex escapes**: Perl spellings such as `\x{0_0_4_1}` and `\o{0_0_1_0_1}` are not yet parsed by Joni. Valid braced octal and unconditional missing-close/empty diagnostics are implemented in the pending parser stack; three `use re 'strict'` non-octal cases remain deferred.
 
 - ✅  **Dynamically-scoped regex variables**: Provisional captures, `$^R`, `$^N`, match positions, and callback locals follow matcher paths and unwind on backtracking.
 - ✅  **Recursive and Dynamic Patterns**: `(?R)`, `(?0)`, and runtime `(??{ code })` execute through Joni. Dynamic expressions may return strings or `qr//` values, nested alternatives participate in outer backtracking without changing outer grouping or capture numbering, and callback and pure-pattern recursion have engine-owned depth ceilings.
@@ -397,8 +397,8 @@ my @copy = @{$z};         # ERROR
 - ✅  **Branch Reset Groups**: `(?|...)` resets capture numbering across alternatives and preserves mapped match variables.
 - ✅  **Advanced Subroutine Calls**: Sub-pattern calls with numbered or named references like `(?1)` and `(?&name)` execute through Joni.
 - ✅  **Conditional Expressions**: Numbered and named capture conditions, positive and negative assertion conditions, recursion conditions `(?(R))`, `(?(R1))`, and `(?(R&name))`, executable callback conditions, and optimistic predicates execute through Joni.
-- 🟡  **Extended Unicode Regex Features**: Focused Script, Block, Script Extensions, `Extended_Pictographic`, `Age`, `In`/`Present_In`, and invalid-property gates execute through Joni, and `regexp_unicode_prop.t` passes 1,110/1,110. The lossless generated `uniprops*.t` matrix currently passes 220,712/290,912 identically on JVM and interpreter, but chunks 01–04 still expose broad loose property/value alias gaps and chunks 05–10 are not yet valid boundary evidence because byte-mode substitution does not normalize upgraded boundary-marker regexes against byte subjects.
-- 🟡  **Extended Grapheme Clusters**: Focused `\X` combining-sequence and emoji-ZWJ cases pass, but comprehensive generated UAX verification remains blocked by byte-mode boundary-marker normalization.
+- 🟡  **Extended Unicode Regex Features**: Focused Script, Block, Script Extensions, `Extended_Pictographic`, `Age`, `In`/`Present_In`, and invalid-property gates execute through Joni, and `regexp_unicode_prop.t` passes 1,110/1,110. Current generated evidence is 100,284/407,344 identically on JVM and interpreter: chunks 01–04 expose property/value alias gaps, and authoritative chunks 05–10 expose native boundary-algorithm gaps.
+- 🟡  **Extended Grapheme Clusters**: Focused `\X` combining-sequence and emoji-ZWJ cases pass. The authoritative generated GCB matrix now passes 2,192/14,953 identically on JVM and interpreter; full native GCB boundary rules remain incomplete.
 - ✅  **Embedded Code in Regex**: `(?{ code })`, optimistic callbacks `(*{ code })`, executable callback conditions, and `(??{ code })` run as lexical closures in Joni with provisional captures and backtracking unwind. Callback `local` frames follow matcher paths, and escaped loop control or `goto` stops at the callback pseudo-block boundary. `$^N` follows capture-close order independently of `$+`.
 - ✅  **Regex Debugging**: Lexically scoped `use/no re 'debug'` and `debugcolor` are supported, including runtime snapshot ownership.
 - ✅  **Runtime Regex Evaluation**: `use re 'eval'` controls whether interpolated patterns containing eval groups may compile. Admitted runtime source is compiled into lexical callback closures and preserves its package, visible lexical cells, Unicode or byte source type, default regex modifiers, and match-once state. Literal callbacks, interpolated `qr//` values (including local, referenced, and tied arrays), raw runtime eval groups, callback conditions, and standalone `(?(DEFINE)...)` containers may be composed in one Joni pattern; dynamic callbacks may return further admitted executable source.

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -1,5 +1,6 @@
 package org.perlonjava.runtime.regex;
 
+import org.jcodings.specific.ISO8859_1Encoding;
 import org.jcodings.specific.UTF8Encoding;
 import org.joni.Matcher;
 import org.joni.CalloutHandler;
@@ -32,6 +33,7 @@ import org.perlonjava.runtime.runtimetypes.*;
  */
 final class JoniRegexPattern {
     private static final Map<String, InputEncoding> INPUT_ENCODINGS = new WeakHashMap<>();
+    private static final Map<String, InputEncoding> BYTE_INPUT_ENCODINGS = new WeakHashMap<>();
 
     // Ruby syntax defaults \w to ASCII even for a Unicode encoding. Perl's
     // default and /u modes use Unicode character classes; /a adds ASCII_RANGE
@@ -52,6 +54,7 @@ final class JoniRegexPattern {
     private final RegexFlags flags;
     private final boolean hasControlVerbState;
     private final boolean hasDeferredUserDefinedUnicodeProperty;
+    private final boolean byteMode;
 
     JoniRegexPattern(String perlPattern, RegexFlags flags) {
         this(perlPattern, flags, 0, false);
@@ -63,14 +66,23 @@ final class JoniRegexPattern {
 
     JoniRegexPattern(String perlPattern, RegexFlags flags, int trustedCalloutCount,
                      boolean forceAsciiClasses) {
+        this(perlPattern, flags, trustedCalloutCount, forceAsciiClasses, false, false);
+    }
+
+    JoniRegexPattern(String perlPattern, RegexFlags flags, int trustedCalloutCount,
+                     boolean forceAsciiClasses, boolean byteMode,
+                     boolean byteBackedPattern) {
         this.flags = flags;
+        this.byteMode = byteMode;
         hasControlVerbState = hasControlVerbState(perlPattern);
         UserPropertyTranslation userProperties = translateUserDefinedProperties(perlPattern, flags);
         hasDeferredUserDefinedUnicodeProperty = userProperties.deferred();
         sourcePattern = translatePattern(userProperties.pattern(), flags, trustedCalloutCount);
-        byte[] bytes = sourcePattern.getBytes(StandardCharsets.UTF_8);
+        byte[] bytes = sourcePattern.getBytes(byteMode && byteBackedPattern
+                ? StandardCharsets.ISO_8859_1 : StandardCharsets.UTF_8);
         regex = new Regex(bytes, 0, bytes.length, toJoniOptions(flags, forceAsciiClasses),
-                UTF8Encoding.INSTANCE, PERLONJAVA_SYNTAX);
+                byteMode ? ISO8859_1Encoding.INSTANCE : UTF8Encoding.INSTANCE,
+                PERLONJAVA_SYNTAX);
         namedGroups = collectNamedGroups(regex);
     }
 
@@ -81,7 +93,7 @@ final class JoniRegexPattern {
     RegexMatcher matcher(String input, List<RuntimeRegexCallback> callbacks,
                          RuntimeScalar subject) {
         return new JoniRegexMatcher(regex, sourcePattern, namedGroups, flags,
-                hasControlVerbState, input, callbacks, subject);
+                hasControlVerbState, byteMode, input, callbacks, subject);
     }
 
     record InputEncoding(byte[] bytes, int[] charToByte, int[] byteToChar) {}
@@ -90,6 +102,20 @@ final class JoniRegexPattern {
         synchronized (INPUT_ENCODINGS) {
             return INPUT_ENCODINGS.computeIfAbsent(input, JoniRegexPattern::buildInputEncoding);
         }
+    }
+
+    static InputEncoding byteInputEncoding(String input) {
+        synchronized (BYTE_INPUT_ENCODINGS) {
+            return BYTE_INPUT_ENCODINGS.computeIfAbsent(input,
+                    JoniRegexPattern::buildByteInputEncoding);
+        }
+    }
+
+    private static InputEncoding buildByteInputEncoding(String input) {
+        byte[] bytes = input.getBytes(StandardCharsets.ISO_8859_1);
+        int[] identity = new int[input.length() + 1];
+        for (int i = 0; i < identity.length; i++) identity[i] = i;
+        return new InputEncoding(bytes, identity, identity);
     }
 
     private static InputEncoding buildInputEncoding(String input) {
@@ -634,22 +660,26 @@ final class JoniRegexPattern {
         private boolean matched;
         private int committedLastClosedCapture = -1;
         private final boolean hasControlVerbState;
+        private final boolean byteMode;
         private final List<RuntimeRegexCallback> callbacks;
         private final RuntimeScalar subject;
         private PerlCalloutHandler calloutHandler;
 
         JoniRegexMatcher(Regex regex, String sourcePattern, Map<String, Integer> namedGroups,
-                         RegexFlags flags, boolean hasControlVerbState, String input,
+                         RegexFlags flags, boolean hasControlVerbState, boolean byteMode,
+                         String input,
                          List<RuntimeRegexCallback> callbacks, RuntimeScalar subject) {
             this.regex = regex;
             this.sourcePattern = sourcePattern;
             this.namedGroups = namedGroups;
             this.flags = flags;
             this.hasControlVerbState = hasControlVerbState;
+            this.byteMode = byteMode;
             this.input = input;
             this.callbacks = callbacks;
             this.subject = subject;
-            InputEncoding encoding = inputEncoding(input);
+            InputEncoding encoding = byteMode
+                    ? byteInputEncoding(input) : inputEncoding(input);
             this.bytes = encoding.bytes();
             this.charToByte = encoding.charToByte();
             this.byteToChar = encoding.byteToChar();
@@ -797,12 +827,12 @@ final class JoniRegexPattern {
             if (knownGroup != null) return knownGroup;
             byte[] nameBytes = name.getBytes(StandardCharsets.UTF_8);
             return regex.nameToBackrefNumber(nameBytes, 0, nameBytes.length,
-                    UTF8Encoding.INSTANCE, captures);
+                    byteMode ? ISO8859_1Encoding.INSTANCE : UTF8Encoding.INSTANCE, captures);
         }
 
         private int advanceCodePoint(int offset) {
             return offset >= regionEnd ? regionEnd + 1
-                    : offset + Character.charCount(input.codePointAt(offset));
+                    : offset + (byteMode ? 1 : Character.charCount(input.codePointAt(offset)));
         }
 
         private int toCharOffset(int byteOffset) {

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -186,12 +186,16 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
     Pattern notemptyPatternUnicode;
     JoniRegexPattern recursivePattern;
     JoniRegexPattern recursivePatternUnicode;
+    JoniRegexPattern recursivePatternBytes;
     List<RuntimeRegexCallback> executableCallbacks = List.of();
     private boolean executableCallbacksReleased;
     int[] branchResetCaptureMap;
     int patternFlags;
     int patternFlagsUnicode;
     public String patternString;
+    // Source scalar provenance needed when a compiled qr// is reused under
+    // lexical use bytes: byte-backed source characters are already octets.
+    private boolean patternByteBacked;
     String javaPatternString; // Preprocessed Java-compatible pattern for recompilation
     private String requiredLiteral;
     boolean hasPreservesMatch = false;  // True if /p was used (outer or inline (?p))
@@ -241,11 +245,13 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         copy.notemptyPatternUnicode = this.notemptyPatternUnicode;
         copy.recursivePattern = this.recursivePattern;
         copy.recursivePatternUnicode = this.recursivePatternUnicode;
+        copy.recursivePatternBytes = this.recursivePatternBytes;
         copy.setExecutableCallbacks(this.executableCallbacks);
         copy.branchResetCaptureMap = this.branchResetCaptureMap;
         copy.patternFlags = this.patternFlags;
         copy.patternFlagsUnicode = this.patternFlagsUnicode;
         copy.patternString = this.patternString;
+        copy.patternByteBacked = this.patternByteBacked;
         copy.javaPatternString = this.javaPatternString;
         copy.requiredLiteral = this.requiredLiteral;
         copy.hasPreservesMatch = this.hasPreservesMatch;
@@ -313,6 +319,10 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
     }
 
     private JoniRegexPattern selectRecursivePattern(RuntimeScalar string) {
+        if (bytesSubstitution && recursivePatternBytes != null
+                && string.type == RuntimeScalarType.BYTE_STRING) {
+            return recursivePatternBytes;
+        }
         if (recursivePatternUnicode != null && recursivePatternUnicode != recursivePattern
                 && regexFlags != null && !regexFlags.isAscii() && Utf8.isUtf8(string)) {
             return recursivePatternUnicode;
@@ -1373,6 +1383,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             regex.patternNoInternalMarkers = originalRegex.patternNoInternalMarkers;
             regex.patternUnicodeNoInternalMarkers = originalRegex.patternUnicodeNoInternalMarkers;
             regex.patternString = originalRegex.patternString;
+            regex.patternByteBacked = originalRegex.patternByteBacked;
             regex.deferredUserDefinedUnicodeProperties =
                     originalRegex.deferredUserDefinedUnicodeProperties;
             regex.hasPreservesMatch = originalRegex.hasPreservesMatch;
@@ -1415,6 +1426,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                     regex.patternNoInternalMarkers = originalRegex.patternNoInternalMarkers;
                     regex.patternUnicodeNoInternalMarkers = originalRegex.patternUnicodeNoInternalMarkers;
                     regex.patternString = originalRegex.patternString;
+                    regex.patternByteBacked = originalRegex.patternByteBacked;
                     regex.deferredUserDefinedUnicodeProperties =
                             originalRegex.deferredUserDefinedUnicodeProperties;
                     regex.hasPreservesMatch = originalRegex.hasPreservesMatch;
@@ -1445,8 +1457,10 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
 
         // Default: compile as string (cloneTracked() creates a tracked copy
         // so the cached RuntimeRegex is not corrupted by refCount changes)
-        return new RuntimeScalar(compile(patternString.toString(), modifierStr, callSiteDebugMode).cloneTracked())
-                .propagateTaint(patternString);
+        RuntimeRegex compiled = compile(patternString.toString(), modifierStr,
+                callSiteDebugMode).cloneTracked();
+        compiled.patternByteBacked = patternString.type == RuntimeScalarType.BYTE_STRING;
+        return new RuntimeScalar(compiled).propagateTaint(patternString);
     }
 
     static boolean containsExecutableSource(String pattern) {
@@ -1617,6 +1631,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
         regex.patternNoInternalMarkers = resolvedRegex.patternNoInternalMarkers;
         regex.patternUnicodeNoInternalMarkers = resolvedRegex.patternUnicodeNoInternalMarkers;
         regex.patternString = resolvedRegex.patternString;
+        regex.patternByteBacked = resolvedRegex.patternByteBacked;
         regex.deferredUserDefinedUnicodeProperties =
                 resolvedRegex.deferredUserDefinedUnicodeProperties;
         regex.regexFlags = resolvedRegex.regexFlags;
@@ -1705,8 +1720,26 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                                                          RuntimeScalar modifiers,
                                                          RuntimeArray callerArgs) {
         RuntimeScalar result = getReplacementRegex(patternString, replacement, modifiers, callerArgs);
-        ((RuntimeRegex) result.value).bytesSubstitution = true;
+        RuntimeRegex regex = (RuntimeRegex) result.value;
+        regex.bytesSubstitution = true;
+        String sourcePattern = patternString.type == RuntimeScalarType.REGEX
+                ? regex.patternString : patternString.toString();
+        if (regex.recursivePattern != null && containsNonAscii(sourcePattern)) {
+            boolean byteBackedPattern = patternString.type == RuntimeScalarType.REGEX
+                    ? regex.patternByteBacked
+                    : patternString.type == RuntimeScalarType.BYTE_STRING;
+            regex.recursivePatternBytes = new JoniRegexPattern(sourcePattern,
+                    regex.regexFlags, regex.executableCallbacks.size(), true,
+                    true, byteBackedPattern);
+        }
         return result;
+    }
+
+    private static boolean containsNonAscii(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) > 0x7f) return true;
+        }
+        return false;
     }
 
     /**

--- a/src/test/resources/unit/regex/bytes_upgraded_pattern_substitution.t
+++ b/src/test/resources/unit/regex/bytes_upgraded_pattern_substitution.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+use Test::More tests => 12;
+
+my $marker_utf8 = my $marker = chr(0xF7);
+utf8::upgrade($marker_utf8);
+
+my $bytes = pack('C*', 0x27, 0xC3, 0xB7, 0x27);
+ok(!utf8::is_utf8($bytes), 'fixture starts as an octet string');
+is(length($bytes), 4, 'fixture contains the encoded marker bytes');
+
+{
+    use bytes;
+    is($bytes =~ s/$marker_utf8/$marker/g, 1,
+        'upgraded pattern matches its encoded octets under use bytes');
+}
+
+ok(!utf8::is_utf8($bytes), 'byte substitution preserves octet storage');
+is(length($bytes), 3, 'encoded marker contracts to one replacement octet');
+is(unpack('H*', $bytes), '27f727', 'replacement has the canonical marker byte');
+
+my $byte_pattern = pack('C*', 0xC3, 0xB7);
+my $byte_pattern_target = pack('C*', 0x41, 0xC3, 0xB7, 0x42);
+{
+    use bytes;
+    is($byte_pattern_target =~ s/$byte_pattern/X/g, 1,
+        'byte-backed pattern remains a literal octet sequence');
+}
+is($byte_pattern_target, 'AXB', 'byte-backed pattern consumes exactly two octets');
+
+my $byte_qr = qr/$byte_pattern/;
+my $byte_qr_target = pack('C*', 0x41, 0xC3, 0xB7, 0x42);
+{
+    use bytes;
+    is($byte_qr_target =~ s/$byte_qr/Y/g, 1,
+        'compiled byte-backed pattern retains its octet provenance');
+}
+is($byte_qr_target, 'AYB', 'compiled byte-backed pattern consumes two octets');
+
+my $ordinary = "A${marker_utf8}B";
+is($ordinary =~ s/$marker_utf8/X/g, 1,
+    'ordinary Unicode substitution still matches one character');
+is($ordinary, 'AXB', 'ordinary Unicode substitution remains character based');


### PR DESCRIPTION
## Summary

- compile non-ASCII substitution patterns with a single-byte Joni encoding under lexical `use bytes`
- preserve upgraded, byte-backed, and compiled byte-backed pattern provenance
- use identity byte/offset maps for byte-native matching while preserving the established ASCII-only path
- activate the genuine generated Unicode boundary corpus and update the Phase 36 tracker

## Validation

- focused byte-pattern oracle: system Perl, JVM, and interpreter all 12/12
- exact upstream marker-stage reducer: JVM and interpreter improve from 2/4 to 4/4
- existing byte substitution suite: JVM and interpreter both 6/6
- generated chunks 05–10: exact JVM/interpreter parity at 2,192/239,843; every plan complete, exit 0, no timeout or incomplete file
- warning-free full `make`: passed in 8m11s under concurrent corpus/build load
- Joni packaging verification and vendored tests: passed

## Corpus result

The repaired marker stage makes chunks 05–10 authoritative. GCB currently
passes 2,192/14,953; line, sentence, and word boundary chunks expose the next
native-Joni implementation gap at 0/224,890.

## Stack

Draft stacked on #1023.
