### PR TITLE
fix: preserve references in utf8::downgrade

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,7 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 - Fix localization of numbered regex captures.
 - Fix IO-handle type checks and uninitialized-value warning locations.
 - Fix numeric-zero results from failed `s///` substitutions.
+- Preserve references in `utf8::downgrade`.
 - Bundle the complete CPAN `File::Path` 2.18 implementation, including modern
   `rmtree`/`remove_tree` options such as `keep_root`, `error`, `result`,
   `safe`, and `verbose`.

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Utf8.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Utf8.java
@@ -172,6 +172,14 @@ public class Utf8 extends PerlModuleBase {
         RuntimeScalar scalar = args.get(0);
         boolean wasTainted = GlobalContext.isTaintModeActive() && scalar.isTainted();
         boolean failOk = args.size() == 2 && args.get(1).getBoolean();
+
+        // References do not have a UTF-8 flag.  Perl treats downgrade() on a
+        // reference as a successful no-op; converting it through toString()
+        // would replace the reference with its stringified form.
+        if (RuntimeScalarType.isReference(scalar)) {
+            return RuntimeScalarCache.scalarTrue.getList();
+        }
+
         String string = scalar.toString();
 
         // Check if the string can be represented in ISO-8859-1

--- a/src/test/resources/unit/utf8_downgrade_references.t
+++ b/src/test/resources/unit/utf8_downgrade_references.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $scalar = 'value';
+my $object = bless {}, 'Local::Downgrade::Object';
+my @references = (
+    [ CODE   => sub { 42 } ],
+    [ ARRAY  => [] ],
+    [ HASH   => {} ],
+    [ SCALAR => \$scalar ],
+    [ 'Local::Downgrade::Object' => $object ],
+);
+
+for my $case (@references) {
+    my ($expected_type, $value) = @$case;
+    is(utf8::downgrade($value, 1), 1, "downgrade succeeds for $expected_type reference");
+    is(ref($value), $expected_type, "downgrade preserves $expected_type reference");
+}
+
+is($references[0][1]->(), 42, 'downgrade preserves a callable code reference');
+
+done_testing;


### PR DESCRIPTION
## Summary

- preserve CODE, ARRAY, HASH, SCALAR, and object references in `utf8::downgrade`
- restore HTTP::Message callback content handling
- add a focused standard-Perl-validated regression test
- update the WIP changelog

Closes #1117

## Validation

- `perl src/test/resources/unit/utf8_downgrade_references.t`
- `./jperl src/test/resources/unit/utf8_downgrade_references.t`
- `./jperl --interpreter src/test/resources/unit/utf8_downgrade_references.t`
- `make`
- `make check-links`

Generated with [Codex](https://openai.com/codex/)
