### PR TITLE
fix: accept whitespace in open modes and dup tied filehandles

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -30,6 +30,10 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 - Package Unicode::Collate DUCET tables in the runtime JAR.
 - Bundle `Class::MethodMaker` 2.25 with its pure-Perl accessor engine and
   portable generated-subroutine naming support.
+- Accept Perl-compatible whitespace in `open` mode strings, such as the `'< '`
+  used by `Perl6::Slurp`.
+- Duplicate the underlying handle when `open` is given a dup mode for a tied
+  filehandle, as `CPAN.pm` does with a tied `STDOUT`.
 
 ## v5.44.1: Regex, Threads, Async/Await, and CPAN Compatibility
 

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -687,8 +687,16 @@ public class IOOperator {
             if (pid > 0) return new RuntimeScalar(pid);
             return scalarTrue;
         }
-        String mode = args[1].toString();
-        RuntimeList runtimeList = new RuntimeList(Arrays.copyOfRange(args, 1, args.length));
+        // Perl allows whitespace around the mode sigil ('< ', ' >', '< :utf8')
+        RuntimeBase[] modeAndArgs = Arrays.copyOfRange(args, 1, args.length);
+        String rawMode = args[1].toString();
+        String mode = RuntimeIO.normalizeOpenMode(rawMode);
+        if (!mode.equals(rawMode)) {
+            // Let openPipe() see the cleaned-up mode too. Taint checks below
+            // still run against the original args, so nothing is lost here.
+            modeAndArgs[0] = new RuntimeScalar(mode);
+        }
+        RuntimeList runtimeList = new RuntimeList(modeAndArgs);
 
         // Preserve a pending fork-open while the child redirects STDOUT/ERR
         // before exec.  The emulated child runs on this same JVM thread, so
@@ -746,7 +754,7 @@ public class IOOperator {
                 if (argStr.matches("^-?\\d+$")) {
                     int fd = Integer.parseInt(argStr);
                     // Handle numeric file descriptor duplication
-                    RuntimeIO sourceHandle = fd >= 0 ? findFileHandleByDescriptor(fd) : null;
+                    RuntimeIO sourceHandle = fd >= 0 ? resolveDupSource(findFileHandleByDescriptor(fd)) : null;
                     if (sourceHandle != null && sourceHandle.ioHandle != null) {
                         if (isParsimonious) {
                             // &= mode: non-owning wrapper sharing the same fd
@@ -769,7 +777,7 @@ public class IOOperator {
                 // Check if it's a GLOB or GLOBREFERENCE
                 else if (secondArg.type == RuntimeScalarType.GLOB || secondArg.type == RuntimeScalarType.GLOBREFERENCE) {
                     try {
-                        RuntimeIO sourceHandle = secondArg.getRuntimeIO();
+                        RuntimeIO sourceHandle = resolveDupSource(secondArg.getRuntimeIO());
                         if (sourceHandle != null && sourceHandle.ioHandle != null) {
                             if (ioDebug) {
                                 String srcFileno;
@@ -801,7 +809,7 @@ public class IOOperator {
                     // (e.g., File::Temp objects passed to open with dup mode)
                     RuntimeIO sourceHandle = null;
                     try {
-                        sourceHandle = secondArg.getRuntimeIO();
+                        sourceHandle = resolveDupSource(secondArg.getRuntimeIO());
                     } catch (Exception ignored) {
                     }
 
@@ -818,7 +826,7 @@ public class IOOperator {
                             // Convert string to proper filehandle reference
                             RuntimeScalar handleRef = GlobalVariable.getGlobalIO("main::" + handleName);
                             if (handleRef != null && handleRef.value instanceof RuntimeGlob) {
-                                sourceHandle = ((RuntimeGlob) handleRef.value).getIO().getRuntimeIO();
+                                sourceHandle = resolveDupSource(((RuntimeGlob) handleRef.value).getIO().getRuntimeIO());
                                 if (sourceHandle != null && sourceHandle.ioHandle != null) {
                                     if (isParsimonious) {
                                         fh = createBorrowedHandle(sourceHandle);
@@ -2990,7 +2998,7 @@ public class IOOperator {
         // Check if it's a numeric file descriptor
         if (fileName.matches("^\\d+$")) {
             int fd = Integer.parseInt(fileName);
-            sourceHandle = findFileHandleByDescriptor(fd);
+            sourceHandle = resolveDupSource(findFileHandleByDescriptor(fd));
             if (sourceHandle == null || sourceHandle.ioHandle == null) {
                 RuntimeIO.handleIOError(9); // EBADF
                 return null;
@@ -3012,7 +3020,7 @@ public class IOOperator {
                     String currentPkgName = currentPkg + "::" + fileName;
                     RuntimeGlob currentGlob = GlobalVariable.getGlobalIO(currentPkgName);
                     if (currentGlob != null) {
-                        sourceHandle = currentGlob.getRuntimeIO();
+                        sourceHandle = resolveDupSource(currentGlob.getRuntimeIO());
                         if (sourceHandle != null && sourceHandle.ioHandle != null) {
                             normalizedName = null; // Already found
                         } else {
@@ -3031,11 +3039,17 @@ public class IOOperator {
             if (sourceHandle == null) {
                 RuntimeGlob glob = GlobalVariable.getGlobalIO(normalizedName);
                 if (glob != null) {
-                    sourceHandle = glob.getRuntimeIO();
+                    sourceHandle = resolveDupSource(glob.getRuntimeIO());
                 }
                 if (sourceHandle == null || sourceHandle.ioHandle == null) {
-                    // Last resort: try static fields for standard handles
-                    switch (fileName.toUpperCase()) {
+                    // Last resort: try static fields for standard handles.
+                    // The name may already be package-qualified, because the
+                    // parser qualifies the handle in the two-argument form.
+                    String bareName = fileName.toUpperCase();
+                    if (bareName.startsWith("MAIN::")) {
+                        bareName = bareName.substring(6);
+                    }
+                    switch (bareName) {
                         case "STDIN": sourceHandle = RuntimeIO.getStdin(); break;
                         case "STDOUT": sourceHandle = RuntimeIO.getStdout(); break;
                         case "STDERR": sourceHandle = RuntimeIO.getStderr(); break;
@@ -3056,6 +3070,29 @@ public class IOOperator {
         } else {
             return duplicateFileHandle(sourceHandle);
         }
+    }
+
+    /**
+     * Resolves the handle that a dup mode ({@code >&}, {@code <&=}, ...) must act on.
+     *
+     * <p>Perl duplicates the PerlIO stored in the glob's IO slot and ignores tie
+     * magic: {@code tie *STDOUT, 'Catch'; open($fh, '>&STDOUT')} dups the real
+     * fd 1, the new handle is not tied, and no tie method (not even FILENO) is
+     * called. {@code TieHandle} keeps the pre-tie {@code RuntimeIO}, so follow
+     * that chain — ties can nest — to reach the handle Perl would dup. When a
+     * tied glob never had a real handle the TieHandle is returned unchanged so
+     * the caller reports EBADF as before.
+     */
+    private static RuntimeIO resolveDupSource(RuntimeIO handle) {
+        RuntimeIO resolved = handle;
+        while (resolved instanceof TieHandle tied) {
+            RuntimeIO previous = tied.getPreviousValue();
+            if (previous == null || previous == resolved) {
+                break;
+            }
+            resolved = previous;
+        }
+        return resolved;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
@@ -676,6 +676,81 @@ public class RuntimeIO extends RuntimeScalar {
     }
 
     /**
+     * Known open() mode prefixes, longest first so that the longest match wins.
+     */
+    private static final String[] OPEN_MODE_PREFIXES = {
+            "+>>&=", "+<&=", "+>&=", ">>&=", "<&=", ">&=",
+            "+>>&", "+<&", "+>&", ">>&", "<&", ">&",
+            "+>>", "+<", "+>", ">>", "<", ">",
+            "-|", "|-"
+    };
+
+    private static boolean isModeSpace(char c) {
+        return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == 0x0b;
+    }
+
+    /**
+     * Removes the whitespace Perl allows in an open() mode string.
+     *
+     * <p>Perl skips whitespace before the mode sigil and between the sigil and
+     * the I/O layer list, so {@code '< '}, {@code ' <'} and
+     * {@code '< :encoding(UTF-8)'} all mean the same as {@code '<'} and
+     * {@code '<:encoding(UTF-8)'}. Whitespace inside the sigil itself is not
+     * allowed ({@code '+ <'} and {@code '> >'} are errors in Perl too), and
+     * anything other than a layer list after the sigil is not a mode, so in
+     * both cases the original string is returned unchanged and the caller
+     * reports it verbatim.
+     *
+     * @param mode the raw mode string
+     * @return the mode with Perl-compatible whitespace removed
+     */
+    public static String normalizeOpenMode(String mode) {
+        if (mode == null || mode.isEmpty()) {
+            return mode;
+        }
+        boolean hasSpace = false;
+        for (int i = 0; i < mode.length(); i++) {
+            if (isModeSpace(mode.charAt(i))) {
+                hasSpace = true;
+                break;
+            }
+        }
+        if (!hasSpace) {
+            return mode;
+        }
+
+        int start = 0;
+        while (start < mode.length() && isModeSpace(mode.charAt(start))) {
+            start++;
+        }
+        for (String prefix : OPEN_MODE_PREFIXES) {
+            if (!mode.startsWith(prefix, start)) {
+                continue;
+            }
+            int rest = start + prefix.length();
+            while (rest < mode.length() && isModeSpace(mode.charAt(rest))) {
+                rest++;
+            }
+            int end = mode.length();
+            while (end > rest && isModeSpace(mode.charAt(end - 1))) {
+                end--;
+            }
+            if (rest == end) {
+                // Nothing but whitespace around the sigil: '< ' -> '<'
+                return prefix;
+            }
+            if (mode.charAt(rest) == ':') {
+                // Layer list follows the sigil: '< :utf8' -> '<:utf8'
+                return prefix + mode.substring(rest, end);
+            }
+            // Not a layer list (a filename in the 2-argument form, or a
+            // malformed mode) - leave the string alone.
+            return mode;
+        }
+        return mode;
+    }
+
+    /**
      * Opens a file with a specific mode and optional I/O layers.
      *
      * <p>The mode string can include I/O layers after a colon:
@@ -690,6 +765,7 @@ public class RuntimeIO extends RuntimeScalar {
      * @return RuntimeIO handle for the opened file, or null on error
      */
     public static RuntimeIO open(String fileName, String mode) {
+        mode = normalizeOpenMode(mode);
         RuntimeIO fh = new RuntimeIO();
         try {
             String ioLayers = "";
@@ -827,6 +903,7 @@ public class RuntimeIO extends RuntimeScalar {
      * @return RuntimeIO handle for the scalar-backed file, or null on error
      */
     public static RuntimeIO open(RuntimeScalar scalarRef, String mode) {
+        mode = normalizeOpenMode(mode);
         RuntimeIO fh = new RuntimeIO();
 
         // Check if the argument is a scalar reference

--- a/src/test/resources/unit/open_mode_whitespace.t
+++ b/src/test/resources/unit/open_mode_whitespace.t
@@ -1,0 +1,103 @@
+use strict;
+use warnings;
+use Test::More tests => 12;
+use File::Spec;
+use File::Temp qw(tempdir);
+
+# Perl skips whitespace before the open() mode sigil and between the sigil
+# and the I/O layer list, so '< ' means the same as '<' and '< :utf8' means
+# the same as '<:utf8'.  Perl6::Slurp opens its input with '< ', which used
+# to abort with "Unknown open() mode '< '" (GitHub issue #1160).
+
+my $dir  = tempdir(CLEANUP => 1);
+my $path = File::Spec->catfile($dir, 'mode.txt');
+
+{
+    open(my $out, '> ', $path) or die "open '> ': $!";
+    print {$out} "first\n";
+    close $out;
+    ok(-s $path, "'> ' opens for writing");
+}
+
+{
+    open(my $in, '< ', $path) or die "open '< ': $!";
+    is(scalar(<$in>), "first\n", "'< ' opens for reading");
+    close $in;
+}
+
+{
+    open(my $in, "<\t", $path) or die "open '<\\t': $!";
+    is(scalar(<$in>), "first\n", "tab after the mode sigil is accepted");
+    close $in;
+}
+
+{
+    open(my $out, '>> ', $path) or die "open '>> ': $!";
+    print {$out} "second\n";
+    close $out;
+    open(my $in, ' <', $path) or die "open ' <': $!";
+    my @lines = <$in>;
+    close $in;
+    is_deeply(\@lines, [ "first\n", "second\n" ],
+        "'>> ' appends and ' <' reads");
+}
+
+{
+    open(my $rw, '+< ', $path) or die "open '+< ': $!";
+    is(scalar(<$rw>), "first\n", "'+< ' opens for read/write");
+    close $rw;
+}
+
+{
+    open(my $out, ' > ', $path) or die "open ' > ': $!";
+    print {$out} "third\n";
+    close $out;
+    open(my $in, '<', $path) or die "open: $!";
+    is(scalar(<$in>), "third\n", "whitespace on both sides is accepted");
+    close $in;
+}
+
+# Layers still work when whitespace separates them from the mode sigil.
+{
+    open(my $out, '> :encoding(UTF-8)', $path) or die "open '> :encoding': $!";
+    print {$out} "\x{263A}\n";
+    close $out;
+
+    open(my $in, '< :encoding(UTF-8)', $path) or die "open '< :encoding': $!";
+    my $line = <$in>;
+    close $in;
+    is($line, "\x{263A}\n", 'whitespace before the layer list is accepted');
+}
+
+{
+    open(my $in, '<:encoding(UTF-8) ', $path) or die "open '<:encoding ': $!";
+    my $line = <$in>;
+    close $in;
+    is($line, "\x{263A}\n", 'trailing whitespace after the layer list is accepted');
+}
+
+# Duplication modes accept the same whitespace.
+{
+    open(my $dup, '>& ', \*STDERR) or die "dup '>& ': $!";
+    ok(defined $dup, "'>& ' duplicates a handle");
+    close $dup;
+}
+
+# The two-argument form keeps the filename intact.
+{
+    open(my $out, '>', $path) or die "open: $!";
+    print {$out} "two-arg\n";
+    close $out;
+
+    open(my $in, "< $path") or die "2-arg open: $!";
+    my $line = <$in>;
+    close $in;
+    is($line, "two-arg\n", 'two-argument open still splits mode from filename');
+}
+
+# Whitespace inside the sigil itself is not a valid mode in Perl either.
+{
+    my $ok = eval { open(my $fh, '+ <', $path); 1 };
+    ok(!$ok, "'+ <' is still rejected");
+    like($@, qr/Unknown open\(\) mode/, 'and reports an unknown mode');
+}

--- a/src/test/resources/unit/tied_handle_dup.t
+++ b/src/test/resources/unit/tied_handle_dup.t
@@ -1,0 +1,77 @@
+use strict;
+use warnings;
+no warnings 'once';    # *SAVEOUT and *SAVEOUT2 are used once, as in CPAN.pm
+use Test::More tests => 8;
+use File::Spec;
+use File::Temp qw(tempdir);
+
+# Duplicating a tied filehandle is valid Perl: open() dups the PerlIO stored in
+# the glob's IO slot and ignores the tie magic, so the duplicate is a plain
+# handle onto the same file and no tie method is called.  CPAN.pm does this
+# during initialization (`my $x = *SAVEOUT; open($x, '>&STDOUT')`), which used
+# to fail with EBADF once a test had tied STDOUT (GitHub issue #1165).
+
+package Catch;
+
+my $fileno_calls = 0;
+
+sub TIEHANDLE { bless { got => [] }, shift }
+sub PRINT     { my $self = shift; push @{ $self->{got} }, join('', @_); 1 }
+sub FILENO    { $fileno_calls++; return 42 }
+sub fileno_calls { $fileno_calls }
+
+package main;
+
+my $dir  = tempdir(CLEANUP => 1);
+my $path = File::Spec->catfile($dir, 'tied.txt');
+
+open(MYOUT, '>', $path) or die "open: $!";
+my $catcher = tie *MYOUT, 'Catch' or die "tie failed: $!";
+
+my $saved = *SAVEOUT;
+ok(open($saved, '>&MYOUT'), 'dup of a tied filehandle succeeds');
+is(Catch::fileno_calls(), 0, 'the dup does not call FILENO on the tied handle');
+ok(!defined(tied *$saved), 'the duplicate is not itself tied');
+
+print {$saved} "to-dup\n";
+print MYOUT "to-tie\n";
+
+close $saved;
+
+my $captured = [ @{ $catcher->{got} } ];
+undef $catcher;    # so untie does not warn about inner references
+untie *MYOUT;
+close MYOUT;
+
+open(my $in, '<', $path) or die "open: $!";
+my @lines = <$in>;
+close $in;
+
+is_deeply(\@lines, ["to-dup\n"], 'writes to the duplicate reach the real file');
+is_deeply($captured, ["to-tie\n"], 'writes to the tied handle reach PRINT');
+
+# A tied glob that never had a real handle has nothing to duplicate.
+{
+    package Catch2;
+    sub TIEHANDLE { bless {}, shift }
+    sub PRINT     { 1 }
+}
+tie *NEVER, 'Catch2' or die "tie failed: $!";
+{
+    local $! = 0;
+    my $result = open(my $dup, '>&NEVER');
+    ok(!$result, 'dup of a tied glob with no underlying handle fails');
+    is($!  + 0, 9, 'and sets $! to EBADF');
+}
+untie *NEVER;
+
+# The CPAN.pm pattern: STDOUT itself is tied.  Untie before reporting so the
+# TAP output is not swallowed by the tie.
+{
+    tie *STDOUT, 'Catch' or die "tie failed: $!";
+    my $out = *SAVEOUT2;
+    my $result = open($out, '>&STDOUT');
+    close $out if $result;
+    untie *STDOUT;
+    ok($result, 'dup of a tied STDOUT succeeds');
+}


### PR DESCRIPTION
Fixes #1160 and #1165 — two `open()` incompatibilities from CPAN tester run `20260827-102602-1611`.

## 1160: whitespace in the mode string

Perl skips whitespace before the mode sigil and between the sigil and the I/O layer list, so `'< '` means `'<'` and `'< :utf8'` means `'<:utf8'`. PerlOnJava aborted with `Unknown open() mode '< '`, which broke `Perl6::Slurp` and the seven `Data::FormValidator::Filters::HTML::Acid` test programs that use it.

`RuntimeIO.normalizeOpenMode()` now removes that whitespace for the 2-arg, 3-arg, in-memory, dup, and pipe forms. It deliberately does *not* rescue strings Perl also rejects: whitespace inside the sigil (`'+ <'`, `'> >'`) and a remainder that is not a layer list (`'< x'`) still fail, and the original string is reported verbatim. Two-argument opens such as `"> $file"` are untouched.

## 1165: dup of a tied filehandle

Perl duplicates the PerlIO in the glob's IO slot and ignores the tie magic: the duplicate is a plain handle onto the same descriptor, is not itself tied, and no tie method — not even `FILENO` — is called. PerlOnJava saw `TieHandle`'s null `ioHandle` and failed with `EBADF`, so `CPAN::Test::Reporter` could not load bundled `CPAN.pm`, which duplicates a tied `STDOUT` during initialization.

Dup sources now resolve through `TieHandle` to the pre-tie handle. A tied glob that never had a real handle still reports `EBADF`, matching Perl. The standard-handle fallback in `openFileHandleDup()` also accepts the package-qualified names the parser produces for the two-argument form.

## Validation

- Both issue reproducers fail on the unfixed parent (verified against the pre-fix `perlonjava-5.44.0` jar) and pass on the JVM and interpreter backends.
- New unit tests `src/test/resources/unit/open_mode_whitespace.t` (12 assertions) and `src/test/resources/unit/tied_handle_dup.t` (8 assertions) were validated against system Perl 5.42 first, including the tie semantics (`FILENO` not called, duplicate not tied, writes reaching the real file).
- `make` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
