### PR TITLE
fix: parse CPAN .tgz test archives

### DIFF
--- a/dev/tools/cpan_random_tester.pl
+++ b/dev/tools/cpan_random_tester.pl
@@ -454,11 +454,11 @@ sub parse_all_module_results {
         # The checksum line directly follows CPAN's module selection.  Keep
         # that association: dependency discovery can change $last_mod before
         # CPAN later returns to configure the original distribution.
-        if ($last_mod && $line =~ m{Checksum for \S+/(\S+)\.tar\.gz}) {
+        if ($last_mod && $line =~ m{Checksum for \S+/(\S+)\.(?:tar\.gz|tgz)}) {
             $dist_to_mod{$1} //= $last_mod;
         }
         # "Configuring A/AU/AUTHOR/Dist-Name-1.0.tar.gz with ..."
-        if ($last_mod && $line =~ m{Configuring \S+/(\S+)\.tar\.gz}) {
+        if ($last_mod && $line =~ m{Configuring \S+/(\S+)\.(?:tar\.gz|tgz)}) {
             $dist_to_mod{$1} //= $last_mod;
         }
     }
@@ -472,7 +472,7 @@ sub parse_all_module_results {
         my $cur_dist;
         my $cur_text = '';
         for my $line (split /\n/, $output) {
-            if ($line =~ m{Running (?:make|Build) test for \S+/(\S+)\.tar\.gz}) {
+            if ($line =~ m{Running (?:make|Build) test for \S+/(\S+)\.(?:tar\.gz|tgz)}) {
                 if ($cur_dist) {
                     push @test_blocks, { dist => $cur_dist, text => $cur_text };
                 }
@@ -602,7 +602,7 @@ sub parse_all_module_results {
         # without necessarily repeating "Running test for module".  Associate
         # its archive path with the module recorded during Pass 1 so a later
         # configure/build failure is not charged to the last dependency.
-        if ($line =~ m{(?:Configuring|Running (?:make|Build) for) \S+/(\S+)\.tar\.gz}) {
+        if ($line =~ m{(?:Configuring|Running (?:make|Build) for) \S+/(\S+)\.(?:tar\.gz|tgz)}) {
             $last_mod = $dist_to_mod{$1} if $dist_to_mod{$1};
         }
 
@@ -666,10 +666,10 @@ sub parse_all_module_results_from_file {
             if ($line =~ /Running (?:test|install) for module '([^']+)'/) {
                 $last_mod = $1;
             }
-            if ($last_mod && $line =~ m{Checksum for \S+/(\S+)\.tar\.gz}) {
+            if ($last_mod && $line =~ m{Checksum for \S+/(\S+)\.(?:tar\.gz|tgz)}) {
                 $dist_to_mod{$1} //= $last_mod;
             }
-            if ($last_mod && $line =~ m{Configuring \S+/(\S+)\.tar\.gz}) {
+            if ($last_mod && $line =~ m{Configuring \S+/(\S+)\.(?:tar\.gz|tgz)}) {
                 $dist_to_mod{$1} //= $last_mod;
             }
         }
@@ -686,7 +686,7 @@ sub parse_all_module_results_from_file {
     my $block;
     if (open my $fh, '<', $path) {
         while (my $line = <$fh>) {
-            if ($line =~ m{Running (?:make|Build) test for \S+/(\S+)\.tar\.gz}) {
+            if ($line =~ m{Running (?:make|Build) test for \S+/(\S+)\.(?:tar\.gz|tgz)}) {
                 finish_streamed_test_block($block, \%dist_to_mod, \%seen, \@results)
                     if $block;
                 $block = new_streamed_test_block($1);
@@ -718,7 +718,7 @@ sub parse_all_module_results_from_file {
             # See the equivalent Pass 3 association in
             # parse_all_module_results: a parent archive can resume after a
             # dependency without another module-selection line.
-            if ($line =~ m{(?:Configuring|Running (?:make|Build) for) \S+/(\S+)\.tar\.gz}) {
+            if ($line =~ m{(?:Configuring|Running (?:make|Build) for) \S+/(\S+)\.(?:tar\.gz|tgz)}) {
                 $last_mod = $dist_to_mod{$1} if $dist_to_mod{$1};
             }
 

--- a/dev/tools/tests/cpan_random_tester_parser.t
+++ b/dev/tools/tests/cpan_random_tester_parser.t
@@ -63,6 +63,36 @@ is_deeply(
     'streaming parser preserves the target association too',
 );
 
+my $tgz_success = <<'LOG';
+Running test for module 'Statistics::Burst'
+Checksum for /tmp/cpan/sources/authors/id/T/TO/TOMMIE/Statistics-Burst-0.2.tgz ok
+Configuring T/TO/TOMMIE/Statistics-Burst-0.2.tgz with Makefile.PL
+Running make test for TOMMIE/Statistics-Burst-0.2.tgz
+t/Statistics-Burst.t .. ok
+All tests successful.
+Files=1, Tests=3
+Result: PASS
+  /usr/bin/make test -- OK
+LOG
+
+my @tgz_memory_results = parse_all_module_results($tgz_success);
+is($tgz_memory_results[0]{status}, 'PASS',
+    'in-memory parser recognizes a successful CPAN .tgz test');
+
+my ($tgz_log_fh, $tgz_log_path) = tempfile();
+print {$tgz_log_fh} $tgz_success;
+close $tgz_log_fh or die "cannot close $tgz_log_path: $!";
+my @tgz_results = parse_all_module_results_from_file($tgz_log_path);
+is_deeply(
+    [map { $_->{module} } @tgz_results],
+    ['Statistics::Burst'],
+    'streaming parser recognizes CPAN .tgz test archives',
+);
+is($tgz_results[0]{status}, 'PASS',
+    'successful CPAN .tgz test is recorded as a pass');
+is($tgz_results[0]{tests}, 3,
+    'successful CPAN .tgz test retains its test count');
+
 my $build_failure_after_dependency = <<'LOG';
 Running test for module 'Marpa::R2'
 Checksum for /tmp/cpan/sources/authors/id/J/JK/JKEGL/Marpa-R2-14.000000.tar.gz ok


### PR DESCRIPTION
## Summary

- Parse CPAN distribution archives ending in `.tgz` as well as `.tar.gz`.
- Prevent successful tests such as `Statistics::Burst` from being recorded as `No parseable output`.
- Add parser coverage for the archived Statistics::Burst success-log shape.

## Verification

- `timeout 60 perl dev/tools/tests/cpan_random_tester_parser.t`
- `make`
