### PR TITLE
chore: sync bundled Perl 5 sources

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -4,6 +4,8 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 
 ## Work in progress
 
+- Fix numeric-zero results from failed `s///` substitutions.
+
 ## v5.44.1: Regex, Threads, Async/Await, and CPAN Compatibility
 
 - Reach 686,288 of 696,597 passing assertions in the Perl standard test suite

--- a/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
+++ b/src/main/java/org/perlonjava/runtime/regex/RuntimeRegex.java
@@ -33,6 +33,7 @@ import java.util.function.Function;
 import static org.perlonjava.runtime.regex.RegexFlags.fromModifiers;
 import static org.perlonjava.runtime.regex.RegexFlags.validateModifiers;
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.getScalarInt;
+import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarFalse;
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarUndef;
 
 /**
@@ -4017,8 +4018,10 @@ public class RuntimeRegex extends RuntimeBase implements RuntimeScalarReference 
                 return string;
             } else {
                 // Perl returns a defined false value for a destructive s/// that
-                // does not match.
-                return RuntimeScalarCache.scalarEmptyString;
+                // does not match.  This is a false scalar, rather than an
+                // ordinary empty string: it stringifies to "" but numifies to
+                // zero without an "isn't numeric" warning.
+                return scalarFalse;
             }
         }
     }

--- a/src/main/perl/lib/IPC/Cmd.pm
+++ b/src/main/perl/lib/IPC/Cmd.pm
@@ -1356,7 +1356,7 @@ sub run {
 
         ### PerlOnJava has no fork(), so forced IPC::Run/Open3 selection must
         ### still use the JVM ProcessBuilder backend.
-        if (_is_perlonjava_runtime()) {
+        if (IS_PERLONJAVA) {
             $self->_debug("# Using PerlOnJava::Process. Have buffer: $have_buffer")
                 if $DEBUG;
             $ok = $self->_perlonjava_run(
@@ -1426,13 +1426,6 @@ sub run {
                 : $ok
 
 
-}
-
-sub _is_perlonjava_runtime {
-    return IS_PERLONJAVA
-        || $^X =~ m{(?:^|[\\/])jperl(?:\.bat)?\z}i
-        || (defined $ENV{PERLONJAVA_EXECUTABLE}
-            && length $ENV{PERLONJAVA_EXECUTABLE});
 }
 
 sub _perlonjava_run {

--- a/src/main/perl/lib/Pod/perlfunc.pod
+++ b/src/main/perl/lib/Pod/perlfunc.pod
@@ -6512,7 +6512,7 @@ removed as of Perl 5.24.
 
 =for Pod::Functions backquote quote a string
 
-Generalized quotes.  See L<perlop/"Quote-Like Operators">.
+Generalized quotes.  See L<perlop/Simpler Quote-Like Operators>.
 
 =item qr/STRING/
 
@@ -9989,7 +9989,7 @@ Portability issues: L<perlport/times>.
 
 The transliteration operator.  Same as
 L<C<yE<sol>E<sol>E<sol>>|/yE<sol>E<sol>E<sol>>.  See
-L<perlop/"Quote-Like Operators">.
+L<perlop/Transliteration Quote-Like Operators>.
 
 =item truncate FILEHANDLE,LENGTH
 X<truncate>
@@ -11009,7 +11009,7 @@ L<C<read>|/read FILEHANDLE,SCALAR,LENGTH,OFFSET>.  Unfortunately.
 
 The transliteration operator.  Same as
 L<C<trE<sol>E<sol>E<sol>>|/trE<sol>E<sol>E<sol>>.  See
-L<perlop/"Quote-Like Operators">.
+L<perlop/Transliteration Quote-Like Operators>.
 
 =back
 

--- a/src/main/perl/lib/Pod/perlgov.pod
+++ b/src/main/perl/lib/Pod/perlgov.pod
@@ -489,15 +489,15 @@ You can also see membership changes over time using the commit history there.
 =head2 Steering Council Members
 
 These are the members of the Steering Council elected to be responsible for
-the release of perl from version 5.43.1 onward through version 5.44.0:
+the release of perl from version 5.45.1 onward through version 5.46.0:
 
 =over
 
-=item * Aristotle Pagaltzis
+=item * Paul Evans
+
+=item * Graham Knop
 
 =item * Leon Timmermans
-
-=item * Paul Evans
 
 =back
 

--- a/src/main/perl/lib/Pod/perlop.pod
+++ b/src/main/perl/lib/Pod/perlop.pod
@@ -3970,11 +3970,11 @@ only to prevent breaking any pre-existing links to it from outside.
 
 =head2 Quote-Like Operators
 
-This section has been replaced by L</Simpler Quote-Like Operators>
+This section has been replaced by L</Simpler Quote-Like Operators>.
 
 =head2 Indented Here-docs
 
-This section has been merged into L</Here-docs>
+This section has been merged into L</Here-docs>.
 
 =head1 APPENDIX
 

--- a/src/test/resources/unit/substitution_failed_count_numeric.t
+++ b/src/test/resources/unit/substitution_failed_count_numeric.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+
+for my $modifier ('', 'g') {
+    my $text = 'unrelated text';
+    my $count = $modifier eq 'g'
+        ? ($text =~ s/constraint//gi)
+        : ($text =~ s/constraint//i);
+
+    ok defined $count, "failed s///$modifier returns a defined scalar";
+    ok !$count, "failed s///$modifier result is false";
+    is "$count", '', "failed s///$modifier result stringifies to empty";
+    is $count + 0, 0, "failed s///$modifier is numeric zero without a warning";
+    is $count == 0, 1, "failed s///$modifier compares numerically as zero";
+}
+
+my $single = 'constraint constraint';
+is $single =~ s/constraint//i, 1, 'successful single substitution returns its count';
+
+my $global = 'constraint constraint';
+is $global =~ s/constraint//gi, 2, 'successful global substitution returns its count';
+
+done_testing;


### PR DESCRIPTION
## Summary

- save the updates generated by `dev/import-perl5/sync.pl`
- return a numeric-zero defined false scalar from failed destructive `s///` and `s///g`

Fixes #1128.

## Validation

- system Perl regression test
- focused regression on the JVM and interpreter backends
- `make`
