### PR TITLE
fix: retain borrowed filehandle aliases

### DIFF
--- a/.agents/skills/debug-perlonjava/SKILL.md
+++ b/.agents/skills/debug-perlonjava/SKILL.md
@@ -234,8 +234,10 @@ existing terse bullet style; do not add it to a released version section.
 For an issue fix, create and push a draft WIP PR as soon as the initial safe
 snapshot is committed. Continue investigation and implementation on that PR.
 
-When the focused regression and required validation pass, mark the draft PR
-ready for review with `gh pr ready <number>` and tell the user to begin UAT.
+Before handing the PR to UAT or CI, rebase the branch onto the latest `master`
+and rerun the focused regression and required validation on the rebased commit.
+Then mark the draft PR ready for review with `gh pr ready <number>` and tell
+the user to begin UAT.
 While the user is testing, monitor the PR's CI checks and fix, validate, and
 push any failures until both UAT feedback and CI are satisfactory.
 

--- a/.agents/skills/debug-perlonjava/SKILL.md
+++ b/.agents/skills/debug-perlonjava/SKILL.md
@@ -231,11 +231,13 @@ existing terse bullet style; do not add it to a released version section.
 
 ### 10. Issue PR lifecycle
 
-For an issue fix, create and push a WIP PR as soon as the initial safe snapshot
-is committed. Continue investigation and implementation on that PR, then mark
-it ready for testing when the focused regression and required validation pass.
-Invite the user to perform UAT, monitor the PR's CI checks, and keep fixing and
-updating the PR until both UAT feedback and CI are satisfactory.
+For an issue fix, create and push a draft WIP PR as soon as the initial safe
+snapshot is committed. Continue investigation and implementation on that PR.
+
+When the focused regression and required validation pass, mark the draft PR
+ready for review with `gh pr ready <number>` and tell the user to begin UAT.
+While the user is testing, monitor the PR's CI checks and fix, validate, and
+push any failures until both UAT feedback and CI are satisfactory.
 
 ## Git Workflow
 
@@ -261,8 +263,8 @@ Co-Authored-By: TOOL_NAME <TOOL_BOT_EMAIL>"
 ```bash
 git push -u origin fix-descriptive-name
 
-# Create PR using gh CLI
-gh pr create --title "Fix: description" --body "## Summary
+# Create a draft WIP PR using gh CLI
+gh pr create --draft --title "Fix: description" --body "## Summary
 - Fixed X by Y
 
 ## Test Plan

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ cody_history.xml
 target/
 .DS_Store
 .gradle/
+.venv/
 .java-version
 build/
 # Bundled Perl build-tool compatibility modules are source, not build output.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,21 @@ Never discard report updates that appear after the locked snapshot.
 
 ## Project Rules
 
+### Python Tooling Dependencies
+
+Homebrew-managed Python environments are externally managed. Do not use `sudo pip`
+or `--break-system-packages` to install tooling dependencies globally. Use a
+repository virtual environment instead:
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install PyYAML
+```
+
+Invoke Python tools that require those dependencies with `.venv/bin/python`.
+Agents may create and populate this project-local environment themselves when
+a required tooling dependency is missing.
+
 ### Maintaining these guidelines
 
 Do not add chronological incident logs to `AGENTS.md` or to skills. When an

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -4,6 +4,8 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 
 ## Work in progress
 
+- Preserve the lifetime of borrowed `+>&=` filehandle aliases, restoring
+  `Tie::File::Indexed` file-backed array storage.
 - Recognize retired `experimental::isa` and `experimental::alpha_assertions`
   warning categories for Perl source compatibility.
 - Fix localization of numbered regex captures.

--- a/src/main/java/org/perlonjava/runtime/io/BorrowedIOHandle.java
+++ b/src/main/java/org/perlonjava/runtime/io/BorrowedIOHandle.java
@@ -3,6 +3,7 @@ package org.perlonjava.runtime.io;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
 import java.nio.charset.Charset;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.perlonjava.runtime.runtimetypes.RuntimeIO.handleIOException;
 import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarTrue;
@@ -23,13 +24,14 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.scalarTrue;
  *
  * <h3>Implementation</h3>
  * <p>BorrowedIOHandle delegates all I/O operations to the underlying delegate IOHandle,
- * but overrides {@link #close()} to only flush — never closing the delegate. This
- * ensures that after {@code close F}, the original handle (e.g. STDOUT) keeps working.</p>
+ * but shares a lifecycle with the handle it borrows. This ensures that closing one
+ * of several parsimonious aliases does not invalidate the others, while the
+ * underlying resource is eventually closed when the last related handle closes.</p>
  *
  * <p>Unlike {@link DupIOHandle}, this wrapper:</p>
  * <ul>
  *   <li>Does NOT allocate a new fd number (shares the delegate's fileno)</li>
- *   <li>Does NOT use reference counting (the delegate is never closed by us)</li>
+ *   <li>Uses reference counting only to retain the shared resource's lifetime</li>
  *   <li>Is much simpler — just a thin delegation layer with a close-guard</li>
  * </ul>
  *
@@ -43,18 +45,44 @@ public class BorrowedIOHandle implements IOHandle {
         return ThreadInheritancePolicy.WRAPPER_COPY;
     }
 
-    /** The underlying handle we're borrowing — never closed by us. */
+    /** The underlying handle shared by all parsimonious aliases. */
     private final IOHandle delegate;
+    /** Shared lifecycle for the source handle and every parsimonious alias. */
+    private final AtomicInteger refCount;
     /** Per-instance closed flag. Once true, all I/O operations on THIS wrapper fail. */
     private boolean closed = false;
 
     /**
      * Creates a BorrowedIOHandle wrapping the given delegate.
      *
-     * @param delegate the underlying IOHandle to borrow (not owned — will not be closed)
+     * @param delegate the underlying IOHandle to borrow
      */
     public BorrowedIOHandle(IOHandle delegate) {
+        this(delegate, new AtomicInteger(1));
+    }
+
+    private BorrowedIOHandle(IOHandle delegate, AtomicInteger refCount) {
         this.delegate = delegate;
+        this.refCount = refCount;
+    }
+
+    /**
+     * Replaces an ordinary source handle with the source side of a borrowed
+     * pair, and returns the alias side. Both wrappers retain the delegate until
+     * they have each been closed.
+     */
+    public static BorrowedIOHandle[] createPair(IOHandle delegate) {
+        AtomicInteger refCount = new AtomicInteger(2);
+        return new BorrowedIOHandle[] {
+                new BorrowedIOHandle(delegate, refCount),
+                new BorrowedIOHandle(delegate, refCount)
+        };
+    }
+
+    /** Creates another parsimonious alias sharing this handle's lifecycle. */
+    public static BorrowedIOHandle addBorrow(BorrowedIOHandle existing) {
+        existing.refCount.incrementAndGet();
+        return new BorrowedIOHandle(existing.delegate, existing.refCount);
     }
 
     /**
@@ -168,14 +196,14 @@ public class BorrowedIOHandle implements IOHandle {
         return delegate.syswrite(data);
     }
 
-    // ---- Close: flush only, do NOT close the delegate ----
+    // ---- Close: retain the delegate while another related handle is live ----
 
     /**
      * Closes this borrowed handle.
      *
-     * <p>Only flushes the delegate — does NOT close the underlying resource.
-     * This matches Perl's fdopen semantics where closing an fdopen'd FILE*
-     * does not invalidate the original handle.</p>
+     * <p>Closes this wrapper while retaining the delegate until the final
+     * source or alias wrapper closes. This lets an alias outlive the lexical
+     * {@code sysopen} handle from which it was created.</p>
      */
     @Override
     public RuntimeScalar close() {
@@ -185,7 +213,9 @@ public class BorrowedIOHandle implements IOHandle {
                     "Handle is already closed.");
         }
         closed = true;
-        // Only flush — never close the delegate. The original handle still owns it.
+        if (refCount.decrementAndGet() == 0) {
+            return delegate.close();
+        }
         delegate.flush();
         return scalarTrue;
     }

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -3070,7 +3070,16 @@ public class IOOperator {
             return null;
         }
         RuntimeIO borrowed = new RuntimeIO();
-        borrowed.ioHandle = new BorrowedIOHandle(source.ioHandle);
+        if (source.ioHandle instanceof BorrowedIOHandle existingBorrow) {
+            borrowed.ioHandle = BorrowedIOHandle.addBorrow(existingBorrow);
+        } else {
+            // The lexical source handle may leave scope immediately after this
+            // open(). Replace it with the source half of a shared lifecycle so
+            // GC cleanup cannot close the delegate while this alias is live.
+            BorrowedIOHandle[] pair = BorrowedIOHandle.createPair(source.ioHandle);
+            source.ioHandle = pair[0];
+            borrowed.ioHandle = pair[1];
+        }
         borrowed.currentLineNumber = source.currentLineNumber;
         // Share the source's fileno (parsimonious dup = same fd)
         int sourceFd = source.getAssignedFileno();

--- a/src/test/resources/unit/borrowed_filehandle_alias.t
+++ b/src/test/resources/unit/borrowed_filehandle_alias.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+use Test::More;
+use Fcntl qw(O_RDWR O_CREAT O_TRUNC SEEK_END);
+use File::Temp qw(tempfile);
+
+my ($x, $first_path) = tempfile();
+my ($y, $second_path) = tempfile();
+close $x;
+close $y;
+
+sub open_alias {
+    my ($path) = @_;
+    sysopen(my $sysfh, $path, O_RDWR | O_CREAT | O_TRUNC, 0666) or die "sysopen: $!";
+    open(my $alias, '+>&=', fileno($sysfh)) or die "open alias: $!";
+    return ($sysfh, $alias);
+}
+
+my ($first_source,  $first)  = open_alias($first_path);
+my ($second_source, $second) = open_alias($second_path);
+
+ok((print {$first} 'a'), 'first borrowed alias remains writable after another alias is opened');
+ok((print {$second} 'b'), 'second borrowed alias is writable');
+ok(seek($first,  0, SEEK_END), 'can seek first borrowed alias');
+ok(seek($second, 0, SEEK_END), 'can seek second borrowed alias');
+is(tell($first),  1, 'first borrowed alias has its own live file position');
+is(tell($second), 1, 'second borrowed alias has its own live file position');
+
+close $first_source;
+ok((print {$first} 'c'), 'borrowed alias outlives its closed source handle');
+ok(seek($first, 0, SEEK_END), 'borrowed alias remains seekable after source close');
+is(tell($first), 2, 'borrowed alias still tracks its file position after source close');
+
+close $first;
+close $second;
+close $second_source;
+unlink $first_path;
+unlink $second_path;
+
+done_testing;


### PR DESCRIPTION
## Summary

Fixes #1153 by retaining the shared resource behind `+>&=` aliases until the final source or alias handle closes.

This prevents a lexical `sysopen` handle from invalidating an alias that escapes its scope, restoring `Tie::File::Indexed` file-backed array storage behavior.

## Validation

- `prove src/test/resources/unit/borrowed_filehandle_alias.t`
- `make`
- `./jperl src/test/resources/unit/borrowed_filehandle_alias.t`
- `./jperl --interpreter src/test/resources/unit/borrowed_filehandle_alias.t`
- `make check-links`
