### PR TITLE
fix: implement Perl vertical whitespace escapes in Joni

### DIFF
--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -224,7 +224,7 @@ compatibility contract.
 
 ### Current Status: Phases 0, 2, and 4 complete; Phases 1 and 3 corpus gates active
 
-The published integration stack is preserved through draft PR #1032, stacked
+The published integration stack is preserved through draft PR #1033, stacked
 on draft PRs #1025–#1026 and review-ready PR #1024. It includes the completed callback/runtime slices,
 lossless generated Unicode fixtures, explicit `Is_*` property/value
 normalization, fatal Joni syntax diagnostics, native GCB semantics, and the
@@ -236,8 +236,9 @@ progression and pinned Perl 5.44 Unicode 17.0 Age properties. PR #1030 adds
 binary `ASCII_Hex_Digit` values, pinned General_Category sets, and exact native
 line boundaries. PR #1031 adds pinned Canonical_Combining_Class sets and valid
 empty-property rendering. PR #1032 integrates native numeric escapes through
-U+10FFFF. The new WIP adds pinned Bidi_Class sets while Decomposition_Type,
-East_Asian_Width, and vertical-whitespace slices advance independently.
+U+10FFFF; PR #1033 adds pinned Bidi_Class sets. The new WIP integrates native
+vertical-whitespace escapes while Decomposition_Type, East_Asian_Width, and
+Numeric_Value slices advance independently.
 
 Lexical `use bytes` now compiles non-ASCII substitution patterns with a
 single-byte Joni encoding while preserving upgraded, byte-backed, and compiled
@@ -319,6 +320,13 @@ The focused oracle passes 99/99 on system Perl, JVM, and interpreter; the
 combined Unicode/property/boundary smoke is 345/345 per backend. Chunk 01 gains
 736 assertions to 34,252/41,843 identically on both execution backends with no
 numbered regression, raising current generated evidence to 342,016/407,367.
+
+Native Joni `\v` now matches Perl's seven vertical-whitespace code points and
+`\V` matches their complement, both directly and inside character classes,
+without changing non-Perl Joni syntax behavior. The focused oracle passes
+92/92 on system Perl, JVM, and interpreter. Unchanged `reg_posixcc.t` improves
+from 2,052/2,560 to 2,560/2,560 on both execution backends with zero numbered
+regressions, closing its entire 508-assertion Joni gap.
 
 Joni now accepts Perl's top-level, scoped, combined, and negative inline `p`
 syntax as matcher-neutral policy. PerlOnJava publishes that policy while
@@ -570,6 +578,9 @@ is retained for now.
     partition with loose aliases and ordered missing defaults. The focused
     oracle passes 99/99 and chunk 01 gains 736 assertions to 34,252/41,843 on
     both backends with zero numbered regressions.
+  - [x] Integrated native Perl `\v`/`\V` dispatch inside and outside character
+    classes (`1eff1db97`, integrated as `6328935cd`). The focused oracle passes
+    92/92 and unchanged `reg_posixcc.t` passes 2,560/2,560 on both backends.
   - [ ] Close the remaining property failures before marking Phase 3 complete.
 - [x] Phase 4: Runtime source and diagnostics (2026-08-17; semantic gate
   complete at 550/555)
@@ -612,15 +623,15 @@ is retained for now.
 
 ### Next Steps
 
-1. Land review-ready PR #1024 and draft PRs #1025–#1032. Publish the validated
-   Bidi_Class slice, then integrate native vertical-whitespace commit
-   `1eff1db97` and the completed Decomposition_Type data handoff in separate
-   focused WIP PRs.
+1. Land review-ready PR #1024 and draft PRs #1025–#1033. Publish the validated
+   native vertical-whitespace slice, then integrate the completed
+   Decomposition_Type data handoff in a separate focused WIP PR.
 2. Preserve the now-complete native Joni boundary corpus at 239,866/239,866:
    sentence chunk 05, line chunks 06–09, and word chunk 10 must remain exact on
    JVM and interpreter while property and parser work continues.
-3. Integrate the independently generated Decomposition_Type and
-   East_Asian_Width slices, then continue the measured residual order: binary
+3. Integrate the independently generated Decomposition_Type,
+   East_Asian_Width, and Numeric_Value slices, then continue the measured
+   residual order: binary
    property values, Block, Script/Script_Extensions, Numeric_Value,
    Joining_Group, and break-property values. Preserve pinned Perl 5.44
    acceptance and rejection semantics rather than inheriting host ICU breadth.

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -371,6 +371,7 @@ my @copy = @{$z};         # ERROR
 - ✅  **Inline comments**: `(?#comment)` in regex is implemented.
 - ✅  **caret modifier**: `(?^` embedded pattern-match modifier, shorthand equivalent to "d-imnsx".
 - ✅  **\b inside character class**: `[\b]` is supported in regex.
+- ✅  **Vertical whitespace escapes**: Native Joni `\v` matches U+000A..U+000D, U+0085, U+2028, and U+2029; `\V` matches the complement. Direct and character-class forms match Perl, and `reg_posixcc.t` passes 2,560/2,560 on both execution backends.
 - ✅  **Unicode boundary assertions**: `\b{gcb}`, `\b{sb}`, `\b{wb}`, and `\b{lb}` (and their `\B` forms) execute natively in Joni from reproducible pinned Perl 5.44 Unicode 17.0 data. The complete 239,866-assertion generated boundary corpus passes on both backends.
 - ✅  **Variable Interpolation in Regex**: Features like `${var}` for embedding variables.
 - ✅  **Non-capturing groups**: `(?:...)` is implemented.

--- a/src/test/resources/unit/regex/vertical_whitespace_escape.t
+++ b/src/test/resources/unit/regex/vertical_whitespace_escape.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use feature 'unicode_strings';
+use Test::More;
+
+my @vertical = (0x0A, 0x0B, 0x0C, 0x0D, 0x85, 0x2028, 0x2029);
+my @other = (0x00, 0x09, 0x20, 0x56, 0xA0, 0x100);
+
+sub check_code_point {
+    my ($code, $expected, $upgraded) = @_;
+    my $character = chr($code);
+    utf8::upgrade($character) if $upgraded;
+    my $mode = $upgraded ? 'upgraded' : 'native';
+    my $label = sprintf 'U+%04X %s', $code, $mode;
+
+    is($character =~ /\v/ ? 1 : 0, $expected, "direct v $label");
+    is($character =~ /\V/ ? 1 : 0, 1 - $expected, "direct V $label");
+    is($character =~ /[\v]/ ? 1 : 0, $expected, "class v $label");
+    is($character =~ /[\V]/ ? 1 : 0, 1 - $expected, "class V $label");
+}
+
+for my $code (@vertical) {
+    check_code_point($code, 1, 0);
+    check_code_point($code, 1, 1) if $code <= 0xFF;
+}
+for my $code (@other) {
+    check_code_point($code, 0, 0);
+    check_code_point($code, 0, 1) if $code <= 0xFF;
+}
+
+done_testing();

--- a/third_party/joni/src/org/joni/Lexer.java
+++ b/third_party/joni/src/org/joni/Lexer.java
@@ -36,10 +36,16 @@ import org.joni.constants.internal.TokenType;
 import org.joni.exception.ErrorMessages;
 
 class Lexer extends ScannerSupport {
+    private static final int[] PERL_VERTICAL_WHITESPACE_CODES = {
+        0x0a, 0x0d, 0x85, 0x2028, 0x2029
+    };
+
     protected final Regex regex;
     protected final ScanEnvironment env;
     protected final Syntax syntax;              // fast access to syntax
     protected final Token token = new Token();  // current token
+    private int perlVerticalWhitespaceTokenIndex = -1;
+    private boolean perlVerticalWhitespaceNegated;
 
     protected Lexer(Regex regex, Syntax syntax, byte[]bytes, int p, int end, WarnCallback warnings) {
         super(regex.enc, bytes, p, end);
@@ -546,6 +552,70 @@ class Lexer extends ScannerSupport {
         token.setPropNot(flag);
     }
 
+    private boolean usesPerlVerticalWhitespaceEscape() {
+        return syntax.op2EscVVerticalWhiteSpace()
+                || syntax.op2OptionPerl() && (syntax == Syntax.Perl
+                        || syntax == Syntax.PerlNG || "PERLONJAVA".equals(syntax.name));
+    }
+
+    private void startPerlVerticalWhitespace(boolean negated, TokenType openType) {
+        perlVerticalWhitespaceTokenIndex = 0;
+        perlVerticalWhitespaceNegated = negated;
+        token.type = openType;
+    }
+
+    private TokenType fetchPerlVerticalWhitespaceToken() {
+        token.base = 0;
+        token.escaped = false;
+
+        int index = perlVerticalWhitespaceTokenIndex++;
+        if (perlVerticalWhitespaceNegated) {
+            if (index == 0) {
+                token.type = TokenType.CHAR;
+                token.setC('^');
+                return token.type;
+            }
+            index--;
+        }
+
+        switch (index) {
+        case 0:
+            token.type = TokenType.CODE_POINT;
+            token.setCode(PERL_VERTICAL_WHITESPACE_CODES[0]);
+            break;
+        case 1:
+            token.type = TokenType.CC_RANGE;
+            token.setC('-');
+            break;
+        case 2:
+            token.type = TokenType.CODE_POINT;
+            token.setCode(PERL_VERTICAL_WHITESPACE_CODES[1]);
+            break;
+        case 3:
+            token.type = TokenType.CODE_POINT;
+            token.setCode(PERL_VERTICAL_WHITESPACE_CODES[2]);
+            break;
+        case 4:
+            token.type = TokenType.CODE_POINT;
+            token.setCode(PERL_VERTICAL_WHITESPACE_CODES[3]);
+            break;
+        case 5:
+            token.type = TokenType.CC_RANGE;
+            token.setC('-');
+            break;
+        case 6:
+            token.type = TokenType.CODE_POINT;
+            token.setCode(PERL_VERTICAL_WHITESPACE_CODES[4]);
+            break;
+        default:
+            token.type = TokenType.CC_CLOSE;
+            token.setC(']');
+            perlVerticalWhitespaceTokenIndex = -1;
+            break;
+        }
+        return token.type;
+    }
+
     private void fetchTokenInCCFor_p() {
         int c2 = peek(); // !!! migrate to peekIs
         if (c2 == '{' && syntax.op2EscPBraceCharProperty()) {
@@ -816,6 +886,9 @@ class Lexer extends ScannerSupport {
     }
 
     protected final TokenType fetchTokenInCC() {
+        if (perlVerticalWhitespaceTokenIndex >= 0) {
+            return fetchPerlVerticalWhitespaceToken();
+        }
         if (!left()) {
             token.type = TokenType.EOT;
             return token.type;
@@ -887,6 +960,14 @@ class Lexer extends ScannerSupport {
             case '7':
                 fetchTokenInCCFor_digit();
                 break;
+
+            case 'v':
+            case 'V':
+                if (usesPerlVerticalWhitespaceEscape()) {
+                    startPerlVerticalWhitespace(c == 'V', TokenType.CC_CC_OPEN);
+                    break;
+                }
+                // fall through
 
             default:
                 unfetch();
@@ -1367,6 +1448,13 @@ class Lexer extends ScannerSupport {
                 case 'K':
                     if (syntax.op2EscCapitalKKeep()) token.type = TokenType.KEEP;
                     break;
+                case 'v':
+                case 'V':
+                    if (usesPerlVerticalWhitespaceEscape()) {
+                        startPerlVerticalWhitespace(c == 'V', TokenType.CC_OPEN);
+                        break;
+                    }
+                    // fall through
                 default:
                     unfetch();
                     fetchEscapedValue();

--- a/third_party/joni/test/org/joni/test/TestPerlVerticalWhitespace.java
+++ b/third_party/joni/test/org/joni/test/TestPerlVerticalWhitespace.java
@@ -1,0 +1,90 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.joni.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.jcodings.specific.UTF8Encoding;
+import org.joni.Option;
+import org.joni.Regex;
+import org.joni.Syntax;
+import org.junit.Test;
+
+public class TestPerlVerticalWhitespace {
+    private static final String VERTICAL = "\n\u000b\f\r\u0085\u2028\u2029";
+    private static final String OTHER = "\0\t V\u00a0\u0100";
+
+    private static int search(String pattern, String input, Syntax syntax) {
+        byte[] patternBytes = pattern.getBytes(StandardCharsets.UTF_8);
+        byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+        Regex regex = new Regex(patternBytes, 0, patternBytes.length, Option.NONE,
+                UTF8Encoding.INSTANCE, syntax);
+        return regex.matcher(inputBytes).search(0, inputBytes.length, Option.NONE);
+    }
+
+    private static void assertMatch(String pattern, String input, Syntax syntax) {
+        assertEquals(0, search("\\A(?:" + pattern + ")\\z", input, syntax));
+    }
+
+    private static void assertNoMatch(String pattern, String input, Syntax syntax) {
+        assertEquals(-1, search("\\A(?:" + pattern + ")\\z", input, syntax));
+    }
+
+    @Test
+    public void implementsPerlVerticalWhitespaceInsideAndOutsideClasses() {
+        for (int offset = 0; offset < VERTICAL.length();) {
+            int codePoint = VERTICAL.codePointAt(offset);
+            String character = new String(Character.toChars(codePoint));
+            assertMatch("\\v", character, Syntax.PerlNG);
+            assertMatch("[\\v]", character, Syntax.PerlNG);
+            assertNoMatch("\\V", character, Syntax.PerlNG);
+            assertNoMatch("[\\V]", character, Syntax.PerlNG);
+            offset += Character.charCount(codePoint);
+        }
+
+        for (int offset = 0; offset < OTHER.length();) {
+            int codePoint = OTHER.codePointAt(offset);
+            String character = new String(Character.toChars(codePoint));
+            assertNoMatch("\\v", character, Syntax.PerlNG);
+            assertNoMatch("[\\v]", character, Syntax.PerlNG);
+            assertMatch("\\V", character, Syntax.PerlNG);
+            assertMatch("[\\V]", character, Syntax.PerlNG);
+            offset += Character.charCount(codePoint);
+        }
+
+        assertMatch("\\v+", VERTICAL, Syntax.PerlNG);
+        assertMatch("[A\\v]", "A", Syntax.PerlNG);
+        assertMatch("[A\\V]", "Z", Syntax.PerlNG);
+    }
+
+    @Test
+    public void preservesNonPerlVerticalTabEscapes() {
+        for (Syntax syntax : new Syntax[] {Syntax.RUBY, Syntax.Java, Syntax.ECMAScript}) {
+            assertMatch("\\v", "\u000b", syntax);
+            assertNoMatch("\\v", "\n", syntax);
+            assertMatch("\\V", "V", syntax);
+            assertNoMatch("\\V", "A", syntax);
+            assertMatch("[\\v]", "\u000b", syntax);
+            assertMatch("[\\V]", "V", syntax);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- implement Perl `\v` and `\V` natively in the forked Joni lexer
- support direct and character-class forms with the exact seven-code-point Perl set
- preserve Ruby, Java, and ECMAScript Joni behavior
- update the Phase 36 tracker and feature matrix after closing the POSIX-class gap

This is stacked on PR #1033.

## Validation

- `make` — warning-free, all five unit shards, direct Joni, packaging, notices, namespace, and SBOM checks pass
- focused vertical-whitespace oracle — 92/92 on system Perl, JVM, and interpreter
- unchanged `reg_posixcc.t` — 2,560/2,560 on JVM and interpreter, +508 with zero numbered regressions
- protected Unicode property and boundary smoke — 345/345 on JVM and interpreter

## Next work

Decomposition_Type is ready for integration. East_Asian_Width and Numeric_Value remain independent pinned-data workstreams.
