### PR TITLE
WIP: fix issue #1224 PPIx::Regexp regressions

### DIFF
--- a/src/main/java/org/perlonjava/runtime/NamedCharacterExpansion.java
+++ b/src/main/java/org/perlonjava/runtime/NamedCharacterExpansion.java
@@ -12,6 +12,8 @@ import org.perlonjava.runtime.runtimetypes.RuntimeScalarType;
 
 import java.nio.charset.StandardCharsets;
 
+import org.perlonjava.runtime.operators.PerlUtfString;
+
 /**
  * Immutable compile-time result of expanding one Perl {@code \N{...}} escape.
  *
@@ -64,7 +66,28 @@ public record NamedCharacterExpansion(
             String name, RuntimeScalar translator, SourceMode inputMode) {
         if (name != null && name.regionMatches(true, 0, "U+", 0, 2)) {
             if (name.matches("(?i)U\\+[0-9A-F]+")) {
-                return resolveStandard(name);
+                try {
+                    long codePoint = Long.parseUnsignedLong(name.substring(2), 16);
+                    if (codePoint < 0) {
+                        return new NamedCharacterExpansion(
+                                "", SourceMode.UNICODE, true, Status.INVALID,
+                                "Invalid hexadecimal number in \\N{U+...}");
+                    }
+                    String sequence;
+                    if (codePoint > 0x10FFFFL) {
+                        sequence = PerlUtfString.encodeBeyondUnicode(codePoint);
+                    } else if (codePoint >= 0xD800L && codePoint <= 0xDFFFL) {
+                        sequence = PerlUtfString.encodeSurrogate(codePoint);
+                    } else {
+                        sequence = new String(Character.toChars((int) codePoint));
+                    }
+                    return new NamedCharacterExpansion(
+                            sequence, SourceMode.UNICODE, true, Status.RESOLVED, null);
+                } catch (IllegalArgumentException failure) {
+                    return new NamedCharacterExpansion(
+                            "", SourceMode.UNICODE, true, Status.INVALID,
+                            "Invalid hexadecimal number in \\N{U+...}");
+                }
             }
             if (name.matches("(?i)U\\+[0-9A-F]+(?:\\.[0-9A-F]+)+")) {
                 try {

--- a/src/test/resources/unit/named_character_beyond_unicode.t
+++ b/src/test/resources/unit/named_character_beyond_unicode.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $wide = "\N{U+11FFFF}";
+is(length($wide), 1, 'beyond-Unicode named character is one logical character');
+is(ord($wide), 0x11FFFF, 'beyond-Unicode named character retains its ordinal');
+is($wide, chr(0x11FFFF), 'named character shares chr representation');
+
+is(ord("\N{U+10FFFF}"), 0x10FFFF,
+    'valid supplementary named character remains unchanged');
+
+my $unknown = eval q{"\N{NOT A CHARACTER NAME}"};
+ok(!defined $unknown, 'ordinary unknown character name remains rejected');
+like($@, qr/Unknown charname 'NOT A CHARACTER NAME'/,
+    'ordinary unknown character name keeps its diagnostic');
+
+done_testing();

--- a/src/test/resources/unit/weak_parent_map_constructor_cleanup.t
+++ b/src/test/resources/unit/weak_parent_map_constructor_cleanup.t
@@ -28,10 +28,28 @@ use Scalar::Util qw(refaddr weaken);
     }
 
     sub parent_count { scalar keys %parent }
+    sub __PPIX_LEXER__record_capture_number { $_[1] }
 
     sub DESTROY {
         $_[0]->_parent(undef);
     }
+}
+
+{
+    package Issue1224::Token;
+    our @ISA = 'Issue1224::Element';
+
+    # Match PPIx::Regexp::Token::__new(): its constructor receives a content
+    # value followed by an optional named-argument hash.
+    sub __new {
+        my ($class, $content, %arg) = @_;
+        my $self = { content => $content };
+        bless $self, ref $class || $class;
+        return $self;
+    }
+
+    sub significant { 1 }
+    sub __PPIX_LEXER__finalize { 0 }
 }
 
 {
@@ -43,6 +61,22 @@ use Scalar::Util qw(refaddr weaken);
         my $self = bless { children => \@children }, ref $class || $class;
         $_->_parent($self) for @children;
         return $self;
+    }
+
+    sub elements { @{ $_[0]{children} } }
+    sub children { @{ $_[0]{children} } }
+    sub __PPIX_LEXER__finalize {
+        my ($self, $lexer) = @_;
+        my $failures = 0;
+        $failures += $_->__PPIX_LEXER__finalize($lexer) for $self->elements;
+        return $failures;
+    }
+
+    sub __PPIX_LEXER__record_capture_number {
+        my ($self, $number) = @_;
+        $number = $_->__PPIX_LEXER__record_capture_number($number)
+            for $self->children;
+        return $number;
     }
 }
 
@@ -57,6 +91,10 @@ use Scalar::Util qw(refaddr weaken);
         $bracket{start} = [@args ? shift @args : ()];
         $bracket{type} = [];
 
+        # PPIx passes both temporary aggregates to a helper before forwarding
+        # the remaining arguments to Node::__new().
+        $class->_check_for_interpolated_match(\%bracket, \@args);
+
         my $self = $class->SUPER::__new(@args);
         for my $key (qw(start type finish)) {
             $self->{$key} = [];
@@ -68,18 +106,79 @@ use Scalar::Util qw(refaddr weaken);
         }
         return $self;
     }
+
+    sub _check_for_interpolated_match {
+        my (undef, $bracket, $args) = @_;
+        return;
+    }
+
+    sub elements {
+        my ($self) = @_;
+        return (
+            @{ $self->{start} },
+            @{ $self->{type} },
+            @{ $self->{children} },
+            @{ $self->{finish} },
+        );
+    }
+
+    sub __PPIX_LEXER__finalize {
+        my ($self, $lexer) = @_;
+        my $failures = 0;
+        $failures += $_->__PPIX_LEXER__finalize($lexer) for $self->elements;
+        $self->{max_capture_number} =
+            $self->__PPIX_LEXER__record_capture_number(1) - 1;
+        return $failures;
+    }
 }
 
-my $structure = Issue1224::Structure->__new(
-    Issue1224::Element->new,
-    Issue1224::Element->new,
-    Issue1224::Element->new,
-);
+{
+    package Issue1224::Lexer;
 
-is(Issue1224::Element->parent_count, 3,
-    'constructor registers start, child, and finish parent entries');
+    # Match PPIx::Regexp::Lexer::lex() and _make_node(): a lexer-owned nested
+    # token vector is popped, its sentinel removed, a closing token appended,
+    # and the result forwarded into Structure::__new().
+    sub lex {
+        my ($self) = @_;
+        my @content;
+        my $prefix = Issue1224::Token->__new('');
+        my $start = Issue1224::Token->__new('/');
+        $self->{_rslt} = [[
+            '', $start,
+            Issue1224::Token->__new('f'),
+            Issue1224::Token->__new('o'),
+            Issue1224::Token->__new('o'),
+        ]];
+        my $suffix = Issue1224::Token->__new('');
+        my $regexp = $self->_make_node($suffix);
+        push @content, $prefix, $regexp, $suffix;
+        $self->_finalize(@content);
+        return @content;
+    }
 
-undef $structure;
+    sub _make_node {
+        my ($self, $token) = @_;
+        my @args = @{ pop @{ $self->{_rslt} } };
+        shift @args;
+        push @args, $token;
+        return Issue1224::Structure->__new(@args);
+    }
+
+    sub _finalize {
+        my ($self, @content) = @_;
+        $self->{failures} += $_->__PPIX_LEXER__finalize($self) for @content;
+        return;
+    }
+}
+
+my $lexer = bless {}, 'Issue1224::Lexer';
+my @nodes = $lexer->lex;
+
+is(Issue1224::Element->parent_count, 5,
+    'constructor registers all bracket and child parent entries');
+
+undef @nodes;
+undef $lexer;
 
 is(Issue1224::Element->parent_count, 0,
     'releasing the structure destroys all parent-map children');

--- a/src/test/resources/unit/weak_parent_map_constructor_cleanup.t
+++ b/src/test/resources/unit/weak_parent_map_constructor_cleanup.t
@@ -1,0 +1,87 @@
+use strict;
+use warnings;
+use Test::More;
+use Scalar::Util qw(refaddr weaken);
+
+# Regression for issue #1224. PPIx::Regexp::Structure constructs an object by
+# separating bracket elements from @args, forwarding the remaining children to
+# SUPER::__new(), and then installing the bracket arrays. Every element has a
+# weak parent-map entry that its DESTROY method removes.
+{
+    package Issue1224::Element;
+    my %parent;
+
+    sub new { bless {}, shift }
+
+    sub _parent {
+        my ($self, @arg) = @_;
+        my $address = Scalar::Util::refaddr($self);
+        if (@arg) {
+            my $value = shift @arg;
+            if (defined $value) {
+                Scalar::Util::weaken($parent{$address} = $value);
+            } else {
+                delete $parent{$address};
+            }
+        }
+        return $parent{$address};
+    }
+
+    sub parent_count { scalar keys %parent }
+
+    sub DESTROY {
+        $_[0]->_parent(undef);
+    }
+}
+
+{
+    package Issue1224::Node;
+    our @ISA = 'Issue1224::Element';
+
+    sub __new {
+        my ($class, @children) = @_;
+        my $self = bless { children => \@children }, ref $class || $class;
+        $_->_parent($self) for @children;
+        return $self;
+    }
+}
+
+{
+    package Issue1224::Structure;
+    our @ISA = 'Issue1224::Node';
+
+    sub __new {
+        my ($class, @args) = @_;
+        my %bracket;
+        $bracket{finish} = [@args ? pop @args : ()];
+        $bracket{start} = [@args ? shift @args : ()];
+        $bracket{type} = [];
+
+        my $self = $class->SUPER::__new(@args);
+        for my $key (qw(start type finish)) {
+            $self->{$key} = [];
+            for my $value (@{ $bracket{$key} }) {
+                next if !defined $value;
+                push @{ $self->{$key} }, $value;
+                $value->_parent($self);
+            }
+        }
+        return $self;
+    }
+}
+
+my $structure = Issue1224::Structure->__new(
+    Issue1224::Element->new,
+    Issue1224::Element->new,
+    Issue1224::Element->new,
+);
+
+is(Issue1224::Element->parent_count, 3,
+    'constructor registers start, child, and finish parent entries');
+
+undef $structure;
+
+is(Issue1224::Element->parent_count, 0,
+    'releasing the structure destroys all parent-map children');
+
+done_testing();


### PR DESCRIPTION
WIP for #1224.

This initial commit fixes numeric `\N{U+...}` escapes above Unicode's Java-supported range by using PerlOnJava's established logical-character representation. It adds a focused test for `U+11FFFF`, a normal supplementary control, and an unknown-name diagnostic control.

The full project gate is currently still running in the primary checkout. Investigation of the independent PPIx::Regexp weak-parent cleanup failure continues before this PR is ready for review.
