### PR TITLE
chore(import-perl5): drop redundant pat.t import

### DIFF
--- a/dev/import-perl5/config.yaml
+++ b/dev/import-perl5/config.yaml
@@ -140,9 +140,6 @@ imports:
     target: perl5_t/t/test.pl
     patch: test.pl.patch
 
-  - source: perl5/t/re/pat.t
-    target: perl5_t/t/re/pat.t
-
   - source: perl5/t/porting/manifest.t
     target: perl5_t/t/porting/manifest.t
     patch: manifest.t.patch


### PR DESCRIPTION
## Summary

- remove the redundant explicit `perl5/t/re/pat.t` import row
- rely on the canonical byte-for-byte `perl5/t` directory import for `pat.t`
- retain all required generated Unicode fixtures and runtime-support patches

No imported test assertion is changed or weakened.

## Validation

- two targeted `sync.pl --only perl5/t` runs: 3 successes, 0 errors each
- complete imported-tree SHA manifests identical after consecutive syncs
- restored upstream `re/pat.t`: 1,174/1,302, matching the accepted merged-#1042 count
- `perl -c dev/import-perl5/sync.pl`
- `git diff --check`
- full warning-free `make`: green in 2m36s, 17 tasks

## Scope

The remaining `test.pl.patch`, `_charnames.pm.patch`, and generated
`TestProp.pl` chunks are retained because they provide shared runtime support or
fixtures rather than weakening regex assertions.
