### PR TITLE
fix(import): preserve patched Git-tracked imports

### DIFF
--- a/dev/import-perl5/config.yaml
+++ b/dev/import-perl5/config.yaml
@@ -749,6 +749,12 @@ imports:
     target: src/main/perl/lib/File/Spec
     type: directory
 
+  # File::Spec::Win32 - preserve PerlOnJava taint propagation overrides
+  # after the encompassing File::Spec directory import.
+  - source: perl5/dist/PathTools/lib/File/Spec/Win32.pm
+    target: src/main/perl/lib/File/Spec/Win32.pm
+    patch: Win32.pm.patch
+
   # File::Spec::Unix - PerlOnJava patch for jar: paths
   - source: perl5/dist/PathTools/lib/File/Spec/Unix.pm
     target: src/main/perl/lib/File/Spec/Unix.pm

--- a/dev/import-perl5/patches/PP.pm.patch
+++ b/dev/import-perl5/patches/PP.pm.patch
@@ -1,5 +1,5 @@
---- perl5/cpan/JSON-PP/lib/JSON/PP.pm	2025-12-30 10:25:00
-+++ src/main/perl/lib/JSON/PP.pm	2026-04-23 21:59:52
+--- perl5/cpan/JSON-PP/lib/JSON/PP.pm
++++ src/main/perl/lib/JSON/PP.pm
 @@ -129,6 +129,17 @@
  
  
@@ -18,7 +18,18 @@
  
  sub new {
      my $class = shift;
-@@ -695,6 +706,9 @@
+@@ -583,6 +594,10 @@
+ 
+     sub __sort {
+         my $self = shift;
++        # JSON::PP's canonical comparator closes over Perl's implicit sort
++        # variables.  Keep the canonical fast path explicit until generated
++        # comparator closures support those aliases.
++        return sort keys %{$_[0]} if $self->{PROPS}[P_CANONICAL];
+         my $keysort = $self->{keysort};
+         defined $keysort ? (sort $keysort (keys %{$_[0]})) : keys %{$_[0]};
+     }
+@@ -661,6 +676,9 @@
              last;
          }
      }
@@ -28,7 +39,7 @@
  }
  
  { # PARSE 
-@@ -1544,8 +1558,30 @@
+@@ -1486,8 +1504,30 @@
  
                  my ($obj, $offset) = $coder->PP_decode_json( $self->{incr_text}, 0x00000001 );
                  push @ret, $obj;

--- a/dev/import-perl5/patches/Win32.pm.patch
+++ b/dev/import-perl5/patches/Win32.pm.patch
@@ -1,0 +1,159 @@
+--- perl5/dist/PathTools/lib/File/Spec/Win32.pm
++++ src/main/perl/lib/File/Spec/Win32.pm
+@@ -15,7 +15,16 @@
+ my $UNC_RX = '(?:\\\\\\\\|//)[^\\\\/]+[\\\\/][^\\\\/]+';
+ my $VOL_RX = "(?:$DRIVE_RX|$UNC_RX)";
+ 
++# The Java-backed File::Spec::Unix methods retain taint explicitly.  Win32
++# overrides several of them in Perl, where the intermediate regex and string
++# operations can otherwise lose a caller's taint metadata.  Preserve it at the
++# public method boundary, matching native Perl's path operations.
++sub _taint_result {
++    my ($result, @sources) = @_;
++    return Internals::taint_propagate($result, @sources);
++}
+ 
++
+ =head1 NAME
+ 
+ File::Spec::Win32 - methods for Win32 file specs
+@@ -133,42 +142,46 @@
+ 
+ sub catfile {
+     shift;
++    my @sources = @_;
+ 
+     # Legacy / compatibility support
+     #
+-    shift, return _canon_cat( "/", @_ )
++    shift, return _taint_result(_canon_cat( "/", @_ ), @sources)
+ 	if !@_ || $_[0] eq "";
+ 
+     # Compatibility with File::Spec <= 3.26:
+     #     catfile('A:', 'foo') should return 'A:\foo'.
+-    return _canon_cat( ($_[0].'\\'), @_[1..$#_] )
++    return _taint_result(_canon_cat( ($_[0].'\\'), @_[1..$#_] ), @sources)
+         if $_[0] =~ m{^$DRIVE_RX\z}o;
+ 
+-    return _canon_cat( @_ );
++    return _taint_result(_canon_cat( @_ ), @sources);
+ }
+ 
+ sub catdir {
+     shift;
++    my @sources = @_;
+ 
+     # Legacy / compatibility support
+     #
+-    return ""
++    return _taint_result("")
+     	unless @_;
+-    shift, return _canon_cat( "/", @_ )
++    shift, return _taint_result(_canon_cat( "/", @_ ), @sources)
+ 	if $_[0] eq "";
+ 
+     # Compatibility with File::Spec <= 3.26:
+     #     catdir('A:', 'foo') should return 'A:\foo'.
+-    return _canon_cat( ($_[0].'\\'), @_[1..$#_] )
++    return _taint_result(_canon_cat( ($_[0].'\\'), @_[1..$#_] ), @sources)
+         if $_[0] =~ m{^$DRIVE_RX\z}o;
+ 
+-    return _canon_cat( @_ );
++    return _taint_result(_canon_cat( @_ ), @sources);
+ }
+ 
+ sub path {
+-    my @path = split(';', $ENV{PATH});
++    my $env_path = $ENV{PATH};
++    my @path = split(';', $env_path);
+     s/"//g for @path;
+     @path = grep length, @path;
++    @path = map { _taint_result($_, $env_path) } @path;
+     unshift(@path, ".");
+     return @path;
+ }
+@@ -187,8 +200,8 @@
+ sub canonpath {
+     # Legacy / compatibility support
+     #
+-    return $_[1] if !defined($_[1]) or $_[1] eq '';
+-    return _canon_cat( $_[1] );
++    return _taint_result($_[1], $_[1]) if !defined($_[1]) or $_[1] eq '';
++    return _taint_result(_canon_cat( $_[1] ), $_[1]);
+ }
+ 
+ =item splitpath
+@@ -218,7 +231,9 @@
+         $path =~ 
+             m{^ ( $VOL_RX ? ) (.*) }sox;
+         $volume    = $1;
+-        $directory = $2;
++        # Unlike the capture-derived fields, the no-file directory is the
++        # caller's path itself and must retain its taint.
++        $directory = _taint_result($2, $path);
+     }
+     else {
+         $path =~ 
+@@ -234,7 +249,13 @@
+     return ($volume,$directory,$file);
+ }
+ 
++sub join {
++    shift;
++    my @sources = @_;
++    return _taint_result(_canon_cat(@_), @sources);
++}
+ 
++
+ =item splitdir
+ 
+ The opposite of L<catdir()|File::Spec/catdir>.
+@@ -289,6 +310,7 @@
+ 
+ sub catpath {
+     my ($self,$volume,$directory,$file) = @_;
++    my @sources = ($volume, $directory, $file);
+ 
+     # If it's UNC, make sure the glue separator is there, reusing
+     # whatever separator is first in the $volume
+@@ -313,7 +335,7 @@
+ 
+     $volume .= $file ;
+ 
+-    return $volume ;
++    return _taint_result($volume, @sources);
+ }
+ 
+ sub _same {
+@@ -326,12 +348,12 @@
+     my $is_abs = $self->file_name_is_absolute($path);
+ 
+     # Check for volume (should probably document the '2' thing...)
+-    return $self->canonpath( $path ) if $is_abs == 2;
++    return _taint_result($self->canonpath( $path ), $path, $base) if $is_abs == 2;
+ 
+     if ($is_abs) {
+       # It's missing a volume, add one
+       my $vol = ($self->splitpath( Cwd::getcwd() ))[0];
+-      return $self->canonpath( $vol . $path );
++      return _taint_result($self->canonpath( $vol . $path ), $path, $vol);
+     }
+ 
+     if ( !defined( $base ) || $base eq '' ) {
+@@ -357,9 +379,15 @@
+ 			   $path_file
+ 			  ) ;
+ 
+-    return $self->canonpath( $path ) ;
++    return _taint_result($self->canonpath( $path ), $path, $base);
+ }
+ 
++sub abs2rel {
++    my ($self, $path, $base) = @_;
++    my $result = File::Spec::Unix::abs2rel(@_);
++    return _taint_result($result, $path, $base);
++}
++
+ =back
+ 
+ =head2 Note For File::Spec::Win32 Maintainers


### PR DESCRIPTION
## Summary

- preserve File::Spec::Win32 compatibility overrides during `sync.pl` directory imports
- refresh the JSON::PP patch against the current Perl upstream source

## Validation

- `perl dev/import-perl5/sync.pl --verify-idempotent`
- `prove dev/import-perl5/t dev/import-perl5/sync_file_mode.t`
- `make`
