### PR TITLE
fix(regex): preserve strict folds in negative classes

### DIFF
--- a/src/test/resources/unit/regex/joni_ascii_strict_negative_sibling_fold.t
+++ b/src/test/resources/unit/regex/joni_ascii_strict_negative_sibling_fold.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More tests => 12;
+
+ok("\x{1E9E}" !~ /^[^\x{00DF}]$/iaa,
+    'aa negative class excludes capital sharp s sibling');
+ok("\x{00DF}" !~ /^[^\x{1E9E}]$/iaa,
+    'aa negative class excludes lowercase sharp s sibling');
+ok("\x{FB06}" !~ /^[^\x{FB05}]$/iaa,
+    'aa negative class excludes second st ligature sibling');
+ok("\x{FB05}" !~ /^[^\x{FB06}]$/iaa,
+    'aa negative class excludes first st ligature sibling');
+
+ok("s" =~ /^[^\x{00DF}]$/iaa,
+    'aa negative sharp s class retains ASCII s');
+ok("ä" =~ /^[^\x{00DF}]$/iaa,
+    'aa negative sharp s class retains unrelated non-ASCII');
+ok("s" =~ /^[^\x{FB05}]$/iaa,
+    'aa negative ligature class retains ASCII s');
+ok("ä" =~ /^[^\x{FB05}]$/iaa,
+    'aa negative ligature class retains unrelated non-ASCII');
+
+ok("x\x{1E9E}y" !~ /^x(?iaa:[^\x{00DF}])y$/u,
+    'scoped aa negative class excludes sharp s sibling');
+ok("xäy" =~ /^x(?iaa:[^\x{00DF}])y$/u,
+    'scoped aa negative class retains unrelated member');
+ok("_\x{FB06}_" !~ /^_(?iaa:[^\x{FB05}])_$/u,
+    'anchored aa negative class excludes ligature sibling');
+ok("_ä_" =~ /^_(?iaa:[^\x{FB05}])_$/u,
+    'anchored aa negative class retains unrelated member');

--- a/third_party/joni/src/org/joni/ApplyCaseFold.java
+++ b/third_party/joni/src/org/joni/ApplyCaseFold.java
@@ -41,7 +41,7 @@ final class ApplyCaseFold implements ApplyAllCaseFoldFunction {
         boolean addFlag;
 
         if (Option.isPerlAsciiStrict(env.option)
-                && Encoding.isAscii(from) != Encoding.isAscii(to[0])) {
+                && perlAsciiStrictRelationCrossesAscii(from, to, length)) {
             return;
         }
 
@@ -109,6 +109,15 @@ final class ApplyCaseFold implements ApplyAllCaseFoldFunction {
 
         }
 
+    }
+
+    private static boolean perlAsciiStrictRelationCrossesAscii(int from, int[] to,
+                                                                int length) {
+        boolean fromAscii = Encoding.isAscii(from);
+        for (int i = 0; i < length; i++) {
+            if (fromAscii != Encoding.isAscii(to[i])) return true;
+        }
+        return false;
     }
 
     static boolean isEligible(CClassNode ascCc, Encoding enc, int code) {

--- a/third_party/joni/src/org/joni/ScanEnvironment.java
+++ b/third_party/joni/src/org/joni/ScanEnvironment.java
@@ -68,9 +68,10 @@ public final class ScanEnvironment {
     }
 
     int caseFoldFlagFor(int option) {
-        return Option.isPerlAsciiStrict(option)
-                ? caseFoldFlag & ~Config.INTERNAL_ENC_CASE_FOLD_MULTI_CHAR
-                : caseFoldFlag;
+        // Character classes need the complete fold relation so
+        // ApplyCaseFold can retain safe non-ASCII siblings under /aa while
+        // filtering relations that cross into ASCII.
+        return caseFoldFlag;
     }
 
     int addMemEntry() {

--- a/third_party/joni/test/org/joni/test/TestPerlAsciiStrictNegativeSafeSibling.java
+++ b/third_party/joni/test/org/joni/test/TestPerlAsciiStrictNegativeSafeSibling.java
@@ -1,0 +1,67 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.joni.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.jcodings.specific.UTF8Encoding;
+import org.joni.Option;
+import org.joni.Regex;
+import org.joni.Syntax;
+import org.junit.Test;
+
+public class TestPerlAsciiStrictNegativeSafeSibling {
+    private static int search(String pattern, String input) {
+        byte[] patternBytes = pattern.getBytes(StandardCharsets.UTF_8);
+        byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+        Regex regex = new Regex(patternBytes, 0, patternBytes.length,
+                Option.IGNORECASE | Option.PERL_ASCII_STRICT,
+                UTF8Encoding.INSTANCE, Syntax.PerlNG);
+        return regex.matcher(inputBytes).search(0, inputBytes.length, Option.NONE);
+    }
+
+    private static void matches(String pattern, String input) {
+        assertEquals(0, search(pattern, input));
+    }
+
+    private static void misses(String pattern, String input) {
+        assertEquals(-1, search(pattern, input));
+    }
+
+    @Test
+    public void appliesSafeSiblingsToOrdinaryPositiveAndNegativeClasses() {
+        matches("^[ß]$", "ẞ");
+        misses("^[^ß]$", "ẞ");
+        matches("^[ﬅ]$", "ﬆ");
+        misses("^[^ﬅ]$", "ﬆ");
+        matches("^[^ß]$", "ä");
+        matches("^[^ﬅ]$", "ä");
+    }
+
+    @Test
+    public void rejectsAsciiAtEveryPositionOfAMultiCharacterFold() {
+        misses("^[ŉ]$", "ʼn");
+        misses("^[ŉ]$", "ʼN");
+        matches("^[ŉ]$", "ŉ");
+        matches("^[^ŉ]$", "ʼ");
+    }
+}


### PR DESCRIPTION
## Summary

- isolate Perl ASCII-strict negative-class sibling behavior
- retain safe fold siblings in negative classes without broadening forbidden folds
- add direct forked-Joni coverage for the native behavior

## Validation

- canonical Perl reducer: 12/12
- direct Joni and existing focused gates: 14/14
- warning-free full `make`: passed

## Notes

This is stacked on the positive safe-sibling PR. Original Joni and JCodings copyright and authorship notices are preserved.
