### PR TITLE
fix: close PR 1087 release regressions

### DIFF
--- a/dev/tools/lib/PerlTestRunner/Scheduler.pm
+++ b/dev/tools/lib/PerlTestRunner/Scheduler.pm
@@ -16,6 +16,17 @@ sub profile_for_test {
     my ($test_file) = @_;
     (my $normalized_file = $test_file) =~ tr{\\}{/};
 
+    # This test creates and executes progtmp* files containing #!./perl. Its
+    # private cwd prevents cross-runner races; an exclusive barrier also keeps
+    # it from competing with other work inside one resource-aware runner.
+    if ($normalized_file =~ m{(?:^|/)perl5_t/t/japh/abigail\.t$}) {
+        return {
+            class => 'exclusive',
+            weight => 3,
+            exclusive => 1,
+        };
+    }
+
     # These fixtures create sustained CPU, memory, or subprocess pressure.
     # Weight three permits three such files within a --jobs 10 budget while
     # leaving one unit available for an ordinary test.
@@ -27,7 +38,6 @@ sub profile_for_test {
         | (?:^|/)perl5_t/t/re/pat_advanced(?:_thr)?\.t$
         | (?:^|/)perl5_t/t/re/regexp_qr_embed_thr\.t$
         | (?:^|/)perl5_t/t/re/speed(?:_thr)?\.t$
-        | (?:^|/)perl5_t/t/japh/abigail\.t$
     }x) {
         return {
             class => 'heavy',
@@ -36,10 +46,8 @@ sub profile_for_test {
         };
     }
 
-    # No current test requires exclusive semantic isolation. The runner
-    # validates TAP semantics, so timing-only benchmarks deliberately receive
-    # no scheduling privilege; authoritative timings use a separate,
-    # controlled benchmark procedure.
+    # Timing-only benchmarks deliberately receive no semantic scheduling
+    # privilege; authoritative timings use a separate controlled procedure.
     return {
         class => 'normal',
         weight => 1,

--- a/dev/tools/perl_test_runner.pl
+++ b/dev/tools/perl_test_runner.pl
@@ -2,12 +2,15 @@
 use strict;
 use warnings;
 use File::Find;
+use File::Path qw(remove_tree);
 use File::Spec;
+use File::Temp qw(tempdir);
 use Time::HiRes qw(time);
 use Getopt::Long;
 use JSON::PP;
 use Data::Dumper;
 use POSIX qw(WNOHANG WIFEXITED WEXITSTATUS WIFSIGNALED WTERMSIG setsid);
+use Text::ParseWords qw(shellwords);
 use Config ();
 use FindBin qw($Bin);
 use lib "$Bin/lib";
@@ -350,6 +353,11 @@ sub process_test_result {
 sub run_single_test {
     my ($test_file) = @_;
 
+    # Resolve the selected launcher before any test-specific chdir. This exact
+    # absolute path is also used by private overlays for literal #!./perl.
+    my $old_dir = File::Spec->rel2abs('.');
+    my $abs_jperl = File::Spec->rel2abs($jperl_path, $old_dir);
+
     # Core thread distributions assume their own build-directory cwd.  In
     # particular, threads and threads-shared resolve ../../t/test.pl when
     # PERL_CORE is set, while Thread-Queue and Thread-Semaphore load their
@@ -439,9 +447,6 @@ sub run_single_test {
     # These tests can crash the JVM with StackOverflowError during regex backtracking
     local $ENV{PERL_SKIP_BIG_MEM_TESTS} = 1;
 
-    # Save current directory
-    my $old_dir = File::Spec->rel2abs('.');
-
     # For perl5_t tests (especially Pod tests), change to the test directory
     # so they can find their test data files with relative paths
     my $local_test_dir = $test_dir;
@@ -487,11 +492,68 @@ sub run_single_test {
         $local_test_dir = $1;
     }
 
-    chdir($local_test_dir) if $local_test_dir && -d $local_test_dir;
+    # abigail.t writes progtmp* programs containing literal #!./perl. Run it in
+    # a private overlay so concurrent runner processes cannot share either the
+    # launcher or generated programs. All authoritative test-tree entries
+    # remain read-only links; only perl and progtmp* live in the private cwd.
+    my $private_test_root;
+    my $private_test_dir;
+    my $test_name;
+    if ($^O ne 'MSWin32' && $^O ne 'cygwin' && $^O ne 'msys'
+            && $test_file =~ m{(?:^|/)perl5_t/t/japh/abigail\.t$}) {
+        my $source_test_dir = File::Spec->rel2abs('perl5_t/t', $old_dir);
+        my $source_lib_dir = File::Spec->rel2abs('perl5_t/lib', $old_dir);
+        $private_test_root = tempdir('perlonjava-abigail-XXXXXX', TMPDIR => 1, CLEANUP => 1);
+        $private_test_dir = File::Spec->catdir($private_test_root, 't');
+        mkdir $private_test_dir or die "Cannot create private test cwd: $!";
+        symlink $source_lib_dir, File::Spec->catfile($private_test_root, 'lib')
+            or die "Cannot link private Perl library tree: $!";
+        opendir my $source, $source_test_dir
+            or die "Cannot read $source_test_dir: $!";
+        while (defined(my $entry = readdir $source)) {
+            next if $entry eq '.' || $entry eq '..' || $entry eq 'perl';
+            next if $entry =~ /^progtmp/;
+            symlink File::Spec->catfile($source_test_dir, $entry),
+                    File::Spec->catfile($private_test_dir, $entry)
+                or die "Cannot link private test-tree entry $entry: $!";
+        }
+        closedir $source;
+        # The selected jperl is normally a shell script. Kernels do not
+        # reliably allow a script to be the interpreter of another shebang
+        # script, so use a native per-run trampoline which execs the exact
+        # selected absolute launcher and forwards the generated script path.
+        my $launcher_source = File::Spec->catfile($private_test_dir, '.jperl-launcher.c');
+        my $launcher_binary = File::Spec->catfile($private_test_dir, 'perl');
+        open my $launcher, '>', $launcher_source
+            or die "Cannot create private launcher source: $!";
+        print {$launcher} <<'NATIVE_LAUNCHER';
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+int main(int argc, char **argv) {
+    const char *target = getenv("PERLONJAVA_SHEBANG_TARGET");
+    if (target == NULL || *target == '\0') {
+        fputs("PERLONJAVA_SHEBANG_TARGET is not set\n", stderr);
+        return 127;
+    }
+    argv[0] = (char *)target;
+    execv(target, argv);
+    perror("execv selected jperl");
+    return 127;
+}
+NATIVE_LAUNCHER
+        close $launcher or die "Cannot close private launcher source: $!";
+        my @compiler = shellwords($Config::Config{cc} || 'cc');
+        system(@compiler, $launcher_source, '-o', $launcher_binary) == 0
+            or die "Cannot build private native jperl trampoline\n";
+        unlink $launcher_source;
+        $ENV{PERLONJAVA_SHEBANG_TARGET} = $abs_jperl;
+        $local_test_dir = $private_test_dir;
+        $test_name = 'japh/abigail.t';
+    }
 
-    # Use absolute path for jperl
-    my $abs_jperl = File::Spec->rel2abs($jperl_path, $old_dir);
-    my $test_name = File::Spec->abs2rel($test_file, $local_test_dir || '.');
+    chdir($local_test_dir) if $local_test_dir && -d $local_test_dir;
+    $test_name //= File::Spec->abs2rel($test_file, $local_test_dir || '.');
 
     # Try to use system timeout command if available.
     # Use --kill-after (-k) so a SIGTERM that the JVM ignores is followed
@@ -589,6 +651,7 @@ sub run_single_test {
 
     # Restore directory
     chdir($old_dir);
+    remove_tree($private_test_root) if defined $private_test_root && -d $private_test_root;
 
     # Check if it was a timeout.
     # 124 = GNU timeout sent SIGTERM and child exited.

--- a/dev/tools/tests/perl_test_runner_japh_isolation.t
+++ b/dev/tools/tests/perl_test_runner_japh_isolation.t
@@ -1,0 +1,117 @@
+use strict;
+use warnings;
+
+use Cwd qw(getcwd);
+use File::Path qw(make_path);
+use File::Spec;
+use File::Temp qw(tempdir);
+use FindBin;
+use Test::More;
+use lib "$FindBin::Bin/../lib";
+use PerlTestRunner::Scheduler qw(profile_for_test);
+
+my $profile = profile_for_test('perl5_t/t/japh/abigail.t');
+is_deeply($profile, { class => 'exclusive', weight => 3, exclusive => 1 },
+    'mutating JAPH fixture is an exclusive scheduling barrier');
+
+my $root = File::Spec->rel2abs(File::Spec->catdir($FindBin::Bin, '..', '..', '..'));
+my $runner = File::Spec->catfile($root, 'dev', 'tools', 'perl_test_runner.pl');
+my $temporary = tempdir(CLEANUP => 1);
+my $test_dir = File::Spec->catdir($temporary, 'perl5_t', 't');
+my $lib_dir = File::Spec->catdir($temporary, 'perl5_t', 'lib');
+my $japh_dir = File::Spec->catdir($test_dir, 'japh');
+my $test_file = File::Spec->catfile($japh_dir, 'abigail.t');
+my $fake_jperl = File::Spec->catfile($temporary, 'fake-jperl');
+make_path($japh_dir);
+make_path($lib_dir);
+write_file($test_file, "# private-overlay fixture\n");
+write_file(File::Spec->catfile($test_dir, 'test.pl'), "1;\n");
+write_file($fake_jperl, <<'FAKE_JPERL');
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use File::Spec;
+use Time::HiRes qw(sleep);
+
+my $token = $ENV{JAPH_ISOLATION_TOKEN};
+my $linked = -x 'perl' && $ENV{PERLONJAVA_SHEBANG_TARGET} eq File::Spec->rel2abs($0);
+my $layout = -d '../lib';
+if (($ENV{JAPH_ISOLATION_MODE} || '') eq 'timeout') {
+    kill 'TERM', $$;
+    sleep 1;
+}
+open my $write, '>', 'progtmp001' or die "cannot create progtmp001: $!";
+print {$write} $token;
+close $write;
+sleep 0.3;
+open my $read, '<', 'progtmp001' or die "cannot read progtmp001: $!";
+chomp(my $seen = <$read>);
+close $read;
+print "1..4\n";
+print $linked ? "ok 1 - private perl link\n" : "not ok 1 - private perl link\n";
+print $seen eq $token ? "ok 2 - private generated file\n" : "not ok 2 - private generated file\n";
+print $layout ? "ok 3 - sibling library view\n" : "not ok 3 - sibling library view\n";
+print (($ENV{JAPH_ISOLATION_MODE} || '') eq 'failure'
+    ? "not ok 4 - requested failure\n" : "ok 4 - no requested failure\n");
+FAKE_JPERL
+chmod 0755, $fake_jperl or die "chmod $fake_jperl failed: $!";
+
+my $old_dir = getcwd();
+my $overlay_parent = File::Spec->catdir($temporary, 'runner-tmp');
+make_path($overlay_parent);
+local $ENV{TMPDIR} = $overlay_parent;
+chdir $temporary or die "chdir $temporary failed: $!";
+my @children;
+for my $token (qw(first second)) {
+    my $pid = fork();
+    die "fork failed: $!" unless defined $pid;
+    if ($pid == 0) {
+        local $ENV{JAPH_ISOLATION_TOKEN} = $token;
+        open STDOUT, '>', "$token.log" or die "redirect failed: $!";
+        open STDERR, '>&', \*STDOUT or die "redirect failed: $!";
+        exec $^X, $runner, '--jperl', $fake_jperl, '--strict-exit',
+            '--jobs', '2', '--timeout', '10', 'perl5_t/t/japh/abigail.t';
+        die "exec runner failed: $!";
+    }
+    push @children, [$pid, $token];
+}
+for my $child (@children) {
+    waitpid($child->[0], 0);
+    is($?, 0, "concurrent runner $child->[1] passes");
+}
+
+for my $case ([failure => 1], [timeout => 1]) {
+    my ($mode, $expected_failure) = @$case;
+    my $pid = fork();
+    die "fork failed: $!" unless defined $pid;
+    if ($pid == 0) {
+        local $ENV{JAPH_ISOLATION_TOKEN} = $mode;
+        local $ENV{JAPH_ISOLATION_MODE} = $mode;
+        open STDOUT, '>', "$mode.log" or die "redirect failed: $!";
+        open STDERR, '>&', \*STDOUT or die "redirect failed: $!";
+        exec $^X, $runner, '--jperl', $fake_jperl, '--strict-exit',
+            '--jobs', '2', '--timeout', '600', 'perl5_t/t/japh/abigail.t';
+        die "exec runner failed: $!";
+    }
+    waitpid($pid, 0);
+    isnt($?, 0, "$mode run reports non-success");
+}
+chdir $old_dir or die "restore cwd failed: $!";
+
+ok(!-e File::Spec->catfile($test_dir, 'perl'),
+    'authoritative test tree receives no perl link');
+ok(!-e File::Spec->catfile($test_dir, 'progtmp001'),
+    'authoritative test tree receives no generated program');
+opendir my $overlays, $overlay_parent or die "cannot inspect overlay parent: $!";
+my @leftovers = grep { /^perlonjava-abigail-/ } readdir $overlays;
+closedir $overlays;
+is_deeply(\@leftovers, [], 'private overlays are removed after success, failure, and timeout');
+
+done_testing;
+
+sub write_file {
+    my ($path, $contents) = @_;
+    open my $fh, '>', $path or die "cannot write $path: $!";
+    print {$fh} $contents;
+    close $fh or die "cannot close $path: $!";
+}

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -3,6 +3,7 @@ package org.perlonjava.backend.bytecode;
 
 import org.perlonjava.backend.jvm.EmitterContext;
 import org.perlonjava.frontend.analysis.ConstantFoldingVisitor;
+import org.perlonjava.frontend.analysis.DoBlockResultAnalysis;
 import org.perlonjava.frontend.analysis.FindDeclarationVisitor;
 import org.perlonjava.frontend.analysis.RegexUsageDetector;
 import org.perlonjava.frontend.analysis.Visitor;
@@ -1434,13 +1435,15 @@ public class BytecodeCompiler implements Visitor {
         }
 
         // Exit scope restores register state.
-        // Flush mortal list for void non-subroutine, non-do blocks so DESTROY fires
-        // promptly at scope exit. Value-producing blocks must NOT flush — their
-        // implicit result may still be in a register and flushing could destroy it
-        // before the parent expression or caller captures it.
-        exitScope(!node.getBooleanAnnotation("blockIsSubroutine")
-                && !node.getBooleanAnnotation("blockIsDoBlock")
-                && outerResultReg < 0);
+        // A value-producing block generally cannot flush because its implicit result
+        // may still refer to an inner lexical. A do-block ending in an always-fresh
+        // scalar operator is safe: its result is independent, so FREETMPS can run at
+        // block exit and transient objects are destroyed before the caller proceeds.
+        boolean isSubroutine = node.getBooleanAnnotation("blockIsSubroutine");
+        boolean isDoBlock = node.getBooleanAnnotation("blockIsDoBlock");
+        boolean flushAtScopeExit = !isSubroutine
+                && (isDoBlock ? DoBlockResultAnalysis.isAlwaysFresh(node) : outerResultReg < 0);
+        exitScope(flushAtScopeExit);
 
         // A pragma inside a nested block (for example `use bytes`) changes the
         // interpreter's runtime call-site hints through APPLY_COMPILER_FLAGS.

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperatorHelper.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperatorHelper.java
@@ -103,6 +103,7 @@ public class CompileBinaryOperatorHelper {
                 bytecodeCompiler.emitReg(rd);
                 bytecodeCompiler.emitReg(rs1);
                 bytecodeCompiler.emitReg(rs2);
+                bytecodeCompiler.emit(bytecodeCompiler.currentCallContext);
             }
             case "<=>" -> {
                 bytecodeCompiler.emit(Opcodes.COMPARE_NUM);

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -468,7 +468,9 @@ public class Disassemble {
                         rd = interpretedCode.bytecode[pc++];
                         rs1 = interpretedCode.bytecode[pc++];
                         rs2 = interpretedCode.bytecode[pc++];
-                        sb.append("REPEAT r").append(rd).append(" = r").append(rs1).append(" x r").append(rs2).append("\n");
+                        int repeatCtx = interpretedCode.bytecode[pc++];
+                        sb.append("REPEAT r").append(rd).append(" = r").append(rs1)
+                                .append(" x r").append(rs2).append(" ctx=").append(repeatCtx).append("\n");
                         break;
                     case Opcodes.LT_NUM:
                         rd = interpretedCode.bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/EvalStringHandler.java
@@ -444,7 +444,7 @@ public class EvalStringHandler {
 
             evalTrace("EvalStringHandler compilePackage=" + compilePackage + " fileName=" + opts.fileName);
 
-            ErrorMessageUtil errorUtil = new ErrorMessageUtil(sourceName, tokens);
+            ErrorMessageUtil errorUtil = new ErrorMessageUtil(evalFileName, tokens);
             EmitterContext ctx = new EmitterContext(
                     new JavaClassInfo(),
                     symbolTable,
@@ -639,7 +639,7 @@ public class EvalStringHandler {
             symbolTable.addVariable("@_", "our", null);
             symbolTable.addVariable("wantarray", "", null);
 
-            ErrorMessageUtil errorUtil = new ErrorMessageUtil(sourceName, tokens);
+            ErrorMessageUtil errorUtil = new ErrorMessageUtil(evalFileName, tokens);
             EmitterContext ctx = new EmitterContext(
                     new JavaClassInfo(),
                     symbolTable,

--- a/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
@@ -351,18 +351,22 @@ public class InlineOpcodeHandler {
 
     /**
      * String/list repetition: rd = rs1 x rs2
-     * Format: REPEAT rd rs1 rs2
+     * Format: REPEAT rd rs1 rs2 ctx
      */
     public static int executeRepeat(int[] bytecode, int pc, RuntimeBase[] registers) {
         int rd = bytecode[pc++];
         int rs1 = bytecode[pc++];
         int rs2 = bytecode[pc++];
+        int repeatCtx = bytecode[pc++];
         RuntimeBase countVal = registers[rs2];
         RuntimeScalar count = (countVal instanceof RuntimeScalar)
                 ? (RuntimeScalar) countVal
                 : countVal.scalar();
-        int repeatCtx = (registers[rs1] instanceof RuntimeScalar)
-                ? RuntimeContextType.SCALAR : RuntimeContextType.LIST;
+        if (repeatCtx == RuntimeContextType.RUNTIME
+                || repeatCtx == RuntimeContextType.INHERITED) {
+            repeatCtx = RuntimeCode.currentRawCallContext();
+        }
+        repeatCtx = RuntimeCode.effectiveCallContext(repeatCtx);
         registers[rd] = Operator.repeat(registers[rs1], count, repeatCtx);
         return pc;
     }

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -190,7 +190,7 @@ public class Opcodes {
     public static final short CONCAT = 27;
 
     /**
-     * String repetition: rd = StringOperators.repeat(rs1, rs2)
+     * String/list repetition: rd = Operator.repeat(rs1, rs2, ctx)
      */
     public static final short REPEAT = 28;
 

--- a/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
@@ -8,6 +8,7 @@ import org.objectweb.asm.Opcodes;
 import org.perlonjava.backend.jvm.astrefactor.LargeBlockRefactorer;
 import org.perlonjava.frontend.analysis.EmitterVisitor;
 import org.perlonjava.frontend.analysis.RegexUsageDetector;
+import org.perlonjava.frontend.analysis.DoBlockResultAnalysis;
 import org.perlonjava.frontend.astnode.*;
 import org.perlonjava.runtime.perlmodule.Warnings;
 import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
@@ -18,69 +19,6 @@ import java.util.List;
 import java.util.Set;
 
 public class EmitBlock {
-
-    /**
-     * "Always-fresh-result" operators: when applied to ANY operand, they
-     * produce a brand-new RuntimeScalar (boolean, number, or string)
-     * that is guaranteed independent of the operand's identity.
-     *
-     * <p>If the last expression of a do-block has one of these as its
-     * top-level operator, then flushing the do-block's MortalList at
-     * scope exit cannot destroy the result (the result is a fresh value,
-     * not a reference back into any inner my-var or container).
-     *
-     * <p>Used by Step D (op/do.t RT 124248) — see plan
-     * {@code dev/prompts/dbic_final_remaining_regressions_plan.md}.
-     */
-    private static final Set<String> ALWAYS_FRESH_UNARY = Set.of(
-            "!", "not",
-            "defined", "exists",
-            "ref", "length", "scalar",
-            "wantarray"
-    );
-
-    private static final Set<String> ALWAYS_FRESH_BINARY = Set.of(
-            "==", "!=", "<", ">", "<=", ">=", "<=>",
-            "eq", "ne", "lt", "gt", "le", "ge", "cmp",
-            "isa"
-    );
-
-    /**
-     * Returns true if the do-block's last expression is guaranteed to
-     * produce a fresh-value result (boolean/number/string) that is not
-     * tied to any inner my-var or container's identity. In that case,
-     * we can safely flush the MortalList at do-block exit (matching
-     * Perl 5 SAVETMPS/FREETMPS), firing DESTROY for transient blessed
-     * objects without risk to the do-block's return value.
-     *
-     * <p>Conservative: returns false for anything not in the whitelist.
-     */
-    private static boolean doBlockResultIsAlwaysFresh(BlockNode block) {
-        if (block == null || block.elements == null || block.elements.isEmpty()) {
-            return false;
-        }
-        Node last = null;
-        for (int i = block.elements.size() - 1; i >= 0; i--) {
-            Node e = block.elements.get(i);
-            if (e == null) continue;
-            // Skip pure-debug/CompilerFlag nodes that aren't real values.
-            if (e instanceof CompilerFlagNode) continue;
-            last = e;
-            break;
-        }
-        if (last == null) return false;
-        // NumberNode/StringNode are pure constants — definitely fresh.
-        if (last instanceof NumberNode || last instanceof StringNode) {
-            return true;
-        }
-        if (last instanceof OperatorNode op) {
-            return ALWAYS_FRESH_UNARY.contains(op.operator);
-        }
-        if (last instanceof BinaryOperatorNode bop) {
-            return ALWAYS_FRESH_BINARY.contains(bop.operator);
-        }
-        return false;
-    }
 
     private static void collectStateDeclSigilNodes(Node node, Set<OperatorNode> out) {
         if (node == null) {
@@ -482,7 +420,7 @@ public class EmitBlock {
         // risking DBIC's `do { my $x = ...; $x }` patterns.
         boolean isSubBody = node.getBooleanAnnotation("blockIsSubroutine");
         boolean isDoBlock = node.getBooleanAnnotation("blockIsDoBlock");
-        boolean doBlockFreshResult = isDoBlock && doBlockResultIsAlwaysFresh(node);
+        boolean doBlockFreshResult = isDoBlock && DoBlockResultAnalysis.isAlwaysFresh(node);
         Object blockResultRegObj = node.getAnnotation("resultRegister");
         boolean hasBlockResultRegister = blockResultRegObj instanceof Integer && (Integer) blockResultRegObj >= 0;
         boolean blockMayNeedResultAfterScopeExit = emitterVisitor.ctx.contextType != RuntimeContextType.VOID

--- a/src/main/java/org/perlonjava/frontend/analysis/DoBlockResultAnalysis.java
+++ b/src/main/java/org/perlonjava/frontend/analysis/DoBlockResultAnalysis.java
@@ -1,0 +1,51 @@
+package org.perlonjava.frontend.analysis;
+
+import org.perlonjava.frontend.astnode.BinaryOperatorNode;
+import org.perlonjava.frontend.astnode.BlockNode;
+import org.perlonjava.frontend.astnode.CompilerFlagNode;
+import org.perlonjava.frontend.astnode.Node;
+import org.perlonjava.frontend.astnode.NumberNode;
+import org.perlonjava.frontend.astnode.OperatorNode;
+import org.perlonjava.frontend.astnode.StringNode;
+
+import java.util.Set;
+
+/** Backend-neutral AST analysis for safe do-block scope cleanup. */
+public final class DoBlockResultAnalysis {
+    private static final Set<String> ALWAYS_FRESH_UNARY = Set.of(
+            "!", "not", "defined", "exists", "ref", "length", "scalar", "wantarray");
+    private static final Set<String> ALWAYS_FRESH_BINARY = Set.of(
+            "==", "!=", "<", ">", "<=", ">=", "<=>",
+            "eq", "ne", "lt", "gt", "le", "ge", "cmp", "isa");
+
+    private DoBlockResultAnalysis() {
+    }
+
+    /**
+     * Returns whether the final expression always produces a fresh scalar that
+     * is independent of inner lexical/container identity.
+     */
+    public static boolean isAlwaysFresh(BlockNode block) {
+        if (block == null || block.elements == null || block.elements.isEmpty()) {
+            return false;
+        }
+        Node last = null;
+        for (int i = block.elements.size() - 1; i >= 0; i--) {
+            Node element = block.elements.get(i);
+            if (element != null && !(element instanceof CompilerFlagNode)) {
+                last = element;
+                break;
+            }
+        }
+        if (last instanceof NumberNode || last instanceof StringNode) {
+            return true;
+        }
+        if (last instanceof OperatorNode operator) {
+            return ALWAYS_FRESH_UNARY.contains(operator.operator);
+        }
+        if (last instanceof BinaryOperatorNode operator) {
+            return ALWAYS_FRESH_BINARY.contains(operator.operator);
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/perlonjava/frontend/parser/ClassTransformer.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ClassTransformer.java
@@ -513,7 +513,7 @@ public class ClassTransformer {
         String sigil = (String) field.getAnnotation("sigil");
         String readerName = (String) field.getAnnotation("attr:reader");
         if (readerName == null || readerName.isEmpty()) {
-            readerName = name; // Use field name as method name
+            readerName = defaultAccessorName(name);
         }
 
         // Create method body
@@ -618,7 +618,7 @@ public class ClassTransformer {
         String name = (String) field.getAnnotation("name");
         String writerName = (String) field.getAnnotation("attr:writer");
         if (writerName == null || writerName.isEmpty()) {
-            writerName = "set_" + name; // Default to set_fieldname
+            writerName = "set_" + defaultAccessorName(name);
         }
 
         // Create method body: $_[0]->{fieldname} = $_[1]; return $_[0]
@@ -670,6 +670,10 @@ public class ClassTransformer {
         );
 
         return writer;
+    }
+
+    private static String defaultAccessorName(String fieldName) {
+        return fieldName.startsWith("_") ? fieldName.substring(1) : fieldName;
     }
 
     /**

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -56,7 +56,9 @@ public class OperatorParser {
         // Since Perl 5.42, `do NAME(...)` is a syntax error rather than an
         // ambiguous do-file expression. CORE() retains its historical special
         // case and `do NAME` without parentheses is still parsed as do-file.
-        if (token.type == IDENTIFIER && !token.text.equals("CORE")) {
+        if (token.type == IDENTIFIER
+                && !token.text.equals("CORE")
+                && !ParsePrimary.isIsQuoteLikeOperator(token.text)) {
             int nextIndex = Whitespace.skipWhitespace(
                     parser, parser.tokenIndex + 1, parser.tokens);
             if (nextIndex < parser.tokens.size()

--- a/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
@@ -7,6 +7,7 @@ import org.perlonjava.frontend.astnode.*;
 import org.perlonjava.frontend.lexer.LexerToken;
 import org.perlonjava.frontend.lexer.LexerTokenType;
 import org.perlonjava.frontend.semantic.SymbolTable;
+import org.perlonjava.runtime.operators.WarnDie;
 import org.perlonjava.runtime.perlmodule.Strict;
 import org.perlonjava.runtime.runtimetypes.GlobalVariable;
 import org.perlonjava.runtime.runtimetypes.NameNormalizer;
@@ -53,6 +54,7 @@ public class ParseInfix {
      */
     public static Node parseInfixOperation(Parser parser, Node left, int precedence) {
         LexerToken token = TokenUtils.consume(parser);
+        int operatorIndex = Math.max(0, parser.tokenIndex - 1);
 
         Node right;
 
@@ -202,6 +204,10 @@ public class ParseInfix {
                             regexOperand, right.getIndex(), parser.ctx);
                 }
                 right = new OperatorNode("quoteRegex", regexOperand, right.getIndex());
+            }
+
+            if (operator.equals("=~") || operator.equals("!~")) {
+                warnAggregateRegexBinding(parser, left, right, operatorIndex);
             }
 
             BinaryOperatorNode node = new BinaryOperatorNode(operator, left, right, parser.tokenIndex);
@@ -497,6 +503,69 @@ public class ParseInfix {
                 || operator.operator.equals("replaceRegex")
                 || operator.operator.equals("tr")
                 || operator.operator.equals("transliterate");
+    }
+
+    /**
+     * Perl scalarizes an aggregate on the left of =~/!~, but warns at compile
+     * time that the operation applies to the aggregate's count.  Keep this at
+     * the binding boundary so match, substitution, transliteration, and a
+     * runtime pattern expression share the same lexical warning policy.
+     */
+    private static void warnAggregateRegexBinding(Parser parser, Node left,
+                                                  Node right, int operatorIndex) {
+        if (!parser.ctx.symbolTable.isWarningCategoryEnabled("misc")) return;
+
+        Node aggregate = left;
+        if (aggregate instanceof OperatorNode declaration
+                && (declaration.operator.equals("my")
+                    || declaration.operator.equals("our")
+                    || declaration.operator.equals("state")
+                    || declaration.operator.equals("local"))) {
+            aggregate = declaration.operand;
+        }
+        if (!(aggregate instanceof OperatorNode aggregateOperator)
+                || !(aggregateOperator.operator.equals("@")
+                    || aggregateOperator.operator.equals("%"))) {
+            return;
+        }
+
+        String operation;
+        int warningCount = 1;
+        if (right instanceof OperatorNode regexOperator) {
+            operation = switch (regexOperator.operator) {
+                case "matchRegex" -> "pattern match (m//)";
+                case "quoteRegex" -> {
+                    // Perl's ck_match and binding checks both report an
+                    // aggregate bound to qr// or a runtime pattern value.
+                    warningCount = 2;
+                    yield "pattern match (m//)";
+                }
+                case "replaceRegex" -> "substitution (s///)";
+                case "tr", "transliterate" -> "transliteration (tr///)";
+                default -> null;
+            };
+        } else {
+            operation = null;
+        }
+        if (operation == null) return;
+
+        String sigil = aggregateOperator.operator;
+        String display = sigil.equals("@") ? "@array" : "%hash";
+        if (aggregateOperator.operand instanceof IdentifierNode identifier) {
+            display = sigil + identifier.name;
+        }
+        String message = "Applying " + operation + " to " + display
+                + " will act on scalar(" + display + ")";
+        RuntimeScalar text = new RuntimeScalar(message);
+        RuntimeScalar location = new RuntimeScalar(
+                parser.ctx.errorUtil.warningLocation(operatorIndex));
+        for (int warning = 0; warning < warningCount; warning++) {
+            if (parser.ctx.symbolTable.isFatalWarningCategory("misc")) {
+                WarnDie.die(text, location);
+            } else {
+                WarnDie.warn(text, location);
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/regex/RegexQuoteMeta.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RegexQuoteMeta.java
@@ -15,6 +15,10 @@ public class RegexQuoteMeta {
     private static final ThreadLocal<String> PARSER_WARNING_BITS = new ThreadLocal<>();
     private static final ThreadLocal<String> MATCH_TARGET_NAME = new ThreadLocal<>();
 
+    /** Lexical outcome for one regex-construction diagnostic. */
+    public record ConstructionWarningDisposition(boolean enabled, boolean fatal) {
+    }
+
     public static void setCallSiteWarningState(int state) {
         CALL_SITE_WARNING_STATE.set(state);
     }
@@ -163,34 +167,52 @@ public class RegexQuoteMeta {
             // than a stale warning-state value from an earlier qr//.
             warningBits = WarningBitsRegistry.getRuntimeWarningBits();
         }
+        ConstructionWarningDisposition disposition =
+                constructionWarningDisposition(message, strictDefault);
+        if (!disposition.enabled()) {
+            return;
+        }
+        if (disposition.fatal()) {
+            WarnDie.die(warning, new RuntimeScalar(WarnDie.getPerlLocationFromStack()));
+        } else if (warningBits != null || state != null) {
+            WarnDie.warn(warning, where);
+        } else {
+            WarnDie.warnWithCategory(warning, where, warningCategory(message));
+        }
+    }
+
+    /**
+     * Resolve warning enablement without dispatching a handler. Fatal regex
+     * diagnostics can then be accumulated with a primary compile error while
+     * ordinary warnings still flow through {@link #warnAtConstruction}.
+     */
+    public static ConstructionWarningDisposition constructionWarningDisposition(
+            String message, boolean strictDefault) {
+        String category = warningCategory(message);
+        String warningBits = CALL_SITE_WARNING_BITS.get();
+        if (warningBits == null) {
+            warningBits = WarningBitsRegistry.getRuntimeWarningBits();
+        }
         if (warningBits != null) {
-            String category = warningCategory(message);
             boolean enabled = WarningFlags.isEnabledInBits(warningBits, category);
             if (!enabled && !isCallSiteWarningExplicitlyDisabled()) {
                 enabled = strictDefault
                         || (WarningFlags.isGlobalWarningVariableEnabled()
                             && !WarningFlags.isWarningSuppressedAtRuntime(category));
             }
-            if (!enabled) {
-                return;
-            }
-            if (WarningFlags.isFatalInBits(warningBits, category)) {
-                WarnDie.die(warning, where);
-            } else {
-                WarnDie.warn(warning, where);
-            }
-            return;
+            return new ConstructionWarningDisposition(enabled,
+                    enabled && WarningFlags.isFatalInBits(warningBits, category));
         }
-        if (state != null && state == 0) {
-            return;
+
+        Integer state = CALL_SITE_WARNING_STATE.get();
+        if (state != null) {
+            return new ConstructionWarningDisposition(state > 0, state == 2);
         }
-        if (state != null && state == 2) {
-            WarnDie.die(warning, where);
-        } else if (state != null) {
-            WarnDie.warn(warning, where);
-        } else {
-            WarnDie.warnWithCategory(warning, where, "regexp");
+        if (WarningFlags.isWarningSuppressedAtRuntime(category)) {
+            return new ConstructionWarningDisposition(false, false);
         }
+        return new ConstructionWarningDisposition(
+                strictDefault || WarningFlags.isGlobalWarningVariableEnabled(), false);
     }
 
     /** Perl assigns a few lexer diagnostics to broader warning categories. */

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -371,7 +371,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 continue;
             }
             WarnDie.warnWithCategory(new RuntimeScalar(warning),
-                    RuntimeScalarCache.scalarEmptyString, category);
+                    new RuntimeScalar(WarnDie.getPerlLocationFromStack()), category);
         }
     }
 
@@ -1008,7 +1008,7 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             // modifier from the same quote-like construct; compiling the
             // pattern first preserves the more specific native syntax error.
             // A valid pattern still reaches the ordinary modifier diagnostic.
-            validateModifiers(modifiers);
+            validateModifiersWithPendingDiagnostics(modifiers, regex);
 
             // Cache the result if the cache is not full
             if (state().compiledRegexCache.size() < MAX_REGEX_CACHE_SIZE
@@ -1025,6 +1025,79 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
             }
         }
         return regex;
+    }
+
+    /**
+     * Perl finishes collecting recoverable regex warnings after recognizing an
+     * invalid modifier. Nonfatal warnings still reach the warning handler;
+     * fatal warnings join the primary modifier error in source order.
+     */
+    private static void validateModifiersWithPendingDiagnostics(
+            String modifiers, RuntimeRegex regex) {
+        try {
+            validateModifiers(modifiers);
+            return;
+        } catch (PerlCompilerException primary) {
+            String location = WarnDie.getPerlLocationFromStack();
+            StringBuilder diagnostics = new StringBuilder(
+                    invalidModifierAtEndOfLine(primary.getMessage(), location));
+
+            for (String warning : regex.warningsOnUse) {
+                RegexQuoteMeta.ConstructionWarningDisposition disposition =
+                        RegexQuoteMeta.constructionWarningDisposition(
+                                warning, regex.lexicalReStrict);
+                if (!disposition.enabled()) continue;
+                if (disposition.fatal()) {
+                    diagnostics.append(regexDiagnosticAtLocation(warning, location));
+                } else {
+                    // A dying __WARN__ handler replaces the pending compile
+                    // error, matching Perl's warning-dispatch semantics.
+                    RegexQuoteMeta.warnAtConstruction(warning, regex.lexicalReStrict);
+                }
+            }
+
+            String compilationUnit = compilationUnitFromLocation(location);
+            if (compilationUnit != null) {
+                diagnostics.append("Execution of ").append(compilationUnit)
+                        .append(" aborted due to compilation errors.\n");
+            }
+            throw new PerlCompilerException(diagnostics.toString());
+        }
+    }
+
+    private static String invalidModifierAtEndOfLine(String message, String location) {
+        String result = message == null ? "Unknown regexp modifier" : message;
+        if (!result.endsWith("\n")) {
+            result += location + ".\n";
+        }
+        if (result.endsWith(".\n")) {
+            return result.substring(0, result.length() - 2) + ", at end of line\n";
+        }
+        return result;
+    }
+
+    private static String regexDiagnosticAtLocation(String warning, String location) {
+        String result = warning == null ? "" : warning;
+        if (result.endsWith("\n")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        if (!location.isEmpty() && !result.endsWith(location)
+                && !result.matches("(?s).* at .+ line \\d+[.,]?$")) {
+            result += location;
+        }
+        if (!result.endsWith(".")) result += ".";
+        return result + "\n";
+    }
+
+    /** Return null for eval STRING, whose compilation error is carried in $@. */
+    private static String compilationUnitFromLocation(String location) {
+        if (location == null || location.isEmpty() || location.contains(" at (eval ")) {
+            return null;
+        }
+        int start = location.startsWith(" at ") ? 4 : 0;
+        int line = location.lastIndexOf(" line ");
+        if (line <= start) return null;
+        return location.substring(start, line);
     }
 
     private static String unmatchedCharacterClassDiagnostic(String pattern) {

--- a/src/test/resources/unit/class_default_accessor_names.t
+++ b/src/test/resources/unit/class_default_accessor_names.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More;
+
+use feature 'class';
+no warnings 'experimental::class';
+
+class DefaultAccessorNames {
+    field $_alpha :reader :writer = 'A';
+    field $__beta :reader :writer = 'B';
+    field $_42 :reader(get_42) :writer = 'forty-two';
+}
+
+my $object = DefaultAccessorNames->new;
+is($object->alpha, 'A', 'reader strips one leading underscore');
+is($object->_beta, 'B', 'reader preserves the second leading underscore');
+
+is($object->set_alpha('AA'), $object, 'writer returns the object');
+is($object->alpha, 'AA', 'writer strips one leading underscore');
+is($object->set__beta('BB'), $object,
+    'writer preserves the second leading underscore');
+is($object->_beta, 'BB', 'double-underscore field round trips');
+
+is($object->set_42('answer'), $object,
+    'default writer accepts a numeric name after the underscore');
+is($object->get_42, 'answer', 'explicit reader name remains exact');
+
+done_testing;

--- a/src/test/resources/unit/do_block_freetmps_fresh_result.t
+++ b/src/test/resources/unit/do_block_freetmps_fresh_result.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+    package DoBlockFreshResult;
+    our $destroyed = 0;
+    sub DESTROY { $destroyed++ }
+}
+
+sub observe_after_argument {
+    is($DoBlockFreshResult::destroyed, 1,
+        'fresh do-block result permits transient lexical destruction at scope exit');
+}
+
+observe_after_argument(do { 1; !!(my $object = bless [], 'DoBlockFreshResult') });
+
+done_testing;

--- a/src/test/resources/unit/do_quote_like_file_operand.t
+++ b/src/test/resources/unit/do_quote_like_file_operand.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+use Test::More;
+
+eval qq{ do qq(a file that does not exist); };
+is($@, '', 'qq expression remains a valid do-file operand');
+
+done_testing;

--- a/src/test/resources/unit/regex/aggregate_bind_warnings.t
+++ b/src/test/resources/unit/regex/aggregate_bind_warnings.t
@@ -1,0 +1,94 @@
+use strict;
+use warnings;
+use Test::More;
+
+sub compile_probe {
+    my ($source) = @_;
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, @_ };
+    my $compiled = eval $source;
+    return ($compiled, $@, join('', @warnings));
+}
+
+my ($compiled, $error, $warning) = compile_probe(
+    q{use warnings 'misc'; sub { my @a =~ // }});
+ok(defined $compiled, 'array-bound match compiles');
+like($warning,
+    qr/^Applying pattern match \(m\/\/\) to \@a will act on scalar\(\@a\) at \(eval \d+\) line 1\.\n$/,
+    'declaration-bound array match warns during compilation');
+
+(undef, undef, $warning) = compile_probe(
+    q{use warnings 'misc'; sub { my @a; @a !~ /x/ }});
+like($warning,
+    qr/^Applying pattern match \(m\/\/\) to \@a will act on scalar\(\@a\)/,
+    'negative match uses pattern-match warning wording');
+
+(undef, $error, $warning) = compile_probe(
+    q{use warnings 'misc'; sub { my @items; @items =~ s/x/y/ }});
+like($warning,
+    qr/^Applying substitution \(s\/\/\/\) to \@items will act on scalar\(\@items\) at \(eval \d+\) line 1\.\n$/,
+    'array substitution uses substitution warning wording');
+
+(undef, $error, $warning) = compile_probe(
+    q{use warnings 'misc'; sub { my @letters; @letters =~ tr/x/y/ }});
+like($warning,
+    qr/^Applying transliteration \(tr\/\/\/\) to \@letters will act on scalar\(\@letters\)/,
+    'array transliteration uses transliteration warning wording');
+
+(undef, undef, $warning) = compile_probe(
+    q{use warnings 'misc'; sub { my %seen; %seen =~ /x/ }});
+like($warning,
+    qr/^Applying pattern match \(m\/\/\) to %seen will act on scalar\(%seen\)/,
+    'hash match uses the named aggregate');
+
+(undef, undef, $warning) = compile_probe(
+    q{use warnings 'misc'; sub { my $ref = []; @$ref =~ /x/ }});
+like($warning,
+    qr/^Applying pattern match \(m\/\/\) to \@array will act on scalar\(\@array\)/,
+    'array dereference uses Perl generic display name');
+
+(undef, $error, $warning) = compile_probe(
+    q{use warnings 'misc'; sub { my $ref = {}; %$ref =~ s/x/y/ }});
+like($warning,
+    qr/^Applying substitution \(s\/\/\/\) to %hash will act on scalar\(%hash\)/,
+    'hash dereference uses Perl generic display name');
+
+(undef, undef, $warning) = compile_probe(
+    q{use warnings; no warnings 'misc'; sub { my @a; @a =~ /x/ }});
+is($warning, '', 'no warnings misc suppresses aggregate binding warning');
+
+(undef, undef, $warning) = compile_probe(
+    q{use warnings; no warnings 'regexp'; sub { my @a; @a =~ /x/ }});
+like($warning, qr/^Applying pattern match/,
+    'regexp suppression does not suppress misc binding warning');
+
+(undef, undef, $warning) = compile_probe(
+    q{use warnings 'misc'; sub { my @a; @a =~ qr/x/ }});
+my @qr_warnings = $warning =~ /^Applying pattern match/mg;
+is(scalar(@qr_warnings), 2,
+    'aggregate bound to qr emits both Perl compile-time warnings');
+like($warning,
+    qr/\A(?:Applying pattern match \(m\/\/\) to \@a will act on scalar\(\@a\) at \(eval \d+\) line 1\.\n){2}\z/,
+    'both qr aggregate warnings retain exact text and location');
+
+($compiled, $error, $warning) = compile_probe(
+    q{use warnings FATAL => 'misc'; sub { my @a; @a =~ /x/ }});
+ok(!defined $compiled, 'fatal misc rejects aggregate-bound match');
+like($error,
+    qr/^Applying pattern match \(m\/\/\) to \@a will act on scalar\(\@a\) at \(eval \d+\) line 1\.\n$/,
+    'fatal misc promotes the warning into the eval error');
+is($warning, '', 'fatal misc does not also dispatch a warning');
+
+(undef, undef, $warning) = compile_probe(
+    q{use warnings 'misc'; sub { my $scalar; $scalar =~ /x/ }});
+is($warning, '', 'scalar match is a warning-free control');
+
+(undef, undef, $warning) = compile_probe(
+    q{use warnings 'misc'; sub { my $scalar; $scalar =~ s/x/y/ }});
+is($warning, '', 'scalar substitution is a warning-free control');
+
+(undef, undef, $warning) = compile_probe(
+    q{use warnings 'misc'; sub { my @a; scalar(@a) =~ /x/ }});
+is($warning, '', 'explicit aggregate scalarization is warning-free');
+
+done_testing;

--- a/src/test/resources/unit/regex/fatal_diagnostic_aggregation.t
+++ b/src/test/resources/unit/regex/fatal_diagnostic_aggregation.t
@@ -1,0 +1,77 @@
+use strict;
+use warnings;
+use Test::More;
+
+sub compile_probe {
+    my ($source, $handler_dies) = @_;
+    my @warnings;
+    local $SIG{__WARN__} = $handler_dies
+        ? sub { die "handler died: $_[0]" }
+        : sub { push @warnings, @_ };
+    my $value = eval $source;
+    return ($value, $@, join('', @warnings));
+}
+
+my ($value, $error, $warning) = compile_probe(
+    q{use warnings FATAL => 'all'; /() {}/X; 1});
+ok(!defined $value, 'fatal warning plus invalid modifier rejects eval');
+like($error,
+    qr{\AUnknown regexp modifier "/X" at \(eval \d+\) line 1, at end of line\nUnescaped left brace in regex is passed through in regex; marked by <-- HERE in m/\(\) \{ <-- HERE \}/ at \(eval \d+\) line 1\.\n\z},
+    'fatal warning is aggregated after the modifier error');
+is($warning, '', 'aggregated fatal warning bypasses warning handler');
+
+($value, $error, $warning) = compile_probe(
+    q{use warnings; /() {}/X; 1});
+ok(!defined $value, 'nonfatal warning plus invalid modifier rejects eval');
+like($error,
+    qr{\AUnknown regexp modifier "/X" at \(eval \d+\) line 1, at end of line\n\z},
+    'nonfatal case retains only the modifier in eval error');
+like($warning,
+    qr{\AUnescaped left brace in regex is passed through in regex; marked by <-- HERE in m/\(\) \{ <-- HERE \}/ at \(eval \d+\) line 1\.\n\z},
+    'nonfatal pending diagnostic reaches warning handler');
+
+($value, $error, $warning) = compile_probe(
+    q{no warnings; /() {}/X; 1});
+like($error,
+    qr{\AUnknown regexp modifier "/X" at \(eval \d+\) line 1, at end of line\n\z},
+    'disabled warning leaves the modifier error intact');
+is($warning, '', 'disabled pending diagnostic stays suppressed');
+
+($value, $error, $warning) = compile_probe(
+    q{use warnings FATAL => 'regexp'; /[\8]/X; 1});
+like($error,
+    qr{\AUnknown regexp modifier "/X".*\nUnrecognized escape \\8 in character class passed through in regex; marked by <-- HERE in m/\[\\8 <-- HERE \]/.*\n\z}s,
+    'fatal native warning aggregates after parser modifier error');
+is($warning, '', 'fatal escape diagnostic is not dispatched as warning');
+
+($value, $error, $warning) = compile_probe(
+    q{use warnings FATAL => 'regexp'; /() {} [\8]/X; 1});
+like($error,
+    qr{\AUnknown regexp modifier "/X".*\nUnescaped left brace.*\nUnrecognized escape \\8.*\n\z}s,
+    'multiple fatal diagnostics retain source order');
+is($warning, '', 'multiple fatal diagnostics bypass warning handler');
+
+($value, $error, $warning) = compile_probe(
+    q{use warnings FATAL => 'all'; /[z-a]/X; 1});
+like($error, qr{\AInvalid \[\] range "z-a" in regex},
+    'truly fatal native syntax remains the primary stop');
+unlike($error, qr{Unknown regexp modifier},
+    'modifier is not appended after unrecoverable native syntax');
+is($warning, '', 'native syntax failure dispatches no warning');
+
+($value, $error, $warning) = compile_probe(
+    q{use warnings; /() {}/X; 1}, 1);
+like($error, qr{\Ahandler died: Unescaped left brace.* line 1\.\n\z}s,
+    'dying warning handler replaces pending modifier error');
+unlike($error, qr{Unknown regexp modifier},
+    'replaced error contains no stale modifier diagnostic');
+is($warning, '', 'dying warning handler leaves no captured warning');
+
+($value, $error, $warning) = compile_probe(
+    q{use warnings FATAL => 'regexp'; $_ = ''; /() {}/; 1});
+like($error,
+    qr{\AUnescaped left brace.* at \(eval \d+\) line 1\.\n\z}s,
+    'standalone fatal regex warning retains eval location');
+is($warning, '', 'standalone fatal warning bypasses warning handler');
+
+done_testing;

--- a/src/test/resources/unit/repeat_zero_dynamic_scalar_context.t
+++ b/src/test/resources/unit/repeat_zero_dynamic_scalar_context.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More;
+
+sub repeated_empty_in_scalar_context {
+    my @left = (11, 12);
+    my @right = (21, 22, 23);
+    return (do { my $unused; @left },
+            (do { my $unused; @right }) x 0);
+}
+
+is(repeated_empty_in_scalar_context(), '',
+    'zero-repeat remains the final empty scalar in a comma expression');
+
+my @list = repeated_empty_in_scalar_context();
+is_deeply(\@list, [11, 12],
+    'the same return expression retains list-context repetition semantics');
+
+my $fixed_scalar = (('left', 'right') x 0);
+is($fixed_scalar, '', 'fixed scalar context returns an empty string');
+
+my @fixed_list = (('left', 'right') x 2);
+is_deeply(\@fixed_list, ['left', 'right', 'left', 'right'],
+    'fixed list context repeats every list element');
+
+done_testing;


### PR DESCRIPTION
## Summary

- normalize newly imported class accessor names
- preserve repeat context and do-block cleanup on both backends
- parse quote-like `do FILE` operands correctly
- isolate self-modifying JAPH tests per runner invocation
- preserve aggregate regex-binding warnings used by the complete `pat*` suite
- aggregate fatal regex-construction diagnostics without losing the primary error

This is a focused child PR for PR #1087. It does not modify imported tests or
add a PerlOnJava-only qx workaround. Latest Perl 5.45.3 itself fails the newly
wrapped JAPH assertion 51 after upstream `_quote_args` commit
`5355a72c746fa5146541d790aece53b22737afee`; the candidate retains that exact
current-Perl behavior.

## Validation

- `make`: green, warning-free
- `op/do.t`: 71/71 on JVM and interpreter in writable current-source state
- `class/accessor.t`: 17/30 on both backends, versus PR 958's 12-pass floor
- `japh/abigail.t`: deterministic 109/130; ID 51 matches latest Perl
- clean serial `pat.t`: 1249/1302, 1302/1302 executed, 386.09s
- clean serial `pat_thr.t`: 1249/1302, 1302/1302 executed, 386.47s
- `pat*` runner disposition: zero errors, timeouts, or incomplete rows
