### PR TITLE
fix(regex): complete native quantifier and control boundaries

### DIFF
--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -92,13 +92,10 @@ affected corpus before taking another slice.
 - `master` contains the validated named-character diagnostics plus native
   `(?(DEFINE)...)`, ordinary lookbehind, branch reset, and plain `\N`; its exact
   head passed warning-free local, Ubuntu, and Windows gates.
-- The successor integration batch carries byte/Unicode provenance and fold
-  policy, dotted-U+ diagnostics, the ordinary-pattern Joni default, a dynamic-
-  pattern edge contract, and the first obsolete import retirement. Its fold,
-  property, and resolver-cache residuals are closed; the exact semantic head
-  passes a warning-free 17-task `make`. The prospective PR head also includes
-  three independent runtime-diagnostic corrections and passes the same full
-  combined gate.
+- Byte/Unicode provenance and fold policy, dotted-U+ diagnostics, the ordinary-
+  pattern Joni default, a dynamic-pattern edge contract, and the first obsolete
+  import retirement are integrated. Fold, property, resolver-cache, and the
+  classified runtime-diagnostic residuals are closed.
 - Native DEFINE, ordinary lookbehind, and branch reset now route through Joni;
   their feature-specific Java rewrites and branch-reset capture-map adapter are
   deleted. Plain Perl `\N` is a native Joni non-line-feed atom, including
@@ -118,6 +115,13 @@ affected corpus before taking another slice.
   evidence.
 - Exact `/aa` routing/folding gates pass on native Joni, and the Java `/aa`
   workaround is removed.
+- Perl grouped nested-quantifier semantics and extended-mode quantifier
+  modifiers are native Joni behavior; the exact `regexp.t` differential removes
+  seven failures with no introductions.
+- Named `(*ACCEPT:NAME)`, `(*FAIL:NAME)`, and `(*F:NAME)` carry control state
+  through native Joni bytecode and publish Perl-compatible `$REGMARK` and
+  `$REGERROR`; the exact `regexp.t` differential removes three failures with no
+  introductions.
 
 ## Execution Phases
 
@@ -229,8 +233,9 @@ behavior.
 
 ## Ordered Next Steps
 
-1. Open the validated successor review PR against `master` and require
-   exact-head Ubuntu/Windows CI.
+1. Run one warning-free full build and affected-corpus differential on the
+   integrated nested-quantifier and named-control-verb batch, then open its
+   review PR and require exact-head Ubuntu/Windows CI.
 2. Complete byte/Unicode pattern provenance through runtime interpolation and
    template composition, then finish `/d`/`u`/`a`/`aa` forward/reverse literal
    and backreference folding from generated data. Require direct Joni plus
@@ -240,8 +245,8 @@ behavior.
    unwind, backtracking re-evaluation, and recursion safety. Route every embedded
    closure to Joni and delete constant inlining, progressive errors, and the
    dynamic Java adapter as their gates pass.
-4. Carry lexical `use re 'strict'` policy through regex compilation and close
-   the unescaped-brace/non-hex diagnostic families. Refresh complete
+4. Finish the remaining lexical `use re 'strict'`, unescaped-brace, and non-hex
+   diagnostic families. Refresh complete
    `reg_mesg.t`, `pat.t`, and `pat_advanced.t` maps after each combined batch.
 5. Repeat the four-leg 80-file Java/Joni × JVM/interpreter matrix on the exact
    successor artifact and compare every file with the PR 958 log. Resolve every

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -122,6 +122,9 @@ affected corpus before taking another slice.
   through native Joni bytecode and publish Perl-compatible `$REGMARK` and
   `$REGERROR`; the exact `regexp.t` differential removes three failures with no
   introductions.
+- Negative lookbehind accepts capture enclosures and uses ACCEPT-aware width
+  analysis in native Joni; named cut errors remain authoritative before an
+  unnamed FAIL. The combined exact `regexp.t` differential has no introductions.
 
 ## Execution Phases
 
@@ -234,8 +237,8 @@ behavior.
 ## Ordered Next Steps
 
 1. Run one warning-free full build and affected-corpus differential on the
-   integrated nested-quantifier and named-control-verb batch, then open its
-   review PR and require exact-head Ubuntu/Windows CI.
+   integrated nested-quantifier, named-control-verb, and negative-lookbehind
+   batch, then open its review PR and require exact-head Ubuntu/Windows CI.
 2. Complete byte/Unicode pattern provenance through runtime interpolation and
    template composition, then finish `/d`/`u`/`a`/`aa` forward/reverse literal
    and backreference folding from generated data. Require direct Joni plus

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -519,6 +519,10 @@ final class JoniRegexPattern {
                 || pattern.contains("(?{=DYNAMIC:")
                 || containsNamedCharacterEscape(pattern)
                 || pattern.contains("(*ACCEPT)")
+                || pattern.contains("(*ACCEPT:")
+                || pattern.contains("(*FAIL")
+                || pattern.contains("(*F)")
+                || pattern.contains("(*F:")
                 || pattern.contains("(*PRUNE")
                 || pattern.contains("(*SKIP")
                 || pattern.contains("(*THEN")
@@ -719,6 +723,8 @@ final class JoniRegexPattern {
 
     private static boolean hasControlVerbState(String pattern) {
         return pattern.contains("(*MARK") || pattern.contains("(*:")
+                || pattern.contains("(*ACCEPT") || pattern.contains("(*FAIL")
+                || pattern.contains("(*F)") || pattern.contains("(*F:")
                 || pattern.contains("(*PRUNE")
                 || pattern.contains("(*SKIP") || pattern.contains("(*THEN")
                 || pattern.contains("(*COMMIT");
@@ -1077,7 +1083,6 @@ final class JoniRegexPattern {
             if (nextStart > regionEnd) {
                 matched = false;
                 committedLastClosedCapture = -1;
-                if (hasControlVerbState) RuntimeRegex.updateControlVerbVariables(null, null);
                 return false;
             }
             matcher = regex.matcher(bytes);
@@ -1103,9 +1108,12 @@ final class JoniRegexPattern {
                 throw failure;
             }
             matched = result >= 0;
-            if (hasControlVerbState || matcher.hasEncounteredControlVerb()) {
+            boolean encounteredControlVerb = matcher.hasEncounteredControlVerb();
+            if ((matched && hasControlVerbState) || encounteredControlVerb) {
+                String mark = matcher.getControlMark();
+                if (matched && mark == null) mark = "1";
                 RuntimeRegex.updateControlVerbVariables(
-                        matcher.getControlMark(), matcher.getControlError());
+                        mark, matcher.getControlError());
             }
             if (calloutHandler != null) calloutHandler.finish(matched);
             if (!matched) {

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -158,10 +158,14 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 ? RuntimeScalarCache.scalarEmptyString : new RuntimeScalar(mark);
         RuntimeScalar errorValue = error == null
                 ? RuntimeScalarCache.scalarEmptyString : new RuntimeScalar(error);
+        String currentPackage = InterpreterState.currentPackage.get().toString();
+        if (currentPackage == null || currentPackage.isEmpty()) currentPackage = "main";
+        GlobalVariable.getGlobalVariable(currentPackage + "::REGMARK").set(markValue);
+        GlobalVariable.getGlobalVariable(currentPackage + "::REGERROR").set(errorValue);
         // Perl activates these otherwise ordinary package variables through
-        // local(). The interpreter does not keep its runtime current-package
-        // facade synchronized with every lexical package statement, so use the
-        // localized scalar identities rather than guessing one package name.
+        // local(). Also update localized scalar identities directly because the
+        // interpreter does not keep its runtime current-package facade
+        // synchronized with every lexical package statement.
         for (Map.Entry<String, RuntimeScalar> entry
                 : DynamicVariableManager.activeLocalizedGlobalScalars().entrySet()) {
             if (entry.getKey().endsWith("::REGMARK")) {

--- a/src/test/java/org/perlonjava/runtime/regex/JoniNestedQuantifierPatternTest.java
+++ b/src/test/java/org/perlonjava/runtime/regex/JoniNestedQuantifierPatternTest.java
@@ -1,0 +1,18 @@
+package org.perlonjava.runtime.regex;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.joni.exception.SyntaxException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+class JoniNestedQuantifierPatternTest {
+    @Test
+    void rejectsNestedIntervalModifiersBeforeRuntimeWrapping() {
+        assertThrows(SyntaxException.class, () -> new JoniRegexPattern(
+                ".{1}??", RegexFlags.fromModifiers("", ".{1}??")));
+        assertThrows(SyntaxException.class, () -> new JoniRegexPattern(
+                ".{1}?+", RegexFlags.fromModifiers("", ".{1}?+")));
+    }
+}

--- a/src/test/resources/unit/regex/named_accept_fail_control_verbs.t
+++ b/src/test/resources/unit/regex/named_accept_fail_control_verbs.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+use Test::More;
+
+our ($REGMARK, $REGERROR);
+$REGMARK = undef;
+$REGERROR = undef;
+
+ok('ab' =~ /a(*ACCEPT:accepted)z/, 'named ACCEPT ends the current match');
+is($&, 'a', 'named ACCEPT preserves its match boundary');
+is($REGMARK, 'accepted', 'named ACCEPT publishes its argument');
+is($REGERROR, '', 'named ACCEPT clears REGERROR');
+
+ok('ac' !~ /a(*FAIL:blocked)c/, 'named FAIL rejects the match');
+is($REGMARK, '', 'named FAIL clears REGMARK after failure');
+is($REGERROR, 'blocked', 'named FAIL publishes its argument');
+
+ok('ac' !~ /a(*F:short)c/, 'named F shorthand rejects the match');
+is($REGERROR, 'short', 'named F publishes its argument');
+
+ok('ab' =~ /a(*FAIL:first)b|ab/, 'named FAIL can backtrack to a successful branch');
+is($REGMARK, '1', 'successful controlled match without a mark publishes true');
+is($REGERROR, '', 'success clears a backtracked named FAIL argument');
+
+ok('ab' =~ /(?=(a(*ACCEPT:inner)z))ab/,
+    'named ACCEPT respects a nested assertion boundary');
+is($1, 'a', 'nested named ACCEPT closes its active capture');
+is($REGMARK, 'inner', 'nested named ACCEPT publishes its argument');
+
+$REGMARK = 'sentinel mark';
+$REGERROR = 'sentinel error';
+ok('x' !~ /z|a(*FAIL:unreached)/, 'pattern can fail before reaching named FAIL');
+is($REGMARK, 'sentinel mark', 'unreached control verb leaves REGMARK untouched on failure');
+is($REGERROR, 'sentinel error', 'unreached control verb leaves REGERROR untouched on failure');
+
+done_testing;

--- a/src/test/resources/unit/regex/negative_lookbehind_capture_accept.t
+++ b/src/test/resources/unit/regex/negative_lookbehind_capture_accept.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $accept = qr/(?<!([cd](*ACCEPT)|x)gggg)blrph/;
+
+ok('cblrph' !~ $accept,
+    'ACCEPT inside negative lookbehind rejects the outer match');
+ok('dblrph' !~ $accept,
+    'alternate ACCEPT path inside negative lookbehind rejects the outer match');
+ok('qblrph' =~ $accept,
+    'failed negative-lookbehind body permits the outer match');
+
+ok('b' =~ /(?<!(a))b/, 'capture group is legal inside negative lookbehind');
+ok(!defined($1), 'capture remains unset when negative lookbehind succeeds');
+ok('ab' !~ /(?<!(a))b/, 'capturing negative lookbehind can reject a match');
+
+done_testing;

--- a/src/test/resources/unit/regex/nested_quantifier_policy.t
+++ b/src/test/resources/unit/regex/nested_quantifier_policy.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More;
+
+for my $pattern ('a**', '.{1}??', '.{1}?+', '(?i:a**)') {
+    my ($regex, @warnings);
+    {
+        local $SIG{__WARN__} = sub { push @warnings, @_ };
+        $regex = eval { qr/$pattern/ };
+    }
+    ok(!defined($regex), "$pattern is rejected");
+    like($@, qr/^Nested quantifiers/, "$pattern uses Perl nested-quantifier diagnostic");
+}
+
+for my $case (
+    [ 'x(~~)*(?:(?:F)?)?', 'x~~', undef, 1 ],
+    [ '(?:r?)*?r|(.{2,4})', 'abcde', 'abcd', 1 ],
+    [ '^(.)(?:(.)+)*[BX]', 'ABCDE', undef, 1 ],
+    [ '(?x:( a | ( bc ) ) {0,0} ? xyz)', 'xyz', undef, 0 ],
+    [ '(?x:( a | ( bc ) ) {0,0} + xyz)', 'xyz', undef, 0 ],
+) {
+    my ($pattern, $subject, $capture, $requires_quiet) = @$case;
+    my (@warnings, $regex);
+    {
+        local $SIG{__WARN__} = sub { push @warnings, @_ };
+        $regex = eval { qr/$pattern/ };
+    }
+    ok(defined($regex) && $@ eq '' && (!$requires_quiet || !@warnings),
+        "$pattern has Perl's legal grouped-quantifier compile policy");
+    ok($subject =~ $regex, "$pattern retains match semantics");
+    is($1, $capture, "$pattern retains capture semantics") if defined($capture);
+}
+
+done_testing;

--- a/third_party/joni/src/org/joni/Analyser.java
+++ b/third_party/joni/src/org/joni/Analyser.java
@@ -1473,8 +1473,7 @@ final class Analyser extends Parser {
     }
 
     private Node setupLookBehind(AnchorNode node) {
-        AcceptLengthInfo acceptLengths = node.type == AnchorType.LOOK_BEHIND
-                ? getAcceptLengthInfo(node.target) : null;
+        AcceptLengthInfo acceptLengths = getAcceptLengthInfo(node.target);
         if (acceptLengths != null && acceptLengths.hasAccept()) {
             int min = acceptLengths.acceptMin;
             int max = acceptLengths.acceptMax;
@@ -2593,7 +2592,10 @@ final class Analyser extends Parser {
                 int allowedInNegativeLookBehind = syntax.op2OptionPerl()
                         ? AnchorType.ALLOWED_IN_PERL_LB_NOT
                         : AnchorType.ALLOWED_IN_LB_NOT;
-                if (checkTypeTree(an.target, NodeType.ALLOWED_IN_LB, EncloseType.ALLOWED_IN_LB_NOT, allowedInNegativeLookBehind)) newSyntaxException(INVALID_LOOK_BEHIND_PATTERN);
+                int allowedEnclosuresInNegativeLookBehind = syntax.op2OptionPerl()
+                        ? EncloseType.ALLOWED_IN_LB
+                        : EncloseType.ALLOWED_IN_LB_NOT;
+                if (checkTypeTree(an.target, NodeType.ALLOWED_IN_LB, allowedEnclosuresInNegativeLookBehind, allowedInNegativeLookBehind)) newSyntaxException(INVALID_LOOK_BEHIND_PATTERN);
                 node = setupLookBehind(an);
                 if (node.getType() != NodeType.ANCHOR) continue restart;
                 setupTree(((AnchorNode)node).target, (state | IN_NOT | IN_LOOKAROUND));

--- a/third_party/joni/src/org/joni/ArrayCompiler.java
+++ b/third_party/joni/src/org/joni/ArrayCompiler.java
@@ -103,10 +103,12 @@ final class ArrayCompiler extends Compiler {
         case ACCEPT:
             regex.requireStack = true;
             addOpcode(OPCode.ACCEPT);
+            addInt(controlVerbLabelId(node.name));
             break;
         case FAIL:
             regex.requireStack = true;
-            addOpcode(OPCode.FAIL);
+            addOpcode(OPCode.CONTROL_FAIL);
+            addInt(controlVerbLabelId(node.name));
             break;
         case PRUNE:
             regex.requireStack = true;
@@ -1372,7 +1374,7 @@ final class ArrayCompiler extends Compiler {
         if (node instanceof ControlVerbNode control) {
             return switch (control.kind) {
                 case ACCEPT -> OPSize.ACCEPT;
-                case FAIL -> OPSize.FAIL;
+                case FAIL -> OPSize.CONTROL_FAIL;
                 case PRUNE -> OPSize.PRUNE;
                 case SKIP -> OPSize.SKIP;
                 case THEN -> OPSize.THEN;

--- a/third_party/joni/src/org/joni/ByteCodeMachine.java
+++ b/third_party/joni/src/org/joni/ByteCodeMachine.java
@@ -2997,7 +2997,12 @@ class ByteCodeMachine extends StackMachine implements MatchView {
     private void opControlFail() {
         controlVerbEncountered = true;
         String name = controlVerbName(code[ip++]);
-        controlError = name == null ? "1" : name;
+        // An unnamed FAIL terminates the current path without replacing a
+        // more specific PRUNE/SKIP/THEN/COMMIT error already encountered on
+        // that path.  A named FAIL remains authoritative.
+        if (name != null || controlError == null) {
+            controlError = name == null ? "1" : name;
+        }
         opFail();
     }
 

--- a/third_party/joni/src/org/joni/ByteCodeMachine.java
+++ b/third_party/joni/src/org/joni/ByteCodeMachine.java
@@ -389,6 +389,7 @@ class ByteCodeMachine extends StackMachine implements MatchView {
                 case OPCode.CHECK_LOOK_BEHIND_END:      opCheckLookBehindEnd();    continue;
                 case OPCode.FINISH:                     return finish();
                 case OPCode.FAIL:                       opFail();                  continue;
+                case OPCode.CONTROL_FAIL:               opControlFail();           continue;
                 case OPCode.CALLOUT:                    opCallout();               continue;
                 case OPCode.CALLOUT_CONDITION:          opCalloutCondition();      continue;
                 case OPCode.DYNAMIC_CALLOUT:            opDynamicCallout();        continue;
@@ -559,6 +560,7 @@ class ByteCodeMachine extends StackMachine implements MatchView {
                 case OPCode.CHECK_LOOK_BEHIND_END:      opCheckLookBehindEnd();    continue;
                 case OPCode.FINISH:                     return finish();
                 case OPCode.FAIL:                       opFail();                  continue;
+                case OPCode.CONTROL_FAIL:               opControlFail();           continue;
                 case OPCode.CALLOUT:                    opCallout();               continue;
                 case OPCode.CALLOUT_CONDITION:          opCalloutCondition();      continue;
                 case OPCode.DYNAMIC_CALLOUT:            opDynamicCallout();        continue;
@@ -2949,6 +2951,9 @@ class ByteCodeMachine extends StackMachine implements MatchView {
      * are not boundaries; calls and assertions are, matching Perl's behavior.
      */
     private boolean opAccept() {
+        controlVerbEncountered = true;
+        String name = controlVerbName(code[ip++]);
+        if (name != null) controlMark = name;
         int callDepth = 0;
         for (int i = stk - 1; i >= 0; i--) {
             StackEntry entry = stack[i];
@@ -2987,6 +2992,13 @@ class ByteCodeMachine extends StackMachine implements MatchView {
 
         closeOpenCaptures(-1);
         return opEnd();
+    }
+
+    private void opControlFail() {
+        controlVerbEncountered = true;
+        String name = controlVerbName(code[ip++]);
+        controlError = name == null ? "1" : name;
+        opFail();
     }
 
     private void opPrune() {

--- a/third_party/joni/src/org/joni/Lexer.java
+++ b/third_party/joni/src/org/joni/Lexer.java
@@ -20,6 +20,7 @@
 package org.joni;
 
 import static org.joni.Option.isAsciiRange;
+import static org.joni.Option.isExtend;
 import static org.joni.Option.isSingleline;
 import static org.joni.Option.isWordBoundAllRange;
 import static org.joni.ast.QuantifierNode.isRepeatInfinite;
@@ -1272,7 +1273,7 @@ class Lexer extends ScannerSupport {
             greedyCheck();
             break;
         case 2:
-            if (syntax.fixedIntervalIsGreedyOnly()) {
+            if (syntax.fixedIntervalIsGreedyOnly() && !syntax.op2OptionPerl()) {
                 possessiveCheck();
             } else {
                 greedyCheck();
@@ -2032,18 +2033,20 @@ class Lexer extends ScannerSupport {
     }
 
     private void greedyCheck() {
+        skipPerlExtendedQuantifierSpace();
         if (left() && peekIs('?') && syntax.opQMarkNonGreedy()) {
-
             fetch();
 
             token.setRepeatGreedy(false);
             token.setRepeatPossessive(false);
+            rejectPerlNestedQuantifierModifier();
         } else {
             possessiveCheck();
         }
     }
 
     private void possessiveCheck() {
+        skipPerlExtendedQuantifierSpace();
         if (left() && peekIs('+') &&
             (syntax.op2PlusPossessiveRepeat() && token.type != TokenType.INTERVAL ||
              syntax.op2PlusPossessiveInterval() && token.type == TokenType.INTERVAL)) {
@@ -2052,9 +2055,35 @@ class Lexer extends ScannerSupport {
 
             token.setRepeatGreedy(true);
             token.setRepeatPossessive(true);
+            rejectPerlNestedQuantifierModifier();
         } else {
             token.setRepeatGreedy(true);
             token.setRepeatPossessive(false);
+        }
+    }
+
+    private void rejectPerlNestedQuantifierModifier() {
+        if (!env.usesPerlDiagnostics() || !left()) return;
+        int next = peek();
+        if (next == '?' || next == '*' || next == '+') {
+            newSyntaxException(PERL_NESTED_QUANTIFIERS);
+        }
+    }
+
+    private void skipPerlExtendedQuantifierSpace() {
+        if (!syntax.op2OptionPerl() || !isExtend(env.option)) return;
+        while (left()) {
+            int next = peek();
+            if (next == ' ' || next == '\t' || next == '\n'
+                    || next == '\r' || next == '\f') {
+                inc();
+                continue;
+            }
+            if (next != '#') return;
+            while (left()) {
+                fetch();
+                if (enc.isNewLine(c)) break;
+            }
         }
     }
 

--- a/third_party/joni/src/org/joni/Parser.java
+++ b/third_party/joni/src/org/joni/Parser.java
@@ -1202,13 +1202,13 @@ class Parser extends Lexer {
 
         final ControlVerbNode.Kind kind;
         final String verb;
-        if (startsWith("ACCEPT)")) {
+        if (startsWith("ACCEPT)") || startsWith("ACCEPT:")) {
             kind = ControlVerbNode.Kind.ACCEPT;
             verb = "ACCEPT";
-        } else if (startsWith("FAIL)")) {
+        } else if (startsWith("FAIL)") || startsWith("FAIL:")) {
             kind = ControlVerbNode.Kind.FAIL;
             verb = "FAIL";
-        } else if (startsWith("F)")) {
+        } else if (startsWith("F)") || startsWith("F:")) {
             kind = ControlVerbNode.Kind.FAIL;
             verb = "F";
         } else if (startsWith("PRUNE)") || startsWith("PRUNE:")) {

--- a/third_party/joni/src/org/joni/ast/QuantifierNode.java
+++ b/third_party/joni/src/org/joni/ast/QuantifierNode.java
@@ -29,6 +29,8 @@ import static org.joni.ast.QuantifierNode.ReduceType.QQ;
 import org.joni.Config;
 import org.joni.ScanEnvironment;
 import org.joni.constants.internal.TargetInfo;
+import org.joni.exception.ErrorMessages;
+import org.joni.exception.ValueException;
 
 public final class QuantifierNode extends StateNode {
     public static final int REPEAT_INFINITE = -1;
@@ -229,6 +231,16 @@ public final class QuantifierNode extends StateNode {
             /* check redundant double repeat. */
             /* verbose warn (?:.?)? etc... but not warn (.?)? etc... */
             QuantifierNode qnt = (QuantifierNode)tgt;
+            if (env.usesPerlDiagnostics()) {
+                if (!group) {
+                    throw new ValueException(ErrorMessages.PERL_NESTED_QUANTIFIERS);
+                }
+                // Parentheses are a semantic boundary in Perl.  Keep both
+                // quantifiers instead of applying Oniguruma's reduction table
+                // or warning about a legal grouped repeat.
+                setTarget(qnt);
+                return 0;
+            }
             int nestQNum = popularNum();
             int targetQNum = qnt.popularNum();
 

--- a/third_party/joni/src/org/joni/constants/internal/OPCode.java
+++ b/third_party/joni/src/org/joni/constants/internal/OPCode.java
@@ -167,6 +167,7 @@ public interface OPCode {
     int WIDE_SCALAR                   = 123;
     int WIDE_SCALAR_CLASS             = 124;
     int PUSH_BRANCH                   = 125;          /* push a syntactic alternation branch */
+    int CONTROL_FAIL                  = 126;          /* explicit Perl (*FAIL[:name]) verb */
 
     String[] OpCodeNames = Config.DEBUG_COMPILE ? new String[] {
         "finish", /*OP_FINISH*/
@@ -296,6 +297,7 @@ public interface OPCode {
         "wide-scalar",
         "wide-scalar-class",
         "push-branch",
+        "control-fail",
     } : null;
 
     int[] OpCodeArgTypes = Config.DEBUG_COMPILE ? new int[] {
@@ -426,5 +428,6 @@ public interface OPCode {
         Arguments.SPECIAL, /*OP_WIDE_SCALAR*/
         Arguments.MEMNUM, /*OP_WIDE_SCALAR_CLASS*/
         Arguments.RELADDR, /*OP_PUSH_BRANCH*/
+        Arguments.MEMNUM, /*OP_CONTROL_FAIL*/
     } : null;
 }

--- a/third_party/joni/src/org/joni/constants/internal/OPSize.java
+++ b/third_party/joni/src/org/joni/constants/internal/OPSize.java
@@ -74,7 +74,8 @@ public interface OPSize {
     int CALLOUT                      = (OPCODE + MEMNUM);
     int CALLOUT_CONDITION            = (OPCODE + MEMNUM + RELADDR);
     int DYNAMIC_CALLOUT              = (OPCODE + MEMNUM);
-    int ACCEPT                       = OPCODE;
+    int ACCEPT                       = (OPCODE + INDEX);
+    int CONTROL_FAIL                 = (OPCODE + INDEX);
     int PRUNE                        = (OPCODE + INDEX);
     int SKIP                         = (OPCODE + INDEX);
     int THEN                         = (OPCODE + INDEX);

--- a/third_party/joni/src/org/joni/exception/ErrorMessages.java
+++ b/third_party/joni/src/org/joni/exception/ErrorMessages.java
@@ -48,6 +48,7 @@ public interface ErrorMessages extends org.jcodings.exception.ErrorMessages {
     String UNMATCHED_RANGE_SPECIFIER_IN_CHAR_CLASS = "unmatched range specifier in char-class";
     String TARGET_OF_REPEAT_OPERATOR_NOT_SPECIFIED = "target of repeat operator is not specified";
     String PERL_QUANTIFIER_FOLLOWS_NOTHING = "Quantifier follows nothing";
+    String PERL_NESTED_QUANTIFIERS = "Nested quantifiers";
     String TARGET_OF_REPEAT_OPERATOR_INVALID = "target of repeat operator is invalid";
     String NESTED_REPEAT_NOT_ALLOWED = "nested repeat is not allowed";
     String NESTED_REPEAT_OPERATOR = "nested repeat operator";

--- a/third_party/joni/test/org/joni/test/TestPerlControlFailPrecedence.java
+++ b/third_party/joni/test/org/joni/test/TestPerlControlFailPrecedence.java
@@ -1,0 +1,55 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.joni.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.jcodings.specific.ASCIIEncoding;
+import org.joni.Matcher;
+import org.joni.Option;
+import org.joni.Regex;
+import org.joni.Syntax;
+import org.junit.Test;
+
+public class TestPerlControlFailPrecedence {
+    private static Matcher match(String pattern, String input) {
+        byte[] patternBytes = pattern.getBytes(StandardCharsets.US_ASCII);
+        byte[] inputBytes = input.getBytes(StandardCharsets.US_ASCII);
+        Regex regex = new Regex(patternBytes, 0, patternBytes.length, Option.NONE,
+                ASCIIEncoding.INSTANCE, Syntax.PerlNG);
+        Matcher matcher = regex.matcher(inputBytes);
+        assertEquals(-1, matcher.search(0, inputBytes.length, Option.NONE));
+        return matcher;
+    }
+
+    @Test
+    public void unnamedFailPreservesEarlierNamedCutError() {
+        assertEquals("blocked",
+                match("a(*PRUNE:blocked)(*FAIL)", "a").getControlError());
+    }
+
+    @Test
+    public void failStillPublishesItsOwnError() {
+        assertEquals("1", match("a(*FAIL)", "a").getControlError());
+        assertEquals("named", match("a(*FAIL:named)", "a").getControlError());
+    }
+}

--- a/third_party/joni/test/org/joni/test/TestPerlNamedAcceptFail.java
+++ b/third_party/joni/test/org/joni/test/TestPerlNamedAcceptFail.java
@@ -1,0 +1,68 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.joni.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.jcodings.specific.ASCIIEncoding;
+import org.joni.Matcher;
+import org.joni.Option;
+import org.joni.Regex;
+import org.joni.Syntax;
+import org.junit.Test;
+
+public class TestPerlNamedAcceptFail {
+    private static Matcher matcher(String pattern, String input) {
+        byte[] patternBytes = pattern.getBytes(StandardCharsets.US_ASCII);
+        byte[] inputBytes = input.getBytes(StandardCharsets.US_ASCII);
+        Regex regex = new Regex(patternBytes, 0, patternBytes.length, Option.NONE,
+                ASCIIEncoding.INSTANCE, Syntax.RUBY);
+        return regex.matcher(inputBytes);
+    }
+
+    @Test
+    public void namedAcceptPublishesItsName() {
+        Matcher matcher = matcher("a(*ACCEPT:accepted)z", "ab");
+
+        assertEquals(0, matcher.search(0, 2, Option.NONE));
+        assertEquals(1, matcher.getEnd());
+        assertEquals("accepted", matcher.getControlMark());
+        assertEquals(null, matcher.getControlError());
+    }
+
+    @Test
+    public void namedFailPublishesItsName() {
+        Matcher matcher = matcher("a(*FAIL:blocked)c", "ac");
+
+        assertEquals(-1, matcher.search(0, 2, Option.NONE));
+        assertEquals(null, matcher.getControlMark());
+        assertEquals("blocked", matcher.getControlError());
+    }
+
+    @Test
+    public void namedFailShorthandPublishesItsName() {
+        Matcher matcher = matcher("a(*F:short)c", "ac");
+
+        assertEquals(-1, matcher.search(0, 2, Option.NONE));
+        assertEquals("short", matcher.getControlError());
+    }
+}

--- a/third_party/joni/test/org/joni/test/TestPerlNegativeLookBehindCapture.java
+++ b/third_party/joni/test/org/joni/test/TestPerlNegativeLookBehindCapture.java
@@ -1,0 +1,57 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.joni.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+
+import org.jcodings.specific.ASCIIEncoding;
+import org.joni.Matcher;
+import org.joni.Option;
+import org.joni.Regex;
+import org.joni.Syntax;
+import org.junit.Test;
+
+public class TestPerlNegativeLookBehindCapture {
+    private static int search(String pattern, String input) {
+        byte[] patternBytes = pattern.getBytes(StandardCharsets.US_ASCII);
+        byte[] inputBytes = input.getBytes(StandardCharsets.US_ASCII);
+        Regex regex = new Regex(patternBytes, 0, patternBytes.length, Option.NONE,
+                ASCIIEncoding.INSTANCE, Syntax.PerlNG);
+        Matcher matcher = regex.matcher(inputBytes);
+        return matcher.search(0, inputBytes.length, Option.NONE);
+    }
+
+    @Test
+    public void permitsCapturesInNegativeLookBehind() {
+        assertEquals(0, search("(?<!(a))b", "b"));
+        assertEquals(-1, search("(?<!(a))b", "ab"));
+    }
+
+    @Test
+    public void acceptTerminatesNegativeLookBehindPath() {
+        String pattern = "(?<!([cd](*ACCEPT)|x)gggg)blrph";
+        assertEquals(-1, search(pattern, "cblrph"));
+        assertEquals(-1, search(pattern, "dblrph"));
+        assertEquals(-1, search(pattern, "xggggblrph"));
+        assertEquals(1, search(pattern, "qblrph"));
+    }
+}

--- a/third_party/joni/test/org/joni/test/TestPerlNestedQuantifier.java
+++ b/third_party/joni/test/org/joni/test/TestPerlNestedQuantifier.java
@@ -1,0 +1,61 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.joni.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+
+import org.jcodings.specific.UTF8Encoding;
+import org.joni.Option;
+import org.joni.Regex;
+import org.joni.Syntax;
+import org.joni.WarnCallback;
+import org.joni.exception.SyntaxException;
+import org.junit.Test;
+
+public class TestPerlNestedQuantifier {
+    private static Regex compile(String pattern) {
+        byte[] bytes = pattern.getBytes(StandardCharsets.UTF_8);
+        return new Regex(bytes, 0, bytes.length, Option.CAPTURE_GROUP,
+                UTF8Encoding.INSTANCE, Syntax.PerlNG, WarnCallback.NONE);
+    }
+
+    @Test
+    public void rejectsUngroupedNestedQuantifier() {
+        assertNestedError("a**");
+        assertNestedError(".{1}??");
+        assertNestedError(".{1}?+");
+    }
+
+    private static void assertNestedError(String pattern) {
+        SyntaxException error = assertThrows(SyntaxException.class,
+                () -> compile(pattern));
+        assertEquals("Nested quantifiers", error.getMessage());
+    }
+
+    @Test
+    public void preservesGroupedNestedQuantifier() {
+        byte[] subject = "x~~".getBytes(StandardCharsets.UTF_8);
+        assertEquals(0, compile("x(~~)*(?:(?:F)?)?").matcher(subject)
+                .search(0, subject.length, Option.NONE));
+    }
+}


### PR DESCRIPTION
## Summary

- preserve Perl grouped nested-quantifier semantics and extended-mode modifiers in the forked Joni parser
- carry named ACCEPT/FAIL/F control state through native bytecode without overwriting earlier named cut errors
- permit captures and ACCEPT-aware width analysis in negative lookbehind
- keep the Phase 36 forward plan aligned with the integrated gate

## Validation

- system-Perl focused oracles pass before PerlOnJava execution
- default and forced-Joni JVM/interpreter focused legs pass
- direct forked-Joni tests pass, including control-error precedence and negative-lookbehind boundaries
- unchanged `perl5_t/t/re/regexp.t` exact differential removes failures with zero introductions
- focused 17-task builds pass for every semantic slice
- full warning-free 17-task `make` on exact head `5ae62c501`: `/tmp/make-phase36-native-quant-control-lookbehind-5ae62c501.log`

## Design

See `dev/design/phase36-regex-parity.md`.
