### PR TITLE
Fix XML::Parser stream handling before IO::Handle load

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -9,6 +9,8 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 - Fix numeric-zero results from failed `s///` substitutions.
 - Preserve references in `utf8::downgrade`.
 - Fix RFC 2047 header decoding for Email::MIME.
+- Fix XML::Parser streaming from native filehandles before `IO::Handle` has
+  been explicitly loaded.
 - Bundle the complete CPAN `File::Path` 2.18 implementation, including modern
   `rmtree`/`remove_tree` options such as `keep_root`, `error`, `result`,
   `safe`, and `verbose`.

--- a/src/main/perl/lib/XML/Parser/Expat.pm
+++ b/src/main/perl/lib/XML/Parser/Expat.pm
@@ -473,11 +473,14 @@ sub parse {
 
     if ( defined $arg ) {
         local *@;
+        # PerlOnJava recognizes native filehandles as IO::Handle objects before
+        # their Perl package is loaded. Load the method provider before either
+        # branch can call input_record_separator below.
+        require IO::Handle;
         if ( ref($arg) and UNIVERSAL::isa( $arg, 'IO::Handle' ) ) {
             $ioref = $arg;
         }
         else {
-            require IO::Handle;
             eval {
                 no strict 'refs';
                 if ( ref $arg eq 'GLOB' ) {


### PR DESCRIPTION
## Summary

- load `IO::Handle` before XML::Parser treats a native filehandle as an IO::Handle object
- restore streaming parsing with `Stream_Delimiter` when `IO::Handle` was not explicitly loaded

## Validation

- system Perl: `src/test/resources/module/XML-Parser/t/stream.t`
- JVM backend: `stream.t`
- interpreter backend: `stream.t`
- `JPERL_TEST_FILTER=XML-Parser make test-bundled-modules`
- `make`
- `make check-links`
- GitHub Actions: Ubuntu and Windows builds passed

## UAT

Full core UAT will be rerun from an idle machine. The runner allows 1,800 seconds for both `re/anyof.t` and `io/crlf_through.t` in that repeat.

## Related

Discovered while validating #1105.

Generated with [Codex](https://openai.com/codex/)
