### PR TITLE
Advance native Joni numeric, class-range, and branch-reset parity

### DIFF
--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -145,6 +145,12 @@ affected corpus before taking another slice.
   when the complete match fails, remain visible when another alternative
   succeeds, and commit when destructive control verbs cut the path, including
   across a dynamic continuation.
+- Native Joni parses bounded decimal, braced, relative, and overflow numeric
+  backreferences without Java-side rewriting. The focused four-backend fixture
+  passes 63/63, and the exact `regexp.t` numeric tranche has zero introductions.
+- Native Joni distinguishes non-ASCII unfinished ranges and accepts Perl false
+  class ranges around `\d`, `\s`, and POSIX classes. The focused system-Perl,
+  direct-Joni, four-backend, and imported-row gates agree.
 
 ## Execution Phases
 
@@ -256,38 +262,38 @@ behavior.
 
 ## Ordered Next Steps
 
-1. Integrate the native `/xx`, adjacent full-fold partition, and `L_` alias
-   batch on the exact merged predecessor. Run one warning-free full build plus
-   zero-introduction `regexp.t` and fold/property gates, then publish a review
-   PR and require exact-head Ubuntu/Windows CI.
-2. Complete recursive and runtime `(??{...})` as native nested Joni execution:
-   preserve captures, `$^R`, `pos`, modes, byte/Unicode provenance, callback
-   unwind, backtracking re-evaluation, and recursion safety. Route every embedded
-   closure to Joni and delete constant inlining, progressive errors, and the
-   dynamic Java adapter as their gates pass.
-3. Complete byte/Unicode pattern provenance through runtime interpolation and
-   template composition, then finish `/d`/`u`/`a`/`aa` forward/reverse literal,
-   class, property, and backreference folding from generated data. Require
-   direct Joni plus ordinary/forced JVM/interpreter zero-introduction gates.
-4. Finish the remaining lexical `use re 'strict'`, unescaped-brace, and non-hex
-   diagnostic families. Refresh complete
-   `reg_mesg.t`, `pat.t`, and `pat_advanced.t` maps after each combined batch.
-5. Repeat the four-leg 80-file Java/Joni × JVM/interpreter matrix on the exact
-   successor artifact and compare every file with the PR 958 log. Resolve every
-   regression, zero-TAP record, timeout, truncation, or incomplete file before
-   user acceptance.
-6. Remove each proven-obsolete regex transformation from `dev/import-perl5`
-   sync sources, regenerate a private unpatched corpus twice, prove byte-for-byte
-   idempotence, and run the affected upstream tests without editing them.
-7. Use the refreshed impact report to move all remaining ordinary constants to
-   native Joni, deleting their Java routes and matcher-semantic preprocessing in
-   the same validated slices. Keep `pat_re_eval.t` at 555/555 throughout.
-8. Delete Java matching, selector, fallback state, and unreachable preprocessors;
-   then run direct/thread regex, CPAN, performance, packaging, notice/license,
-   warning-free build, Ubuntu, Windows, and full CI gates.
+1. Complete and integrate the current non-overlapping native-Joni batch:
+   ordinary repeated-capture clearing, physical branch-reset names/conditions,
+   named-character grammar/diagnostics, numeric backreferences, and class-range
+   semantics. Run one warning-free full `make`, four-backend focused fixtures,
+   and an exact zero-introduction `regexp.t` comparison on the combined SHA.
+2. Close the remaining capture/region identities, including inactive named and
+   numeric branch-reset slots, final successful quantified iterations, failed
+   alternatives, recursive-frame publication, and nested match-state restore.
+3. Move remaining Perl named-character, escape, strict-mode, brace, control-
+   character, and warning semantics into Joni lexer/compiler internals. Remove
+   each corresponding `JoniRegexPattern`/preprocessor rewrite in the same gated
+   slice; keep only source-policy and final diagnostic rendering outside Joni.
+4. Finish whole-pattern recursion `(?R)`, recursive numbered/named calls,
+   recursion conditions, capture publication, and recursion safety. Keep
+   runtime `(??{...})`, callback unwind, and `pat_re_eval.t` 555/555 green.
+5. Finish `/d`/`u`/`a`/`aa` forward/reverse literal and backreference folding
+   from generated data, then rerun complete Unicode, `pat.t`, `pat_advanced.t`,
+   `reg_mesg.t`, and bounded speed/psycho gates on one immutable artifact.
+6. Use the refreshed impact ledger to close every remaining semantic regex
+   identity and move all ordinary constants to Joni. Reject zero-TAP, timeout,
+   truncated, incomplete, JVM/interpreter, or direct/thread mismatches.
+7. Remove proven-obsolete `dev/import-perl5` regex patches, rerun targeted sync
+   twice, prove byte-for-byte idempotence, and validate the restored unchanged
+   upstream tests.
+8. Delete Java matching, the backend selector, fallback state, matcher-semantic
+   preprocessors, and unreachable adapter code. Prove performance, CPAN,
+   packaging, notice/license, and warning-free build gates before removal is
+   accepted.
 9. Update the feature matrix and final as-implemented/fork documents, remove or
-   summarize redundant design documents, rebase the final stack on `master`, and
-   run the complete PR 958 parity audit before declaring Phase 36 complete.
+   summarize redundant design documents, rebase each final PR on `master`, pass
+   Ubuntu/Windows CI, and compare the complete runner output file-by-file with
+   the immutable PR 958 baseline.
 
 ## Parallel Work
 
@@ -375,6 +381,14 @@ gates may reopen it if a semantic regression appears.
 - [x] Native branch reset and removal of its capture-map adapter
 - [x] Native plain `\N` non-newline atom and interval forms
 - [x] Native recursive/runtime `(??{...})` and removal of dynamic adapters
+- [x] Native bounded numeric backreference parsing and removal of Joni-side
+      brace-backreference rewriting
+- [x] Native Perl false-class ranges and unfinished non-ASCII range diagnostics
+- [ ] Final-iteration, optional, alternation, and failed-path capture clearing
+- [ ] Physical branch-reset named calls, conditions, and inactive-slot publication
+- [ ] Native named-character whitespace/missing-brace/comment diagnostics and
+      removal of the duplicate Java translation path
+- [ ] Whole-pattern `(?R)` recursion and recursive capture publication
 - [ ] Retire proven-obsolete `dev/import-perl5` regex patches
 - [ ] Refresh the complete Unicode, `pat.t`, `pat_advanced.t`, `reg_mesg.t`, and
       80-file forced-Joni gates on one integrated artifact

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -151,6 +151,11 @@ affected corpus before taking another slice.
 - Native Joni distinguishes non-ASCII unfinished ranges and accepts Perl false
   class ranges around `\d`, `\s`, and POSIX classes. The focused system-Perl,
   direct-Joni, four-backend, and imported-row gates agree.
+- Physical branch-reset names now bind named calls and named conditions to the
+  correct definition without changing numeric condition operands. The combined
+  numeric-backreference, class-range, and branch-reset boundary passes full
+  `make`; exact `regexp.t` is 2,074/2,210, fixing 57 identities from the prior
+  integrated boundary with no newly failing identity.
 
 ## Execution Phases
 
@@ -262,11 +267,12 @@ behavior.
 
 ## Ordered Next Steps
 
-1. Complete and integrate the current non-overlapping native-Joni batch:
-   ordinary repeated-capture clearing, physical branch-reset names/conditions,
-   named-character grammar/diagnostics, numeric backreferences, and class-range
-   semantics. Run one warning-free full `make`, four-backend focused fixtures,
-   and an exact zero-introduction `regexp.t` comparison on the combined SHA.
+1. Complete and integrate the active non-overlapping successor lanes: dynamic
+   source boundaries, ordinary repeated-capture clearing, native named-character
+   and escape diagnostics, and whole-pattern recursion. Preserve each lane as
+   reviewable semantic commits, then run one warning-free full `make`, four-leg
+   focused fixtures, and an exact zero-introduction `regexp.t` comparison on the
+   combined SHA.
 2. Close the remaining capture/region identities, including inactive named and
    numeric branch-reset slots, final successful quantified iterations, failed
    alternatives, recursive-frame publication, and nested match-state restore.
@@ -385,7 +391,8 @@ gates may reopen it if a semantic regression appears.
       brace-backreference rewriting
 - [x] Native Perl false-class ranges and unfinished non-ASCII range diagnostics
 - [ ] Final-iteration, optional, alternation, and failed-path capture clearing
-- [ ] Physical branch-reset named calls, conditions, and inactive-slot publication
+- [x] Physical branch-reset named calls and conditions
+- [ ] Inactive branch-reset slot publication
 - [ ] Native named-character whitespace/missing-brace/comment diagnostics and
       removal of the duplicate Java translation path
 - [ ] Whole-pattern `(?R)` recursion and recursive capture publication

--- a/dev/design/phase36-regex-parity.md
+++ b/dev/design/phase36-regex-parity.md
@@ -353,7 +353,7 @@ failure blocks backend removal, not semantic fixes.
 
 - [x] Phase 0 — reproducible differential baseline
 - [ ] Phase 1 — ordinary-pattern Joni parity
-- [x] Phase 2 — conditions and backtracking-visible state
+- [ ] Phase 2 — conditions and backtracking-visible state
 - [ ] Phase 3 — Unicode and native pattern syntax
 - [ ] Phase 4 — runtime source and diagnostics
 - [ ] Phase 5 — remove migration scaffolding

--- a/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
+++ b/src/main/java/org/perlonjava/runtime/regex/JoniRegexPattern.java
@@ -807,22 +807,6 @@ final class JoniRegexPattern {
                         continue;
                     }
                 }
-                // In Perl, \g{name} is a backreference.  Ruby/Oniguruma uses
-                // \g<name> for a subexpression call and \k<name> for the
-                // backreference, so passing the brace form through makes Joni
-                // diagnose it as an invalid subexpression call.  Numeric and
-                // relative brace forms follow the same translation.
-                if (!inClass && pattern.startsWith("\\g{", i)) {
-                    int end = pattern.indexOf('}', i + 3);
-                    if (end > i + 3) {
-                        String backreference = pattern.substring(i + 3, end);
-                        if (isValidPerlBraceBackreference(backreference)) {
-                            out.append("\\k<").append(backreference).append('>');
-                            i = end;
-                            continue;
-                        }
-                    }
-                }
                 out.append(ch);
                 escaped = true;
                 continue;
@@ -947,22 +931,6 @@ final class JoniRegexPattern {
             out.append(ch);
         }
         return out.toString();
-    }
-
-    private static boolean isValidPerlBraceBackreference(String content) {
-        if (content.isEmpty()) return false;
-        int start = content.charAt(0) == '-' ? 1 : 0;
-        if (start == content.length()) return false;
-        if (start == 1 || Character.isDigit(content.charAt(0))) {
-            for (int i = start; i < content.length(); i++) {
-                if (!Character.isDigit(content.charAt(i))) return false;
-            }
-            return true;
-        }
-        for (int i = 0; i < content.length(); i++) {
-            if (Character.isWhitespace(content.charAt(i))) return false;
-        }
-        return true;
     }
 
     private static void appendResolvedNamedCharacter(StringBuilder out, int codePoint,

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -824,7 +824,8 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 }
                 if ("invalid backref number/name".equals(e.getMessage())
                         || "invalid backref number".equals(e.getMessage())) {
-                    throw new PerlCompilerException("Reference to nonexistent group");
+                    throw new PerlCompilerException(
+                            "Reference to nonexistent group in regex");
                 }
                 String invalidProperty = invalidUnicodePropertyName(e.getMessage());
                 if (invalidProperty != null) {

--- a/src/test/resources/unit/regex/branch_reset_capture_semantics.t
+++ b/src/test/resources/unit/regex/branch_reset_capture_semantics.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use Test::More;
+
+plan skip_all => 'GH 20653 semantics require Perl 5.44+' if $] < 5.044;
+
+ok('bbab' =~ /(?|(?<a>a)|(?<b>b))\1(?&a)(?&b)/,
+    'branch-reset numbered and named subroutine targets share captures');
+ok('byb' =~ /(?|(?<a>a)|(?<b>b))(?(<a>)x|y)\1/,
+    'named condition sees unset sibling capture');
+ok(!('bxb' =~ /(?|(?<a>a)|(?<b>b))(?(<a>)x|y)\1/),
+    'named condition rejects wrong unset-capture branch');
+ok('axa' =~ /(?|(?<a>a)|(?<b>b))(?(<a>)x|y)\1/,
+    'named condition sees set capture');
+
+'a' =~ /(?|(?<a>a)|(?<b>b))/;
+is("$1-$+{a}-" . (defined $+{b} ? $+{b} : ''), 'a-a-',
+    'first branch publishes only its named capture');
+'b' =~ /(?|(?<a>a)|(?<b>b))/;
+is("$1-" . (defined $+{a} ? $+{a} : '') . "-$+{b}", 'b--b',
+    'second branch publishes only its named capture');
+
+for my $case (
+    ['preabcpost', 'a-b-c'],
+    ['predepost', 'd-e-'],
+    ['prefpost', 'f--'],
+) {
+    my ($subject, $expected) = @$case;
+    $subject =~ /(?<pre>pre)(?|(?<a>a)(?<b>b)(?<c>c)|(?<d>d)(?<e>e)|(?<f>f))(?<post>post)/;
+    is("$2-" . (defined $3 ? $3 : '') . '-' . (defined $4 ? $4 : ''),
+        $expected, 'branch-reset physical slots preserve post-group numbering');
+}
+
+for my $letter (qw(a b c)) {
+    my $subject = $letter x 2;
+    ok($subject =~ /((?|(?<a>a)(?-1)|(?<b>b)(?-1)|(?<c>c)(?-1)))/,
+        'relative subroutine target resolves inside each branch-reset alternative');
+    is($1, $subject, 'relative subroutine target consumes the matching pair');
+}
+
+done_testing;

--- a/src/test/resources/unit/regex/joni_extended_class_range_diagnostic.t
+++ b/src/test/resources/unit/regex/joni_extended_class_range_diagnostic.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $invalid_range = eval q{ qr/[\xdf-/i; 1 } ? '' : $@;
+like($invalid_range, qr/^Invalid \[\] range/,
+     'unterminated character-class range uses the Perl diagnostic');
+
+done_testing;

--- a/src/test/resources/unit/regex/joni_false_class_ranges.t
+++ b/src/test/resources/unit/regex/joni_false_class_ranges.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More;
+
+my @cases = (
+    [ qr/([a-\d]+)/,                'za-9z', 'a-9', 'backslash d after a-dash' ],
+    [ qr/([\d-z]+)/,                'a0-za', '0-z', 'backslash d before dash-z' ],
+    [ qr/([\d-\s]+)/,              'a0- z', '0- ', 'backslash d through dash-space' ],
+    [ qr/([a-[:digit:]]+)/,          'za-9z', 'a-9', 'POSIX digit after a-dash' ],
+    [ qr/([[:digit:]-z]+)/,          '=0-z=', '0-z', 'POSIX digit before dash-z' ],
+    [ qr/([[:digit:]-[:alpha:]]+)/, '=0-z=', '0-z', 'POSIX digit and alpha around dash' ],
+);
+
+for my $case (@cases) {
+    my ($regex, $input, $want, $name) = @$case;
+    my ($got) = $input =~ $regex;
+    is($got, $want, $name);
+}
+
+done_testing;

--- a/src/test/resources/unit/regex/native_numeric_backreference_boundaries.t
+++ b/src/test/resources/unit/regex/native_numeric_backreference_boundaries.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+use Test::More;
+
+for my $pattern (q{\87}, q{a\87}, q{a\97}) {
+    my $compiled = eval "qr/$pattern/";
+    like($@, qr/Reference to nonexistent group in regex/,
+         "$pattern is a nonexistent decimal backreference");
+}
+
+for my $digits (qw(2147483648 2147483649 2147483650
+                   4294967296 4294967297 4294967298)) {
+    for my $prefix ('', 'a') {
+        for my $form ("\\g$digits}", "\\g{$digits}", "\\g{ $digits }") {
+            my $compiled = eval "qr/${prefix}(.)$form/";
+            like($@, qr/Reference to nonexistent group in regex/,
+                 "$form rejects overflow safely after ${prefix}capture");
+        }
+    }
+
+    my ($octal, $tail) = $digits =~ /^([0-7]{1,3})(.*)$/;
+    for my $prefix ('', 'a') {
+        my $pattern = "${prefix}(.)\\$digits";
+        my $compiled = eval "qr/$pattern/";
+        ok(defined($compiled), "$pattern compiles as octal plus literal tail");
+        my $subject = $prefix . 'b' . chr(oct($octal)) . $tail;
+        ok($subject =~ $compiled && $1 eq 'b',
+           "$pattern matches its octal boundary without integer overflow");
+    }
+}
+
+done_testing;

--- a/third_party/joni/src/org/joni/Analyser.java
+++ b/third_party/joni/src/org/joni/Analyser.java
@@ -449,14 +449,14 @@ final class Analyser extends Parser {
             BackRefNode br = (BackRefNode)node;
             if (br.isRecursion()) break;
 
-            if (br.back[0] > env.numMem) {
+            if (invalidBackrefNode(br.back[0])) {
                 if (!syntax.op3OptionECMAScript()) newValueException(INVALID_BACKREF);
             } else {
                 min = getMinMatchLength(env.memNodes[br.back[0]]);
             }
 
             for (int i=1; i<br.backNum; i++) {
-                if (br.back[i] > env.numMem) {
+                if (invalidBackrefNode(br.back[i])) {
                     if (!syntax.op3OptionECMAScript()) newValueException(INVALID_BACKREF);
                 } else {
                     int tmin = getMinMatchLength(env.memNodes[br.back[i]]);
@@ -596,7 +596,7 @@ final class Analyser extends Parser {
             }
 
             for (int i=0; i<br.backNum; i++) {
-                if (br.back[i] > env.numMem) {
+                if (invalidBackrefNode(br.back[i])) {
                     if(!syntax.op3OptionECMAScript()) newValueException(INVALID_BACKREF);
                 } else {
                     int tmax = getMaxMatchLength(env.memNodes[br.back[i]]);
@@ -2500,7 +2500,7 @@ final class Analyser extends Parser {
         case NodeType.BREF:
             BackRefNode br = (BackRefNode)node;
             for (int i=0; i<br.backNum; i++) {
-                if (br.back[i] > env.numMem) {
+                if (invalidBackrefNode(br.back[i])) {
                     if (!syntax.op3OptionECMAScript()) newValueException(INVALID_BACKREF);
                 } else {
                     env.backrefedMem = bsOnAt(env.backrefedMem, br.back[i]);
@@ -3065,5 +3065,10 @@ final class Analyser extends Parser {
         if (Config.DEBUG_COMPILE || Config.DEBUG_MATCH) {
             Config.log.println(regex.optimizeInfoToString());
         }
+    }
+
+    private boolean invalidBackrefNode(int number) {
+        return number <= 0 || number > env.numMem || env.memNodes == null
+                || number >= env.memNodes.length || env.memNodes[number] == null;
     }
 }

--- a/third_party/joni/src/org/joni/Analyser.java
+++ b/third_party/joni/src/org/joni/Analyser.java
@@ -1414,6 +1414,10 @@ final class Analyser extends Parser {
                             newValueException(MULTIPLEX_DEFINITION_NAME_CALL, cn.nameP, cn.nameEnd);
                         } else {
                             cn.groupNum = ne.backRef1; // ne.backNum == 1 ? ne.backRef1 : ne.backRefs[0]; // ??? need to check ?
+                            if (ne.backNum == 1) {
+                                cn.lexicalTarget = env.physicalNamedMemNode(
+                                        ne.getPhysicalBackRefs()[0]);
+                            }
                             if (ne.backNum > 1) cn.setRecursion();
                             setCallAttr(cn);
                         }

--- a/third_party/joni/src/org/joni/ArrayCompiler.java
+++ b/third_party/joni/src/org/joni/ArrayCompiler.java
@@ -1123,6 +1123,7 @@ final class ArrayCompiler extends Compiler {
                             : OPCode.CONDITION);
                     addMemNum(node.calloutConditionId >= 0 ? node.calloutConditionId
                             : node.recursionConditionGroup >= 0 ? node.recursionConditionGroup
+                            : node.physicalNamedCondition > 0 ? -node.physicalNamedCondition
                             : node.regNum);
                     addRelAddr(len + OPSize.JUMP);
                 }

--- a/third_party/joni/src/org/joni/ByteCodeMachine.java
+++ b/third_party/joni/src/org/joni/ByteCodeMachine.java
@@ -946,6 +946,16 @@ class ByteCodeMachine extends StackMachine implements MatchView {
     private void opCondition() {
         int mem = code[ip++];
         int addr = code[ip++];
+        if (mem < 0) {
+            int physical = -mem;
+            if (physicalNamedCaptureBeg == null
+                    || physical >= physicalNamedCaptureBeg.length
+                    || physicalNamedCaptureBeg[physical] == INVALID_INDEX
+                    || physicalNamedCaptureEnd[physical] == INVALID_INDEX) {
+                ip += addr;
+            }
+            return;
+        }
         if (mem > regex.numMem || repeatStk[memEndStk + mem] == INVALID_INDEX || repeatStk[memStartStk + mem] == INVALID_INDEX) {
             ip += addr;
         }

--- a/third_party/joni/src/org/joni/Lexer.java
+++ b/third_party/joni/src/org/joni/Lexer.java
@@ -1356,6 +1356,7 @@ class Lexer extends ScannerSupport {
         }
 
         if (c == '8' || c == '9') { /* normal char */ // skip_backref:
+            if (syntax.op2OptionPerl()) newValueException(INVALID_BACKREF);
             p = last;
             inc();
             return;
@@ -1440,10 +1441,10 @@ class Lexer extends ScannerSupport {
             return;
         }
         if (Config.USE_NAMED_GROUP) {
-            if (syntax.op2EscGBraceBackref() && left()) {
+            if ((syntax.op2EscGBraceBackref() || syntax.op2OptionPerl()) && left()) {
                 fetch();
                 if (c == '{') {
-                    fetchNamedBackrefToken();
+                    if (!fetchPerlNumericBackrefToken()) fetchNamedBackrefToken();
                 } else {
                     unfetch();
                 }
@@ -1495,6 +1496,46 @@ class Lexer extends ScannerSupport {
                 }
             }
         }
+    }
+
+    private boolean fetchPerlNumericBackrefToken() {
+        if (!syntax.op2OptionPerl()) return false;
+
+        int cursor = p;
+        while (cursor < stop && Character.isWhitespace(codeAt(cursor, stop))) {
+            cursor = nextChar(cursor, stop);
+        }
+        boolean negative = cursor < stop && codeAt(cursor, stop) == '-';
+        if (negative) cursor = nextChar(cursor, stop);
+        int digitsStart = cursor;
+        long number = 0;
+        boolean overflow = false;
+        while (cursor < stop && enc.isDigit(codeAt(cursor, stop))) {
+            int digit = Encoding.digitVal(codeAt(cursor, stop));
+            if (number > (Integer.MAX_VALUE - digit) / 10L) overflow = true;
+            else if (!overflow) number = number * 10 + digit;
+            cursor = nextChar(cursor, stop);
+        }
+        if (cursor == digitsStart) return false;
+        while (cursor < stop && Character.isWhitespace(codeAt(cursor, stop))) {
+            cursor = nextChar(cursor, stop);
+        }
+        if (cursor >= stop || codeAt(cursor, stop) != '}') return false;
+        p = nextChar(cursor, stop);
+
+        if (overflow || number == 0) newValueException(INVALID_BACKREF);
+        long absolute = negative ? (long)env.numMem + 1 - number : number;
+        if (absolute <= 0 || absolute > env.numMem || env.memNodes == null
+                || absolute >= env.memNodes.length
+                || env.memNodes[(int)absolute] == null) {
+            newValueException(INVALID_BACKREF);
+        }
+        token.type = TokenType.BACKREF;
+        token.setBackrefByName(false);
+        token.setBackrefNum(1);
+        token.setBackrefRef1((int)absolute);
+        if (Config.USE_BACKREF_WITH_LEVEL) token.setBackrefExistLevel(false);
+        return true;
     }
 
     private void rejectMalformedPerlBackref() {
@@ -1580,7 +1621,8 @@ class Lexer extends ScannerSupport {
                 if (backNum <= 0) newValueException(INVALID_BACKREF);
             }
 
-            if (syntax.strictCheckBackref() && (backNum > env.numMem || env.memNodes == null)) {
+            if (syntax.strictCheckBackref() && (backNum > env.numMem || env.memNodes == null
+                    || backNum >= env.memNodes.length || env.memNodes[backNum] == null)) {
                 newValueException(INVALID_BACKREF);
             }
             token.type = TokenType.BACKREF;

--- a/third_party/joni/src/org/joni/Lexer.java
+++ b/third_party/joni/src/org/joni/Lexer.java
@@ -1445,6 +1445,7 @@ class Lexer extends ScannerSupport {
                 fetch();
                 if (c == '{') {
                     if (!fetchPerlNumericBackrefToken()) fetchNamedBackrefToken();
+                    return;
                 } else {
                     unfetch();
                 }

--- a/third_party/joni/src/org/joni/Parser.java
+++ b/third_party/joni/src/org/joni/Parser.java
@@ -914,6 +914,7 @@ class Parser extends Lexer {
                 if (left() && syntax.op2QMarkLParenCondition()) {
                     int num = -1;
                     int name = -1;
+                    int physicalNamedCondition = -1;
                     int calloutConditionId = -1;
                     AnchorNode assertionCondition = null;
                     int recursionConditionGroup = -1;
@@ -977,6 +978,10 @@ class Parser extends Lexer {
                                 fetchNamedBackrefToken();
                                 inc();
                                 num = token.getBackrefNum() > 1 ? token.getBackrefRefs()[0] : token.getBackrefRef1();
+                                NameEntry named = regex.nameToGroupNumbers(bytes, name, value);
+                                if (named != null && named.backNum == 1) {
+                                    physicalNamedCondition = named.getPhysicalBackRefs()[0];
+                                }
                             }
                         } else { // USE_NAMED_GROUP
                             newSyntaxException(INVALID_CONDITION_PATTERN);
@@ -984,6 +989,7 @@ class Parser extends Lexer {
                     }
                     EncloseNode en = new EncloseNode(EncloseType.CONDITION);
                     en.regNum = num;
+                    en.physicalNamedCondition = physicalNamedCondition;
                     en.calloutConditionId = calloutConditionId;
                     en.assertionCondition = assertionCondition;
                     en.recursionConditionGroup = recursionConditionGroup;

--- a/third_party/joni/src/org/joni/Parser.java
+++ b/third_party/joni/src/org/joni/Parser.java
@@ -614,6 +614,14 @@ class Parser extends Lexer {
                 break;
 
             case EOT:
+                // Perl distinguishes an unfinished range after a non-ASCII
+                // class value (for example /[\xdf-/i) from a bare unmatched
+                // opening bracket. Preserve the ordinary EOT diagnostic for
+                // ASCII ranges such as /[a-/.
+                if (arg.state == CCSTATE.RANGE && arg.to >= 0x80
+                        && env.usesPerlDiagnostics()) {
+                    newSyntaxException(PERL_INVALID_RANGE_IN_CHAR_CLASS);
+                }
                 newSyntaxException(PREMATURE_END_OF_CHAR_CLASS);
 
             default:

--- a/third_party/joni/src/org/joni/Parser.java
+++ b/third_party/joni/src/org/joni/Parser.java
@@ -511,6 +511,16 @@ class Parser extends Lexer {
 
             case CC_RANGE:
                 if (arg.state == CCSTATE.VALUE) {
+                    if (arg.type == CCVALTYPE.CLASS && env.usesPerlDiagnostics()) {
+                        // Perl accepts [\d-z] as a false range: retain the
+                        // class and make the hyphen a pending literal value.
+                        arg.state = CCSTATE.COMPLETE;
+                        arg.to = '-';
+                        arg.toIsRaw = false;
+                        arg.inType = CCVALTYPE.SB;
+                        cc.nextStateValue(arg, ascCc, foldCc, env);
+                        break;
+                    }
                     fetchTokenInCC();
                     fetched = true;
                     if (token.type == TokenType.CC_CLOSE) { /* allow [x-] */

--- a/third_party/joni/src/org/joni/ScanEnvironment.java
+++ b/third_party/joni/src/org/joni/ScanEnvironment.java
@@ -46,6 +46,7 @@ public final class ScanEnvironment {
     int numNamed; // USE_NAMED_GROUP
 
     public EncloseNode[] memNodes;
+    private EncloseNode[] physicalNamedMemNodes;
 
     // USE_COMBINATION_EXPLOSION_CHECK
     int numCombExpCheck;
@@ -104,9 +105,30 @@ public final class ScanEnvironment {
             } else if (memNodes[num] != node) {
                 multiplexMemNodes[num] = true;
             }
+            if (node.physicalNamedCaptureId > 0) {
+                setPhysicalNamedMemNode(node.physicalNamedCaptureId, node);
+            }
         } else {
             throw new InternalException(ErrorMessages.PARSER_BUG);
         }
+    }
+
+    private void setPhysicalNamedMemNode(int physicalId, EncloseNode node) {
+        if (physicalNamedMemNodes == null) {
+            physicalNamedMemNodes = new EncloseNode[Config.SCANENV_MEMNODES_SIZE];
+        } else if (physicalId >= physicalNamedMemNodes.length) {
+            EncloseNode[] expanded = new EncloseNode[physicalNamedMemNodes.length << 1];
+            System.arraycopy(physicalNamedMemNodes, 0, expanded, 0,
+                    physicalNamedMemNodes.length);
+            physicalNamedMemNodes = expanded;
+        }
+        physicalNamedMemNodes[physicalId] = node;
+    }
+
+    EncloseNode physicalNamedMemNode(int physicalId) {
+        return physicalNamedMemNodes == null || physicalId <= 0
+                || physicalId >= physicalNamedMemNodes.length
+                ? null : physicalNamedMemNodes[physicalId];
     }
 
     boolean isMultiplexMemNode(int num) {

--- a/third_party/joni/src/org/joni/ScannerSupport.java
+++ b/third_party/joni/src/org/joni/ScannerSupport.java
@@ -57,16 +57,18 @@ abstract class ScannerSupport extends IntHolder implements ErrorMessages {
         return p - begin;
     }
 
-    private static final int INT_SIGN_BIT = 1 << 31;
     protected final int scanUnsignedNumber() {
         int last = c;
         int num = 0; // long ???
         while(left()) {
             fetch();
             if (enc.isDigit(c)) {
-                int onum = num;
-                num = num * 10 + Encoding.digitVal(c);
-                if (((onum ^ num) & INT_SIGN_BIT) != 0) return -1;
+                int digit = Encoding.digitVal(c);
+                if (num > (Integer.MAX_VALUE - digit) / 10) {
+                    c = last;
+                    return -1;
+                }
+                num = num * 10 + digit;
             } else {
                 unfetch();
                 break;
@@ -103,10 +105,12 @@ abstract class ScannerSupport extends IntHolder implements ErrorMessages {
         while(left() && maxLength-- != 0) {
             fetch();
             if (enc.isDigit(c) && c < '8') {
-                int onum = num;
                 int val = Encoding.odigitVal(c);
+                if (num > (Integer.MAX_VALUE - val) / 8) {
+                    c = last;
+                    return -1;
+                }
                 num = (num << 3) + val;
-                if (((onum ^ num) & INT_SIGN_BIT) != 0) return -1;
             } else {
                 unfetch();
                 break;

--- a/third_party/joni/src/org/joni/ast/CClassNode.java
+++ b/third_party/joni/src/org/joni/ast/CClassNode.java
@@ -637,7 +637,21 @@ public final class CClassNode extends Node {
 
     public void nextStateClass(CCStateArg arg, CClassNode ascCc,
                                CClassNode foldCc, ScanEnvironment env) {
-        if (arg.state == CCSTATE.RANGE) throw new SyntaxException(ErrorMessages.CHAR_CLASS_VALUE_AT_END_OF_RANGE);
+        if (arg.state == CCSTATE.RANGE) {
+            if (!env.usesPerlDiagnostics()) {
+                throw new SyntaxException(ErrorMessages.CHAR_CLASS_VALUE_AT_END_OF_RANGE);
+            }
+
+            // Perl accepts a character class as a false range endpoint, such
+            // as [a-\d].  The hyphen is literal and both operands remain
+            // members of the surrounding class.
+            arg.state = CCSTATE.VALUE;
+            nextStateValue(arg, ascCc, foldCc, env);
+            arg.to = '-';
+            arg.toIsRaw = false;
+            arg.inType = CCVALTYPE.SB;
+            nextStateValue(arg, ascCc, foldCc, env);
+        }
 
         if (arg.state == CCSTATE.VALUE && arg.type != CCVALTYPE.CLASS) {
             if (arg.type == CCVALTYPE.SB) {

--- a/third_party/joni/src/org/joni/ast/EncloseNode.java
+++ b/third_party/joni/src/org/joni/ast/EncloseNode.java
@@ -35,6 +35,8 @@ public final class EncloseNode extends StateNode implements EncloseType {
     public int charLength;
     public int optCount;            // referenced count in optimize_node_left()
     public int calloutConditionId = -1;
+    /** Distinguishes unique named captures that reuse a branch-reset slot. */
+    public int physicalNamedCondition = -1;
     public AnchorNode assertionCondition;
     public int recursionConditionGroup = -1;
     public int recursionConditionNameP = -1;

--- a/third_party/joni/test/org/joni/test/TestPerlBranchResetNamedCall.java
+++ b/third_party/joni/test/org/joni/test/TestPerlBranchResetNamedCall.java
@@ -71,6 +71,20 @@ public class TestPerlBranchResetNamedCall {
     }
 
     @Test
+    public void distinctNamedBranchResetCallsUseTheirOwnPhysicalDefinitions() {
+        String pattern = "(?|(?<a>a)|(?<b>b))\\1\\g<a>\\g<b>";
+        assertMatches(pattern, "bbab");
+    }
+
+    @Test
+    public void distinctNamedBranchResetConditionsUsePhysicalDefinitions() {
+        String pattern = "(?|(?<a>a)|(?<b>b))(?(<a>)x|y)\\1";
+        assertMatches(pattern, "byb");
+        assertDoesNotMatch(pattern, "bxb");
+        assertMatches(pattern, "axa");
+    }
+
+    @Test
     public void numericBranchResetCallTargetsLeftmostPhysicalGroup() {
         String pattern = "(?|(1)|(2))\\g<1>";
         assertMatches(pattern, "11");

--- a/third_party/joni/test/org/joni/test/TestPerlNumericBackreferenceBoundaries.java
+++ b/third_party/joni/test/org/joni/test/TestPerlNumericBackreferenceBoundaries.java
@@ -1,0 +1,85 @@
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.joni.test;
+
+import static org.joni.exception.ErrorMessages.INVALID_BACKREF;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.nio.charset.StandardCharsets;
+
+import org.jcodings.specific.ISO8859_1Encoding;
+import org.jcodings.specific.UTF8Encoding;
+import org.joni.Option;
+import org.joni.Regex;
+import org.joni.Syntax;
+import org.joni.WarnCallback;
+import org.joni.exception.SyntaxException;
+import org.junit.Test;
+
+public class TestPerlNumericBackreferenceBoundaries {
+    private static Regex compile(String pattern) {
+        byte[] bytes = pattern.getBytes(StandardCharsets.UTF_8);
+        return new Regex(bytes, 0, bytes.length, Option.CAPTURE_GROUP,
+                UTF8Encoding.INSTANCE, Syntax.PerlNG, WarnCallback.NONE);
+    }
+
+    private static void assertInvalid(String pattern) {
+        SyntaxException error = assertThrows(SyntaxException.class,
+                () -> compile(pattern));
+        assertEquals(INVALID_BACKREF, error.getMessage());
+    }
+
+    @Test
+    public void rejectsNonexistentAndOverflowingDecimalBackreferences() {
+        assertInvalid("\\87");
+        assertInvalid("a\\87");
+        assertInvalid("a\\97");
+        for (String digits : new String[] {"2147483648", "2147483649",
+                "2147483650", "4294967296", "4294967297", "4294967298"}) {
+            assertInvalid("(.)\\g" + digits + "}");
+            assertInvalid("(.)\\g{" + digits + "}");
+            assertInvalid("(.)\\g{ " + digits + " }");
+            assertInvalid("a(.)\\g" + digits + "}");
+            assertInvalid("a(.)\\g{" + digits + "}");
+            assertInvalid("a(.)\\g{ " + digits + " }");
+        }
+    }
+
+    @Test
+    public void longDecimalEscapesUseOnlyTheMaximalOctalPrefix() {
+        for (String digits : new String[] {"2147483648", "2147483649",
+                "2147483650", "4294967296", "4294967297", "4294967298"}) {
+            int octalLength = 0;
+            while (octalLength < 3 && octalLength < digits.length()
+                    && digits.charAt(octalLength) <= '7') octalLength++;
+            int octal = Integer.parseInt(digits.substring(0, octalLength), 8);
+            String tail = digits.substring(octalLength);
+            String pattern = "(.)\\" + digits;
+            byte[] patternBytes = pattern.getBytes(StandardCharsets.ISO_8859_1);
+            Regex regex = new Regex(patternBytes, 0, patternBytes.length,
+                    Option.CAPTURE_GROUP, ISO8859_1Encoding.INSTANCE,
+                    Syntax.PerlNG, WarnCallback.NONE);
+            byte[] input = ("b" + (char)octal + tail)
+                    .getBytes(StandardCharsets.ISO_8859_1);
+            assertEquals(0, regex.matcher(input).search(0, input.length, Option.NONE));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- move bounded numeric and braced backreference parsing into Joni internals
- implement Perl false and non-ASCII unfinished character-class range behavior
- bind branch-reset named calls and conditions to their physical definitions
- refresh the Phase 36 document with forward-only execution steps

## Validation

- `make` passes at `648d14588` (Joni suite, five unit shards, packaging, shadow JAR)
- exact `perl5_t/t/re/regexp.t`: 2074/2210, up from 2017/2210 at the stacked base
- 57 identities fixed; zero newly failing identities

This is stacked on PR #1085. It remains draft while successor migration lanes
continue in parallel.
