### PR TITLE
fix: retain CPAN target mapping across dependency discovery

### DIFF
--- a/dev/tools/cpan_random_tester.pl
+++ b/dev/tools/cpan_random_tester.pl
@@ -416,9 +416,15 @@ sub parse_all_module_results {
         if ($line =~ /Running (?:test|install) for module '([^']+)'/) {
             $last_mod = $1;
         }
+        # The checksum line directly follows CPAN's module selection.  Keep
+        # that association: dependency discovery can change $last_mod before
+        # CPAN later returns to configure the original distribution.
+        if ($last_mod && $line =~ m{Checksum for \S+/(\S+)\.tar\.gz}) {
+            $dist_to_mod{$1} //= $last_mod;
+        }
         # "Configuring A/AU/AUTHOR/Dist-Name-1.0.tar.gz with ..."
         if ($last_mod && $line =~ m{Configuring \S+/(\S+)\.tar\.gz}) {
-            $dist_to_mod{$1} = $last_mod;
+            $dist_to_mod{$1} //= $last_mod;
         }
     }
 
@@ -611,8 +617,11 @@ sub parse_all_module_results_from_file {
             if ($line =~ /Running (?:test|install) for module '([^']+)'/) {
                 $last_mod = $1;
             }
+            if ($last_mod && $line =~ m{Checksum for \S+/(\S+)\.tar\.gz}) {
+                $dist_to_mod{$1} //= $last_mod;
+            }
             if ($last_mod && $line =~ m{Configuring \S+/(\S+)\.tar\.gz}) {
-                $dist_to_mod{$1} = $last_mod;
+                $dist_to_mod{$1} //= $last_mod;
             }
         }
         close $fh;

--- a/dev/tools/tests/cpan_random_tester_parser.t
+++ b/dev/tools/tests/cpan_random_tester_parser.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+
+use File::Spec;
+use File::Temp qw(tempfile);
+use FindBin;
+use Test::More;
+
+my $root = File::Spec->rel2abs(
+    File::Spec->catdir($FindBin::Bin, '..', '..', '..'));
+my $tool = File::Spec->catfile($root, 'dev', 'tools', 'cpan_random_tester.pl');
+
+open my $fh, '<', $tool or die "cannot read $tool: $!";
+my $source = do { local $/; <$fh> };
+close $fh or die "cannot close $tool: $!";
+
+my ($parser_source) = $source =~ /(sub parse_all_module_results \{.*?)(?=\n# Helpers)/s;
+ok(defined $parser_source, 'extracted the CPAN result parser');
+eval $parser_source;
+die "cannot load CPAN result parser: $@" if $@;
+
+my $output = <<'LOG';
+Running test for module 'POE::Loop::Gtk'
+Checksum for /tmp/cpan/sources/authors/id/R/RC/RCAPUTO/POE-Loop-Gtk-1.306.tar.gz ok
+---- Unsatisfied dependencies detected during ----
+    POE::Test::Loops [configure_requires]
+Running test for module 'POE::Test::Loops'
+Checksum for /tmp/cpan/sources/authors/id/R/RC/RCAPUTO/POE-Test-Loops-1.360.tar.gz ok
+Configuring R/RC/RCAPUTO/POE-Test-Loops-1.360.tar.gz with Makefile.PL
+Running make for R/RC/RCAPUTO/POE-Test-Loops-1.360.tar.gz
+  Skipping dependency tests; use --strict-dependency-tests to enable them
+Configuring R/RC/RCAPUTO/POE-Loop-Gtk-1.306.tar.gz with Makefile.PL
+Running make test for R/RC/RCAPUTO/POE-Loop-Gtk-1.306.tar.gz
+Result: FAIL
+make test -- NOT OK
+LOG
+
+my @results = parse_all_module_results($output);
+is_deeply(
+    [map { $_->{module} } @results],
+    ['POE::Loop::Gtk'],
+    'a target test block remains associated with its target after dependency discovery',
+);
+is($results[0]{status}, 'FAIL', 'target test failure is retained');
+
+my ($log_fh, $log_path) = tempfile();
+print {$log_fh} $output;
+close $log_fh or die "cannot close $log_path: $!";
+my @streamed_results = parse_all_module_results_from_file($log_path);
+is_deeply(
+    [map { $_->{module} } @streamed_results],
+    ['POE::Loop::Gtk'],
+    'streaming parser preserves the target association too',
+);
+
+done_testing;


### PR DESCRIPTION
## Summary

- retain the direct module-to-distribution association from CPAN's checksum line
- prevent nested dependency discovery from assigning an incomplete target test block to the dependency
- add system-Perl coverage for both the in-memory and streaming CPAN output parsers

This prevents the false `POE::Test::Loops` PASS-to-FAIL regression observed while testing `POE::Loop::Gtk`.

## Validation

- `perl dev/tools/tests/cpan_random_tester_parser.t`
- `perl -c dev/tools/cpan_random_tester.pl`
- `git diff --check`

`make` was intentionally not run: this only changes developer CPAN-report tooling, per request.
