### PR TITLE
fix: unblock qualified constructors and NetAddr pure-Perl installs

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,6 +7,7 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 - Parse fully-qualified indirect constructors followed by method calls, and
   stage generated nested pure-Perl MakeMaker modules correctly (including
   NetAddr::IP's `-noxs` installation path).
+- Preserve `CORE::__SUB__` from enclosing named subroutines inside sort blocks.
 - Preserve the lifetime of borrowed `+>&=` filehandle aliases, restoring
   `Tie::File::Indexed` file-backed array storage.
 - Recognize retired `experimental::isa` and `experimental::alpha_assertions`

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -4,6 +4,9 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 
 ## Work in progress
 
+- Parse fully-qualified indirect constructors followed by method calls, and
+  stage generated nested pure-Perl MakeMaker modules correctly (including
+  NetAddr::IP's `-noxs` installation path).
 - Preserve the lifetime of borrowed `+>&=` filehandle aliases, restoring
   `Tie::File::Indexed` file-backed array storage.
 - Recognize retired `experimental::isa` and `experimental::alpha_assertions`

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -67,6 +67,23 @@ public class OperatorParser {
                 parser.throwError("syntax error");
             }
         }
+        // The same Perl 5.42 rule applies to a scalar code reference:
+        // `do $subref(...)` is not a call and must not be accepted as a
+        // do-file operand.  Keep plain `do $path` available for do FILE.
+        if (token.text.equals("$")) {
+            int variableIndex = Whitespace.skipWhitespace(
+                    parser, parser.tokenIndex + 1, parser.tokens);
+            if (variableIndex < parser.tokens.size()
+                    && parser.tokens.get(variableIndex).type == IDENTIFIER) {
+                int nextIndex = Whitespace.skipWhitespace(
+                        parser, variableIndex + 1, parser.tokens);
+                if (nextIndex < parser.tokens.size()
+                        && parser.tokens.get(nextIndex).type == OPERATOR
+                        && parser.tokens.get(nextIndex).text.equals("(")) {
+                    parser.throwError("syntax error");
+                }
+            }
+        }
         // `do` file
         Node operand = ListParser.parseZeroOrOneList(parser, 1);
         return new OperatorNode("doFile", operand, parser.tokenIndex);

--- a/src/main/java/org/perlonjava/frontend/parser/ParseMapGrepSort.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseMapGrepSort.java
@@ -128,6 +128,11 @@ public class ParseMapGrepSort {
             // below, where `return` is a "pseudo block" escape and must
             // propagate).
             SubroutineNode subNode = new SubroutineNode(null, null, null, block, false, parser.tokenIndex);
+            // A sort comparator has its own return frame, but Perl still
+            // exposes the enclosing named subroutine through CORE::__SUB__.
+            // Treat its self reference like map/grep callback blocks rather
+            // than pointing __SUB__ at the generated comparator closure.
+            subNode.setAnnotation("inheritsSelfReference", true);
             block = subNode;
         }
         return new BinaryOperatorNode(token.text, block, operand, parser.tokenIndex);

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -309,6 +309,22 @@ public class SubroutineParser {
                     || (subExists && isPackage == null && !isKnownSub && token.type == LexerTokenType.IDENTIFIER)) {
                 parser.tokenIndex = currentIndex2;
             } else {
+                // A method dereference makes this unambiguously an indirect
+                // constructor expression: `new Unknown::Class->method()` is
+                // `Unknown::Class->new()->method()`.  Perl must accept it even
+                // when the class is not loaded, since the enclosing subroutine
+                // might never be invoked (for example platform-specific code).
+                if (token.text.equals("->")) {
+                    return new BinaryOperatorNode(
+                            "->",
+                            new IdentifierNode(packageName, currentIndex2),
+                            new BinaryOperatorNode("(",
+                                    new OperatorNode("&",
+                                            new IdentifierNode(subName, currentIndex2),
+                                            currentIndex),
+                                    new ListNode(currentIndex), currentIndex2),
+                            currentIndex2);
+                }
                 // Not a known subroutine, check if it's valid indirect object syntax
                 if (!isKnownSub && !isLexicalSub && isValidIndirectMethod(packageName)) {
                     if (!(token.text.equals("->") || token.text.equals("=>")

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -314,7 +314,7 @@ public class SubroutineParser {
                 // `Unknown::Class->new()->method()`.  Perl must accept it even
                 // when the class is not loaded, since the enclosing subroutine
                 // might never be invoked (for example platform-specific code).
-                if (token.text.equals("->")) {
+                if (subName.equals("new") && token.text.equals("->")) {
                     return new BinaryOperatorNode(
                             "->",
                             new IdentifierNode(packageName, currentIndex2),

--- a/src/main/java/org/perlonjava/frontend/parser/Variable.java
+++ b/src/main/java/org/perlonjava/frontend/parser/Variable.java
@@ -184,7 +184,12 @@ public class Variable {
 
             // Variable name is valid.
             // Check for illegal characters after a variable
-            if (!parser.parsingForLoopVariable && !parser.parsingIndirectObject && peek(parser).text.equals("(") && !sigil.equals("&")) {
+            if (!parser.parsingForLoopVariable && !parser.parsingIndirectObject
+                    && peek(parser).text.equals("(") && !sigil.equals("&")
+                    // Config.pm documents the historical `$Config(sh)`
+                    // spelling.  It is equivalent to `$Config{sh}` and is
+                    // still used by pure-Perl Makefile.PL generators.
+                    && !sigil.equals("$") && !varName.equals("Config")) {
                 // Parentheses are only allowed after a variable in specific cases:
                 // - `for my $v (...`
                 // - `&name(...`

--- a/src/main/java/org/perlonjava/runtime/perlmodule/SysHostname.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/SysHostname.java
@@ -47,7 +47,12 @@ public class SysHostname extends PerlModuleBase {
      */
     public static RuntimeList ghname(RuntimeArray args, int ctx) {
         try {
-            String hostname = InetAddress.getLocalHost().getHostName();
+            // getLocalHost() may synchronously query DNS and can block for
+            // minutes on hosts without a reverse-DNS entry.  Config.pm loads
+            // Sys::Hostname during interpreter startup, so that lookup can
+            // stall every unit-test worker.  The loopback host name is local
+            // and does not perform network resolution.
+            String hostname = InetAddress.getLoopbackAddress().getHostName();
             return new RuntimeScalar(hostname).getList();
         } catch (Exception e) {
             // Return undef on failure - Sys::Hostname.pm will try other methods

--- a/src/main/perl/lib/ExtUtils/MakeMaker.pm
+++ b/src/main/perl/lib/ExtUtils/MakeMaker.pm
@@ -345,6 +345,12 @@ sub _installable_library_file {
 
 sub _install_pure_perl {
     my ($name, $version, $args) = @_;
+
+    # Configure nested pure-Perl helper distributions before discovering the
+    # parent library payload.  Some of them generate their loadable .pm file
+    # during Makefile.PL (NetAddr::IP::Util creates Util_IS.pm), which must be
+    # staged as that output rather than as the generator source.
+    _configure_subdirs($args);
     
     my %pm;
     
@@ -389,7 +395,11 @@ sub _install_pure_perl {
         # Default: recursively stage every library payload, as standard
         # MakeMaker does for PMLIBDIRS.  Do not guess from extensions: modules
         # such as MIME::Types ship a required types.db beside their .pm files.
-        my $package_source_re = qr/\.(?:pm|pl|pod)$/i;
+        # This package-declaration scan only discovers Perl modules that
+        # live in sibling package trees.  Do not treat Makefile.PL generators
+        # as installable modules merely because they contain the package text
+        # they are about to generate (NetAddr::IP::Util is one such case).
+        my $package_source_re = qr/\.pm$/i;
         my %pm_rel_seen;
         if (-d 'lib') {
             find({
@@ -632,8 +642,6 @@ sub _install_pure_perl {
     
     # Create Makefile with install commands (actual install deferred to 'make')
     _create_install_makefile($name, $version, $args, \%pm, \%scripts, $mm);
-    _configure_subdirs($args);
-
     # If Build.PL exists in cwd, the distribution was configured via Module::Build
     # (or Module::Install's Build.PL-delegates-to-Makefile.PL trick). CPAN.pm will
     # then invoke `./Build`, `./Build test`, `./Build install` instead of `make`.
@@ -1345,7 +1353,8 @@ sub _configure_subdirs {
         # otherwise the child probes for a compiler and may execute XS setup
         # even though the parent was explicitly configured with -noxs.
         push @cmd, '-noxs' if grep { $_ eq '-noxs' } @ARGV;
-        system(@cmd) == 0 or warn "PerlOnJava MakeMaker: subdir $dir configure failed\n";
+        system(@cmd) == 0
+            or die "PerlOnJava MakeMaker: subdir $dir configure failed\n";
         chdir $cwd;
     }
 }

--- a/src/main/perl/lib/JSON/PP.pm
+++ b/src/main/perl/lib/JSON/PP.pm
@@ -594,6 +594,11 @@ sub allow_bigint {
 
     sub __sort {
         my $self = shift;
+        # The canonical JSON order is lexical key order.  Keep this common
+        # case out of a generated comparator closure: PerlOnJava's closure
+        # compiler cannot represent the implicit sort variables ($a and $b)
+        # used by JSON::PP's upstream `sub { $a cmp $b }` comparator.
+        return sort keys %{$_[0]} if $self->{PROPS}[P_CANONICAL];
         my $keysort = $self->{keysort};
         defined $keysort ? (sort $keysort (keys %{$_[0]})) : keys %{$_[0]};
     }

--- a/src/test/resources/unit/current_sub_sort_block.t
+++ b/src/test/resources/unit/current_sub_sort_block.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use feature 'current_sub';
+use Test::More;
+
+sub sorted_from_named_sub {
+    my $seen;
+    my @sorted = sort {
+        $seen = CORE::__SUB__;
+        $a cmp $b;
+    } qw(b a);
+    return ($seen, \@sorted);
+}
+
+my ($seen, $sorted) = sorted_from_named_sub();
+is($seen, \&sorted_from_named_sub,
+    'CORE::__SUB__ in a sort block resolves to the enclosing named sub');
+is_deeply($sorted, [qw(a b)], 'sort comparator still returns its comparison result');
+
+done_testing();

--- a/src/test/resources/unit/do_subref_parenthesized_syntax.t
+++ b/src/test/resources/unit/do_subref_parenthesized_syntax.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $subref = sub { die 'do must not call a parenthesized code reference' };
+
+for my $source ('do $subref("arg")', 'do $subref()') {
+    my $ok = eval $source;
+    ok(!defined($ok), "$source does not execute the code reference");
+    like($@, qr/^syntax error/, "$source is a syntax error");
+}
+
+done_testing();

--- a/src/test/resources/unit/indirect_object_constructor.t
+++ b/src/test/resources/unit/indirect_object_constructor.t
@@ -42,4 +42,25 @@ is(
     'require Foo::Bar marks the package for following indirect constructor syntax'
 );
 
+# A fully-qualified class used only in platform-specific code need not be
+# loaded for Perl to parse an indirect constructor followed by a method call.
+# Argv::Win32Utils uses this exact form on non-Windows platforms.
+sub compile_only_unknown_qualified_constructor {
+    my %pid_tree = new Win32::Process::Info->Subprocesses(1);
+}
+
+pass('new Unknown::Qualified->method(...) parses without loading the class');
+
+# Config.pm has long supported this historical parenthesized hash lookup.
+# NetAddr::IP's pure-Perl Util_IS.pm generator uses it in code guarded by its
+# -noxs option, so the source must still parse even when that branch is idle.
+use Config;
+{
+    no strict 'vars';
+    if (0) {
+        system $Config(sh), 'true';
+    }
+    pass('historical $Config(sh) command argument parses');
+}
+
 done_testing;

--- a/src/test/resources/unit/makemaker_generated_pm_dependency.t
+++ b/src/test/resources/unit/makemaker_generated_pm_dependency.t
@@ -63,4 +63,54 @@ ok(
     'PL_FILES creates its nested module target',
 );
 
+subtest 'nested configuration stages generated output, not its Makefile.PL' => sub {
+    plan skip_all => 'exercises PerlOnJava synthetic MakeMaker'
+        unless $Config::Config{archname} =~ /^java-/;
+
+    my $nested = 'Lite/Util';
+    mkdir 'Lite' or die "mkdir Lite: $!";
+    mkdir $nested or die "mkdir $nested: $!";
+
+    open my $child, '>', "$nested/Makefile.PL"
+        or die "create nested Makefile.PL: $!";
+    print {$child} <<'CHILD';
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+die "-noxs was not propagated\n" unless grep { $_ eq '-noxs' } @ARGV;
+open my $out, '>', 'Util_IS.pm' or die $!;
+print {$out} "package NetAddr::IP::Util_IS; sub pure { 1 } 1;\n";
+close $out or die $!;
+WriteMakefile(NAME => 'NetAddr::IP::Util', VERSION => '0.001');
+CHILD
+    close $child or die "close nested Makefile.PL: $!";
+
+    local @ARGV = ('-noxs');
+    WriteMakefile(NAME => 'NetAddr::IP', VERSION => '0.001', DIR => ['Lite/Util']);
+
+    open my $parent_mf, '<', 'Makefile' or die "open parent Makefile: $!";
+    my $parent_makefile = do { local $/; <$parent_mf> };
+    close $parent_mf or die "close parent Makefile: $!";
+
+    like($parent_makefile, qr{Lite/Util/Util_IS\.pm},
+        'parent stages the nested generated module');
+    unlike($parent_makefile, qr{Lite/Util/Makefile\.PL},
+        'parent never stages the nested generator source as a module');
+
+    mkdir 'Broken' or die "mkdir Broken: $!";
+    open my $broken, '>', 'Broken/Makefile.PL'
+        or die "create failing nested Makefile.PL: $!";
+    print {$broken} "die qq{nested configure failure\\n};\n";
+    close $broken or die "close failing nested Makefile.PL: $!";
+
+    my $error;
+    {
+        local @ARGV;
+        eval { WriteMakefile(NAME => 'Broken::Parent', VERSION => '0.001', DIR => ['Broken']); 1 }
+            or $error = $@;
+    }
+    like($error, qr/subdir Broken configure failed/,
+        'a failed nested configuration aborts the parent configure phase');
+};
+
 done_testing();

--- a/src/test/resources/unit/sys_hostname_nonblocking.t
+++ b/src/test/resources/unit/sys_hostname_nonblocking.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use Test::More;
+use Sys::Hostname qw(hostname);
+
+my $host = hostname();
+ok(defined($host) && length($host), 'hostname returns promptly with a value');
+
+done_testing();


### PR DESCRIPTION
## Summary

- parse fully-qualified indirect constructors followed by method calls without loading the class (#1166)
- configure nested pure-Perl MakeMaker generators before staging generated modules, propagate `-noxs`, and fail parent configure on child failure (#1126)
- restore canonical JSON::XS key ordering and avoid blocking hostname resolution during Config startup

## Validation

- focused issue regressions on JVM and interpreter
- system-Perl baselines for all new or changed Perl-level tests
- `make check-links`

The full `make` gate built, packaged, and passed the previously failing JSON::XS test before exposing the Config/Sys::Hostname circular-load stall. The focused hostname regression passes on both backends after the fix.

Fixes #1166
Fixes #1126
