### PR TITLE
fix: restore Date::Calc Bit::Vector calendar support

### DIFF
--- a/src/main/perl/lib/Bit/Vector.pm
+++ b/src/main/perl/lib/Bit/Vector.pm
@@ -18,7 +18,11 @@ sub Create {
     $count = 1 unless defined $count;
 
     my @vectors = map {
-        bless { bits => 0 + $bits, value => Math::BigInt->new(0) }, $class
+        bless {
+            bits     => 0 + $bits,
+            value    => Math::BigInt->new(0),
+            set_bits => {},
+        }, $class
     } 1 .. $count;
 
     return wantarray ? @vectors : $vectors[-1];
@@ -42,6 +46,7 @@ sub from_Dec {
     my $number = Math::BigInt->new("$value")->bmod($modulus);
     $number->badd($modulus) if $number->is_neg;
     $self->{value} = $number;
+    _set_bits_from_value($self);
     return $self;
 }
 
@@ -49,6 +54,7 @@ sub to_Dec {
     my ($self) = @_;
     return '0' unless $self->{bits};
 
+    _sync_value_from_bits($self);
     my $number = $self->{value}->copy;
     my $sign = Math::BigInt->new(2)->bpow($self->{bits} - 1);
     if ($number->bcmp($sign) >= 0) {
@@ -66,16 +72,21 @@ sub Concat_List {
     my ($self, @others) = @_;
     my $class = ref($self) || $self;
     my $bits = $self->{bits};
+    _sync_value_from_bits($self);
     my $value = $self->{value}->copy;
+    my %set_bits = %{ $self->{set_bits} };
 
     for my $other (@others) {
         die "Bit::Vector::Concat_List(): not a Bit::Vector object\n"
             unless ref($other) && $other->isa('Bit::Vector');
+        _sync_value_from_bits($other);
         $value->blsft($other->{bits})->badd($other->{value});
+        %set_bits = map { $_ + $other->{bits} => 1 } keys %set_bits;
+        $set_bits{$_} = 1 for keys %{ $other->{set_bits} };
         $bits += $other->{bits};
     }
 
-    return bless { bits => $bits, value => $value }, $class;
+    return bless { bits => $bits, value => $value, set_bits => \%set_bits }, $class;
 }
 
 sub Chunk_Read {
@@ -85,9 +96,150 @@ sub Chunk_Read {
         unless defined($offset) && $offset =~ /\A\d+\z/
             && $offset + $chunk_bits <= $self->{bits};
 
+    _sync_value_from_bits($self);
     my $mask = Math::BigInt->new(2)->bpow($chunk_bits)->bdec;
     my $chunk = $self->{value}->copy->brsft($offset)->band($mask);
     return 0 + "$chunk";
+}
+
+sub Bit_Off {
+    my ($self, $index) = @_;
+    $index = _check_index('Bit_Off', $self, $index);
+    delete $self->{set_bits}{$index};
+    return;
+}
+
+sub Bit_On {
+    my ($self, $index) = @_;
+    $index = _check_index('Bit_On', $self, $index);
+    $self->{set_bits}{$index} = 1;
+    return;
+}
+
+sub Empty {
+    $_[0]->{set_bits} = {};
+    return;
+}
+
+sub Fill {
+    my ($self) = @_;
+    $self->{set_bits} = { map { $_ => 1 } 0 .. $self->{bits} - 1 };
+    return;
+}
+
+sub Interval_Fill {
+    my ($self, $lower, $upper) = @_;
+    $lower = _check_index('Interval_Fill', $self, $lower);
+    $upper = _check_index('Interval_Fill', $self, $upper);
+    die "Bit::Vector::Interval_Fill(): minimum greater than maximum\n"
+        if $lower > $upper;
+    $self->{set_bits}{$_} = 1 for $lower .. $upper;
+    return;
+}
+
+sub AndNot {
+    my ($self, $left, $right) = @_;
+    $self->{set_bits} = {
+        map { $_ => 1 } grep { !$right->{set_bits}{$_} } keys %{ $left->{set_bits} }
+    };
+    return;
+}
+
+sub And {
+    my ($self, $left, $right) = @_;
+    $self->{set_bits} = {
+        map { $_ => 1 } grep { $right->{set_bits}{$_} } keys %{ $left->{set_bits} }
+    };
+    return;
+}
+
+sub Norm { scalar keys %{ $_[0]->{set_bits} } }
+
+sub Interval_Scan_dec {
+    my ($self, $index) = @_;
+    $index = _check_index('Interval_Scan_dec', $self, $index);
+    return unless $self->{set_bits}{$index};
+    my $min = $index;
+    --$min while $min > 0 && $self->{set_bits}{ $min - 1 };
+    return ($min, $index);
+}
+
+sub Interval_Scan_inc {
+    my ($self, $index) = @_;
+    $index = _check_index('Interval_Scan_inc', $self, $index);
+    return unless $self->{set_bits}{$index};
+    my $max = $index;
+    ++$max while $max + 1 < $self->{bits} && $self->{set_bits}{ $max + 1 };
+    return ($index, $max);
+}
+
+sub bit_flip {
+    my ($self, $index) = @_;
+    $index = _check_index('bit_flip', $self, $index);
+    $self->{set_bits}{$index}
+        ? delete $self->{set_bits}{$index}
+        : ($self->{set_bits}{$index} = 1);
+    return $self->bit_test($index);
+}
+
+sub flip { shift->bit_flip(@_) }
+
+sub bit_test {
+    my ($self, $index) = @_;
+    $index = _check_index('bit_test', $self, $index);
+    return $self->{set_bits}{$index} ? 1 : 0;
+}
+
+sub contains { shift->bit_test(@_) }
+sub in       { shift->bit_test(@_) }
+
+sub Bit_Copy {
+    my ($self, $index, $bit) = @_;
+    $index = _check_index('Bit_Copy', $self, $index);
+    $bit ? $self->Bit_On($index) : $self->Bit_Off($index);
+    return;
+}
+
+sub LSB {
+    my $self = shift;
+    $self->Bit_Copy(0, @_);
+}
+
+sub MSB {
+    my $self = shift;
+    $self->Bit_Copy($self->{bits} - 1, @_);
+}
+
+sub lsb { shift->bit_test(0) }
+sub msb {
+    my $self = shift;
+    $self->bit_test($self->{bits} - 1);
+}
+
+sub _check_index {
+    my ($method, $self, $index) = @_;
+    $index = 0 + $index;
+    die "Bit::Vector::$method(): index out of range\n"
+        unless $index >= 0 && $index < $self->{bits};
+    return int $index;
+}
+
+sub _set_bits_from_value {
+    my ($self) = @_;
+    my $binary = $self->{value}->as_bin;
+    $binary =~ s/^0b//;
+    my %set_bits;
+    for my $index (0 .. length($binary) - 1) {
+        $set_bits{$index} = 1 if substr($binary, -1 - $index, 1) eq '1';
+    }
+    $self->{set_bits} = \%set_bits;
+}
+
+sub _sync_value_from_bits {
+    my ($self) = @_;
+    my $value = Math::BigInt->new(0);
+    $value->bior(Math::BigInt->new(2)->bpow($_)) for keys %{ $self->{set_bits} };
+    $self->{value} = $value;
 }
 
 sub _check_size {

--- a/src/test/resources/module/Bit-Vector/t/date-calc-calendar-bits.t
+++ b/src/test/resources/module/Bit-Vector/t/date-calc-calendar-bits.t
@@ -1,0 +1,58 @@
+use strict;
+use warnings;
+use Test::More tests => 21;
+
+use Bit::Vector;
+
+# Date::Calendar::Year marks the day-of-year entries that are holidays using
+# Bit::Vector.  Keep this focused representation here: Date::Calc itself is
+# an external CPAN consumer, not a bundled module.
+my $calendar = Bit::Vector->new(366);
+
+is($calendar->bit_test(0), 0, 'a new calendar starts with no marked days');
+$calendar->Bit_On(0);
+$calendar->Bit_On(59);
+$calendar->Bit_On(365);
+is($calendar->bit_test(0), 1, 'marks the first day');
+is($calendar->contains(59), 1, 'contains aliases bit_test');
+is($calendar->bit_test(365), 1, 'marks the leap-year final day');
+
+$calendar->Bit_Off(59);
+is($calendar->bit_test(59), 0, 'clears a calendar day');
+is($calendar->bit_flip(59), 1, 'flip returns the new set value');
+is($calendar->flip(59), 0, 'flip alias returns the new clear value');
+
+$calendar->Bit_Copy(59, 1);
+is($calendar->bit_test(59), 1, 'copies a true bit value');
+$calendar->Bit_Copy(59, 0);
+is($calendar->bit_test(59), 0, 'copies a false bit value');
+
+$calendar->LSB(1);
+$calendar->MSB(1);
+is($calendar->lsb, 1, 'reads the least significant calendar bit');
+is($calendar->msb, 1, 'reads the most significant calendar bit');
+
+my $workdays = Bit::Vector->new(366);
+$workdays->Interval_Fill(0, 4);
+$workdays->AndNot($workdays, $calendar);
+is($workdays->Norm, 4, 'removes a calendar holiday from a workday interval');
+$workdays->Interval_Fill(0, 4);
+$workdays->And($workdays, $calendar);
+is($workdays->Norm, 1, 'finds a calendar holiday via intersection');
+$workdays->Empty;
+is($workdays->Norm, 0, 'clears the calendar work space');
+$workdays->Interval_Fill(2, 4);
+is_deeply([ $workdays->Interval_Scan_inc(3) ], [ 3, 4 ],
+    'incremental scan starts at the requested day');
+is_deeply([ $workdays->Interval_Scan_dec(3) ], [ 2, 3 ],
+    'decremental scan ends at the requested day');
+
+for my $method (qw(Bit_On Bit_Off bit_test bit_flip Bit_Copy)) {
+    my $ok = eval {
+        $method eq 'Bit_Copy'
+            ? $calendar->$method(366, 1)
+            : $calendar->$method(366);
+        1;
+    };
+    ok(!$ok && $@ =~ /index out of range/, "$method rejects an index past the calendar");
+}


### PR DESCRIPTION
## Summary

- implement the Bit::Vector single-bit, set, interval, and scan operations used by Date::Calc calendars
- preserve fixed-width conversion compatibility while keeping calendar bit operations efficient on both backends
- add focused permanent Date::Calc calendar regression coverage

Fixes #1193.

## Validation

- `make`
- system Perl: `date-calc-calendar-bits.t` (21 assertions)
- JVM and interpreter: `date-calc-calendar-bits.t` (21 assertions each)
- `./jcpan -t Date::Calc` — 51 files, 3381 tests passed
