### PR TITLE
docs: clarify active development status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 We welcome contributions! This guide will help you get started.
 
+PerlOnJava is actively developed in its
+[compatibility and performance phase](docs/about/roadmap.md#current-project-status).
+The broad language implementation is in place, so the highest-impact work now
+closes remaining Perl behavior gaps, expands CPAN compatibility, and improves
+CPU and memory performance.
+
 ## Ways to Contribute
 
 - **Report bugs** - Open issues on GitHub
@@ -10,6 +16,8 @@ We welcome contributions! This guide will help you get started.
 - **Improve docs** - Fix typos, add examples, clarify explanations
 - **Port modules** - Help port CPAN modules to PerlOnJava
 - **Write tests** - Add test coverage
+- **Share compatibility results** - Report reproducible `jcpan -t` failures
+- **Measure performance** - Contribute repeatable CPU, memory, and startup benchmarks
 
 ## Quick Start for Contributors
 
@@ -33,7 +41,7 @@ make test-all
 1. Create a feature branch: `git checkout -b feature-name`
 2. **Never push directly to master** — always use feature branches and PRs
 3. Read the [Architecture Guide](docs/reference/architecture.md)
-4. Check [Roadmap](docs/about/roadmap.md) for planned features
+4. Check [Project Status and Roadmap](docs/about/roadmap.md#current-project-status) for current priorities
 
 **While coding:**
 1. Follow existing code style

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -4,10 +4,13 @@
 
 ## Current Development
 
-See **[Roadmap](docs/about/roadmap.md)** for:
-- Work in progress
-- Upcoming milestones
-- Future development areas
+PerlOnJava is actively developed in its compatibility and performance phase.
+See **[Project Status and Roadmap](docs/about/roadmap.md#current-project-status)**
+for:
+
+- Current compatibility measurements
+- Active development priorities
+- Upcoming milestones and future development areas
 
 ## Release History
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -217,4 +217,4 @@ docker run -it perlonjava ./jperl -E 'say "Hello from Docker!"'
 
 ### Contribute
 - **[CONTRIBUTING.md](CONTRIBUTING.md)** - How to contribute
-- **[Roadmap](docs/about/roadmap.md)** - Future plans
+- **[Project Status and Roadmap](docs/about/roadmap.md#current-project-status)** - Current priorities and future plans

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 PerlOnJava compiles Perl to JVM bytecode, so many existing Perl scripts can run on any platform with a JVM and use supported Java-backed libraries. Compatibility is substantial but not complete; check the [feature matrix](docs/reference/feature-matrix.md) and [bundled-module list](docs/reference/bundled-modules.md) before relying on a particular language feature or CPAN module. One jar file runs on Linux, macOS, and Windows — just add Java 24+. PerlOnJava is an independent project, not part of the Perl core distribution.
 
+> **Project status:** PerlOnJava is actively developed and is now in its
+> **compatibility and performance phase**. The broad language implementation is
+> in place; current work closes the remaining Perl compatibility gaps, expands
+> CPAN coverage, and improves CPU and memory performance. See the
+> [current status and priorities](docs/about/roadmap.md#current-project-status).
+
 ## Features
 
 - **Single jar distribution** — no installation, no dependencies beyond Java
@@ -41,7 +47,7 @@ make
 | [One-liners](docs/getting-started/oneliners.md) | [Using CPAN Modules](docs/guides/using-cpan-modules.md) | [Testing](docs/reference/testing.md) |
 | | [Module Porting](docs/guides/module-porting.md) | [Bundled Modules](docs/reference/bundled-modules.md) |
 
-**About:** [Why PerlOnJava?](docs/about/why-perlonjava.md) | [Roadmap](docs/about/roadmap.md) | [Changelog](docs/about/changelog.md) | [Support](docs/about/support.md) | [Security](SECURITY.md) | [AI Policy](AI_POLICY.md)
+**About:** [Why PerlOnJava?](docs/about/why-perlonjava.md) | [Project Status and Roadmap](docs/about/roadmap.md#current-project-status) | [Changelog](docs/about/changelog.md) | [Support](docs/about/support.md) | [Security](SECURITY.md) | [AI Policy](AI_POLICY.md)
 
 ## About Perl
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ Technical reference documentation:
 Project information:
 
 - **[Why PerlOnJava?](about/why-perlonjava.md)** - Project goals and use cases
-- **[Roadmap](about/roadmap.md)** - Future plans and upcoming features
+- **[Project Status and Roadmap](about/roadmap.md#current-project-status)** - Current development phase, priorities, and future plans
 - **[Changelog](about/changelog.md)** - Release history
 - **[Support](about/support.md)** - Get help and contribute
 - **[Resources](about/resources.md)** - External links and references
@@ -66,6 +66,6 @@ Looking to contribute? See:
 
 **"How does it work?"** → Read [Architecture](reference/architecture.md)
 
-**"Where's the roadmap?"** → Check [Roadmap](about/roadmap.md)
+**"Is the project active, and what's next?"** → Check [Project Status and Roadmap](about/roadmap.md#current-project-status)
 
 **"I want to contribute"** → Read [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -1,8 +1,19 @@
 # Changelog
 
-Release history of PerlOnJava. See [Roadmap](roadmap.md) for future plans.
+Release history of PerlOnJava. See the
+[Project Status and Roadmap](roadmap.md#current-project-status) for current
+priorities and future plans.
 
 ## Work in progress
+
+- Enter the compatibility and performance phase: the broad language
+  implementation is in place, and active development now focuses on remaining
+  Perl compatibility gaps, wider CPAN coverage, and CPU and memory performance.
+  The 2026-09-03 imported upstream compatibility run reports 669,688 of 673,847
+  checks passing (99.4%); the 2026-09-02 sampled CPAN report records 8,315 of
+  16,443 tested modules passing all tests (50.6%). See the
+  [current project status](roadmap.md#current-project-status) for scope and
+  methodology.
 
 - Exclude upstream Perl release-engineering `t/porting` tests from the
   selectively imported compatibility fixture.

--- a/docs/about/roadmap.md
+++ b/docs/about/roadmap.md
@@ -1,22 +1,63 @@
 # Roadmap
 
-Future plans for PerlOnJava. See [Changelog](changelog.md) for release history
-and [Feature Matrix](../reference/feature-matrix.md) for detailed implementation status.
+Current priorities and future plans for PerlOnJava. See the
+[Changelog](changelog.md) for release history and the
+[Feature Matrix](../reference/feature-matrix.md) for detailed feature support.
 
 ## Table of Contents
 
-1. [Guiding Principles](#guiding-principles)
-2. [Recently Completed](#recently-completed)
-3. [Active Development](#active-development)
-4. [Objective 1: Language Correctness & Perl5 Alignment](#objective-1-language-correctness--perl5-alignment)
-5. [Objective 2: Java Platform Alignment](#objective-2-java-platform-alignment)
-6. [Objective 3: Ecosystem & Module Compatibility](#objective-3-ecosystem--module-compatibility)
-7. [Objective 4: Performance & Optimization](#objective-4-performance--optimization)
-8. [Objective 5: Developer Tooling](#objective-5-developer-tooling)
-9. [Objective 6: Concurrency & Runtime Isolation](#objective-6-concurrency--runtime-isolation)
-10. [Objective 7: Distribution & Packaging](#objective-7-distribution--packaging)
-11. [Exploratory / Research](#exploratory--research)
-12. [Features Intentionally Deferred](#features-intentionally-deferred)
+1. [Current Project Status](#current-project-status)
+2. [Guiding Principles](#guiding-principles)
+3. [Recently Completed](#recently-completed)
+4. [Current Priorities](#current-priorities)
+5. [Objective 1: Language Correctness & Perl5 Alignment](#objective-1-language-correctness--perl5-alignment)
+6. [Objective 2: Java Platform Alignment](#objective-2-java-platform-alignment)
+7. [Objective 3: Ecosystem & Module Compatibility](#objective-3-ecosystem--module-compatibility)
+8. [Objective 4: Performance & Optimization](#objective-4-performance--optimization)
+9. [Objective 5: Developer Tooling](#objective-5-developer-tooling)
+10. [Objective 6: Concurrency & Runtime Isolation](#objective-6-concurrency--runtime-isolation)
+11. [Objective 7: Distribution & Packaging](#objective-7-distribution--packaging)
+12. [Exploratory / Research](#exploratory--research)
+13. [Features Intentionally Deferred](#features-intentionally-deferred)
+
+---
+
+## Current Project Status
+
+PerlOnJava is **actively developed** and is in its **compatibility and
+performance phase**. The broad Perl language implementation and JVM runtime are
+in place. The project is not finished, frozen, or limited to critical fixes:
+development now concentrates on the long tail of language compatibility,
+real-world CPAN support, and runtime efficiency.
+
+The latest measured snapshots are:
+
+- **Imported upstream Perl tests:** 669,688 of 673,847 checks pass across 585
+  imported test files (**99.4%**), measured on 2026-09-03. This is the imported
+  compatibility corpus, not every test distributed with upstream Perl.
+- **CPAN sample:** 8,315 of 16,443 tested modules pass their complete test suites
+  (**50.6%**), as reported on 2026-09-02. Modules are selected randomly from the
+  CPAN index, and dependencies encountered during testing are also recorded.
+
+These figures are dated progress measurements, not guarantees that an
+individual script or distribution will work. Check the
+[Feature Matrix](../reference/feature-matrix.md) for language boundaries and the
+[current CPAN compatibility report](../../dev/cpan-reports/cpan-compatibility.md)
+for module results. The [testing guide](../reference/testing.md#interpreting-compatibility-figures)
+explains how the project calculates these measurements.
+
+Current development has three primary goals:
+
+1. Close the remaining upstream Perl compatibility gaps and keep both execution
+   backends aligned.
+2. Broaden CPAN coverage and fix reusable compiler, runtime, tooling, and
+   Java-backed XS blockers.
+3. Reduce CPU time, memory use, and startup overhead without sacrificing
+   correctness.
+
+Bug reports, reproducible CPAN test results, benchmarks, documentation fixes,
+and pull requests are welcome; see the [support guide](support.md) and
+[contribution guide](../../CONTRIBUTING.md).
 
 ---
 
@@ -26,7 +67,7 @@ and [Feature Matrix](../reference/feature-matrix.md) for detailed implementation
 2. **Java platform alignment** — follow JDK evolution, use standard APIs, publish to Maven Central
 3. **Ecosystem over features** — working CPAN modules matter more than exotic new capabilities
 4. **Dual-backend architecture** — JVM bytecode for performance, interpreter for flexibility
-5. **Measure progress** — track perl5 test suite pass rates as the north-star metric
+5. **Measure progress** — track the imported upstream Perl suite and sampled CPAN results with dated, reproducible measurements
 
 ---
 
@@ -71,15 +112,21 @@ These capabilities are implemented and available in the current release:
 
 ---
 
-## Active Development
+## Current Priorities
 
-Work currently in progress:
+Work currently in progress is organized around the compatibility and
+performance goals above:
 
-- **Warnings Subsystem** — Improving lexical `warnings` pragma scope handling and warning message formatting for Perl5 compatibility. See `dev/design/warnings-scope.md`.
-- **Overload Completeness** — Adding remaining overload operators: `--`, bitwise, string repeat, and their compound forms. `++`, copy-constructor `=`, and concatenation are verified. See [Feature Matrix — overload](../reference/feature-matrix.md#pragmas).
-- **Compiler Hardening** — Automatic fallback to interpreter mode when JVM "Method too large" errors occur. Fix remaining global variable aliasing edge cases in `for` loops.
-- **perl5 Test Suite** — Expanding pass rates across `perl5_t/t/` categories (op, re, uni, mro, io, lib).
-
+- **Perl compatibility** — Close incomplete and failing cases in the imported
+  upstream suite, including diagnostic, compiler, runtime, and standard-library
+  differences, while keeping the JVM and interpreter backends aligned. The
+  [Feature Matrix](../reference/feature-matrix.md) records known boundaries.
+- **CPAN compatibility** — Use sampled distribution results to find reusable
+  blockers, expand Java replacements for XS dependencies, and validate
+  representative applications and libraries.
+- **CPU and memory performance** — Profile real workloads, remove allocation
+  and dispatch hot spots, reduce startup overhead, and retain correctness gates
+  for every optimization.
 ---
 
 ## Objective 1: Language Correctness & Perl5 Alignment
@@ -127,7 +174,7 @@ implementation and delivery record is preserved in the
 
 ## Objective 2: Java Platform Alignment
 
-*Priority: High — These items ensure PerlOnJava stays current with the Java ecosystem.*
+*Priority: Ongoing platform stewardship.*
 
 ### Maven Central Publishing
 
@@ -196,7 +243,7 @@ Ensure seamless installation of key pure-Perl modules via `jcpan`:
 
 ## Objective 4: Performance & Optimization
 
-*Priority: Medium — Important for production use, but correctness comes first.*
+*Priority: High — Runtime efficiency is a current development focus alongside correctness.*
 
 ### Interpreter Optimizations
 
@@ -266,7 +313,7 @@ Introduce a normalization pass between parsing and code generation to eliminate 
 
 ## Objective 6: Concurrency & Runtime Isolation
 
-*Priority: Maintenance and ecosystem hardening.*
+*Priority: Compatibility and ecosystem hardening.*
 
 See `dev/design/concurrency.md` for the comprehensive design covering multiplicity, fork emulation, and threads.
 

--- a/docs/about/support.md
+++ b/docs/about/support.md
@@ -5,13 +5,19 @@
 ### Documentation
 - [README.md](../../README.md) - Project overview and setup instructions
 - [Feature Matrix](../reference/feature-matrix.md) - Detailed feature compatibility list
-- [Roadmap](roadmap.md) - Future plans
+- [Project Status and Roadmap](roadmap.md#current-project-status) - Current priorities and future plans
 - [Changelog](changelog.md) - Release history
 
 ### Community Resources
-- GitHub Issues: Technical questions and bug reports
-- GitHub Discussions: General questions and community interaction
+- GitHub Issues: Technical questions, bug reports, and reproducible CPAN test failures
+- GitHub Discussions: General questions, compatibility reports, and community interaction
 - Stack Overflow: Use the tags `perl` and eventually `perlonjava`
+
+PerlOnJava is actively developed in its
+[compatibility and performance phase](roadmap.md#current-project-status).
+Reports that isolate a remaining Perl behavior difference, identify a CPAN
+distribution failure, or include a repeatable CPU or memory benchmark are
+especially useful.
 
 ## Version Support
 
@@ -51,6 +57,13 @@ vulnerability.
 - Add code examples where helpful
 - Keep the style consistent
 - Include references to related features
+
+### Compatibility and Performance Contributions
+
+- Report CPAN results produced by `jcpan -t`, including the module version and complete failure output
+- Reduce failures to the smallest Perl program possible and compare it with standard Perl
+- Include before-and-after measurements for CPU, memory, or startup optimizations
+- Prefer fixes to shared compiler, runtime, or tooling behavior over distribution-specific workarounds
 
 ### Pull Request Process
 1. Update documentation

--- a/docs/about/why-perlonjava.md
+++ b/docs/about/why-perlonjava.md
@@ -1,6 +1,17 @@
 ### Introduction
 
-PerlOnJava offers a unique solution for JVM-based environments or use cases where integration with Java ecosystems is critical. However, traditional Perl remains the go-to choice for most projects, thanks to its maturity, extensive module ecosystem, and performance advantages. The choice depends on the specific needs of the project and the existing technological context.
+PerlOnJava brings Perl 5 to JVM-based environments where integration with Java
+libraries, deployment tooling, or runtime infrastructure matters. Its broad
+language implementation is in place, and the project is actively working
+through the remaining compatibility, CPAN ecosystem, and performance gaps. See
+the [current project status](roadmap.md#current-project-status) and
+[feature matrix](../reference/feature-matrix.md) before choosing it for a
+specific workload.
+
+Traditional Perl remains the best default for projects that do not need JVM
+integration: its implementation and CPAN ecosystem are more mature, and native
+XS extensions work directly. The right choice depends on the required modules,
+platform constraints, and Java interoperability needs.
 
 
 ### Why Use PerlOnJava?
@@ -17,8 +28,10 @@ PerlOnJava offers a unique solution for JVM-based environments or use cases wher
 4. **JVM Performance Optimizations**:
    The project uses modern Java and ASM techniques to optimize execution. The JVM's just-in-time (JIT) compilation and garbage collection can provide performance benefits for compute-intensive tasks.
 
-5. **Educational and Experimental Value**:  
-   PerlOnJava is a compelling resource for understanding compiler design, language interoperability, and the translation of high-level languages to bytecode.
+5. **Compiler and Runtime Research**:
+   PerlOnJava is also a useful resource for understanding compiler design,
+   language interoperability, and the translation of a dynamic language to
+   bytecode.
 
 6. **Customizability**:  
    Developers can modify and extend the compiler to meet specific requirements, benefiting from JVM's debugging and profiling tools.
@@ -40,4 +53,3 @@ PerlOnJava offers a unique solution for JVM-based environments or use cases wher
 
 5. **Community and Ecosystem**:  
    The community and ecosystem around PerlOnJava are smaller than those of traditional Perl, potentially limiting support and available resources.
-

--- a/docs/reference/feature-matrix.md
+++ b/docs/reference/feature-matrix.md
@@ -1,5 +1,11 @@
 # Perl on JVM Feature Matrix
 
+This matrix is the canonical reference for supported Perl behavior and known
+boundaries. PerlOnJava is actively developed in its
+[compatibility and performance phase](../about/roadmap.md#current-project-status):
+the broad language implementation is in place, but support is not complete and
+an individual script may depend on one of the remaining gaps.
+
 ## Status Legend
 
 - ✅ Fully implemented

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -2,6 +2,28 @@
 
 PerlOnJava provides a two-level testing strategy to balance development speed with comprehensive validation.
 
+## Interpreting Compatibility Figures
+
+Project-wide compatibility percentages are dated snapshots, not support
+guarantees. A published figure must identify its corpus, measurement date,
+passing count, and total count.
+
+- The upstream Perl percentage is calculated by
+  `dev/tools/perl_test_runner.pl` as passing TAP checks divided by the checks in
+  the imported `perl5_t` compatibility corpus. It describes that imported
+  corpus, not every test distributed with upstream Perl. Skips, TODOs,
+  incomplete files, and errors are reported separately.
+- The CPAN percentage comes from the generated
+  [CPAN compatibility report](../../dev/cpan-reports/cpan-compatibility.md).
+  Modules are randomly selected from the CPAN index and run with `jcpan -t`;
+  dependencies encountered during testing are recorded too. A pass means the
+  tested module's complete test suite passed in that run.
+
+See the [current project status](../about/roadmap.md#current-project-status) for
+the latest published snapshots. For adoption decisions, consult the
+[Feature Matrix](feature-matrix.md) and test the exact CPAN distributions and
+versions required by the application.
+
 ## Quick Start
 
 ### Fast Unit Tests (Recommended for Development)


### PR DESCRIPTION
## Summary

- describe PerlOnJava as actively developed in its compatibility and performance phase
- make the roadmap the canonical project-status page and publish dated Perl and CPAN compatibility measurements
- align the README, changelog, documentation indexes, support and contribution guides, feature matrix, and testing guide
- document the scope and methodology behind compatibility percentages

## Validation

- `make check-links` (634 links checked, 0 errors)
- build and runtime tests not run; this PR changes documentation only
