### PR TITLE
Isolate CPAN report PR merges from tester checkout

### DIFF
--- a/.agents/skills/publish-cpan-reports/SKILL.md
+++ b/.agents/skills/publish-cpan-reports/SKILL.md
@@ -55,6 +55,14 @@ When the user asked to save or publish the reports, merge the report-only PR
 after verifying that it is open and contains exactly the four expected files.
 If the user asked only to open a PR, leave it open.
 
-Use the repository's normal merge method. After merging, do not switch branches
-or otherwise mutate a checkout where active testers have produced later report
-updates.
+Run the GitHub PR creation, inspection, and merge commands from a neutral
+temporary directory outside every Git worktree, and pass the repository
+explicitly with `--repo`. In particular, never run `gh pr merge` from the
+report checkout: with branch deletion enabled, the CLI may switch that checkout
+to the base branch and fast-forward it. Using a neutral directory makes
+`--delete-branch` a remote-only cleanup.
+
+Use the repository's normal merge method and verify the merged PR from the same
+neutral directory. After merging, do not fetch, switch branches, or otherwise
+mutate the report checkout; active testers may already have produced the next
+set of report updates there.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,13 +206,14 @@ Never discard report updates that appear after the locked snapshot.
 ╚══════════════════════════════════════════════════════════════════════════════╝
 ```
 
-## Incident Log
-
-| Date | What happened | Root cause and prevention |
-|---|---|---|
-| 2026-08-25 | No source work was lost; an unintended `make` invocation failed before tests started because Gradle could not create its sandboxed lock file. | A Markdown search pattern containing backticks was placed inside a double-quoted shell command, so the shell treated `make` as command substitution. Keep backtick-containing arguments single-quoted or pass them without shell interpolation. |
-
 ## Project Rules
+
+### Maintaining these guidelines
+
+Do not add chronological incident logs to `AGENTS.md` or to skills. When an
+incident exposes a reusable lesson, integrate the prevention into the relevant
+main-text rule or design document; otherwise record it in the commit message.
+Skills must describe the current workflow, not its history.
 
 ### Progress Tracking for Multi-Phase Work
 
@@ -404,9 +405,11 @@ PRs.** This runs all unit tests and catches regressions early.
    git push origin feature/descriptive-name
    gh pr create --title "Title" --body-file /tmp/pr_body.md
    ```
-   **IMPORTANT: Never use `--body` with inline text containing backticks.** Bash
-   interprets backticks as command substitution, silently corrupting the PR body.
-   Always write the body to a temp file first and use `--body-file`:
+   **IMPORTANT: Never place backtick-containing text inside a double-quoted
+   shell argument.** The shell treats backticks as command substitution; this
+   can execute an unintended command in search patterns or silently corrupt a
+   PR body. Use literal-safe single quotes for arguments. For PR text, always
+   write the body to a temp file and use `--body-file`:
    ```bash
    cat > /tmp/pr_body.md << 'EOF'
    PR body with `backticks` and other markdown...


### PR DESCRIPTION
## Summary

- require CPAN report PR creation, inspection, and merge to run from a neutral non-worktree directory
- require an explicit GitHub repository argument so merge-time branch cleanup cannot mutate the tester checkout
- forbid chronological incident logs in `AGENTS.md` and skills; integrate reusable prevention into the relevant guidance instead
- broaden the shell-quoting guidance to prevent command substitution from backticks in any double-quoted argument

## Live-test result

PR #1122 successfully published and merged a lock-consistent report snapshot. The report checkout had no newer edits to lose, but `gh pr merge --delete-branch` switched it to `master` and fast-forwarded it. This correction prevents that local side effect.

## Validation

- skill validator: pass
- `make check-links`: pass, 0 errors
- direct offline link check for `AGENTS.md` and the skill: pass, 0 errors
- full build and runtime tests not run; documentation and non-executable skill instructions only
