### PR TITLE
complete Symbol::Util typeglob semantics (#1119)

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -33,8 +33,9 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
    `undef $Pkg::{name}` now detach every slot (so `*Pkg::name{ARRAY}` and friends
    read back as undef) while leaving referenced containers intact for
    re-installation, `&name` inside `defined eval { ... }` is called instead of
-   being turned into a code reference, and `require` no longer adds a phantom
-   `DATA` entry to the requiring package's stash.
+   being turned into a code reference, typeglob assignment correctly replaces
+   `@ISA`, and `require` no longer adds a phantom `DATA` entry to the requiring
+   package's stash.
 - Parse fully-qualified indirect constructors followed by method calls, and
   stage generated nested pure-Perl MakeMaker modules correctly (including
   NetAddr::IP's `-noxs` installation path).

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -29,6 +29,12 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 * Add JDBC-backed `DBD::mysql` and `DBD::Pg` compatibility shims and preserve
   SQLite URI-file schema state across DBI connections.
 
+ - Fix typeglob slot semantics exposed by `Symbol::Util`: `undef *Pkg::name` and
+   `undef $Pkg::{name}` now detach every slot (so `*Pkg::name{ARRAY}` and friends
+   read back as undef) while leaving referenced containers intact for
+   re-installation, `&name` inside `defined eval { ... }` is called instead of
+   being turned into a code reference, and `require` no longer adds a phantom
+   `DATA` entry to the requiring package's stash.
 - Parse fully-qualified indirect constructors followed by method calls, and
   stage generated nested pure-Perl MakeMaker modules correctly (including
   NetAddr::IP's `-noxs` installation path).

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -5169,17 +5169,17 @@ public class BytecodeCompiler implements Visitor {
                 if (codeRef == null) {
                     codeRef = GlobalVariable.getGlobalCodeRefForFreshLookup(subName);
                 }
-                // Plain `&name` is an invocation, not a code-reference
-                // expression (the latter is handled by `\&name` below).
-                // Retain the last visible CODE slot for this call site after
-                // a stash delete, while still observing later replacements.
+                // A plain `&name` expression is a code reference.  Snapshot
+                // its current CV; subroutine-call nodes use directNamedCall
+                // above and are the only sites that need deletion survival.
+                RuntimeScalar codeSnapshot = new RuntimeScalar();
+                codeSnapshot.type = codeRef.type;
+                codeSnapshot.value = codeRef.value;
                 int rd = allocateOutputRegister();
-                int nameIdx = addToStringPool(subName);
-                int cacheIdx = addToConstantPool(new RuntimeScalar());
-                emit(Opcodes.DIRECT_NAMED_CODE_CALL);
+                int constIdx = addToConstantPool(codeSnapshot);
+                emit(Opcodes.LOAD_CONST);
                 emitReg(rd);
-                emit(nameIdx);
-                emit(cacheIdx);
+                emit(constIdx);
 
                 lastResultReg = rd;
             } else if (node.operand instanceof StringNode strNode) {

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -5148,38 +5148,13 @@ public class BytecodeCompiler implements Visitor {
                 subName = NameNormalizer.normalizeVariableName(subName, getCurrentPackage());
 
                 if (node.getBooleanAnnotation("directNamedCall")) {
-                    // An unresolved call compiled after a stash deletion must
-                    // install a new undefined slot instead of falling through
-                    // to the old pinned CV at execution time.
-                    RuntimeScalar parseTimeCodeRef = node.getAnnotation("parseTimeCodeRef") instanceof RuntimeScalar codeRef
-                            ? codeRef
-                            : null;
-                    RuntimeScalar emissionTimeCodeRef = parseTimeCodeRef == null
-                            ? null
-                            : GlobalVariable.getGlobalCodeRefForDirectCall(subName);
-                    if (parseTimeCodeRef != null && emissionTimeCodeRef != parseTimeCodeRef) {
-                        // A BEGIN block displaced this call site's original CV
-                        // during compilation. Snapshot the original CV just as
-                        // an ordinary compiled code reference does.
-                        RuntimeScalar codeSnapshot = new RuntimeScalar();
-                        codeSnapshot.type = parseTimeCodeRef.type;
-                        codeSnapshot.value = parseTimeCodeRef.value;
-                        int rd = allocateOutputRegister();
-                        int constIdx = addToConstantPool(codeSnapshot);
-                        emit(Opcodes.LOAD_CONST);
-                        emitReg(rd);
-                        emit(constIdx);
-                        lastResultReg = rd;
-                        return;
-                    }
-                    if (parseTimeCodeRef == null) {
-                        GlobalVariable.getGlobalCodeRefForFreshLookup(subName);
-                    }
                     int rd = allocateOutputRegister();
                     int nameIdx = addToStringPool(subName);
-                    emit(Opcodes.LOAD_GLOBAL_CODE);
+                    int cacheIdx = addToConstantPool(new RuntimeScalar());
+                    emit(Opcodes.DIRECT_NAMED_CODE_CALL);
                     emitReg(rd);
                     emit(nameIdx);
+                    emit(cacheIdx);
                     lastResultReg = rd;
                     return;
                 }
@@ -5194,21 +5169,17 @@ public class BytecodeCompiler implements Visitor {
                 if (codeRef == null) {
                     codeRef = GlobalVariable.getGlobalCodeRefForFreshLookup(subName);
                 }
-                // A compiled reference captures the current CV, not the mutable
-                // stash slot that points at it.  namespace::clean can remove the
-                // glob later while existing \&name references remain callable.
-                RuntimeScalar codeSnapshot = new RuntimeScalar();
-                codeSnapshot.type = codeRef.type;
-                codeSnapshot.value = codeRef.value;
-                codeRef = codeSnapshot;
-
-                // Allocate register and load from constant pool
+                // Plain `&name` is an invocation, not a code-reference
+                // expression (the latter is handled by `\&name` below).
+                // Retain the last visible CODE slot for this call site after
+                // a stash delete, while still observing later replacements.
                 int rd = allocateOutputRegister();
-                int constIdx = addToConstantPool(codeRef);
-
-                emit(Opcodes.LOAD_CONST);
+                int nameIdx = addToStringPool(subName);
+                int cacheIdx = addToConstantPool(new RuntimeScalar());
+                emit(Opcodes.DIRECT_NAMED_CODE_CALL);
                 emitReg(rd);
-                emit(constIdx);
+                emit(nameIdx);
+                emit(cacheIdx);
 
                 lastResultReg = rd;
             } else if (node.operand instanceof StringNode strNode) {

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -839,6 +839,13 @@ public class BytecodeInterpreter {
                                 pc = InlineOpcodeHandler.executeUndefineScalar(bytecode, pc, registers);
                             }
 
+                            case Opcodes.UNDEFINE_SCALAR_LVALUE -> {
+                                // `undef EXPR` on a scalar lvalue. A stash entry is a
+                                // typeglob, so undefining it empties the whole glob.
+                                int rd = bytecode[pc++];
+                                RuntimeGlob.undefineScalarLvalue(registers[rd]);
+                            }
+
                             case Opcodes.MY_SCALAR -> {
                                 // Lexical scalar assignment: rd = new RuntimeScalar(); rd.set(rs)
                                 int rd = bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -2523,7 +2523,7 @@ public class BytecodeInterpreter {
                                  Opcodes.ALARM_OP, Opcodes.DEREF_GLOB, Opcodes.DEREF_GLOB_NONSTRICT,
                                  Opcodes.LOAD_GLOB_DYNAMIC, Opcodes.DEREF_SCALAR_STRICT,
                                  Opcodes.DEREF_SCALAR_NONSTRICT, Opcodes.CODE_DEREF_NONSTRICT,
-                                 Opcodes.NAMED_CODE_REFERENCE -> {
+                                 Opcodes.NAMED_CODE_REFERENCE, Opcodes.DIRECT_NAMED_CODE_CALL -> {
                                 pc = executeSpecialIO(opcode, bytecode, pc, registers, code);
                             }
 
@@ -3978,6 +3978,9 @@ public class BytecodeInterpreter {
             }
             case Opcodes.NAMED_CODE_REFERENCE -> {
                 return SlowOpcodeHandler.executeNamedCodeReference(bytecode, pc, registers, code);
+            }
+            case Opcodes.DIRECT_NAMED_CODE_CALL -> {
+                return SlowOpcodeHandler.executeDirectNamedCodeCall(bytecode, pc, registers, code);
             }
             default -> throw new RuntimeException("Unknown special I/O opcode: " + opcode);
         }

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -1505,12 +1505,10 @@ public class CompileOperator {
                     } else if (isScalarUndefTarget(undefTarget)) {
                         compileScalarUndefTarget(bytecodeCompiler, undefTarget);
                         int operandReg = bytecodeCompiler.lastResultReg;
-                        int valueReg = bytecodeCompiler.allocateRegister();
-                        bytecodeCompiler.emit(Opcodes.LOAD_UNDEF);
-                        bytecodeCompiler.emitReg(valueReg);
-                        bytecodeCompiler.emit(Opcodes.SET_SCALAR);
+                        // A stash entry is a typeglob: `undef $Pkg::{name}` empties
+                        // the whole glob rather than storing undef into it.
+                        bytecodeCompiler.emit(Opcodes.UNDEFINE_SCALAR_LVALUE);
                         bytecodeCompiler.emitReg(operandReg);
-                        bytecodeCompiler.emitReg(valueReg);
                     } else {
                         // Container/code-slot targets keep the explicit undefine
                         // path: undef @array, undef %hash, undef *glob, undef &sub.

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -2644,6 +2644,10 @@ public class Disassemble {
                         rd = interpretedCode.bytecode[pc++];
                         sb.append("UNDEFINE_SCALAR r").append(rd).append("\n");
                         break;
+                    case Opcodes.UNDEFINE_SCALAR_LVALUE:
+                        rd = interpretedCode.bytecode[pc++];
+                        sb.append("UNDEFINE_SCALAR_LVALUE r").append(rd).append("\n");
+                        break;
                     case Opcodes.SAVE_REGEX_STATE: {
                         // Format: SAVE_REGEX_STATE dummy
                         int srsDummy = interpretedCode.bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -1895,6 +1895,14 @@ public class Disassemble {
                         sb.append("UNDEFINE_GLOBAL_CODE &")
                                 .append(interpretedCode.stringPool[undefCodeNameIdx]).append("\n");
                         break;
+                    case Opcodes.DIRECT_NAMED_CODE_CALL:
+                        int directCallRd = interpretedCode.bytecode[pc++];
+                        int directCallNameIdx = interpretedCode.bytecode[pc++];
+                        int directCallCacheIdx = interpretedCode.bytecode[pc++];
+                        sb.append("DIRECT_NAMED_CODE_CALL r").append(directCallRd)
+                                .append(" = &").append(interpretedCode.stringPool[directCallNameIdx])
+                                .append(" cache=").append(directCallCacheIdx).append("\n");
+                        break;
                     case Opcodes.PUSH_LABELED_BLOCK: {
                         int labelIdx = interpretedCode.bytecode[pc++];
                         int exitPc = interpretedCode.bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -2523,6 +2523,14 @@ public class Opcodes {
      */
     public static final short JOIN_INTERPOLATION = 533;
 
+    /**
+     * Apply the `undef EXPR` operator to an already evaluated scalar lvalue.
+     * A stash entry is a typeglob, so `undef $Pkg::{name}` empties the glob;
+     * any other target is assigned undef.
+     * Format: UNDEFINE_SCALAR_LVALUE targetReg.
+     */
+    public static final short UNDEFINE_SCALAR_LVALUE = 534;
+
     /** Return the mutable {@code $#array} cell. Format: ARRAY_LAST_INDEX_LVALUE rd arrayReg. */
     public static final short ARRAY_LAST_INDEX_LVALUE = 518;
 

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -2531,6 +2531,9 @@ public class Opcodes {
      */
     public static final short UNDEFINE_SCALAR_LVALUE = 534;
 
+    /** Resolve a direct named call with a call-site CV cache. Format: rd nameStringIdx cacheConstIdx. */
+    public static final short DIRECT_NAMED_CODE_CALL = 535;
+
     /** Return the mutable {@code $#array} cell. Format: ARRAY_LAST_INDEX_LVALUE rd arrayReg. */
     public static final short ARRAY_LAST_INDEX_LVALUE = 518;
 

--- a/src/main/java/org/perlonjava/backend/bytecode/SlowOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/SlowOpcodeHandler.java
@@ -1466,6 +1466,18 @@ public class SlowOpcodeHandler {
         return pc;
     }
 
+    /** Resolve a direct named call, preserving its last visible CV after stash deletion. */
+    public static int executeDirectNamedCodeCall(int[] bytecode, int pc,
+                                                  RuntimeBase[] registers, InterpretedCode code) {
+        int rd = bytecode[pc++];
+        int nameIdx = bytecode[pc++];
+        int cacheIdx = bytecode[pc++];
+        RuntimeScalar cached = (RuntimeScalar) code.constants[cacheIdx];
+        registers[rd] = GlobalVariable.getGlobalCodeRefForDirectCall(
+                code.stringPool[nameIdx], cached);
+        return pc;
+    }
+
     /**
      * Dispatch MODIFY_*_ATTRIBUTES at runtime for my/state variable declarations.
      * Format: DISPATCH_VAR_ATTRS var_reg const_idx

--- a/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
@@ -1339,13 +1339,14 @@ public class EmitOperator {
             context = RuntimeContextType.LVALUE;
         }
         operand.accept(emitterVisitor.with(context));
-        emitUndef(mv);
-        mv.visitInsn(Opcodes.SWAP);
+        // A stash entry is a typeglob, so `undef $Pkg::{name}` must empty the
+        // whole glob instead of storing undef into it.  Everything else keeps
+        // the plain scalar assignment.
         mv.visitMethodInsn(
-                Opcodes.INVOKEVIRTUAL,
-                "org/perlonjava/runtime/runtimetypes/RuntimeBase",
-                "addToScalar",
-                "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;",
+                Opcodes.INVOKESTATIC,
+                "org/perlonjava/runtime/runtimetypes/RuntimeGlob",
+                "undefineScalarLvalue",
+                "(Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;",
                 false);
     }
 

--- a/src/main/java/org/perlonjava/frontend/parser/DataSection.java
+++ b/src/main/java/org/perlonjava/frontend/parser/DataSection.java
@@ -48,7 +48,18 @@ public class DataSection {
      * @param parser the parser instance
      */
     public static void createPlaceholderDataHandle(Parser parser) {
-        String handleName = parser.ctx.symbolTable.getCurrentPackage() + "::DATA";
+        // Perl only gives a package a DATA filehandle when the source actually
+        // has a __DATA__ section (or a top-level __END__), and the handle belongs
+        // to the package that encloses the marker.  Creating the placeholder
+        // unconditionally in the current package added a phantom `DATA` symbol to
+        // whatever package happened to be current when a required file started
+        // compiling, which showed up in `keys %Pkg::` (Symbol::Util t/10use.t).
+        String dataPackage = dataSectionPackage(parser);
+        if (dataPackage == null) {
+            return;
+        }
+
+        String handleName = dataPackage + "::DATA";
 
         if (state().placeholderCreated.contains(handleName)) {
             return; // Already created placeholder for this package
@@ -74,6 +85,81 @@ public class DataSection {
         RuntimeScalar emptyContent = new RuntimeScalar("");
         var fileHandle = RuntimeIO.open(emptyContent.createReference(), "<");
         GlobalVariable.getGlobalIO(handleName).setIO(fileHandle);
+    }
+
+    /**
+     * Returns the package that will own this compilation unit's DATA filehandle,
+     * or {@code null} when the unit has no DATA section at all.
+     * <p>
+     * The package is the one declared by the last {@code package NAME;} statement
+     * before the marker, which is what {@link #dataHandleName} computes once
+     * parsing actually reaches it. A {@code __END__} marker only produces a handle
+     * for a top-level script, and then always {@code main::DATA}.
+     *
+     * @param parser the parser instance
+     * @return the owning package name, or null when there is no DATA section
+     */
+    private static String dataSectionPackage(Parser parser) {
+        String pending = parser.ctx.symbolTable.getCurrentPackage();
+        List<LexerToken> tokens = parser.tokens;
+        for (int i = 0; i < tokens.size(); i++) {
+            LexerToken token = tokens.get(i);
+            if (token.type != LexerTokenType.IDENTIFIER) {
+                continue;
+            }
+            switch (token.text) {
+                case "__DATA__" -> {
+                    return pending;
+                }
+                case "__END__" -> {
+                    // A non-top-level __END__ stops parsing but does not populate
+                    // a DATA handle - see parseDataSection().
+                    return parser.isTopLevelScript ? "main" : null;
+                }
+                case "package" -> {
+                    String name = readPackageName(tokens, i + 1);
+                    if (name != null) {
+                        pending = name;
+                    }
+                }
+                default -> {
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Reads a possibly qualified package name starting at {@code index}.
+     *
+     * @param tokens the token list
+     * @param index  index just past the {@code package} keyword
+     * @return the package name, or null when no name follows
+     */
+    private static String readPackageName(List<LexerToken> tokens, int index) {
+        StringBuilder name = new StringBuilder();
+        boolean expectIdentifier = true;
+        for (int i = index; i < tokens.size(); i++) {
+            LexerToken token = tokens.get(i);
+            if (token.type == LexerTokenType.WHITESPACE || token.type == LexerTokenType.NEWLINE) {
+                if (name.isEmpty()) {
+                    continue;
+                }
+                break;
+            }
+            if (expectIdentifier && token.type == LexerTokenType.IDENTIFIER) {
+                name.append(token.text);
+                expectIdentifier = false;
+            } else if (!expectIdentifier
+                    && token.type == LexerTokenType.OPERATOR
+                    && token.text.equals("::")) {
+                name.append("::");
+                expectIdentifier = true;
+            } else {
+                break;
+            }
+        }
+        return expectIdentifier ? null : name.toString();
     }
 
     /**

--- a/src/main/java/org/perlonjava/frontend/parser/ParseBlock.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseBlock.java
@@ -52,6 +52,23 @@ public class ParseBlock {
      * @see StatementParser#parseOptionalPackageBlock for usage with class blocks
      */
     public static BlockWithScope parseBlock(Parser parser, boolean exitScope) {
+        // Perl's "take reference" mode (`\&name`, `defined &name`, `undef &name`)
+        // only suppresses the call for the symbol that immediately follows the
+        // operator.  A brace-delimited block is an independent evaluation
+        // context, so `&name` inside `defined eval { &name }` must still be a
+        // call.  Without this reset the flag leaked into the block and turned
+        // the call into a code reference, which made `eval { &missing }`
+        // succeed instead of dying (Symbol::Util t/70export_glob.t).
+        boolean savedParsingTakeReference = parser.parsingTakeReference;
+        parser.parsingTakeReference = false;
+        try {
+            return parseBlockBody(parser, exitScope);
+        } finally {
+            parser.parsingTakeReference = savedParsingTakeReference;
+        }
+    }
+
+    private static BlockWithScope parseBlockBody(Parser parser, boolean exitScope) {
         // Store the starting position of the block for backtracking
         int currentIndex = parser.tokenIndex;
 

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -661,8 +661,19 @@ public class SubroutineParser {
 
             // Rewrite and return the subroutine call as `&name(arguments)`
             OperatorNode codeRefNode = new OperatorNode("&", nameNode, currentIndex);
-            codeRefNode.setAnnotation("directNamedCall", true);
-            if (!isMethod && parseTimeCodeRef == null) {
+            // A core keyword without a visible Perl override is not a named
+            // subroutine call.  In particular, routing `chop <DATA>` through
+            // the direct-CV path materializes main::chop and turns DATA into
+            // an unopened indirect handle.  Keep the ordinary core-operator
+            // path unless a real subroutine shadows the keyword.
+            boolean unshadowedCoreBuiltin = !isMethod
+                    && CORE_PROTOTYPES.containsKey(subName)
+                    && parseTimeCodeRef == null
+                    && !GlobalVariable.isSubs.containsKey(fullName);
+            if (!unshadowedCoreBuiltin) {
+                codeRefNode.setAnnotation("directNamedCall", true);
+            }
+            if (!isMethod && parseTimeCodeRef == null && !unshadowedCoreBuiltin) {
                 // Perl allocates and pins the call site's GV while parsing an
                 // unresolved direct call. A later BEGIN-time typeglob alias
                 // fills that same placeholder, so deleting the visible stash

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -865,7 +865,18 @@ public class SubroutineParser {
 
         // Check if the next token is an opening parenthesis '(' indicating a prototype.
         if (peek(parser).text.equals("(")) {
-            if (parser.ctx.symbolTable.isFeatureCategoryEnabled("signatures")) {
+            // A required file may execute a BEGIN-time callback while this
+            // compilation unit is still being parsed.  Those callbacks use a
+            // transient symbol-table snapshot; its feature bits can be copied
+            // back into the active parser scope even though the feature was
+            // never enabled in this file.  In particular, that made ordinary
+            // prototypes in a later do FILE load look like signatures after
+            // test.pl's watchdog setup.  The Feature manager records actual
+            // lexical imports, so require both sources of evidence here.
+            boolean signaturesEnabled = parser.ctx.symbolTable.isFeatureCategoryEnabled("signatures")
+                    && org.perlonjava.runtime.perlmodule.Feature.getFeatureManager()
+                    .getEnabledFeatures().contains("signatures");
+            if (signaturesEnabled) {
                 if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("Signatures feature enabled");
                 // Enter a scope for signature parameter variables so the parse-time
                 // strict vars check can find them.  SignatureParser.parseParameter()

--- a/src/main/java/org/perlonjava/runtime/operators/Readline.java
+++ b/src/main/java/org/perlonjava/runtime/operators/Readline.java
@@ -32,7 +32,16 @@ public class Readline {
                 }
             }
 
-            // Perl warns and returns undef for unopened filehandle, doesn't die
+            // DATA exists as a special handle even in a source file that has no
+            // __DATA__ section.  Perl returns undef silently in that case;
+            // treating it as an ordinary unopened handle emits a spurious
+            // warning for expressions such as `chop($line .= <DATA>)`.
+            if ("DATA".equals(RuntimeIO.getLastReadlineHandleName())) {
+                return ctx == RuntimeContextType.LIST ? new RuntimeList() : scalarUndef;
+            }
+
+            // Perl warns and returns undef for ordinary unopened filehandles,
+            // rather than dying.
             WarnDie.warn(new RuntimeScalar("readline() on unopened filehandle"), new RuntimeScalar("\n"));
             return ctx == RuntimeContextType.LIST ? new RuntimeList() : scalarUndef;
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalVariable.java
@@ -1807,6 +1807,30 @@ public class GlobalVariable {
     }
 
     /**
+     * Resolve an interpreter direct-call site.  A visible replacement always
+     * wins; after the stash entry is deleted, retain the most recently visible
+     * CV for this already-compiled call site.
+     */
+    public static RuntimeScalar getGlobalCodeRefForDirectCall(String key, RuntimeScalar cached) {
+        String resolvedKey = resolveAliasedFqn(key);
+        RuntimeScalar current = globalCodeRefs.get(resolvedKey);
+        if (current == null && !resolvedKey.equals(key)) {
+            current = globalCodeRefs.get(key);
+        }
+        if (current != null) {
+            cached.type = current.type;
+            cached.value = current.value;
+            return cached;
+        }
+        if (cached.type == RuntimeScalarType.CODE
+                && cached.value instanceof RuntimeCode code
+                && code.defined()) {
+            return cached;
+        }
+        return getGlobalCodeRefForDirectCall(key);
+    }
+
+    /**
      * Undefines the CODE slot currently visible through a package stash.
      * Unlike compiled direct-call lookup, this operation must not fall back to
      * an old pinned CV or create a slot after the stash entry was deleted.

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
@@ -900,9 +900,11 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         // `@Fooo::ISA = (...)` visible through Baro even when neither side
         // had an ARRAY slot at alias time.  Ordinary absent ARRAY slots stay
         // unmaterialized so `defined *glob{ARRAY}` retains its Perl meaning.
-        if (GlobalVariable.existsGlobalArray(globName) || globName.endsWith("::ISA")) {
+        if (GlobalVariable.existsGlobalArray(globName)
+                || this.globName.endsWith("::ISA")
+                || globName.endsWith("::ISA")) {
             RuntimeArray sourceArray;
-            if (globName.endsWith("::ISA")) {
+            if (this.globName.endsWith("::ISA") || globName.endsWith("::ISA")) {
                 // Read the source slot directly.  Alias-group lookup here can
                 // see Target's old @ISA after `*Target::ISA = *Empty` and
                 // incorrectly retain its inherited classes.

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
@@ -1531,31 +1531,69 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         // DESTROY immediately. A typeglob scalar slot can also directly alias
         // a read-only constant (for example after `*a = "a"`); that referent
         // cannot and need not be cleared.
+        // A scalar that Perl code has taken a reference to must keep its value:
+        // the referent outlives the typeglob, so re-installing the saved
+        // reference restores the original value (Symbol::Util::delete_glob).
         RuntimeScalar oldScalar = GlobalVariable.globalVariables.get(this.globName);
-        if (oldScalar != null && !(oldScalar instanceof RuntimeScalarReadOnly)) {
+        if (oldScalar != null && !(oldScalar instanceof RuntimeScalarReadOnly)
+                && !oldScalar.referencedByScalarReference) {
             oldScalar.undefine();
         }
         // Replace the slot in either case. Undefining the glob severs aliases;
         // it must not leave a read-only constant installed as the glob's SV.
         GlobalVariable.aliasGlobalVariable(this.globName, new RuntimeScalar());
 
-        // Undefine ARRAY - clear the existing array (fires DESTROY on blessed
-        // elements via MortalList) before replacing with an empty one. Just
-        // putting a new empty array would orphan the old contents without
-        // running their destructors, breaking `undef *Pkg::arr` for arrays
-        // holding blessed values.
-        RuntimeArray oldArray = GlobalVariable.globalArrays.get(this.globName);
-        if (oldArray != null) oldArray.undefine();
-        GlobalVariable.globalArrays.put(this.globName, GlobalVariable.markPackageGlobalRoot(new RuntimeArray()));
+        // Undefine ARRAY - Perl detaches the AV from the typeglob, so
+        // `defined *Pkg::name{ARRAY}` becomes false afterwards.  The container
+        // itself only dies when nothing else refers to it; when a Perl-level
+        // reference was taken (\@Pkg::name) the body must survive so that
+        // re-installing it through `*Pkg::name = $ref` restores the contents
+        // (Symbol::Util::delete_glob backs slots up exactly this way).
+        // With no outstanding reference, clear the old array first so blessed
+        // elements still run DESTROY via MortalList.
+        RuntimeArray oldArray = GlobalVariable.globalArrays.remove(this.globName);
+        if (oldArray != null && oldArray.refCount == -1) oldArray.undefine();
         GlobalVariable.invalidatePackageRootSnapshot();
 
         // Undefine HASH - same reasoning as ARRAY above.
-        RuntimeHash oldHash = GlobalVariable.globalHashes.get(this.globName);
-        if (oldHash != null) oldHash.undefine();
-        GlobalVariable.globalHashes.put(this.globName, GlobalVariable.markPackageGlobalRoot(new RuntimeHash()));
+        RuntimeHash oldHash = GlobalVariable.globalHashes.remove(this.globName);
+        if (oldHash != null && oldHash.refCount == -1) oldHash.undefine();
         GlobalVariable.invalidatePackageRootSnapshot();
 
+        // Undefine IO - detach the handle from the symbol without closing it,
+        // so a saved *Pkg::name{IO} reference can be re-installed later.
+        RuntimeGlob ioGlob = GlobalVariable.getExistingGlobalIO(this.globName);
+        if (ioGlob != null) {
+            ioGlob.IO = new RuntimeScalar();
+            GlobalVariable.hideIORefAfterStashDelete(this.globName);
+        }
+        if (ioGlob != this) {
+            this.IO = new RuntimeScalar();
+        }
+        GlobalVariable.invalidateStashEnumerationCache();
+
         return this;
+    }
+
+    /**
+     * Runtime helper for the {@code undef EXPR} operator when EXPR is a scalar
+     * lvalue.  A stash entry ({@code undef $Pkg::{name}}) is a typeglob, and
+     * Perl empties the whole glob in that case; every other scalar target is
+     * simply assigned {@code undef}.
+     *
+     * <p>Note that this is deliberately different from the assignment
+     * {@code $Pkg::{name} = undef}, which Perl treats as an undefined value
+     * assigned to a typeglob (a warning and no slot change).
+     *
+     * @param target The evaluated lvalue.
+     * @return The undefined value.
+     */
+    public static RuntimeScalar undefineScalarLvalue(RuntimeBase target) {
+        if (target instanceof RuntimeGlob glob && glob.globName != null) {
+            glob.undefine();
+            return new RuntimeScalar();
+        }
+        return new RuntimeScalar().addToScalar((RuntimeScalar) target);
     }
 
     @Override

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
@@ -901,7 +901,20 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         // had an ARRAY slot at alias time.  Ordinary absent ARRAY slots stay
         // unmaterialized so `defined *glob{ARRAY}` retains its Perl meaning.
         if (GlobalVariable.existsGlobalArray(globName) || globName.endsWith("::ISA")) {
-            RuntimeArray sourceArray = GlobalVariable.getGlobalArray(globName);
+            RuntimeArray sourceArray;
+            if (globName.endsWith("::ISA")) {
+                // Read the source slot directly.  Alias-group lookup here can
+                // see Target's old @ISA after `*Target::ISA = *Empty` and
+                // incorrectly retain its inherited classes.
+                sourceArray = GlobalVariable.globalArrays.get(globName);
+                if (sourceArray == null) {
+                    sourceArray = GlobalVariable.markPackageGlobalRoot(new RuntimeArray());
+                    sourceArray.markIsaArray();
+                    GlobalVariable.globalArrays.put(globName, sourceArray);
+                }
+            } else {
+                sourceArray = GlobalVariable.getGlobalArray(globName);
+            }
             GlobalVariable.markPackageGlobalRoot(sourceArray);
             GlobalVariable.globalArrays.put(this.globName, sourceArray);
             GlobalVariable.invalidatePackageRootSnapshot();
@@ -1553,6 +1566,15 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
         // elements still run DESTROY via MortalList.
         RuntimeArray oldArray = GlobalVariable.globalArrays.remove(this.globName);
         if (oldArray != null && oldArray.refCount == -1) oldArray.undefine();
+        // Keep an empty @ISA slot after undefining a glob.  A later
+        // `*Class::ISA = *Empty` must alias that empty source rather than
+        // rediscovering Class's former inheritance array through the alias
+        // group.
+        if (this.globName.endsWith("::ISA")) {
+            RuntimeArray emptyIsa = GlobalVariable.markPackageGlobalRoot(new RuntimeArray());
+            emptyIsa.markIsaArray();
+            GlobalVariable.globalArrays.put(this.globName, emptyIsa);
+        }
         GlobalVariable.invalidatePackageRootSnapshot();
 
         // Undefine HASH - same reasoning as ARRAY above.

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStashEntry.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeStashEntry.java
@@ -466,23 +466,11 @@ public class RuntimeStashEntry extends RuntimeGlob {
     public RuntimeStashEntry undefine() {
         GlobalVariable.clearGlobalPseudoConstant(this.globName);
 
-        // Undefine CODE
-        GlobalVariable.getGlobalCodeRef(this.globName).set(new RuntimeScalar());
-
-        // Undefine FORMAT
-        GlobalVariable.getGlobalFormatRef(this.globName).undefineFormat();
-
-        // Undefine SCALAR
-        GlobalVariable.getGlobalVariable(this.globName).set(new RuntimeScalar());
-
-        // Undefine ARRAY - create empty array
-        GlobalVariable.globalArrays.put(this.globName, new RuntimeArray());
-
-        // Undefine HASH - create empty hash
-        GlobalVariable.globalHashes.put(this.globName, new RuntimeHash());
-
-        // Invalidate the method resolution cache
-        InheritanceResolver.invalidateCache();
+        // `undef $Pkg::{name}` is the same operation as `undef *Pkg::name`:
+        // every slot is detached from the symbol, so `*Pkg::name{ARRAY}` and
+        // friends report undef afterwards while containers that still have a
+        // Perl-level reference survive for later re-installation.
+        super.undefine();
 
         type = RuntimeScalarType.UNDEF;
 

--- a/src/main/perl/lib/File/Spec/Win32.pm
+++ b/src/main/perl/lib/File/Spec/Win32.pm
@@ -15,6 +15,15 @@ my $DRIVE_RX = '[a-zA-Z]:';
 my $UNC_RX = '(?:\\\\\\\\|//)[^\\\\/]+[\\\\/][^\\\\/]+';
 my $VOL_RX = "(?:$DRIVE_RX|$UNC_RX)";
 
+# The Java-backed File::Spec::Unix methods retain taint explicitly.  Win32
+# overrides several of them in Perl, where the intermediate regex and string
+# operations can otherwise lose a caller's taint metadata.  Preserve it at the
+# public method boundary, matching native Perl's path operations.
+sub _taint_result {
+    my ($result, @sources) = @_;
+    return Internals::taint_propagate($result, @sources);
+}
+
 
 =head1 NAME
 
@@ -133,42 +142,46 @@ complete path ending with a filename
 
 sub catfile {
     shift;
+    my @sources = @_;
 
     # Legacy / compatibility support
     #
-    shift, return _canon_cat( "/", @_ )
+    shift, return _taint_result(_canon_cat( "/", @_ ), @sources)
 	if !@_ || $_[0] eq "";
 
     # Compatibility with File::Spec <= 3.26:
     #     catfile('A:', 'foo') should return 'A:\foo'.
-    return _canon_cat( ($_[0].'\\'), @_[1..$#_] )
+    return _taint_result(_canon_cat( ($_[0].'\\'), @_[1..$#_] ), @sources)
         if $_[0] =~ m{^$DRIVE_RX\z}o;
 
-    return _canon_cat( @_ );
+    return _taint_result(_canon_cat( @_ ), @sources);
 }
 
 sub catdir {
     shift;
+    my @sources = @_;
 
     # Legacy / compatibility support
     #
-    return ""
+    return _taint_result("")
     	unless @_;
-    shift, return _canon_cat( "/", @_ )
+    shift, return _taint_result(_canon_cat( "/", @_ ), @sources)
 	if $_[0] eq "";
 
     # Compatibility with File::Spec <= 3.26:
     #     catdir('A:', 'foo') should return 'A:\foo'.
-    return _canon_cat( ($_[0].'\\'), @_[1..$#_] )
+    return _taint_result(_canon_cat( ($_[0].'\\'), @_[1..$#_] ), @sources)
         if $_[0] =~ m{^$DRIVE_RX\z}o;
 
-    return _canon_cat( @_ );
+    return _taint_result(_canon_cat( @_ ), @sources);
 }
 
 sub path {
-    my @path = split(';', $ENV{PATH});
+    my $env_path = $ENV{PATH};
+    my @path = split(';', $env_path);
     s/"//g for @path;
     @path = grep length, @path;
+    @path = map { _taint_result($_, $env_path) } @path;
     unshift(@path, ".");
     return @path;
 }
@@ -187,8 +200,8 @@ On Win32 makes
 sub canonpath {
     # Legacy / compatibility support
     #
-    return $_[1] if !defined($_[1]) or $_[1] eq '';
-    return _canon_cat( $_[1] );
+    return _taint_result($_[1], $_[1]) if !defined($_[1]) or $_[1] eq '';
+    return _taint_result(_canon_cat( $_[1] ), $_[1]);
 }
 
 =item splitpath
@@ -218,7 +231,9 @@ sub splitpath {
         $path =~ 
             m{^ ( $VOL_RX ? ) (.*) }sox;
         $volume    = $1;
-        $directory = $2;
+        # Unlike the capture-derived fields, the no-file directory is the
+        # caller's path itself and must retain its taint.
+        $directory = _taint_result($2, $path);
     }
     else {
         $path =~ 
@@ -232,6 +247,12 @@ sub splitpath {
     }
 
     return ($volume,$directory,$file);
+}
+
+sub join {
+    shift;
+    my @sources = @_;
+    return _taint_result(_canon_cat(@_), @sources);
 }
 
 
@@ -289,6 +310,7 @@ the $volume become significant.
 
 sub catpath {
     my ($self,$volume,$directory,$file) = @_;
+    my @sources = ($volume, $directory, $file);
 
     # If it's UNC, make sure the glue separator is there, reusing
     # whatever separator is first in the $volume
@@ -313,7 +335,7 @@ sub catpath {
 
     $volume .= $file ;
 
-    return $volume ;
+    return _taint_result($volume, @sources);
 }
 
 sub _same {
@@ -326,12 +348,12 @@ sub rel2abs {
     my $is_abs = $self->file_name_is_absolute($path);
 
     # Check for volume (should probably document the '2' thing...)
-    return $self->canonpath( $path ) if $is_abs == 2;
+    return _taint_result($self->canonpath( $path ), $path, $base) if $is_abs == 2;
 
     if ($is_abs) {
       # It's missing a volume, add one
       my $vol = ($self->splitpath( Cwd::getcwd() ))[0];
-      return $self->canonpath( $vol . $path );
+      return _taint_result($self->canonpath( $vol . $path ), $path, $vol);
     }
 
     if ( !defined( $base ) || $base eq '' ) {
@@ -357,7 +379,13 @@ sub rel2abs {
 			   $path_file
 			  ) ;
 
-    return $self->canonpath( $path ) ;
+    return _taint_result($self->canonpath( $path ), $path, $base);
+}
+
+sub abs2rel {
+    my ($self, $path, $base) = @_;
+    my $result = File::Spec::Unix::abs2rel(@_);
+    return _taint_result($result, $path, $base);
 }
 
 =back

--- a/src/main/perl/lib/File/Spec/Win32.pm
+++ b/src/main/perl/lib/File/Spec/Win32.pm
@@ -15,15 +15,6 @@ my $DRIVE_RX = '[a-zA-Z]:';
 my $UNC_RX = '(?:\\\\\\\\|//)[^\\\\/]+[\\\\/][^\\\\/]+';
 my $VOL_RX = "(?:$DRIVE_RX|$UNC_RX)";
 
-# The Java-backed File::Spec::Unix methods retain taint explicitly.  Win32
-# overrides several of them in Perl, where the intermediate regex and string
-# operations can otherwise lose a caller's taint metadata.  Preserve it at the
-# public method boundary, matching native Perl's path operations.
-sub _taint_result {
-    my ($result, @sources) = @_;
-    return Internals::taint_propagate($result, @sources);
-}
-
 
 =head1 NAME
 
@@ -142,46 +133,42 @@ complete path ending with a filename
 
 sub catfile {
     shift;
-    my @sources = @_;
 
     # Legacy / compatibility support
     #
-    shift, return _taint_result(_canon_cat( "/", @_ ), @sources)
+    shift, return _canon_cat( "/", @_ )
 	if !@_ || $_[0] eq "";
 
     # Compatibility with File::Spec <= 3.26:
     #     catfile('A:', 'foo') should return 'A:\foo'.
-    return _taint_result(_canon_cat( ($_[0].'\\'), @_[1..$#_] ), @sources)
+    return _canon_cat( ($_[0].'\\'), @_[1..$#_] )
         if $_[0] =~ m{^$DRIVE_RX\z}o;
 
-    return _taint_result(_canon_cat( @_ ), @sources);
+    return _canon_cat( @_ );
 }
 
 sub catdir {
     shift;
-    my @sources = @_;
 
     # Legacy / compatibility support
     #
-    return _taint_result("")
+    return ""
     	unless @_;
-    shift, return _taint_result(_canon_cat( "/", @_ ), @sources)
+    shift, return _canon_cat( "/", @_ )
 	if $_[0] eq "";
 
     # Compatibility with File::Spec <= 3.26:
     #     catdir('A:', 'foo') should return 'A:\foo'.
-    return _taint_result(_canon_cat( ($_[0].'\\'), @_[1..$#_] ), @sources)
+    return _canon_cat( ($_[0].'\\'), @_[1..$#_] )
         if $_[0] =~ m{^$DRIVE_RX\z}o;
 
-    return _taint_result(_canon_cat( @_ ), @sources);
+    return _canon_cat( @_ );
 }
 
 sub path {
-    my $env_path = $ENV{PATH};
-    my @path = split(';', $env_path);
+    my @path = split(';', $ENV{PATH});
     s/"//g for @path;
     @path = grep length, @path;
-    @path = map { _taint_result($_, $env_path) } @path;
     unshift(@path, ".");
     return @path;
 }
@@ -200,8 +187,8 @@ On Win32 makes
 sub canonpath {
     # Legacy / compatibility support
     #
-    return _taint_result($_[1], $_[1]) if !defined($_[1]) or $_[1] eq '';
-    return _taint_result(_canon_cat( $_[1] ), $_[1]);
+    return $_[1] if !defined($_[1]) or $_[1] eq '';
+    return _canon_cat( $_[1] );
 }
 
 =item splitpath
@@ -231,9 +218,7 @@ sub splitpath {
         $path =~ 
             m{^ ( $VOL_RX ? ) (.*) }sox;
         $volume    = $1;
-        # Unlike the capture-derived fields, the no-file directory is the
-        # caller's path itself and must retain its taint.
-        $directory = _taint_result($2, $path);
+        $directory = $2;
     }
     else {
         $path =~ 
@@ -247,12 +232,6 @@ sub splitpath {
     }
 
     return ($volume,$directory,$file);
-}
-
-sub join {
-    shift;
-    my @sources = @_;
-    return _taint_result(_canon_cat(@_), @sources);
 }
 
 
@@ -310,7 +289,6 @@ the $volume become significant.
 
 sub catpath {
     my ($self,$volume,$directory,$file) = @_;
-    my @sources = ($volume, $directory, $file);
 
     # If it's UNC, make sure the glue separator is there, reusing
     # whatever separator is first in the $volume
@@ -335,7 +313,7 @@ sub catpath {
 
     $volume .= $file ;
 
-    return _taint_result($volume, @sources);
+    return $volume ;
 }
 
 sub _same {
@@ -348,12 +326,12 @@ sub rel2abs {
     my $is_abs = $self->file_name_is_absolute($path);
 
     # Check for volume (should probably document the '2' thing...)
-    return _taint_result($self->canonpath( $path ), $path, $base) if $is_abs == 2;
+    return $self->canonpath( $path ) if $is_abs == 2;
 
     if ($is_abs) {
       # It's missing a volume, add one
       my $vol = ($self->splitpath( Cwd::getcwd() ))[0];
-      return _taint_result($self->canonpath( $vol . $path ), $path, $vol);
+      return $self->canonpath( $vol . $path );
     }
 
     if ( !defined( $base ) || $base eq '' ) {
@@ -379,13 +357,7 @@ sub rel2abs {
 			   $path_file
 			  ) ;
 
-    return _taint_result($self->canonpath( $path ), $path, $base);
-}
-
-sub abs2rel {
-    my ($self, $path, $base) = @_;
-    my $result = File::Spec::Unix::abs2rel(@_);
-    return _taint_result($result, $path, $base);
+    return $self->canonpath( $path ) ;
 }
 
 =back

--- a/src/main/perl/lib/JSON/PP.pm
+++ b/src/main/perl/lib/JSON/PP.pm
@@ -594,10 +594,9 @@ sub allow_bigint {
 
     sub __sort {
         my $self = shift;
-        # The canonical JSON order is lexical key order.  Keep this common
-        # case out of a generated comparator closure: PerlOnJava's closure
-        # compiler cannot represent the implicit sort variables ($a and $b)
-        # used by JSON::PP's upstream `sub { $a cmp $b }` comparator.
+        # JSON::PP's canonical comparator closes over Perl's implicit sort
+        # variables.  Keep the canonical fast path explicit until generated
+        # comparator closures support those aliases.
         return sort keys %{$_[0]} if $self->{PROPS}[P_CANONICAL];
         my $keysort = $self->{keysort};
         defined $keysort ? (sort $keysort (keys %{$_[0]})) : keys %{$_[0]};

--- a/src/main/perl/lib/Pod/perldelta.pod
+++ b/src/main/perl/lib/Pod/perldelta.pod
@@ -27,6 +27,25 @@ here, but most should go in the L</Performance Enhancements> section.
 
 [ List each enhancement as a =head2 entry ]
 
+=head2 Undef-aware equality operators
+
+Four new operators have been added, which are similar to the regular equality operators except for their handling of C<undef>. Whereas the regular operators treat C<undef> as equal to the empty string or the number zero, these operators consider C<undef> to be a distinct value, equal to itself, but unequal to any defined value.
+
+    if( $x equ $y ) {
+     # $x and $y are both undef, or
+     # $x and $y are both defined and equal
+     ...
+    }
+
+This is approximately equal to the following, except that it is more efficient and avoids duplicate evaluation of operands or fetching of tied scalar values:
+
+    if( (!defined $x and !defined $y) or
+        (defined $x and defined $y and $x eq $y) ) {
+      ...
+    }
+
+For more detail, see L<perlop/Equality Operators>.
+
 =head1 Security
 
 XXX Any security-related notices go here. In particular, any security

--- a/src/main/perl/lib/Pod/perldiag.pod
+++ b/src/main/perl/lib/Pod/perldiag.pod
@@ -6790,6 +6790,12 @@ think the U.S. Government thinks it's a secret, or at least that they
 will continue to pretend that it is.  And if you quote me on that, I
 will deny it.
 
+=item The 'equ' operator is experimental
+
+(S experimental::equ) This warning is emitted if you use the C<equ>
+undef-aware equality operator.  This operator is currently experimental
+and its behaviour may change in future releases of Perl.
+
 =item The experimental declared_refs feature is not enabled
 
 (F) To declare references to variables, as in C<my \%x>, you must first enable
@@ -6802,6 +6808,24 @@ the feature:
 
 (F) The function indicated isn't implemented on this architecture,
 according to the probings of Configure.
+
+=item The 'neu' operator is experimental
+
+(S experimental::equ) This warning is emitted if you use the C<neu>
+undef-aware equality operator.  This operator is currently experimental
+and its behaviour may change in future releases of Perl.
+
+=item The '===' operator is experimental
+
+(S experimental::equ) This warning is emitted if you use the C<===>
+undef-aware equality operator.  This operator is currently experimental
+and its behaviour may change in future releases of Perl.
+
+=item The '!==' operator is experimental
+
+(S experimental::equ) This warning is emitted if you use the C<!==>
+undef-aware equality operator.  This operator is currently experimental
+and its behaviour may change in future releases of Perl.
 
 =item The private_use feature is experimental
 

--- a/src/main/perl/lib/Pod/perlop.pod
+++ b/src/main/perl/lib/Pod/perlop.pod
@@ -140,7 +140,7 @@ values only, not array values.
     nonassoc    named unary operators
     nonassoc    isa
     chained     < > <= >= lt gt le ge
-    chain/na    == != eq ne <=> cmp ~~
+    chain/na    == != eq ne === !== equ neu <=> cmp ~~
     left        & &.
     left        | |. ^ ^.
     left        &&
@@ -645,6 +645,28 @@ $z">>, performs chained comparisons, in the manner described above in
 the section L</"Operator Precedence and Associativity">.
 Beware that they do not chain with relational operators, which have
 higher precedence.
+
+Each of these four operators has a variant whose name is one character longer,
+which has different behaviour to the base operator when either (or both) of
+its arguments is C<undef>. These operators, called the I<undef-aware equality
+operators>, consider that C<undef> is equal to another C<undef> but not equal
+to any defined value - even the number zero or the empty string. Furtheremore,
+these operators will not invoke warnings when invoked on undefined values,
+even when their base counterparts would. (Though other warnings are still
+possible, such as C<===> warning about non-numerical values).
+
+These four operators are currently considered B<experimental> and will emit
+warnings in the C<experimental::equ> category.
+
+Binary C<< "===" >> returns true if both arguments are C<undef>, or if both
+are defined and numerically equal as according to C<< "==" >>.
+
+Binary C<< "equ" >> returns true if both arguments are C<undef>, or if both
+are defined and stringwise equal as according to C<< "eq" >>.
+
+Binary C<< "!==" >> and C<< "neu" >> are the complements to these; returning
+true if exactly one argument is C<undef>, or if both are defined but not
+equal, either numerically or stringwise respectively.
 
 Binary C<< "<=>" >> returns -1, 0, or 1 depending on whether the left
 argument is numerically less than, equal to, or greater than the right

--- a/src/main/perl/lib/overload.pm
+++ b/src/main/perl/lib/overload.pm
@@ -1,9 +1,7 @@
-package overload;
+package overload 1.42;
 
-use strict;
+use v5.42;
 no strict 'refs';
-
-our $VERSION = '1.40';
 
 our %ops = (
     with_assign         => "+ - * / % ** << >> x .",
@@ -99,7 +97,6 @@ sub OverloadedStringify {
 sub Method {
     my $package = shift;
     if (ref $package) {
-        no warnings 'experimental::builtin';
         $package = builtin::blessed($package);
         return undef if !defined $package;
     }
@@ -577,6 +574,23 @@ then it will not be called again - avoiding infinite recursion.
     nomethod  fallback  =
 
 See L</Special Keys for C<use overload>>.
+
+=back
+
+There are also some operators that perl does not allow to be directly
+overloaded.
+
+=over 5
+
+=item * I<Undef-aware Equality>
+
+    ===  !==  equ  neu
+
+The four undef-aware equality operators do not allow specific overloading.
+They are internally implemented in terms of a C<defined> test (which itself
+cannot be overloaded), combined with a following call to the base
+non undef-aware versions of those operators. This call will use any
+overloading behaviour defined by those regular operators.
 
 =back
 

--- a/src/test/resources/unit/direct_builtin_data_handle.t
+++ b/src/test/resources/unit/direct_builtin_data_handle.t
@@ -1,0 +1,12 @@
+use Test::More;
+
+our $line = '';
+my @warnings;
+{
+    local $SIG{__WARN__} = sub { push @warnings, @_ };
+    chop ($line .= <DATA>);
+}
+is($line, '', 'a direct core chop call on unopened DATA leaves its argument empty');
+is_deeply(\@warnings, [], 'a direct core chop call does not warn about unopened DATA');
+
+done_testing;

--- a/src/test/resources/unit/prototype_after_watchdog.t
+++ b/src/test/resources/unit/prototype_after_watchdog.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+    my $watchdog_alarm;
+
+    END { watchdog(0); }
+
+    sub watchdog ($;$) {
+        my $timeout = shift;
+        if ($watchdog_alarm) {
+            alarm(0);
+            undef $watchdog_alarm;
+        }
+        return if $timeout == 0;
+        $watchdog_alarm = alarm($timeout);
+    }
+}
+
+watchdog(60);
+
+# Core test preambles install a watchdog during BEGIN-time setup.  That must
+# not make a later ordinary ($$$$) declaration parse as a signature.
+sub four_arguments ($$$$) { scalar @_ }
+
+is(four_arguments(1, 2, 3, 4), 4, 'ordinary prototype remains valid after watchdog setup');
+is(prototype(\&four_arguments), '$$$$', 'prototype was retained');
+
+done_testing;

--- a/src/test/resources/unit/taint_filespec.t
+++ b/src/test/resources/unit/taint_filespec.t
@@ -34,8 +34,16 @@ ok(!tainted(File::Spec->rel2abs($abs, '/base')),
     'rel2abs() with an absolute path and base is clean');
 ok(tainted(File::Spec->rel2abs('x', 'rel_base')),
     'rel2abs() with a relative base is tainted: the base is resolved via getcwd()');
-ok(tainted(File::Spec->rel2abs('x', '')),
-    "rel2abs() with an empty base falls back to getcwd() and is tainted");
+if ($^O eq 'MSWin32') {
+    # Win32 consults getdcwd() for an empty base. Its path decomposition
+    # launders that value, matching system Perl's File::Spec::Win32.
+    ok(!tainted(File::Spec->rel2abs('x', '')),
+        'Win32 rel2abs() with an empty base is clean after getdcwd() decomposition');
+}
+else {
+    ok(tainted(File::Spec->rel2abs('x', '')),
+        "rel2abs() with an empty base falls back to getcwd() and is tainted");
+}
 ok(tainted(File::Spec->rel2abs('.')),
     "rel2abs('.') is tainted");
 

--- a/src/test/resources/unit/typeglob_compiled_call_pin.t
+++ b/src/test/resources/unit/typeglob_compiled_call_pin.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+    package TypeglobCompiledCallPin;
+    no warnings 'once';
+    *run = sub { 'pinned CV' };
+}
+
+is(TypeglobCompiledCallPin->run, 'pinned CV', 'method call sees installed CODE slot');
+is(&TypeglobCompiledCallPin::run, 'pinned CV', 'direct call is compiled against CODE slot');
+
+delete $TypeglobCompiledCallPin::{run};
+
+ok(!TypeglobCompiledCallPin->can('run'), 'stash deletion removes method lookup');
+is(&TypeglobCompiledCallPin::run, 'pinned CV',
+   'direct call compiled before stash deletion keeps its CV');
+
+done_testing;

--- a/src/test/resources/unit/typeglob_isa_glob_assignment.t
+++ b/src/test/resources/unit/typeglob_isa_glob_assignment.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+    package TypeglobIsaGlobAssignment;
+    our @ISA = ('TypeglobIsaGlobAssignmentBase');
+}
+
+ok(TypeglobIsaGlobAssignment->isa('TypeglobIsaGlobAssignmentBase'),
+   'inheritance exists before glob assignment');
+
+undef *TypeglobIsaGlobAssignmentEmpty;
+*TypeglobIsaGlobAssignment::ISA = *TypeglobIsaGlobAssignmentEmpty;
+
+ok(!TypeglobIsaGlobAssignment->isa('TypeglobIsaGlobAssignmentBase'),
+   'glob assignment to an empty source removes inherited classes');
+
+done_testing;

--- a/src/test/resources/unit/typeglob_undef_slot_semantics.t
+++ b/src/test/resources/unit/typeglob_undef_slot_semantics.t
@@ -1,0 +1,198 @@
+use strict;
+use warnings;
+use Test::More;
+
+# Perl's typeglob slots are independent, and `undef` on a typeglob (either
+# `undef *Pkg::name` or `undef $Pkg::{name}`) detaches every slot while leaving
+# containers that still have a Perl-level reference intact.  Symbol::Util builds
+# delete_glob()/delete_sub() on exactly these primitives.
+
+sub slot_states {
+    my ($glob_ref) = @_;
+    return join ',', map { defined *{$glob_ref}{$_} ? "$_=1" : "$_=0" }
+        qw(SCALAR ARRAY HASH CODE IO);
+}
+
+# ---------------------------------------------------------------------------
+# `undef *Pkg::name` detaches ARRAY/HASH/CODE/IO but keeps the SCALAR slot
+# (Perl always reports a SCALAR slot, holding undef).
+# ---------------------------------------------------------------------------
+{
+    package UndefGlobTarget;
+    no warnings 'once';
+    our $io_data = "io line\n";
+    open FOO, '<', \$io_data or die $!;
+    *FOO = sub { 'code' };
+    our $FOO = 'scalar';
+    our @FOO = ('array');
+    our %FOO = (hash => 1);
+}
+
+is(slot_states(\*UndefGlobTarget::FOO), 'SCALAR=1,ARRAY=1,HASH=1,CODE=1,IO=1',
+    'all five slots are populated before undef');
+
+undef *UndefGlobTarget::FOO;
+
+is(slot_states(\*UndefGlobTarget::FOO), 'SCALAR=1,ARRAY=0,HASH=0,CODE=0,IO=0',
+    'undef *glob detaches ARRAY, HASH, CODE and IO slots');
+ok(!defined $UndefGlobTarget::FOO, 'undef *glob clears the scalar slot value');
+is(scalar(@UndefGlobTarget::FOO), 0, 'undef *glob leaves an empty array');
+is(scalar(keys %UndefGlobTarget::FOO), 0, 'undef *glob leaves an empty hash');
+ok(!eval { &UndefGlobTarget::FOO }, 'undef *glob removes the subroutine');
+
+# ---------------------------------------------------------------------------
+# `undef $Pkg::{name}` is the same operation reached through the stash.
+# ---------------------------------------------------------------------------
+{
+    package UndefStashTarget;
+    no warnings 'once';
+    our $io_data = "io line\n";
+    open FOO, '<', \$io_data or die $!;
+    *FOO = sub { 'code' };
+    our $FOO = 'scalar';
+    our @FOO = ('array');
+    our %FOO = (hash => 1);
+}
+
+is(slot_states(\*UndefStashTarget::FOO), 'SCALAR=1,ARRAY=1,HASH=1,CODE=1,IO=1',
+    'stash target starts with all five slots');
+
+undef $UndefStashTarget::{FOO};
+
+is(slot_states(\*UndefStashTarget::FOO), 'SCALAR=1,ARRAY=0,HASH=0,CODE=0,IO=0',
+    'undef $Pkg::{name} detaches ARRAY, HASH, CODE and IO slots');
+ok(!defined $UndefStashTarget::FOO, 'undef $Pkg::{name} clears the scalar value');
+ok(!eval { &UndefStashTarget::FOO }, 'undef $Pkg::{name} removes the subroutine');
+ok(!defined *UndefStashTarget::FOO{IO}, 'undef $Pkg::{name} removes the IO slot');
+
+# Assigning undef through the stash hash is a different operation: Perl treats
+# it as an undefined value assigned to a typeglob and leaves the slots alone.
+{
+    package AssignUndefTarget;
+    no warnings 'once';
+    our $FOO = 'scalar';
+    our @FOO = ('array');
+}
+{
+    no warnings;
+    $AssignUndefTarget::{FOO} = undef;
+}
+is($AssignUndefTarget::FOO, 'scalar', '$Pkg::{name} = undef keeps the scalar slot');
+is_deeply(\@AssignUndefTarget::FOO, ['array'], '$Pkg::{name} = undef keeps the array slot');
+
+# ---------------------------------------------------------------------------
+# Backed-up slots survive the undef and can be re-installed, which is how
+# Symbol::Util::delete_glob() deletes a single slot.
+# ---------------------------------------------------------------------------
+{
+    package RoundTripTarget;
+    no warnings 'once';
+    our $io_data = "io line\n";
+    open FOO, '<', \$io_data or die $!;
+    *FOO = sub { 'code' };
+    our $FOO = 'scalar';
+    our @FOO = ('array');
+    our %FOO = (hash => 1);
+}
+
+my %backup = (
+    ARRAY => *RoundTripTarget::FOO{ARRAY},
+    HASH  => *RoundTripTarget::FOO{HASH},
+    CODE  => *RoundTripTarget::FOO{CODE},
+    IO    => *RoundTripTarget::FOO{IO},
+);
+
+undef $RoundTripTarget::{FOO};
+
+is_deeply($backup{ARRAY}, ['array'], 'backed-up ARRAY body survives the undef');
+is_deeply($backup{HASH}, {hash => 1}, 'backed-up HASH body survives the undef');
+
+{
+    no strict 'refs';
+    no warnings 'once';
+    *RoundTripTarget::FOO = $backup{$_} for qw(ARRAY HASH CODE IO);
+}
+
+is(slot_states(\*RoundTripTarget::FOO), 'SCALAR=1,ARRAY=1,HASH=1,CODE=1,IO=1',
+    'restoring backed-up slots reproduces the glob');
+ok(!defined $RoundTripTarget::FOO, 'the deliberately dropped SCALAR value stays undef');
+is_deeply(\@RoundTripTarget::FOO, ['array'], 'restored ARRAY slot keeps its values');
+is_deeply(\%RoundTripTarget::FOO, {hash => 1}, 'restored HASH slot keeps its values');
+is(eval { &RoundTripTarget::FOO }, 'code', 'restored CODE slot is callable');
+is(scalar <RoundTripTarget::FOO>, "io line\n", 'restored IO slot still reads');
+
+# `delete $Pkg::{name}` removes the whole glob from the stash.
+delete $RoundTripTarget::{FOO};
+ok(!grep({ $_ eq 'FOO' } keys %RoundTripTarget::),
+    'delete $Pkg::{name} removes the stash entry');
+
+# ---------------------------------------------------------------------------
+# Assigning one slot must not make unrelated slots visible.
+# ---------------------------------------------------------------------------
+{
+    package SlotSource;
+    no warnings 'once';
+    sub FOO { 'FOO' }
+    our $FOO = 'FOO';
+}
+
+{
+    no strict 'refs';
+    no warnings 'once';
+    *SlotOnlyScalar::FOO = *SlotSource::FOO{SCALAR};
+}
+is($SlotOnlyScalar::FOO, 'FOO', 'exporting the SCALAR slot copies the value');
+ok(!defined *SlotOnlyScalar::FOO{CODE},
+    'exporting the SCALAR slot does not create a phantom CODE slot');
+ok(!defined eval { &SlotOnlyScalar::FOO },
+    'a glob with only a SCALAR slot is not callable');
+
+{
+    no strict 'refs';
+    no warnings 'once';
+    *SlotOnlyCode::FOO = *SlotSource::FOO{CODE};
+}
+is(eval { &SlotOnlyCode::FOO }, 'FOO', 'exporting the CODE slot copies the sub');
+ok(!defined $SlotOnlyCode::FOO,
+    'exporting the CODE slot does not populate the SCALAR slot');
+
+# A slot that was never populated must read back as undef.
+ok(!defined *SlotSource::FOO{ARRAY}, '*glob{ARRAY} is undef for an unused slot');
+ok(!defined *SlotSource::FOO{HASH}, '*glob{HASH} is undef for an unused slot');
+{
+    no warnings 'once';
+    ok(!defined *NeverUsed::BAR{CODE}, '*glob{CODE} is undef for an unknown symbol');
+}
+
+# Merely mentioning a glob must not vivify a CODE slot.
+{
+    no strict 'refs';
+    my $ignored = \*Vivified::BAZ;
+}
+ok(!defined *Vivified::BAZ{CODE}, 'taking a glob reference creates no CODE slot');
+ok(!defined eval { &Vivified::BAZ }, 'a vivified glob is not callable');
+
+# ---------------------------------------------------------------------------
+# `defined`/`undef` take-reference mode must not leak into a nested block:
+# `&name` inside `defined eval { ... }` is a call, not a code reference.
+# ---------------------------------------------------------------------------
+our $call_count = 0;
+sub counted { $call_count++; return 'called' }
+
+ok(!defined eval { &missing_sub_for_test },
+    'defined eval { &missing } sees the die, not a code reference');
+ok(defined eval { &counted }, 'defined eval { &existing } sees the return value');
+is($call_count, 1, '&name inside defined eval { } is actually called');
+
+# ---------------------------------------------------------------------------
+# Requiring a module without a DATA section must not add a DATA stash entry
+# to the requiring package.
+# ---------------------------------------------------------------------------
+{
+    package NoDataImport;
+    eval q{ require Scalar::Util; 1 } or die $@;
+}
+ok(!grep({ $_ eq 'DATA' } keys %NoDataImport::),
+    'require does not add a phantom DATA entry to the caller package');
+
+done_testing;


### PR DESCRIPTION
Refs #1119

Completes `Symbol::Util` typeglob semantics on both backends. The interpreter now retains each compiled direct call site's most recently visible CV after a stash deletion, while a later visible typeglob replacement refreshes that call site.

Validation:

- `make` (rebased UAT candidate)
- `Symbol::Util` 0.0203: 307/307 tests on both JVM and interpreter backends
