### PR TITLE
fix: preserve plain strings in %vd formatting

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -20,6 +20,8 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 - Preserve string-compatible scalar channels for arithmetic results derived
   from string operands on both execution backends.
 - Honor imported overrides of the core `chmod` and `lock` built-ins.
+- Preserve plain-string semantics for `%vd` formatting instead of treating
+  dotted numeric strings as v-strings.
 
 ## v5.44.1: Regex, Threads, Async/Await, and CPAN Compatibility
 

--- a/src/main/java/org/perlonjava/runtime/operators/sprintf/SprintfVectorFormatter.java
+++ b/src/main/java/org/perlonjava/runtime/operators/sprintf/SprintfVectorFormatter.java
@@ -11,19 +11,14 @@ import java.nio.charset.StandardCharsets;
  *
  * <p>Vector formatting (indicated by the 'v' flag) treats the input as a sequence
  * of values and formats each one according to the conversion specifier, joining
- * them with dots. This class supports two types of vector input:
- * <ul>
- *   <li>Version strings - dotted numeric strings like "5.10.1"</li>
- *   <li>Byte strings - regular strings where each character is treated as a byte value</li>
- * </ul>
+ * them with dots. Regular strings are formatted as character code points;
+ * version objects retain their component representation.
  *
  * <p>Example vector formats:
  * <pre>
  *   sprintf "%vd", "ABC"      # "65.66.67"
  *   sprintf "%vx", "ABC"      # "41.42.43"
  *   sprintf "%v.2x", "ABC"    # "41.42.43" (with precision)
- *   sprintf "%vd", "5.10.1"   # "5.10.1" (version string)
- * /**
  * </pre>
  */
 public class SprintfVectorFormatter {
@@ -70,13 +65,9 @@ public class SprintfVectorFormatter {
 
         String str = value.toString();
 
-        // Handle version objects or dotted numeric strings
-        // ONLY treat as version if it contains dots!
-        if (str.contains(".") && str.matches("\\d+(\\.\\d+)*")) {
-            return formatVersionVector(str, flags, width, precision, conversionChar, separator);
-        }
-
-        // Handle regular strings (byte-by-byte)
+        // V-string semantics are represented by the scalar type. Do not infer
+        // them from a plain string's dotted-numeric text: %vd must format an
+        // ordinary string as its character code points.
         return formatByteVector(str, flags, width, precision, conversionChar, separator, bytesMode);
     }
 
@@ -92,9 +83,9 @@ public class SprintfVectorFormatter {
     }
 
     /**
-     * Format a version-style vector (dotted numeric string).
+     * Format a version object's dotted numeric representation.
      *
-     * <p>Version strings like "5.10.1" are split on dots and each numeric
+     * <p>Version object representations like "5.10.1" are split on dots and each numeric
      * component is formatted individually. This is commonly used for
      * version number display.
      *

--- a/src/test/resources/unit/vstring.t
+++ b/src/test/resources/unit/vstring.t
@@ -41,6 +41,13 @@ subtest 'V-String length and conversion' => sub {
     is($number, 1, 'V-String to number conversion');
 };
 
+subtest 'V-String vector formatting preserves scalar type' => sub {
+    is(sprintf('%vd', '1.22.333'), '49.46.50.50.46.51.51.51',
+       'plain dotted numeric string formats as character code points');
+    is(sprintf('%vd', v1.22.333), '1.22.333',
+       'v-string formats as version components');
+};
+
 subtest 'V-String in collections' => sub {
     # V-String in array context
     my @vstring_array = (v1.2.3, v4.5.6);


### PR DESCRIPTION
Closes #1162

WIP: fixes `%vd` to distinguish v-strings from ordinary dotted numeric strings by using the scalar representation rather than a text-shape heuristic.

Validation:

- `prove src/test/resources/unit/vstring.t` passes on system Perl.
- The regression fails on the unfixed JVM backend and passes on both PerlOnJava backends after the fix.
- Two full `make` attempts were affected by concurrent Gradle test-result collisions (`EOFException` / missing in-progress results); one also reported the unrelated `unit/cli_warning_overrides.t` failure.
