### PR TITLE
Fix active formats for write filehandles

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -9,6 +9,8 @@ Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
 
 - Fix format declarations being discarded during compilation, unblocking `write` execution.
 
+- Make `write FILEHANDLE` use that handle's active `$~` format, including when the format undefines its own glob during execution.
+
 - Clear weakened references after a nested method releases its final
   array-slot owner, restoring `Algorithm::SlidingWindow` eviction and clear
   behavior on both execution backends.

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -498,7 +498,7 @@ in this capability matrix.
 - ✅  **User/Group operators, Network info operators**: `getlogin`, `getpwnam`, `getpwuid`, `getgrnam`, `getgrgid`, `getpwent`, `getgrent`, `setpwent`, `setgrent`, `endpwent`, `endgrent`, `gethostbyname`, `gethostbyaddr`, `getservbyname`, `getservbyport`, `getprotobyname`, `getprotobynumber`.
 - ✅  **Network enumeration operators**: `endhostent`, `endnetent`, `endprotoent`, `endservent`, `gethostent`, `getnetbyaddr`, `getnetbyname`, `getnetent`, `getprotoent`, `getservent`, `sethostent`, `setnetent`, `setprotoent`, `setservent`.
 - ✅  **System V IPC operators**: `msgctl`, `msgget`, `msgrcv`, `msgsnd`, `semctl`, `semget`, `semop`, `shmctl`, `shmget`, `shmread`, `shmwrite`.
-- ✅  **`format` operator**: `format` and `write` functions for report generation are implemented.
+- 🚧  **`format` operator**: Format declarations, basic `write`, and per-filehandle active-format (`$~`) selection work. Format argument lines do not yet execute general Perl expressions: lexical captures, blocks, anonymous data structures, operators, method calls, tied/overloaded values, evaluation-order side effects, and normal expression diagnostics are incomplete. `^` field consumption and `~~` continuation semantics remain incomplete. See [#1234](https://github.com/fglock/PerlOnJava/issues/1234).
 - ✅  **`formline` operator**: `formline` and `$^A` accumulator variable are implemented.
 
 ---

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -1767,41 +1767,29 @@ public class IOOperator {
      */
     public static RuntimeScalar write(int ctx, RuntimeBase... args) {
         String formatName;
-        RuntimeIO fh = RuntimeIO.getStdout(); // Default output handle
+        RuntimeIO fh = RuntimeIO.getSelectedHandle();
+        if (fh == null) fh = RuntimeIO.getStdout();
 
         if (args.length == 0) {
-            // No arguments: write() - use STDOUT format to STDOUT handle
-            formatName = "STDOUT";
+            // No argument writes to the selected handle using its active format.
+            formatName = CurrentFormatVariable.currentFormatName(fh);
         } else {
-            // One argument: write FORMAT_NAME - use named format to STDOUT handle
+            // One argument: write FILEHANDLE uses that handle's active format.
             RuntimeScalar arg = args[0].scalar();
+            RuntimeIO argFh = arg.getRuntimeIO();
 
-            // Check if argument is a glob reference (which contains the format name)
-            if (arg.type == RuntimeScalarType.GLOBREFERENCE && arg.value instanceof RuntimeGlob glob) {
+            if (argFh != null) {
+                fh = argFh;
+                formatName = CurrentFormatVariable.currentFormatName(fh);
+            // A named bareword can still be a glob whose IO slot is not materialized.
+            } else if (arg.type == RuntimeScalarType.GLOBREFERENCE && arg.value instanceof RuntimeGlob glob) {
                 formatName = glob.globName;
             } else {
-                // Check if argument is a filehandle or format name
-                RuntimeIO argFh = arg.getRuntimeIO();
-                if (argFh != null) {
-                    // Argument is a filehandle - determine format name from handle
-                    fh = argFh;
-                    if (fh == RuntimeIO.getStdout()) {
-                        formatName = "STDOUT";
-                    } else if (fh == RuntimeIO.getStderr()) {
-                        formatName = "STDERR";
-                    } else if (fh == RuntimeIO.getStdin()) {
-                        formatName = "STDIN";
-                    } else {
-                        formatName = "STDOUT"; // Default fallback
-                    }
-                } else {
-                    // Argument is a format name string (most common case)
-                    formatName = arg.toString();
-                    // Normalize the format name
-                    formatName = NameNormalizer.normalizeVariableName(formatName, "main");
-                }
+                formatName = arg.toString();
             }
         }
+
+        formatName = NameNormalizer.normalizeVariableName(formatName, RuntimeCode.getCurrentPackage());
 
         // Look up the format
         RuntimeFormat format = GlobalVariable.getGlobalFormatRef(formatName);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/CurrentFormatVariable.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/CurrentFormatVariable.java
@@ -1,0 +1,101 @@
+package org.perlonjava.runtime.runtimetypes;
+
+import java.util.Stack;
+
+/**
+ * Filehandle-backed magic scalar for $~ (current format) and $^ (top format).
+ * Perl keeps these names on the currently selected output handle, rather than
+ * in one process-global scalar slot.
+ */
+public final class CurrentFormatVariable extends RuntimeScalar {
+    private final boolean topFormat;
+
+    @SuppressWarnings("unchecked")
+    private Stack<State> stateStack() {
+        return (Stack<State>) (Stack<?>) PerlRuntime.current().executionState().currentFormatStates;
+    }
+
+    public CurrentFormatVariable(boolean topFormat) {
+        this.topFormat = topFormat;
+    }
+
+    private RuntimeIO currentHandle() {
+        RuntimeIO handle = RuntimeIO.getSelectedHandle();
+        return handle != null ? handle : RuntimeIO.getStdout();
+    }
+
+    private static String defaultName(RuntimeIO handle, boolean topFormat) {
+        String name = handle != null ? handle.globName : null;
+        if (name == null || name.isEmpty()) return null;
+        int separator = name.lastIndexOf("::");
+        String shortName = separator >= 0 ? name.substring(separator + 2) : name;
+        return topFormat ? shortName + "_TOP" : shortName;
+    }
+
+    public static String currentFormatName(RuntimeIO handle) {
+        if (handle == null) handle = RuntimeIO.getStdout();
+        return handle.currentFormatInitialized ? handle.currentFormatName : defaultName(handle, false);
+    }
+
+    private String getName() {
+        RuntimeIO handle = currentHandle();
+        boolean initialized = topFormat ? handle.currentTopFormatInitialized : handle.currentFormatInitialized;
+        if (!initialized) return defaultName(handle, topFormat);
+        return topFormat ? handle.currentTopFormatName : handle.currentFormatName;
+    }
+
+    private void setName(String name) {
+        RuntimeIO handle = currentHandle();
+        if (topFormat) {
+            handle.currentTopFormatName = name;
+            handle.currentTopFormatInitialized = true;
+        } else {
+            handle.currentFormatName = name;
+            handle.currentFormatInitialized = true;
+        }
+        this.type = name == null ? RuntimeScalarType.UNDEF : RuntimeScalarType.STRING;
+        this.value = name;
+    }
+
+    @Override
+    public RuntimeScalar set(RuntimeScalar value) {
+        setName(value.getDefinedBoolean() ? value.toString() : null);
+        return this;
+    }
+
+    @Override public RuntimeScalar set(String value) { setName(value); return this; }
+    @Override public RuntimeScalar set(int value) { setName(Integer.toString(value)); return this; }
+    @Override public RuntimeScalar set(long value) { setName(Long.toString(value)); return this; }
+    @Override public RuntimeScalar set(boolean value) { setName(value ? "1" : ""); return this; }
+
+    @Override public String toString() { return getName() == null ? "" : getName(); }
+    @Override public boolean getDefinedBoolean() { return getName() != null; }
+    @Override public boolean getBoolean() { return getName() != null && !getName().isEmpty() && !"0".equals(getName()); }
+    @Override public int getInt() { try { return Integer.parseInt(toString()); } catch (NumberFormatException ignored) { return 0; } }
+    @Override public long getLong() { try { return Long.parseLong(toString()); } catch (NumberFormatException ignored) { return 0; } }
+    @Override public double getDouble() { try { return Double.parseDouble(toString()); } catch (NumberFormatException ignored) { return 0; } }
+
+    @Override
+    public void dynamicSaveState() {
+        RuntimeIO handle = currentHandle();
+        stateStack().push(new State(handle,
+                topFormat ? handle.currentTopFormatName : handle.currentFormatName,
+                topFormat ? handle.currentTopFormatInitialized : handle.currentFormatInitialized));
+        setName(null);
+    }
+
+    @Override
+    public void dynamicRestoreState() {
+        if (stateStack().isEmpty()) return;
+        State state = stateStack().pop();
+        if (topFormat) {
+            state.handle.currentTopFormatName = state.name;
+            state.handle.currentTopFormatInitialized = state.initialized;
+        } else {
+            state.handle.currentFormatName = state.name;
+            state.handle.currentFormatInitialized = state.initialized;
+        }
+    }
+
+    private record State(RuntimeIO handle, String name, boolean initialized) { }
+}

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ExecutionRuntimeState.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ExecutionRuntimeState.java
@@ -29,6 +29,7 @@ public final class ExecutionRuntimeState {
     final Stack<Object> tiedHashProxyStates = new Stack<>();
     final Stack<Object> inputLineStates = new Stack<>();
     final Stack<Object> autoFlushStates = new Stack<>();
+    final Stack<Object> currentFormatStates = new Stack<>();
     final Stack<Object> errnoStates = new Stack<>();
     final Stack<String> outputFieldSeparatorStates = new Stack<>();
     final Stack<String> outputRecordSeparatorStates = new Stack<>();

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalContext.java
@@ -122,6 +122,8 @@ public class GlobalContext {
             GlobalVariable.globalVariables.put("main::,", ofs);
         }
         GlobalVariable.globalVariables.put("main::|", new OutputAutoFlushVariable());
+        GlobalVariable.globalVariables.put("main::~", new CurrentFormatVariable(false));
+        GlobalVariable.globalVariables.put("main::^", new CurrentFormatVariable(true));
         // Only set $\ if it hasn't been set yet - prevents overwriting during re-entrant calls
         if (!GlobalVariable.globalVariables.containsKey("main::\\")) {
             var ors = new OutputRecordSeparator();
@@ -154,7 +156,7 @@ public class GlobalContext {
         GlobalVariable.globalVariables.put("main::(", new ScalarSpecialVariable(ScalarSpecialVariable.Id.REAL_GID));  // $( - real GID (lazy)
         GlobalVariable.globalVariables.put("main::)", new ScalarSpecialVariable(ScalarSpecialVariable.Id.EFFECTIVE_GID));  // $) - effective GID (lazy)
         GlobalVariable.getGlobalVariable("main::=");  // TODO
-        GlobalVariable.getGlobalVariable("main::^");  // TODO
+        // $^ is installed above as a per-filehandle current top-format variable.
         GlobalVariable.getGlobalVariable("main:::");  // TODO
 
         // Only set $/ if it hasn't been set yet - prevents overwriting during re-entrant calls
@@ -197,7 +199,7 @@ public class GlobalContext {
         GlobalVariable.globalVariables.put(encodeSpecialVar("WARNING_BITS"), new ScalarSpecialVariable(ScalarSpecialVariable.Id.WARNING_BITS));  // ${^WARNING_BITS}
         GlobalVariable.getGlobalVariable(encodeSpecialVar("UTF8CACHE")).set(0);  // ${^UTF8CACHE}
         GlobalVariable.getGlobalVariable("main::[").set(0);  // $[ (array base, deprecated)
-        GlobalVariable.getGlobalVariable("main::~");  // $~ (current format name)
+        // $~ is installed above as a per-filehandle current format variable.
         GlobalVariable.getGlobalVariable("main::%").set(0);  // $% (page number)
         
         // Initialize capture variables $1-$9 (these are read-only and return undef until a match)

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/GlobalRuntimeScalar.java
@@ -51,6 +51,10 @@ public class GlobalRuntimeScalar extends RuntimeScalar {
             DynamicVariableManager.pushLocalVariable(original);
             return original;
         }
+        if (original instanceof CurrentFormatVariable) {
+            DynamicVariableManager.pushLocalVariable(original);
+            return original;
+        }
         if (original instanceof ErrnoVariable) {
             DynamicVariableManager.pushLocalVariable(original);
             return original;

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeIO.java
@@ -372,6 +372,16 @@ public class RuntimeIO extends RuntimeScalar {
      */
     public String globName;
     /**
+     * The current body and top format names for this handle ($~ and $^).
+     * A null name with the corresponding initialized flag clear means the
+     * Perl default derived from the handle name still applies; a set flag
+     * with a null name represents a dynamically-localized undef value.
+     */
+    public String currentFormatName;
+    public String currentTopFormatName;
+    public boolean currentFormatInitialized;
+    public boolean currentTopFormatInitialized;
+    /**
      * Flag indicating if this handle has unflushed output.
      * Used to determine when automatic flushing is needed.
      */

--- a/src/test/resources/unit/format_write_regression.t
+++ b/src/test/resources/unit/format_write_regression.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 1;
+use Test::More tests => 4;
 
 format STDOUT =
 .
@@ -13,3 +13,22 @@ my $error;
 }
 
 ok !$error, 'write registers and executes a declared format';
+
+open(UNDEF, '>', 'format_write_active_format.tmp') or die "open: $!";
+select +(select(UNDEF), $~ = 'UNDEFFORMAT')[0];
+format UNDEFFORMAT =
+@
+undef *UNDEFFORMAT
+.
+eval { write UNDEF };
+ok !$@, 'write uses the handle active format after its format glob is freed';
+
+my $old = select UNDEF;
+is $~, 'UNDEFFORMAT', 'current format remains associated with its handle';
+{
+    local $~ = 'LOCAL_FORMAT';
+    is $~, 'LOCAL_FORMAT', 'local current format applies to the selected handle';
+}
+select $old;
+close UNDEF;
+unlink 'format_write_active_format.tmp';


### PR DESCRIPTION
Closes #1229

## Summary

- store `$~` and `$^` state on each output handle, with dynamic `local` support
- make `write FILEHANDLE` resolve that handle's active format before executing it
- cover the active-format self-undefinition scenario from `op/write.t`

## Validation

- `prove src/test/resources/unit/format_write_regression.t` (system Perl)
- `./jperl src/test/resources/unit/format_write_regression.t`
- `./jperl --interpreter src/test/resources/unit/format_write_regression.t`
- `make`
- `make check-links`

Generated with [Codex](https://openai.com/codex/)
