### PR TITLE
WIP: match caller line metadata for multiline calls (#1135)

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -29,13 +29,16 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 * Add JDBC-backed `DBD::mysql` and `DBD::Pg` compatibility shims and preserve
   SQLite URI-file schema state across DBI connections.
 
- - Fix typeglob slot semantics exposed by `Symbol::Util`: `undef *Pkg::name` and
-   `undef $Pkg::{name}` now detach every slot (so `*Pkg::name{ARRAY}` and friends
-   read back as undef) while leaving referenced containers intact for
-   re-installation, `&name` inside `defined eval { ... }` is called instead of
-   being turned into a code reference, typeglob assignment correctly replaces
-   `@ISA`, and `require` no longer adds a phantom `DATA` entry to the requiring
-   package's stash.
+- Fix typeglob slot semantics exposed by `Symbol::Util`: `undef *Pkg::name` and
+  `undef $Pkg::{name}` now detach every slot (so `*Pkg::name{ARRAY}` and friends
+  read back as undef) while leaving referenced containers intact for
+  re-installation, `&name` inside `defined eval { ... }` is called instead of
+  being turned into a code reference, typeglob assignment correctly replaces
+  `@ISA`, and `require` no longer adds a phantom `DATA` entry to the requiring
+  package's stash.
+- Report the enclosing statement's source line for calls inside multi-line
+  expressions, so `caller`, `warn`, and Test::Builder diagnostics identify the
+  statement instead of the closing `)->method` line of a chained call.
 - Parse fully-qualified indirect constructors followed by method calls, and
   stage generated nested pure-Perl MakeMaker modules correctly (including
   NetAddr::IP's `-noxs` installation path).

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -1363,13 +1363,18 @@ public class BytecodeCompiler implements Visitor {
                 pcToTokenIndex.put(pc, stmtTokenIndex);
             }
 
-            // Publish the statement's first token for the call compilers, so that
-            // caller() inside a multi-line statement reports the statement's line.
-            statementTokenIndex = stmt instanceof AbstractNode stmtNode
-                    && stmtNode.getAnnotation("statementStartIndex") instanceof Integer start
-                    && start > 0
-                    ? start
-                    : -1;
+            // Publish the statement's COP token for the call compilers, so that
+            // caller() and warn/die inside a multi-line statement report the
+            // statement's line. A statement whose COP Perl nulled keeps the
+            // enclosing statement's line instead (op_scope; see StatementCopline).
+            if (!(stmt instanceof AbstractNode scoped
+                    && scoped.getBooleanAnnotation("inheritEnclosingCopline"))) {
+                statementTokenIndex = stmt instanceof AbstractNode stmtNode
+                        && stmtNode.getAnnotation("statementStartIndex") instanceof Integer start
+                        && start > 0
+                        ? start
+                        : -1;
+            }
 
             // Emit DEBUG opcode for debugger support (only when -d flag is active)
             // Skip debug opcodes for internal/infrastructure nodes (marked with skipDebug)

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -89,6 +89,10 @@ public class BytecodeCompiler implements Visitor {
     // Perl attributes calls inside boolean short-circuit expressions to the
     // outermost expression's first line.
     int callerLineTokenOverride = -1;
+    // Token index of the first token of the statement being compiled. Perl keeps
+    // one COP (source line) per statement, so calls anywhere inside a multi-line
+    // statement report the statement's first line. -1 when unknown.
+    int statementTokenIndex = -1;
     // Callsite ID counter for /o modifier support (unique across all compilations)
     private static final AtomicInteger nextCallsiteId = new AtomicInteger(1);
     // Track last result register for expression chaining
@@ -1337,6 +1341,7 @@ public class BytecodeCompiler implements Visitor {
         if (lastMeaningfulIndex == -1) lastMeaningfulIndex = numStatements - 1;
 
         int savedLastResultReg = -1;
+        int savedStatementTokenIndex = statementTokenIndex;
         for (int i = 0; i < numStatements; i++) {
             // Skip the 'local $_' child when For1Node handles it via LOCAL_SCALAR_SAVE_LEVEL
             if (i == 0 && skipFirstChild) continue;
@@ -1357,6 +1362,14 @@ public class BytecodeCompiler implements Visitor {
                 int pc = bytecode.size();
                 pcToTokenIndex.put(pc, stmtTokenIndex);
             }
+
+            // Publish the statement's first token for the call compilers, so that
+            // caller() inside a multi-line statement reports the statement's line.
+            statementTokenIndex = stmt instanceof AbstractNode stmtNode
+                    && stmtNode.getAnnotation("statementStartIndex") instanceof Integer start
+                    && start > 0
+                    ? start
+                    : -1;
 
             // Emit DEBUG opcode for debugger support (only when -d flag is active)
             // Skip debug opcodes for internal/infrastructure nodes (marked with skipDebug)
@@ -1417,6 +1430,7 @@ public class BytecodeCompiler implements Visitor {
             recycleTemporaryRegisters();
 
         }
+        statementTokenIndex = savedStatementTokenIndex;
 
         // Use the saved result reg from the last meaningful statement if subsequent
         // statements (like package declarations) reset lastResultReg to -1

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -1365,8 +1365,8 @@ public class BytecodeCompiler implements Visitor {
 
             // Publish the statement's COP token for the call compilers, so that
             // caller() and warn/die inside a multi-line statement report the
-            // statement's line. A statement whose COP Perl nulled keeps the
-            // enclosing statement's line instead (op_scope; see StatementCopline).
+            // statement's line. A do-block's lone statement inherits the
+            // enclosing statement's line (op_scope; see StatementCopline).
             if (!(stmt instanceof AbstractNode scoped
                     && scoped.getBooleanAnnotation("inheritEnclosingCopline"))) {
                 statementTokenIndex = stmt instanceof AbstractNode stmtNode
@@ -7030,8 +7030,16 @@ public class BytecodeCompiler implements Visitor {
             return;
         }
 
-        // Non-constant condition - compile normal if/else bytecode
+        // Non-constant condition - compile normal if/else bytecode. An elsif is
+        // an else-branch AST child rather than a block statement, so publish its
+        // own COP while compiling its condition.
+        int savedConditionStatementToken = statementTokenIndex;
+        Object annotatedStatementStart = node.getAnnotation("statementStartIndex");
+        if (annotatedStatementStart instanceof Integer token && token > 0) {
+            statementTokenIndex = token;
+        }
         compileNode(node.condition, -1, RuntimeContextType.SCALAR);
+        statementTokenIndex = savedConditionStatementToken;
         int condReg = lastResultReg;
 
         // Mark position for forward jump to else/end

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
@@ -210,7 +210,10 @@ public class CompileBinaryOperator {
                 // Use emitWithToken so pcToTokenIndex maps the call instruction to the
                 // coderef's token index (call-site line), not the closing ')' line.
                 int callSiteToken = effectiveCallerLineToken(
-                        bytecodeCompiler, node, node.left.getIndex());
+                        bytecodeCompiler, node,
+                        bytecodeCompiler.statementTokenIndex > 0
+                                ? bytecodeCompiler.statementTokenIndex
+                                : node.left.getIndex());
                 if (callSiteToken > 0) {
                     bytecodeCompiler.emitWithToken(Opcodes.CALL_SUB, callSiteToken);
                 } else {
@@ -304,7 +307,8 @@ public class CompileBinaryOperator {
                     // arguments report the block/arg line.
                     int callSiteToken = effectiveCallerLineToken(
                             bytecodeCompiler, node,
-                            methodCallerLineCallSiteToken(node, argsNode));
+                            methodCallerLineCallSiteToken(node, argsNode,
+                                    bytecodeCompiler.statementTokenIndex));
                     if (callSiteToken > 0) {
                         bytecodeCompiler.emitWithToken(Opcodes.CALL_METHOD, callSiteToken);
                     } else {
@@ -485,7 +489,8 @@ public class CompileBinaryOperator {
             // expression start for ordinary multi-line calls, but literal anon
             // sub/block arguments and &-prototype calls report the block/arg line.
             int callSiteToken = effectiveCallerLineToken(
-                    bytecodeCompiler, node, callerLineCallSiteToken(node));
+                    bytecodeCompiler, node,
+                    callerLineCallSiteToken(node, bytecodeCompiler.statementTokenIndex));
             int rd = CompileBinaryOperatorHelper.compileBinaryOperatorSwitch(
                     bytecodeCompiler, node, rs1, rs2, callSiteToken,
                     shareCallerArgs);
@@ -889,9 +894,11 @@ public class CompileBinaryOperator {
         bytecodeCompiler.lastResultReg = rd;
     }
 
-    private static int callerLineCallSiteToken(BinaryOperatorNode node) {
+    private static int callerLineCallSiteToken(BinaryOperatorNode node, int statementTokenIndex) {
         if (!usesBlockArgumentLine(node)) {
-            return expressionStartIndex(node);
+            // Perl's per-statement COP: a call anywhere inside a multi-line
+            // statement reports the statement's first line.
+            return statementTokenIndex > 0 ? statementTokenIndex : expressionStartIndex(node);
         }
 
         if (node.right != null && node.right.getIndex() > 0) {
@@ -918,11 +925,17 @@ public class CompileBinaryOperator {
         return node.getIndex() > 0 ? node.getIndex() : -1;
     }
 
-    private static int methodCallerLineCallSiteToken(BinaryOperatorNode node, Node argsNode) {
+    private static int methodCallerLineCallSiteToken(BinaryOperatorNode node, Node argsNode,
+                                                     int statementTokenIndex) {
         if (firstArgumentIsLiteralSub(argsNode) && argsNode.getIndex() > 0) {
             return argsNode.getIndex();
         }
 
+        // Perl's per-statement COP: a method call at the end of a multi-line chain
+        // reports the statement's first line, not the closing `)->method` line.
+        if (statementTokenIndex > 0) {
+            return statementTokenIndex;
+        }
         return node.left != null ? node.left.getIndex() : -1;
     }
 

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -256,8 +256,11 @@ public class CompileOperator {
         if (lineObj != null && fileObj != null) {
             locationMsg = " at " + fileObj + " line " + lineObj;
         } else if (bc.errorUtil != null) {
-            // Use getSourceLocationAccurate to honor #line directives
-            var loc = bc.errorUtil.getSourceLocationAccurate(node.getIndex());
+            // Use getSourceLocationAccurate to honor #line directives.
+            // warn/die report the enclosing statement's COP line, exactly like
+            // caller, so "$ok\n  or warn ..." blames the statement's own line.
+            int tokenIndex = bc.statementTokenIndex > 0 ? bc.statementTokenIndex : node.getIndex();
+            var loc = bc.errorUtil.getSourceLocationAccurate(tokenIndex);
             locationMsg = " at " + loc.fileName() + " line " + loc.lineNumber();
         } else {
             locationMsg = " at " + bc.sourceName + " line " + bc.sourceLine;

--- a/src/main/java/org/perlonjava/backend/jvm/Dereference.java
+++ b/src/main/java/org/perlonjava/backend/jvm/Dereference.java
@@ -1007,14 +1007,17 @@ public class Dereference {
 
             // Allocate a unique callsite ID for inline method caching
             int callsiteId = nextMethodCallsiteId.getAndIncrement();
-            // Perl reports the method expression start for ordinary multi-line
-            // calls, but literal anon sub/block arguments report the block line.
+            // Perl attaches one COP per statement, so a method call at the end of a
+            // multi-line chained expression reports the statement's first line, not
+            // the closing `)->method` line. Literal anon sub/block arguments still
+            // report the block line (handled below).
             Object annotatedCallerLine = node.getAnnotation("callerLineTokenOverride");
+            int statementTokenIndex = emitterVisitor.ctx.javaClassInfo.statementTokenIndex;
             int callSiteIndex = annotatedCallerLine instanceof Integer token && token > 0
                     ? token
                     : (emitterVisitor.ctx.javaClassInfo.callerLineTokenOverride > 0
                             ? emitterVisitor.ctx.javaClassInfo.callerLineTokenOverride
-                            : node.left.getIndex());
+                            : (statementTokenIndex > 0 ? statementTokenIndex : node.left.getIndex()));
             if (node.right instanceof BinaryOperatorNode callNode
                     && "(".equals(callNode.operator)
                     && firstMethodArgumentIsLiteralSub(callNode)

--- a/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
@@ -266,6 +266,7 @@ public class EmitBlock {
             forNode.preEvaluatedArrayIndex = tempArrayIndex;
         }
 
+        int savedStatementTokenIndex = emitterVisitor.ctx.javaClassInfo.statementTokenIndex;
         try {
             for (int i = 0; i < list.size(); i++) {
                 Node element = list.get(i);
@@ -285,6 +286,16 @@ public class EmitBlock {
                 if (!(element instanceof AbstractNode an && an.getBooleanAnnotation("skipDebug"))) {
                     ByteCodeSourceMapper.setDebugInfoLineNumber(emitterVisitor.ctx, element.getIndex());
                 }
+
+                // Perl attaches one COP per statement, so calls anywhere inside a
+                // multi-line statement report the statement's first line. Publish it
+                // for the call emitters (see EmitSubroutine / Dereference).
+                emitterVisitor.ctx.javaClassInfo.statementTokenIndex =
+                        element instanceof AbstractNode stmtNode
+                                && stmtNode.getAnnotation("statementStartIndex") instanceof Integer start
+                                && start > 0
+                                ? start
+                                : -1;
 
                 // Check if this block should store its result in a register (for bare block expressions)
                 Object resultRegObj = node.getAnnotation("resultRegister");
@@ -350,6 +361,7 @@ public class EmitBlock {
 
             }
         } finally {
+            emitterVisitor.ctx.javaClassInfo.statementTokenIndex = savedStatementTokenIndex;
             if (preEvalForNode != null) {
                 preEvalForNode.preEvaluatedArrayIndex = savedPreEvaluatedArrayIndex;
             }

--- a/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
@@ -288,14 +288,19 @@ public class EmitBlock {
                 }
 
                 // Perl attaches one COP per statement, so calls anywhere inside a
-                // multi-line statement report the statement's first line. Publish it
-                // for the call emitters (see EmitSubroutine / Dereference).
-                emitterVisitor.ctx.javaClassInfo.statementTokenIndex =
-                        element instanceof AbstractNode stmtNode
-                                && stmtNode.getAnnotation("statementStartIndex") instanceof Integer start
-                                && start > 0
-                                ? start
-                                : -1;
+                // multi-line statement report that statement's line. Publish it for
+                // the call emitters (see EmitSubroutine / Dereference / EmitOperator).
+                // A statement whose COP Perl nulled keeps the enclosing statement's
+                // line instead (op_scope; see StatementCopline).
+                if (!(element instanceof AbstractNode scoped
+                        && scoped.getBooleanAnnotation("inheritEnclosingCopline"))) {
+                    emitterVisitor.ctx.javaClassInfo.statementTokenIndex =
+                            element instanceof AbstractNode stmtNode
+                                    && stmtNode.getAnnotation("statementStartIndex") instanceof Integer start
+                                    && start > 0
+                                    ? start
+                                    : -1;
+                }
 
                 // Check if this block should store its result in a register (for bare block expressions)
                 Object resultRegObj = node.getAnnotation("resultRegister");

--- a/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
@@ -290,8 +290,8 @@ public class EmitBlock {
                 // Perl attaches one COP per statement, so calls anywhere inside a
                 // multi-line statement report that statement's line. Publish it for
                 // the call emitters (see EmitSubroutine / Dereference / EmitOperator).
-                // A statement whose COP Perl nulled keeps the enclosing statement's
-                // line instead (op_scope; see StatementCopline).
+                // A do-block's lone statement inherits the enclosing statement's
+                // line (op_scope; see StatementCopline).
                 if (!(element instanceof AbstractNode scoped
                         && scoped.getBooleanAnnotation("inheritEnclosingCopline"))) {
                     emitterVisitor.ctx.javaClassInfo.statementTokenIndex =

--- a/src/main/java/org/perlonjava/backend/jvm/EmitForeach.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitForeach.java
@@ -636,14 +636,17 @@ public class EmitForeach {
                 }
 
                 ByteCodeSourceMapper.setDebugInfoLineNumber(emitterVisitor.ctx, element.getIndex());
-                // Perl attaches one COP per statement; publish this statement's first
+                // Perl attaches one COP per statement; publish this statement's COP
                 // token so calls inside it report the statement's line (see EmitBlock).
-                emitterVisitor.ctx.javaClassInfo.statementTokenIndex =
-                        element instanceof org.perlonjava.frontend.astnode.AbstractNode stmtNode
-                                && stmtNode.getAnnotation("statementStartIndex") instanceof Integer start
-                                && start > 0
-                                ? start
-                                : -1;
+                if (!(element instanceof org.perlonjava.frontend.astnode.AbstractNode scoped
+                        && scoped.getBooleanAnnotation("inheritEnclosingCopline"))) {
+                    emitterVisitor.ctx.javaClassInfo.statementTokenIndex =
+                            element instanceof org.perlonjava.frontend.astnode.AbstractNode stmtNode
+                                    && stmtNode.getAnnotation("statementStartIndex") instanceof Integer start
+                                    && start > 0
+                                    ? start
+                                    : -1;
+                }
                 element.accept(voidVisitor);
 
                 // Check RuntimeControlFlowRegistry after each statement, so that

--- a/src/main/java/org/perlonjava/backend/jvm/EmitForeach.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitForeach.java
@@ -628,6 +628,7 @@ public class EmitForeach {
                 }
             }
 
+            int savedStatementTokenIndex = emitterVisitor.ctx.javaClassInfo.statementTokenIndex;
             for (int i = 0; i < list.size(); i++) {
                 Node element = list.get(i);
                 if (element == null) {
@@ -635,12 +636,21 @@ public class EmitForeach {
                 }
 
                 ByteCodeSourceMapper.setDebugInfoLineNumber(emitterVisitor.ctx, element.getIndex());
+                // Perl attaches one COP per statement; publish this statement's first
+                // token so calls inside it report the statement's line (see EmitBlock).
+                emitterVisitor.ctx.javaClassInfo.statementTokenIndex =
+                        element instanceof org.perlonjava.frontend.astnode.AbstractNode stmtNode
+                                && stmtNode.getAnnotation("statementStartIndex") instanceof Integer start
+                                && start > 0
+                                ? start
+                                : -1;
                 element.accept(voidVisitor);
 
                 // Check RuntimeControlFlowRegistry after each statement, so that
                 // eval q{ next; } stops the loop iteration immediately.
                 emitRegistryCheck(mv, currentLoopLabels, redoLabel, continueLabel, loopEnd);
             }
+            emitterVisitor.ctx.javaClassInfo.statementTokenIndex = savedStatementTokenIndex;
 
             popGotoLabelsForBlock(emitterVisitor, blockNode);
 

--- a/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
@@ -480,8 +480,12 @@ public class EmitOperator {
         // Accept the operand in LIST context.
         node.operand.accept(emitterVisitor.with(RuntimeContextType.LIST));
 
-        // Push the formatted line number as a message using getSourceLocationAccurate to honor #line directives
-        var loc = emitterVisitor.ctx.errorUtil.getSourceLocationAccurate(node.tokenIndex);
+        // Push the formatted line number as a message using getSourceLocationAccurate to honor #line directives.
+        // warn/die report the enclosing statement's COP line, exactly like caller,
+        // so "$ok\n  or warn ..." blames the line the statement started on.
+        int statementTokenIndex = emitterVisitor.ctx.javaClassInfo.statementTokenIndex;
+        int locationTokenIndex = statementTokenIndex > 0 ? statementTokenIndex : node.tokenIndex;
+        var loc = emitterVisitor.ctx.errorUtil.getSourceLocationAccurate(locationTokenIndex);
         String fileName = loc.fileName();
         int lineNumber = loc.lineNumber();
         Node message = new StringNode(" at " + fileName + " line " + lineNumber, node.tokenIndex);

--- a/src/main/java/org/perlonjava/backend/jvm/EmitStatement.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitStatement.java
@@ -492,8 +492,18 @@ public class EmitStatement {
         // so the condition value is returned when no branch is taken (Perl semantics)
         boolean needConditionValue = (node.elseBranch == null && emitterVisitor.ctx.contextType != RuntimeContextType.VOID);
 
+        // An elsif is an else-branch AST child rather than an EmitBlock statement,
+        // so publish its own COP while compiling its condition. This prevents a
+        // call in a chained elsif condition from inheriting the previous branch's
+        // line.
+        int savedConditionStatementToken = emitterVisitor.ctx.javaClassInfo.statementTokenIndex;
+        Object annotatedStatementStart = node.getAnnotation("statementStartIndex");
+        if (annotatedStatementStart instanceof Integer token && token > 0) {
+            emitterVisitor.ctx.javaClassInfo.statementTokenIndex = token;
+        }
         // Visit the condition node in scalar context
         node.condition.accept(emitterVisitor.with(RuntimeContextType.SCALAR));
+        emitterVisitor.ctx.javaClassInfo.statementTokenIndex = savedConditionStatementToken;
 
         if (needConditionValue) {
             emitterVisitor.ctx.mv.visitInsn(Opcodes.DUP);

--- a/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
@@ -1051,15 +1051,16 @@ public class EmitSubroutine {
                 "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;Ljava/lang/String;)V",
                 false);
 
-        // Set debug line number to the call site. Perl reports the expression
-        // start for ordinary multi-line calls, but literal anon sub/block
-        // arguments and &-prototype calls report the block/arg line.
+        // Set debug line number to the call site. Perl reports the enclosing
+        // statement's first line for ordinary multi-line calls, but literal anon
+        // sub/block arguments and &-prototype calls report the block/arg line.
         Object annotatedCallerLine = node.getAnnotation("callerLineTokenOverride");
         int callSiteIndex = annotatedCallerLine instanceof Integer token && token > 0
                 ? token
                 : (emitterVisitor.ctx.javaClassInfo.callerLineTokenOverride > 0
                         ? emitterVisitor.ctx.javaClassInfo.callerLineTokenOverride
-                        : callerLineCallSiteIndex(node));
+                        : callerLineCallSiteIndex(node,
+                                emitterVisitor.ctx.javaClassInfo.statementTokenIndex));
         if (callSiteIndex > 0) {
             ByteCodeSourceMapper.setDebugInfoLineNumber(emitterVisitor.ctx, callSiteIndex);
         }
@@ -1183,9 +1184,11 @@ public class EmitSubroutine {
         }
     }
 
-    private static int callerLineCallSiteIndex(BinaryOperatorNode node) {
+    private static int callerLineCallSiteIndex(BinaryOperatorNode node, int statementTokenIndex) {
         if (!usesBlockArgumentLine(node)) {
-            return expressionStartIndex(node);
+            // Perl's per-statement COP: a call anywhere inside a multi-line
+            // statement reports the statement's first line.
+            return statementTokenIndex > 0 ? statementTokenIndex : expressionStartIndex(node);
         }
 
         if (node.right != null && node.right.getIndex() > 0) {

--- a/src/main/java/org/perlonjava/backend/jvm/JavaClassInfo.java
+++ b/src/main/java/org/perlonjava/backend/jvm/JavaClassInfo.java
@@ -25,6 +25,14 @@ public class JavaClassInfo {
     public int callerLineTokenOverride = -1;
 
     /**
+     * Token index of the first token of the statement currently being emitted.
+     * Perl keeps one COP (source line) per statement, so every call inside a
+     * multi-line statement reports the statement's first line. -1 when unknown,
+     * in which case the call's own expression start is used instead.
+     */
+    public int statementTokenIndex = -1;
+
+    /**
      * The name of the Java class.
      */
     public String javaClassName;

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -51,6 +51,12 @@ public class OperatorParser {
             // are on the JVM operand stack and must not be destroyed before
             // the caller captures them (e.g., $self->{cursor} ||= do { ... }).
             block.setAnnotation("blockIsDoBlock", true);
+            // Perl passes a do-block through op_scope(), which nulls a lone leading
+            // nextstate, so a single-statement do-block reports the enclosing
+            // statement's line.
+            if (block instanceof BlockNode doBlock) {
+                StatementCopline.markOpScopedBlock(doBlock);
+            }
             return block;
         }
         // Since Perl 5.42, `do NAME(...)` is a syntax error rather than an

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -51,9 +51,8 @@ public class OperatorParser {
             // are on the JVM operand stack and must not be destroyed before
             // the caller captures them (e.g., $self->{cursor} ||= do { ... }).
             block.setAnnotation("blockIsDoBlock", true);
-            // Perl passes a do-block through op_scope(), which nulls a lone leading
-            // nextstate, so a single-statement do-block reports the enclosing
-            // statement's line.
+            // Perl passes a do-block through op_scope(), so a single-statement
+            // body reports the enclosing statement's line.
             if (block instanceof BlockNode doBlock) {
                 StatementCopline.markOpScopedBlock(doBlock);
             }

--- a/src/main/java/org/perlonjava/frontend/parser/ParseBlock.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseBlock.java
@@ -2,6 +2,7 @@ package org.perlonjava.frontend.parser;
 
 import org.perlonjava.app.cli.CompilerOptions;
 
+import org.perlonjava.frontend.astnode.AbstractNode;
 import org.perlonjava.frontend.astnode.BlockNode;
 import org.perlonjava.frontend.astnode.LabelNode;
 import org.perlonjava.frontend.astnode.ListNode;
@@ -119,12 +120,22 @@ public class ParseBlock {
                 continue;
             }
 
-            // Parse the actual statement, passing any label found
+            // Parse the actual statement, passing any label found.
+            // Remember where the statement begins: Perl attaches one COP (source
+            // line) per statement, taken from the statement's first token, and
+            // every call inside a multi-line statement reports that line.  Most
+            // AST nodes carry the token index they were *finished* at, so the
+            // statement start has to be captured here before parsing begins.
+            int statementStartIndex = parser.tokenIndex;
             Node statement = StatementResolver.parseStatement(parser, label);
 
             // parseStatement should never return null, but if it does, it's a parser bug
             // that should be fixed at the source. For now, add defensive check.
             if (statement != null) {
+                if (statement instanceof AbstractNode statementNode
+                        && statementNode.getAnnotation("statementStartIndex") == null) {
+                    statementNode.setAnnotation("statementStartIndex", statementStartIndex);
+                }
                 statements.add(statement);
             } else {
                 // This should never happen - log and skip

--- a/src/main/java/org/perlonjava/frontend/parser/ParseBlock.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseBlock.java
@@ -52,6 +52,32 @@ public class ParseBlock {
      * @return BlockWithScope containing the block and scope index
      * @see StatementParser#parseOptionalPackageBlock for usage with class blocks
      */
+    /**
+     * Reports whether the statement just parsed makes the next statement lose its
+     * first token's contribution to Perl's {@code copline}.
+     *
+     * <p>A brace-terminated compound statement needs one lookahead token past its
+     * closing brace before Perl's LALR parser can reduce it; that lookahead is the
+     * next statement's first token, and creating the compound statement's COP
+     * clears {@code copline}, discarding whatever the lookahead armed.  Constructs
+     * that produce no COP -- a named {@code sub} declaration, a phaser block, a
+     * bare {@code package NAME;} -- never clear {@code copline}, so they leave the
+     * following statement alone.
+     */
+    private static boolean leavesLookaheadSwallowed(Parser parser, Node statement,
+                                                    int statementStartIndex) {
+        if (statement == null) {
+            return false;
+        }
+        if (statement instanceof AbstractNode node
+                && (node.getBooleanAnnotation("compileTimeOnly")
+                || node.getBooleanAnnotation("noReturnValue"))) {
+            return false;
+        }
+        return StatementCopline.endsWithClosingBrace(
+                parser.tokens, statementStartIndex, parser.tokenIndex);
+    }
+
     public static BlockWithScope parseBlock(Parser parser, boolean exitScope) {
         // Perl's "take reference" mode (`\&name`, `defined &name`, `undef &name`)
         // only suppresses the call for the symbol that immediately follows the
@@ -86,6 +112,12 @@ public class ParseBlock {
         List<Node> statements = new ArrayList<>();
         List<String> blockLabels = new ArrayList<>(); // track labels
 
+        // True when the statement about to be parsed had its first token consumed
+        // as the lookahead that let the previous brace-terminated statement reduce.
+        // The first statement of a block is never affected: the opening brace
+        // resets copline.
+        boolean swallowedLookahead = false;
+
         // Get the current token without consuming it
         LexerToken token = peek(parser);
 
@@ -113,19 +145,22 @@ public class ParseBlock {
                 }
             }
 
-            // Handle empty statements (lone semicolons)
+            // Handle empty statements (lone semicolons). Perl parses these as
+            // bare_statement_null, whose action resets copline to NOLINE without
+            // creating a COP, so a block followed by ";" does not shift the line of
+            // the statement after it.
             if (token.text.equals(";")) {
                 TokenUtils.consume(parser);
+                swallowedLookahead = false;
                 token = peek(parser);
                 continue;
             }
 
             // Parse the actual statement, passing any label found.
-            // Remember where the statement begins: Perl attaches one COP (source
-            // line) per statement, taken from the statement's first token, and
-            // every call inside a multi-line statement reports that line.  Most
-            // AST nodes carry the token index they were *finished* at, so the
-            // statement start has to be captured here before parsing begins.
+            // Perl attaches one COP (source line) per statement and caller/warn/die
+            // all report it, so remember where the statement begins: most AST nodes
+            // carry the token index they *finished* parsing at, which is the closing
+            // line of a multi-line expression rather than the statement's own line.
             int statementStartIndex = parser.tokenIndex;
             Node statement = StatementResolver.parseStatement(parser, label);
 
@@ -134,13 +169,23 @@ public class ParseBlock {
             if (statement != null) {
                 if (statement instanceof AbstractNode statementNode
                         && statementNode.getAnnotation("statementStartIndex") == null) {
-                    statementNode.setAnnotation("statementStartIndex", statementStartIndex);
+                    // Perl's copline bookkeeping decides which token in the statement
+                    // supplies the line; see StatementCopline. swallowedLookahead is
+                    // set when the previous statement was a COP-producing statement
+                    // that ended at a closing brace, because reducing it consumed
+                    // this statement's first token as its lookahead.
+                    int coplineIndex = StatementCopline.coplineTokenIndex(
+                            parser.tokens, statementStartIndex, parser.tokenIndex,
+                            swallowedLookahead);
+                    statementNode.setAnnotation("statementStartIndex", coplineIndex);
                 }
                 statements.add(statement);
             } else {
                 // This should never happen - log and skip
                 if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("WARNING: parseStatement returned null at token: " + token.text);
             }
+
+            swallowedLookahead = leavesLookaheadSwallowed(parser, statement, statementStartIndex);
 
             token = peek(parser);
         }

--- a/src/main/java/org/perlonjava/frontend/parser/StatementCopline.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementCopline.java
@@ -1,0 +1,354 @@
+package org.perlonjava.frontend.parser;
+
+import org.perlonjava.frontend.astnode.AbstractNode;
+import org.perlonjava.frontend.astnode.BlockNode;
+import org.perlonjava.frontend.astnode.Node;
+import org.perlonjava.frontend.astnode.NumberNode;
+import org.perlonjava.frontend.astnode.OperatorNode;
+import org.perlonjava.frontend.astnode.StringNode;
+import org.perlonjava.frontend.lexer.LexerToken;
+import org.perlonjava.frontend.lexer.LexerTokenType;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Computes the source line Perl associates with a statement (its COP line).
+ *
+ * <p>Perl attaches one COP per statement and {@code caller}, {@code warn}, and
+ * {@code die} all report that single line.  The line is not simply the
+ * statement's first line: {@code perl}'s lexer maintains {@code PL_parser->copline}
+ * and lowers it through the {@code CLINE} macro
+ * ({@code copline = min(copline, current_lexer_line)}) at selected token points
+ * only.  {@code newSTATEOP} then consumes {@code copline}, or, when no
+ * {@code CLINE} fired, falls back to the lexer's line at the moment the COP is
+ * created — in practice the statement's terminating semicolon.
+ *
+ * <p>Two consequences are visible to Perl programs and are modelled here:
+ *
+ * <ul>
+ *   <li><b>Which tokens arm the line.</b>  Only tokens returned through
+ *       {@code TERM()}/{@code LOP()} and a handful of explicit {@code CLINE}
+ *       sites in {@code toke.c} count: literals, quote-like constructs,
+ *       barewords used as terms, sigils, {@code )}, {@code ]}, list operators.
+ *       {@code my}, {@code return}, {@code ->method}, {@code (} and most infix
+ *       operators do not.  So {@code sub f { return\n  $x\n  ->m; }} reports the
+ *       {@code $x} line, not the {@code return} line.</li>
+ *   <li><b>The lookahead swallow.</b>  A brace-terminated compound statement
+ *       ({@code if (...) { }}, a loop, a bare block, {@code { package X; ... }})
+ *       needs one lookahead token past its {@code }} before the LALR parser can
+ *       reduce it and build its COP.  That lookahead is the <i>next</i>
+ *       statement's first token, and building the compound statement's COP
+ *       resets {@code copline}, discarding it.  The following statement
+ *       therefore loses its first token's contribution and takes the next
+ *       armed line instead.  A construct that produces no COP (a named
+ *       {@code sub} declaration, {@code package NAME;}, a phaser block) does not
+ *       consume {@code copline}, so it does not cause the shift.</li>
+ * </ul>
+ *
+ * <p>Only multi-line statements can observe any of this: when every token of a
+ * statement is on one line, each candidate yields the same line.
+ */
+final class StatementCopline {
+
+    /**
+     * Identifiers that do not arm {@code copline} in {@code perl}'s lexer.
+     * Declarators and {@code return} use {@code OPERATOR()}, control-flow
+     * keywords use {@code TOKEN()}/{@code OPERATOR()}, and the word-ish infix
+     * operators are not terms.  Quote-like operators ({@code q}, {@code qq},
+     * {@code qw}, {@code m}, {@code s}, {@code tr}, {@code y}, {@code qr}) are
+     * deliberately absent: they go through {@code sublex_start()} and do arm the
+     * line.
+     */
+    private static final Set<String> NON_ARMING_WORDS = Set.of(
+            "my", "our", "state", "local", "return",
+            "if", "unless", "while", "until", "for", "foreach",
+            "do", "sub", "method", "package", "class", "use", "no",
+            "else", "elsif", "given", "when", "default",
+            "last", "next", "redo", "goto", "BEGIN", "END", "CHECK", "INIT", "UNITCHECK",
+            "and", "or", "not", "xor",
+            "eq", "ne", "lt", "gt", "le", "ge", "cmp", "isa", "x");
+
+    /**
+     * Operators that arm {@code copline} when they appear in term position.
+     * The sigils and the closing brackets reach {@code TERM()} in {@code toke.c};
+     * the quote delimiters reach it through {@code sublex_start()}.
+     */
+    private static final Set<String> ARMING_OPERATORS = Set.of(
+            "$", "@", "%", "&", "*", "$#",
+            ")", "]",
+            "\"", "'", "`",
+            "++", "--");
+
+    /**
+     * Token texts that end a complete term.  Used to tell an infix {@code %} or
+     * {@code *} from the sigil spelled the same way.
+     */
+    private static final Set<String> TERM_ENDERS = Set.of(")", "]", "}");
+
+    private StatementCopline() {
+    }
+
+    /**
+     * Annotation name marking a statement whose own COP Perl discards, so calls in
+     * it report the enclosing statement's line.
+     */
+    static final String INHERIT_ENCLOSING_COPLINE = "inheritEnclosingCopline";
+
+    /**
+     * Emulates {@code Perl_op_scope}: a block passed through {@code op_scope()}
+     * has its leading {@code nextstate} nulled when the block is a plain
+     * {@code LINESEQ}, which in practice means it holds exactly one statement.
+     * The nulled COP never executes, so {@code PL_curcop} stays on the enclosing
+     * statement and {@code caller} inside that statement reports the enclosing
+     * line -- e.g. a call in {@code if ($x) {\n  f();\n}} is attributed to the
+     * {@code if} line, not to {@code f()}'s own line.
+     *
+     * <p>Applies to the then-branch of {@code if}/{@code unless}/{@code elsif} and
+     * to {@code do BLOCK}.  It does <em>not</em> apply to an {@code else} branch
+     * (Perl sets {@code OPf_PARENS} there, which takes the {@code ENTER}/
+     * {@code LEAVE} path instead), nor to loop bodies, {@code eval} blocks,
+     * subroutine bodies, or bare blocks.
+     *
+     * @param block the block whose leading statement may lose its COP
+     */
+    static void markOpScopedBlock(BlockNode block) {
+        if (block == null || block.elements.size() != 1) {
+            return;
+        }
+        if (block.elements.getFirst() instanceof AbstractNode first) {
+            first.setAnnotation(INHERIT_ENCLOSING_COPLINE, true);
+        }
+    }
+
+    /**
+     * Reports whether a condition is a compile-time constant.  Perl folds
+     * {@code if (1) { ... }} into a plain block, which skips {@code op_scope()}
+     * and so keeps the body statement's own COP.
+     */
+    static boolean isConstantCondition(Node condition) {
+        Node node = condition;
+        while (node instanceof OperatorNode operatorNode
+                && ("-".equals(operatorNode.operator) || "+".equals(operatorNode.operator)
+                || "!".equals(operatorNode.operator))) {
+            node = operatorNode.operand;
+        }
+        return node instanceof NumberNode || node instanceof StringNode;
+    }
+
+    /**
+     * Returns the index of the token whose line becomes the statement's COP line.
+     *
+     * @param tokens          the full token list
+     * @param startIndex      index of the statement's first token
+     * @param endIndex        exclusive index one past the statement's last token
+     * @param swallowFirst    true when the preceding statement was a
+     *                        COP-producing brace-terminated statement, so this
+     *                        statement's first token was consumed as its
+     *                        lookahead
+     * @return a token index, or {@code startIndex} when the range is degenerate
+     */
+    static int coplineTokenIndex(List<LexerToken> tokens, int startIndex, int endIndex,
+                                 boolean swallowFirst) {
+        if (startIndex < 0 || startIndex >= tokens.size()) {
+            return Math.max(startIndex, 0);
+        }
+        int limit = Math.min(endIndex, tokens.size());
+
+        int firstSignificant = -1;
+        int lastSignificant = -1;
+        int previousSignificant = -1;
+        int armed = -1;
+        // Exclusive end of the tokens that make up the statement's first token as
+        // perl's lexer sees it; only meaningful when swallowFirst is set.
+        int swallowedEnd = -1;
+        for (int i = startIndex; i < limit; i++) {
+            LexerToken token = tokens.get(i);
+            if (isSkippable(token)) {
+                continue;
+            }
+            if (token.type == LexerTokenType.EOF) {
+                break;
+            }
+            if (isCommentStart(tokens, i, previousSignificant)) {
+                i = skipComment(tokens, i, limit);
+                continue;
+            }
+            if (firstSignificant < 0) {
+                firstSignificant = i;
+                swallowedEnd = swallowFirst ? firstLexemeEnd(tokens, i, limit) : i;
+            }
+            lastSignificant = i;
+            boolean eligible = !(swallowFirst && i < swallowedEnd);
+            if (eligible && armed < 0 && armsCopline(tokens, i, previousSignificant)) {
+                armed = i;
+            }
+            previousSignificant = i;
+        }
+
+        if (armed >= 0) {
+            return armed;
+        }
+        // No token armed copline: newSTATEOP falls back to the lexer's line,
+        // which by then has reached the statement's final token.
+        if (lastSignificant >= 0) {
+            return lastSignificant;
+        }
+        return firstSignificant >= 0 ? firstSignificant : startIndex;
+    }
+
+    /**
+     * Reports whether the token range ends at a closing brace, meaning the
+     * statement was terminated by a block rather than by a semicolon.
+     */
+    static boolean endsWithClosingBrace(List<LexerToken> tokens, int startIndex, int endIndex) {
+        int limit = Math.min(endIndex, tokens.size());
+        int previousSignificant = -1;
+        LexerToken last = null;
+        for (int i = Math.max(startIndex, 0); i < limit; i++) {
+            LexerToken token = tokens.get(i);
+            if (isSkippable(token)) {
+                continue;
+            }
+            if (token.type == LexerTokenType.EOF) {
+                break;
+            }
+            if (isCommentStart(tokens, i, previousSignificant)) {
+                i = skipComment(tokens, i, limit);
+                continue;
+            }
+            last = token;
+            previousSignificant = i;
+        }
+        return last != null && last.type == LexerTokenType.OPERATOR && "}".equals(last.text);
+    }
+
+    /**
+     * Returns the exclusive end of the tokens forming what perl's lexer treats as a
+     * single token starting at {@code index}.
+     *
+     * <p>This lexer splits things perl keeps whole: {@code Foo::Bar} arrives as
+     * {@code Foo}, {@code ::}, {@code Bar} and {@code $x} as {@code $}, {@code x}.
+     * The lookahead that a brace-terminated statement swallows is one <i>perl</i>
+     * token, so the whole group has to be skipped -- otherwise the trailing piece
+     * would arm the line and hide the shift.
+     */
+    private static int firstLexemeEnd(List<LexerToken> tokens, int index, int limit) {
+        int i = index;
+        LexerToken token = tokens.get(i);
+        if (token.type == LexerTokenType.OPERATOR && SIGILS.contains(token.text)) {
+            // A sigil may be repeated for dereferences: $$x, @$$y.
+            while (i < limit && tokens.get(i).type == LexerTokenType.OPERATOR
+                    && SIGILS.contains(tokens.get(i).text)) {
+                i++;
+            }
+        }
+        // A possibly package-qualified name, with optional leading "::".
+        while (i < limit && tokens.get(i).type == LexerTokenType.OPERATOR
+                && "::".equals(tokens.get(i).text)) {
+            i++;
+        }
+        if (i < limit && tokens.get(i).type == LexerTokenType.IDENTIFIER) {
+            i++;
+            while (i + 1 < limit && tokens.get(i).type == LexerTokenType.OPERATOR
+                    && "::".equals(tokens.get(i).text)
+                    && tokens.get(i + 1).type == LexerTokenType.IDENTIFIER) {
+                i += 2;
+            }
+            // Trailing "::" is part of the name, as in "Foo::"->method.
+            while (i < limit && tokens.get(i).type == LexerTokenType.OPERATOR
+                    && "::".equals(tokens.get(i).text)) {
+                i++;
+            }
+        }
+        return i > index ? i : index + 1;
+    }
+
+    /**
+     * Variable sigils, which this lexer emits separately from the name.
+     */
+    private static final Set<String> SIGILS = Set.of("$", "@", "%", "&", "*", "$#");
+
+    private static boolean isSkippable(LexerToken token) {
+        return token.type == LexerTokenType.WHITESPACE || token.type == LexerTokenType.NEWLINE;
+    }
+
+    /**
+     * The lexer emits a comment as a plain {@code #} operator followed by ordinary
+     * tokens up to the end of the line.  A {@code #} that follows a sigil is part
+     * of a variable such as {@code $#array} and starts no comment.
+     */
+    private static boolean isCommentStart(List<LexerToken> tokens, int index, int previousSignificant) {
+        LexerToken token = tokens.get(index);
+        if (token.type != LexerTokenType.OPERATOR || !"#".equals(token.text)) {
+            return false;
+        }
+        if (previousSignificant >= 0) {
+            String previous = tokens.get(previousSignificant).text;
+            if ("$".equals(previous) || "@".equals(previous) || "%".equals(previous)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns the index of the last token of the comment starting at {@code index},
+     * so that a {@code for} loop's increment lands on the terminating newline.
+     */
+    private static int skipComment(List<LexerToken> tokens, int index, int limit) {
+        int i = index;
+        while (i < limit && tokens.get(i).type != LexerTokenType.NEWLINE
+                && tokens.get(i).type != LexerTokenType.EOF) {
+            i++;
+        }
+        return i;
+    }
+
+    /**
+     * Reports whether the token at {@code index} arms {@code copline}.
+     *
+     * @param tokens              the token list
+     * @param index               the token to classify
+     * @param previousSignificant index of the previous non-whitespace token in
+     *                            the statement, or -1
+     */
+    private static boolean armsCopline(List<LexerToken> tokens, int index, int previousSignificant) {
+        LexerToken token = tokens.get(index);
+        String previous = previousSignificant >= 0 ? tokens.get(previousSignificant).text : null;
+
+        switch (token.type) {
+            case NUMBER, STRING -> {
+                return true;
+            }
+            case IDENTIFIER -> {
+                // A method name after "->" is forced as METHCALL0 and never arms
+                // the line; neither does the name in "sub NAME".
+                if ("->".equals(previous) || "sub".equals(previous) || "method".equals(previous)) {
+                    return false;
+                }
+                return !NON_ARMING_WORDS.contains(token.text);
+            }
+            case OPERATOR -> {
+                if (!ARMING_OPERATORS.contains(token.text)) {
+                    return false;
+                }
+                // "%", "*", "&" and the postfix increments are only terms when
+                // they do not follow a completed term.
+                if (previous != null
+                        && ("%".equals(token.text) || "*".equals(token.text) || "&".equals(token.text))) {
+                    LexerToken previousToken = tokens.get(previousSignificant);
+                    if (previousToken.type == LexerTokenType.NUMBER
+                            || previousToken.type == LexerTokenType.IDENTIFIER
+                            || TERM_ENDERS.contains(previous)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            default -> {
+                return false;
+            }
+        }
+    }
+}

--- a/src/main/java/org/perlonjava/frontend/parser/StatementCopline.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementCopline.java
@@ -61,13 +61,26 @@ final class StatementCopline {
      * line.
      */
     private static final Set<String> NON_ARMING_WORDS = Set.of(
-            "my", "our", "state", "local", "return",
-            "if", "unless", "while", "until", "for", "foreach",
-            "do", "sub", "method", "package", "class", "use", "no",
-            "else", "elsif", "given", "when", "default",
-            "last", "next", "redo", "goto", "BEGIN", "END", "CHECK", "INIT", "UNITCHECK",
-            "and", "or", "not", "xor",
-            "eq", "ne", "lt", "gt", "le", "ge", "cmp", "isa", "x");
+            "ADJUST", "AUTOLOAD", "BEGIN", "CHECK", "DESTROY", "END", "INIT", "UNITCHECK",
+            "__CLASS__", "__DATA__", "__END__", "abs", "alarm", "all", "and", "break", "caller",
+            "catch", "chdir", "chomp", "chop", "chr", "chroot", "class", "close", "closedir",
+            "cmp", "continue", "cos", "dbmclose", "default", "defer", "defined", "delete", "do",
+            "dump", "each", "else", "elsif", "endgrent", "endhostent", "endnetent",
+            "endprotoent", "endpwent", "endservent", "eof", "eq", "eval", "evalbytes", "exists",
+            "exit", "exp", "fc", "field", "fileno", "finally", "for", "foreach", "fork",
+            "format", "ge", "getc", "getgrent", "getgrgid", "getgrnam", "gethostbyname",
+            "gethostent", "getlogin", "getnetbyname", "getnetent", "getpeername", "getpgrp",
+            "getppid", "getprotobyname", "getprotoent", "getpwent", "getpwnam", "getpwuid",
+            "getservent", "getsockname", "given", "gmtime", "goto", "gt", "hex", "if", "int",
+            "isa", "keys", "last", "lc", "lcfirst", "le", "length", "local", "localtime",
+            "lock", "log", "lstat", "lt", "method", "my", "ne", "next", "no", "not", "oct",
+            "or", "ord", "our", "pop", "pos", "prototype", "quotemeta", "rand", "readdir",
+            "readline", "readlink", "readpipe", "redo", "ref", "require", "reset", "return",
+            "rewinddir", "rmdir", "scalar", "setgrent", "sethostent", "setnetent",
+            "setprotoent", "setpwent", "setservent", "shift", "sin", "sleep", "sqrt", "srand",
+            "stat", "state", "study", "sub", "tell", "telldir", "tied", "time", "times", "try",
+            "uc", "ucfirst", "umask", "undef", "unless", "untie", "until", "use", "values",
+            "wait", "wantarray", "when", "while", "write", "x", "xor");
 
     /**
      * Operators that arm {@code copline} when they appear in term position.
@@ -162,6 +175,10 @@ final class StatementCopline {
         // Exclusive end of the tokens that make up the statement's first token as
         // perl's lexer sees it; only meaningful when swallowFirst is set.
         int swallowedEnd = -1;
+        // A block's opening brace also lowers copline, but from perly.y's block
+        // rule rather than from the lexer, so it runs after the COP-consuming
+        // reset and survives the lookahead swallow.
+        int firstBrace = -1;
         for (int i = startIndex; i < limit; i++) {
             LexerToken token = tokens.get(i);
             if (isSkippable(token)) {
@@ -179,6 +196,10 @@ final class StatementCopline {
                 swallowedEnd = swallowFirst ? firstLexemeEnd(tokens, i, limit) : i;
             }
             lastSignificant = i;
+            if (firstBrace < 0 && token.type == LexerTokenType.OPERATOR
+                    && "{".equals(token.text)) {
+                firstBrace = i;
+            }
             boolean eligible = !(swallowFirst && i < swallowedEnd);
             if (eligible && armed < 0 && armsCopline(tokens, i, previousSignificant)) {
                 armed = i;
@@ -187,7 +208,10 @@ final class StatementCopline {
         }
 
         if (armed >= 0) {
-            return armed;
+            return firstBrace >= 0 ? Math.min(armed, firstBrace) : armed;
+        }
+        if (firstBrace >= 0) {
+            return firstBrace;
         }
         // No token armed copline: newSTATEOP falls back to the lexer's line,
         // which by then has reached the statement's final token.

--- a/src/main/java/org/perlonjava/frontend/parser/StatementCopline.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementCopline.java
@@ -2,10 +2,6 @@ package org.perlonjava.frontend.parser;
 
 import org.perlonjava.frontend.astnode.AbstractNode;
 import org.perlonjava.frontend.astnode.BlockNode;
-import org.perlonjava.frontend.astnode.Node;
-import org.perlonjava.frontend.astnode.NumberNode;
-import org.perlonjava.frontend.astnode.OperatorNode;
-import org.perlonjava.frontend.astnode.StringNode;
 import org.perlonjava.frontend.lexer.LexerToken;
 import org.perlonjava.frontend.lexer.LexerTokenType;
 
@@ -103,50 +99,20 @@ final class StatementCopline {
     }
 
     /**
-     * Annotation name marking a statement whose own COP Perl discards, so calls in
-     * it report the enclosing statement's line.
+     * Annotation name marking a do-block statement whose COP Perl discards, so
+     * calls in it report the enclosing statement's line.
      */
     static final String INHERIT_ENCLOSING_COPLINE = "inheritEnclosingCopline";
 
     /**
-     * Emulates {@code Perl_op_scope}: a block passed through {@code op_scope()}
-     * has its leading {@code nextstate} nulled when the block is a plain
-     * {@code LINESEQ}, which in practice means it holds exactly one statement.
-     * The nulled COP never executes, so {@code PL_curcop} stays on the enclosing
-     * statement and {@code caller} inside that statement reports the enclosing
-     * line -- e.g. a call in {@code if ($x) {\n  f();\n}} is attributed to the
-     * {@code if} line, not to {@code f()}'s own line.
-     *
-     * <p>Applies to the then-branch of {@code if}/{@code unless}/{@code elsif} and
-     * to {@code do BLOCK}.  It does <em>not</em> apply to an {@code else} branch
-     * (Perl sets {@code OPf_PARENS} there, which takes the {@code ENTER}/
-     * {@code LEAVE} path instead), nor to loop bodies, {@code eval} blocks,
-     * subroutine bodies, or bare blocks.
-     *
-     * @param block the block whose leading statement may lose its COP
+     * A do-block passed through {@code op_scope()} nulls the leading COP when it
+     * contains one statement, preserving the enclosing statement's caller line.
      */
     static void markOpScopedBlock(BlockNode block) {
-        if (block == null || block.elements.size() != 1) {
-            return;
-        }
-        if (block.elements.getFirst() instanceof AbstractNode first) {
+        if (block != null && block.elements.size() == 1
+                && block.elements.getFirst() instanceof AbstractNode first) {
             first.setAnnotation(INHERIT_ENCLOSING_COPLINE, true);
         }
-    }
-
-    /**
-     * Reports whether a condition is a compile-time constant.  Perl folds
-     * {@code if (1) { ... }} into a plain block, which skips {@code op_scope()}
-     * and so keeps the body statement's own COP.
-     */
-    static boolean isConstantCondition(Node condition) {
-        Node node = condition;
-        while (node instanceof OperatorNode operatorNode
-                && ("-".equals(operatorNode.operator) || "+".equals(operatorNode.operator)
-                || "!".equals(operatorNode.operator))) {
-            node = operatorNode.operand;
-        }
-        return node instanceof NumberNode || node instanceof StringNode;
     }
 
     /**

--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -377,6 +377,12 @@ public class StatementParser {
         TestMoreHelper.handleSkipTest(parser, thenBranch);
 
         IfNode result = new IfNode(operator.text, condition, thenBranch, elseBranch, parser.tokenIndex);
+        // An elsif is parsed as the previous if's else branch rather than as a
+        // top-level block statement. Preserve its own COP start so calls in its
+        // condition do not inherit the preceding branch's line.
+        if (!enterNewScope) {
+            result.setAnnotation("statementStartIndex", statementStartIndex);
+        }
         // A lexical declaration in the condition owns the next COP in Perl, so
         // the first standalone call reports the conditional's source line.
         // Ordinary conditions keep the call's own line (see op/caller.t).
@@ -385,12 +391,6 @@ public class StatementParser {
                 && "(".equals(first.operator)
                 && conditionContainsLexicalDeclaration(condition)) {
             first.setAnnotation("callerLineTokenOverride", statementStartIndex);
-        }
-        // Perl runs the then-branch through op_scope(), which nulls a lone leading
-        // nextstate, so a single-statement body reports the conditional's line. A
-        // constant condition is folded away and keeps the body's own line.
-        if (!StatementCopline.isConstantCondition(condition)) {
-            StatementCopline.markOpScopedBlock(thenBranch);
         }
         if (enterNewScope) {
             result.setAnnotation("postBlockHintHashId", HintHashRegistry.snapshotCurrentHintHash());

--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -386,6 +386,12 @@ public class StatementParser {
                 && conditionContainsLexicalDeclaration(condition)) {
             first.setAnnotation("callerLineTokenOverride", statementStartIndex);
         }
+        // Perl runs the then-branch through op_scope(), which nulls a lone leading
+        // nextstate, so a single-statement body reports the conditional's line. A
+        // constant condition is folded away and keeps the body's own line.
+        if (!StatementCopline.isConstantCondition(condition)) {
+            StatementCopline.markOpScopedBlock(thenBranch);
+        }
         if (enterNewScope) {
             result.setAnnotation("postBlockHintHashId", HintHashRegistry.snapshotCurrentHintHash());
         }

--- a/src/test/resources/unit/caller_block_terminated_copline.t
+++ b/src/test/resources/unit/caller_block_terminated_copline.t
@@ -1,0 +1,18 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 1;
+
+{
+    package CallerBlockTerminatedCopline::Thing;
+    sub new { bless {}, shift }
+    sub report { return (caller)[2] }
+}
+
+# This is the exact shape from issue #1135.  The preceding package block has
+# no semicolon, so Perl's COP lookahead reports the argument line, not the line
+# containing the invocant or the final method call.
+my $line = CallerBlockTerminatedCopline::Thing->new(
+    value => 1,
+)->report;
+is($line, __LINE__ - 3, 'block-terminated predecessor preserves Perl COP line');

--- a/src/test/resources/unit/caller_conditional_block_line.t
+++ b/src/test/resources/unit/caller_conditional_block_line.t
@@ -1,0 +1,23 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+sub report_caller_line { (caller)[2] }
+
+my $condition = 1;
+if (0) {
+    fail('unreachable');
+}
+elsif ($condition) {
+    my $expected = __LINE__ + 1;
+    is(report_caller_line(), $expected,
+        'a call in an elsif block keeps its own statement line');
+}
+
+my $expected_do = __LINE__ + 1;
+my $from_do = do {
+    report_caller_line();
+};
+is($from_do, $expected_do,
+    'a call in a do block inherits its enclosing statement line');

--- a/src/test/resources/unit/caller_multiline_chained_call_line.t
+++ b/src/test/resources/unit/caller_multiline_chained_call_line.t
@@ -1,0 +1,105 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More tests => 10;
+
+# Perl keeps one COP (source line) per statement, taken from the statement's
+# first token, so every call inside a multi-line statement -- including a method
+# call at the very end of a chained expression -- reports the line the statement
+# started on, not the closing ")->method" line.
+#
+# Each case below is preceded by an ordinary ";"-terminated statement on purpose:
+# after a block-terminated statement ("if (...) { }", a bare block, "{ package
+# ... }") Perl's own copline bookkeeping shifts the reported line, and that
+# artifact is deliberately not reproduced here.
+
+{
+    package CallerMultilineChain::Obj;
+    sub new { bless {}, shift }
+    sub report { return (caller)[2] }
+    sub chain { $_[0] }
+}
+
+my $obj = CallerMultilineChain::Obj->new;
+
+sub plain_report { return (caller)[2] }
+
+# 1. the issue's shape: multi-line argument list, then ")->method"
+my $expected_chain = __LINE__ + 1;
+my $chain = CallerMultilineChain::Obj->new(
+    value => 1,
+)->report;
+is($chain, $expected_chain,
+    'method call after a multi-line argument list reports the statement line');
+
+# 2. call finished on one line, arrow continued on the next
+my $expected_arrow_next = __LINE__ + 1;
+my $arrow_next = CallerMultilineChain::Obj->new(1)
+    ->report;
+is($arrow_next, $expected_arrow_next,
+    'arrow on a continuation line reports the statement line');
+
+# 3. invocant alone on the first line
+my $expected_invocant = __LINE__ + 1;
+my $invocant = $obj
+    ->report;
+is($invocant, $expected_invocant,
+    'method call on a continuation line reports the statement line');
+
+# 4. deeper chain: every call in the chain shares the statement line
+my $expected_deep = __LINE__ + 1;
+my $deep = CallerMultilineChain::Obj->new(
+)->chain(
+)->report;
+is($deep, $expected_deep,
+    'deep multi-line chain reports the statement line');
+
+# 5. arguments spread over several lines
+my $expected_wide = __LINE__ + 1;
+my $wide = CallerMultilineChain::Obj->new(
+    a => 1,
+    b => 2,
+    c => 3,
+)->report;
+is($wide, $expected_wide,
+    'method call after a wide argument list reports the statement line');
+
+# 6. plain (non-method) multi-line call
+my $expected_plain = __LINE__ + 1;
+my $plain = plain_report(
+    1,
+);
+is($plain, $expected_plain,
+    'plain multi-line call reports the statement line');
+
+# 7. assignment operator on its own line before the chain
+my $expected_assign = __LINE__ + 1;
+my $assign =
+    CallerMultilineChain::Obj->new(
+        1,
+    )->report;
+is($assign, $expected_assign,
+    'chain below an assignment reports the statement line');
+
+# 8. warn uses the same per-statement source line
+my @warnings;
+local $SIG{__WARN__} = sub { push @warnings, $_[0] };
+my $expected_warn = __LINE__ + 1;
+warn(
+    "multiline warn",
+);
+like($warnings[0], qr/\bline $expected_warn\b/,
+    'multi-line warn reports the statement line');
+
+# 9. single-line calls are unaffected
+my $expected_single = __LINE__ + 1;
+my $single = $obj->report;
+is($single, $expected_single, 'single-line method call reports its own line');
+
+# 10. a literal anon sub argument is still exempt from the statement line
+my $expected_block = __LINE__ + 3;
+my $block = plain_report(
+    sub { 1 }
+);
+is($block, $expected_block,
+    'literal anon sub argument keeps its own block line');


### PR DESCRIPTION
Fixes #1135.

Split from #1186. Includes the caller COP-line model and a permanent test for the original block-terminated reproducer. Focused system Perl, JVM, and interpreter validation passed; full gate remains required before review.
