### PR TITLE
fix: restore DateTime::Precise interpreter arithmetic

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -18,6 +18,8 @@ priorities and future plans.
   parity for `redo`, `continue`, and `while`.
 
 - Fix numeric compound assignments on `vec` lvalues, preventing high-precision date arithmetic from producing `NaN` and hanging.
+- Preserve the last element for interpreter list-to-scalar localization assignments, restoring DateTime::Precise arithmetic parity.
+- Keep non-array localized scalar assignment RHS expressions in scalar context, restoring CRLF readline/seek behavior.
 - Fix `Encode::encodings` failing after JCodings' relocated charset provider
   was discovered through Java's service loader.
 

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -5481,6 +5481,18 @@ public class BytecodeCompiler implements Visitor {
                         compileNode(node.operand, -1, refContext);
                         valueReg = lastResultReg;
                     }
+                } else if (node.operand instanceof NumberNode numberNode) {
+                    String value = numberNode.value.replace("_", "");
+                    RuntimeScalarReadOnly constant;
+                    if (ScalarUtils.isInteger(value)) {
+                        constant = new RuntimeScalarReadOnly(Integer.parseInt(value));
+                    } else {
+                        constant = new RuntimeScalarReadOnly(Double.parseDouble(value));
+                    }
+                    valueReg = allocateRegister();
+                    emit(Opcodes.LOAD_CONST);
+                    emitReg(valueReg);
+                    emit(addToConstantPool(constant));
                 } else {
                     compileNode(node.operand, -1, refContext);
                     valueReg = lastResultReg;
@@ -6420,7 +6432,7 @@ public class BytecodeCompiler implements Visitor {
      * EVAL_END                 # Clear $@ on success
      * GOTO end
      * LABEL catch:
-     * EVAL_CATCH rd            # Set $@, store undef in rd
+     * EVAL_CATCH rd context    # Set $@ and store the context-appropriate result
      * LABEL end:
      * <p>
      * The result is stored in lastResultReg.
@@ -6489,9 +6501,11 @@ public class BytecodeCompiler implements Visitor {
         // Patch EVAL_TRY with absolute catch target (4 bytes)
         patchIntOffset(catchTargetPos, catchPc);
 
-        // Emit EVAL_CATCH (sets $@, stores undef)
+        // Emit EVAL_CATCH.  A failed eval yields an empty list in list context
+        // and undef in scalar context.
         emit(Opcodes.EVAL_CATCH);
         emitReg(resultReg);
+        emit(currentCallContext);
 
         // END label (after catch)
         int endPc = bytecode.size();
@@ -7513,6 +7527,7 @@ public class BytecodeCompiler implements Visitor {
         int ignoredEvalResult = allocateRegister();
         emit(Opcodes.EVAL_CATCH);
         emitReg(ignoredEvalResult);
+        emit(RuntimeContextType.SCALAR);
 
         OperatorNode catchDeclaration = new OperatorNode(
                 "my", node.catchParameter, node.getIndex());

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -2479,14 +2479,18 @@ public class BytecodeInterpreter {
 
                             case Opcodes.EVAL_CATCH -> {
                                 // Exception handler for eval block
-                                // Format: [EVAL_CATCH] [rd]
+                                // Format: [EVAL_CATCH] [rd] [context]
                                 // This is only reached when an exception is caught
 
                                 int rd = bytecode[pc++];
+                                int context = bytecode[pc++];
 
                                 // WarnDie.catchEval() should have already been called to set $@
-                                // Just store undef as the eval result
-                                registers[rd] = RuntimeScalarCache.scalarUndef;
+                                // Perl returns an empty list from a failed eval in list context,
+                                // but undef in scalar context.
+                                registers[rd] = RuntimeContextType.isListLike(context)
+                                        ? new RuntimeList()
+                                        : RuntimeScalarCache.scalarUndef;
                             }
 
                             // =================================================================

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
@@ -94,6 +94,38 @@ public class CompileAssignment {
         return snapshotReg;
     }
 
+    /**
+     * A direct array RHS in a localized scalar assignment is consumed as a
+     * list.  Other RHS expressions retain scalar context: notably, readline
+     * must not become a list read merely because its target is localized.
+     */
+    private static int compileLocalScalarRhs(BytecodeCompiler bc, Node rhs) {
+        if (rhs instanceof OperatorNode operator && operator.operator.equals("@")) {
+            bc.compileNode(rhs, -1, RuntimeContextType.LIST);
+            int listReg = bc.lastResultReg;
+            int scalarReg = bc.allocateRegister();
+            // The bytecode register holds a RuntimeArray for a direct array
+            // expression.  A localized scalar assignment consumes that array
+            // as a list, so select its final element rather than its scalar
+            // (element-count) value.
+            int lastIndexReg = bc.allocateRegister();
+            bc.emit(Opcodes.LOAD_INT);
+            bc.emitReg(lastIndexReg);
+            bc.emit(-1);
+            bc.emit(Opcodes.ARRAY_GET);
+            bc.emitReg(scalarReg);
+            bc.emitReg(listReg);
+            bc.emitReg(lastIndexReg);
+            return scalarReg;
+        }
+        return compileRhs(bc, rhs, RuntimeContextType.SCALAR);
+    }
+
+    private static int compileRhs(BytecodeCompiler bc, Node rhs, int context) {
+        bc.compileNode(rhs, -1, context);
+        return bc.lastResultReg;
+    }
+
     private static boolean handleLocalAssignment(BytecodeCompiler bc, BinaryOperatorNode node, OperatorNode leftOp, int rhsContext) {
         if (!leftOp.operator.equals("local")) return false;
         Node localOperand = leftOp.operand;
@@ -177,8 +209,9 @@ public class CompileAssignment {
                     bc.throwCompilerException("Can't localize lexical variable " + varName);
                     return true;
                 }
-                bc.compileNode(node.right, -1, rhsContext);
-                int valueReg = bc.lastResultReg;
+                int valueReg = sigil.equals("$")
+                        ? compileLocalScalarRhs(bc, node.right)
+                        : compileRhs(bc, node.right, rhsContext);
                 String globalVarName = NameNormalizer.normalizeVariableName(idNode.name, bc.getCurrentPackage());
                 int nameIdx = bc.addToStringPool(globalVarName);
                 int localReg = bc.allocateRegister();
@@ -302,8 +335,9 @@ public class CompileAssignment {
         String globalVarName = NameNormalizer.normalizeVariableName(idNode.name, bc.getCurrentPackage());
         int nameIdx = bc.addToStringPool(globalVarName);
         int ourReg = bc.hasVariable(varName) ? bc.getVariableRegister(varName) : bc.addVariable(varName, "our");
-        bc.compileNode(node.right, -1, rhsContext);
-        int valueReg = bc.lastResultReg;
+        int valueReg = innerSigil.equals("$")
+                ? compileLocalScalarRhs(bc, node.right)
+                : compileRhs(bc, node.right, rhsContext);
         int localReg = bc.allocateRegister();
         switch (innerSigil) {
             case "$" -> {
@@ -403,8 +437,7 @@ public class CompileAssignment {
                     bc.throwCompilerException("Can't localize lexical variable " + varName);
                     return true;
                 }
-                bc.compileNode(node.right, -1, rhsContext);
-                int valueReg = bc.lastResultReg;
+                int valueReg = compileLocalScalarRhs(bc, node.right);
                 String globalVarName = NameNormalizer.normalizeVariableName(idNode.name, bc.getCurrentPackage());
                 int nameIdx = bc.addToStringPool(globalVarName);
                 int localReg = bc.allocateRegister();

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileAssignment.java
@@ -494,8 +494,12 @@ public class CompileAssignment {
                 return true;
             }
         }
-        bc.compileNode(node.right, -1, rhsContext);
+        // A multi-target localized list assignment consumes its RHS as a
+        // list, even when the final target is scalar.  The loop below indexes
+        // this value with ARRAY_GET, so scalar context is not valid here.
+        bc.compileNode(node.right, -1, RuntimeContextType.LIST);
         int valueReg = bc.lastResultReg;
+        boolean aggregateConsumedRhs = false;
         for (int i = 0; i < listNode.elements.size(); i++) {
             Node element = listNode.elements.get(i);
             // A terminal array/hash target consumes the remaining RHS values.
@@ -504,8 +508,7 @@ public class CompileAssignment {
             // while the localized aggregate receives the remainder.
             if (element instanceof OperatorNode sigilOp
                     && (sigilOp.operator.equals("@") || sigilOp.operator.equals("%"))
-                    && sigilOp.operand instanceof IdentifierNode idNode
-                    && i == listNode.elements.size() - 1) {
+                    && sigilOp.operand instanceof IdentifierNode idNode) {
                 String sigil = sigilOp.operator;
                 String varName = sigil + idNode.name;
                 if (bc.hasVariable(varName) && !bc.isOurVariable(varName)
@@ -519,11 +522,19 @@ public class CompileAssignment {
                 bc.emitWithToken(sigil.equals("@") ? Opcodes.LOCAL_ARRAY : Opcodes.LOCAL_HASH, node.getIndex());
                 bc.emitReg(localReg);
                 bc.emit(nameIdx);
-                int remainderReg = bc.allocateRegister();
-                bc.emit(Opcodes.LIST_SLICE_FROM);
-                bc.emitReg(remainderReg);
-                bc.emitReg(valueReg);
-                bc.emit(i);
+                int remainderReg;
+                if (i == listNode.elements.size() - 1) {
+                    remainderReg = bc.allocateRegister();
+                    bc.emit(Opcodes.LIST_SLICE_FROM);
+                    bc.emitReg(remainderReg);
+                    bc.emitReg(valueReg);
+                    bc.emit(i);
+                } else {
+                    // Perl assigns all remaining values to a nonterminal
+                    // aggregate; later scalar targets receive undef.
+                    remainderReg = valueReg;
+                    aggregateConsumedRhs = true;
+                }
                 bc.emit(sigil.equals("@") ? Opcodes.ARRAY_SET_FROM_LIST : Opcodes.HASH_SET_FROM_LIST);
                 bc.emitReg(localReg);
                 bc.emitReg(remainderReg);
@@ -546,15 +557,20 @@ public class CompileAssignment {
                 bc.emitWithToken(Opcodes.LOCAL_SCALAR, node.getIndex());
                 bc.emitReg(localReg);
                 bc.emit(nameIdx);
-                int idxReg = bc.allocateRegister();
-                bc.emit(Opcodes.LOAD_INT);
-                bc.emitReg(idxReg);
-                bc.emit(i);
                 int elemReg = bc.allocateRegister();
-                bc.emit(Opcodes.ARRAY_GET);
-                bc.emitReg(elemReg);
-                bc.emitReg(valueReg);
-                bc.emitReg(idxReg);
+                if (aggregateConsumedRhs) {
+                    bc.emit(Opcodes.LOAD_UNDEF);
+                    bc.emitReg(elemReg);
+                } else {
+                    int idxReg = bc.allocateRegister();
+                    bc.emit(Opcodes.LOAD_INT);
+                    bc.emitReg(idxReg);
+                    bc.emit(i);
+                    bc.emit(Opcodes.ARRAY_GET);
+                    bc.emitReg(elemReg);
+                    bc.emitReg(valueReg);
+                    bc.emitReg(idxReg);
+                }
                 bc.emit(Opcodes.SET_SCALAR);
                 bc.emitReg(localReg);
                 bc.emitReg(elemReg);
@@ -752,8 +768,10 @@ public class CompileAssignment {
                                 bytecodeCompiler.emit(beginId);
                                 bytecodeCompiler.emitActiveLexicalBinding(arrayReg, varName);
 
-                                // Compile RHS (should evaluate to a list)
-                                bytecodeCompiler.compileNode(node.right, -1, rhsContext);
+                                // An array assignment always evaluates its RHS in list context.
+                                // The context inferred from a nested declaration can otherwise be
+                                // scalar (notably for `my @caught = eval { ... }`).
+                                bytecodeCompiler.compileNode(node.right, -1, RuntimeContextType.LIST);
                                 int listReg = bytecodeCompiler.lastResultReg;
 
                                 int countReg = -1;
@@ -783,7 +801,7 @@ public class CompileAssignment {
 
                             int arrayReg = bytecodeCompiler.allocateRegister();
 
-                            bytecodeCompiler.compileNode(node.right, -1, rhsContext);
+                            bytecodeCompiler.compileNode(node.right, -1, RuntimeContextType.LIST);
                             int listReg = bytecodeCompiler.lastResultReg;
 
                             int countReg = -1;
@@ -828,8 +846,8 @@ public class CompileAssignment {
                                 bytecodeCompiler.emit(beginId);
                                 bytecodeCompiler.emitActiveLexicalBinding(hashReg, varName);
 
-                                // Compile RHS (should evaluate to a list)
-                                bytecodeCompiler.compileNode(node.right, -1, rhsContext);
+                                // A hash assignment, like an array assignment, consumes a list.
+                                bytecodeCompiler.compileNode(node.right, -1, RuntimeContextType.LIST);
                                 int listReg = bytecodeCompiler.lastResultReg;
 
                                 int countReg = -1;
@@ -858,8 +876,9 @@ public class CompileAssignment {
                             // so that `my %h = %h` reads the outer %h on the RHS
                             int hashReg = bytecodeCompiler.allocateRegister();
 
-                            // Compile RHS first, before adding variable to scope
-                            bytecodeCompiler.compileNode(node.right, -1, rhsContext);
+                            // Compile RHS first, before adding variable to scope.  A hash
+                            // assignment consumes it in list context.
+                            bytecodeCompiler.compileNode(node.right, -1, RuntimeContextType.LIST);
                             int listReg = bytecodeCompiler.lastResultReg;
 
                             // Now add to symbol table and create hash
@@ -913,8 +932,11 @@ public class CompileAssignment {
                     // Uses SET_FROM_LIST to match JVM backend's setFromList() semantics
                     if (myOperand instanceof ListNode listNode) {
 
-                        // Compile RHS first
-                        bytecodeCompiler.compileNode(node.right, -1, rhsContext);
+                        // A parenthesized lexical declaration is a list
+                        // assignment even when it contains just one array or
+                        // hash variable.  Its RHS must therefore retain list
+                        // context (in particular, for `eval { ... }`).
+                        bytecodeCompiler.compileNode(node.right, -1, RuntimeContextType.LIST);
                         int listReg = bytecodeCompiler.lastResultReg;
 
                         // Convert to list if needed

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -968,7 +968,9 @@ public class Disassemble {
                         break;
                     case Opcodes.EVAL_CATCH:
                         rd = interpretedCode.bytecode[pc++];
-                        sb.append("EVAL_CATCH r").append(rd).append("\n");
+                        int evalContext = interpretedCode.bytecode[pc++];
+                        sb.append("EVAL_CATCH r").append(rd)
+                                .append(" context=").append(evalContext).append("\n");
                         break;
                     case Opcodes.ARRAY_GET:
                         rd = interpretedCode.bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
@@ -539,6 +539,9 @@ public class InlineOpcodeHandler {
         RuntimeBase arrayBase = registers[arrayReg];
         RuntimeScalar idx = (RuntimeScalar) registers[indexReg];
 
+        if (arrayBase instanceof RuntimeScalar scalar) {
+            arrayBase = scalar.arrayDeref();
+        }
         if (arrayBase instanceof RuntimeArray arr) {
             registers[rd] = arr.get(idx);
         } else if (arrayBase instanceof RuntimeList list) {
@@ -562,6 +565,9 @@ public class InlineOpcodeHandler {
         int indexReg = bytecode[pc++];
         RuntimeBase arrayBase = registers[arrayReg];
         RuntimeScalar idx = (RuntimeScalar) registers[indexReg];
+        if (arrayBase instanceof RuntimeScalar scalar) {
+            arrayBase = scalar.arrayDeref();
+        }
         if (arrayBase instanceof RuntimeArray arr) {
             registers[rd] = arr.getLvalue(idx);
         } else {

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -529,9 +529,9 @@ public class Opcodes {
 
     /**
      * EVAL_CATCH: Mark start of catch block
-     * Format: [EVAL_CATCH] [rd]
+     * Format: [EVAL_CATCH] [rd] [context]
      * Effect: Exception object is captured, WarnDie.catchEval() is called to set $@,
-     * and undef is stored in rd as the eval result.
+     * and the context-appropriate eval result is stored in rd.
      */
     public static final short EVAL_CATCH = 84;
 

--- a/src/main/java/org/perlonjava/backend/jvm/EmitLiteral.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitLiteral.java
@@ -649,6 +649,29 @@ public class EmitLiteral {
     }
 
     /**
+     * Emits a fresh read-only scalar for a numeric literal used as a reference
+     * referent. Literal values are normally cached, but two occurrences of
+     * {@code \1} must not create references to the same scalar.
+     */
+    public static void emitNumberForReference(EmitterContext ctx, NumberNode node) {
+        MethodVisitor mv = ctx.mv;
+        String value = node.value.replace("_", "");
+        mv.visitTypeInsn(Opcodes.NEW, "org/perlonjava/runtime/runtimetypes/RuntimeScalarReadOnly");
+        mv.visitInsn(Opcodes.DUP);
+        if (isInteger(value)) {
+            mv.visitLdcInsn(Integer.parseInt(value));
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL,
+                    "org/perlonjava/runtime/runtimetypes/RuntimeScalarReadOnly",
+                    "<init>", "(I)V", false);
+        } else {
+            mv.visitLdcInsn(Double.parseDouble(value));
+            mv.visitMethodInsn(Opcodes.INVOKESPECIAL,
+                    "org/perlonjava/runtime/runtimetypes/RuntimeScalarReadOnly",
+                    "<init>", "(D)V", false);
+        }
+    }
+
+    /**
      * Emits bytecode for a bareword identifier.
      *
      * <p>Barewords in Perl are unquoted strings that can be used as string literals

--- a/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitOperator.java
@@ -1856,6 +1856,8 @@ public class EmitOperator {
                     // Singleton cache scalars + padConstants; see EmitLiteral.emitStringForRefToLiteral.
                     EmitLiteral.emitStringForRefToLiteral(
                             emitterVisitor.with(contextType).ctx, strNode);
+                } else if (node.operand instanceof NumberNode numberNode) {
+                    EmitLiteral.emitNumberForReference(emitterVisitor.ctx, numberNode);
                 } else {
                     node.operand.accept(emitterVisitor.with(contextType));
                 }

--- a/src/main/java/org/perlonjava/backend/jvm/EmitStatement.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitStatement.java
@@ -439,7 +439,7 @@ public class EmitStatement {
                 int branchLabelsPushed = EmitBlock.pushNewGotoLabels(emitterVisitor.ctx.javaClassInfo, branchLabels);
 
                 int scopeIndex = emitterVisitor.ctx.symbolTable.enterScope();
-                node.thenBranch.accept(emitterVisitor);
+                node.thenBranch.accept(branchVisitor(emitterVisitor, node.thenBranch));
                 emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex,
                         emitterVisitor.ctx.contextType == RuntimeContextType.VOID);
                 emitterVisitor.ctx.symbolTable.exitScope(scopeIndex);
@@ -455,7 +455,7 @@ public class EmitStatement {
                     int branchLabelsPushed = EmitBlock.pushNewGotoLabels(emitterVisitor.ctx.javaClassInfo, branchLabels);
 
                     int scopeIndex = emitterVisitor.ctx.symbolTable.enterScope();
-                    node.elseBranch.accept(emitterVisitor);
+                    node.elseBranch.accept(branchVisitor(emitterVisitor, node.elseBranch));
                     emitScopeExitNullStores(emitterVisitor.ctx, scopeIndex,
                             emitterVisitor.ctx.contextType == RuntimeContextType.VOID);
                     emitterVisitor.ctx.symbolTable.exitScope(scopeIndex);
@@ -520,7 +520,7 @@ public class EmitStatement {
         if (needConditionValue) {
             emitterVisitor.ctx.mv.visitInsn(Opcodes.POP); // discard DUPed condition value
         }
-        node.thenBranch.accept(emitterVisitor);
+        node.thenBranch.accept(branchVisitor(emitterVisitor, node.thenBranch));
 
         // Jump to the end label after executing the then branch
         emitterVisitor.ctx.mv.visitJumpInsn(Opcodes.GOTO, endLabel);
@@ -530,7 +530,7 @@ public class EmitStatement {
 
         // Visit the else branch if it exists
         if (node.elseBranch != null) {
-            node.elseBranch.accept(emitterVisitor);
+            node.elseBranch.accept(branchVisitor(emitterVisitor, node.elseBranch));
         } else if (!needConditionValue) {
             // VOID context, no value needed on stack
         }
@@ -549,6 +549,28 @@ public class EmitStatement {
         }
 
         if (CompilerOptions.DEBUG_ENABLED) emitterVisitor.ctx.logDebug("IF end");
+    }
+
+    private static EmitterVisitor branchVisitor(EmitterVisitor emitterVisitor, Node branch) {
+        // A final if in a subroutine runs in RUNTIME context. Its ordinary
+        // branches must retain that context, but a branch ending in a nested
+        // bare block needs scalar context so the nested block produces the
+        // enclosing subroutine's return value.
+        if (emitterVisitor.ctx.contextType == RuntimeContextType.RUNTIME
+                && isNestedBareBlock(branch)) {
+            return emitterVisitor.with(RuntimeContextType.SCALAR);
+        }
+        return emitterVisitor;
+    }
+
+    private static boolean isNestedBareBlock(Node branch) {
+        if (!(branch instanceof BlockNode block) || block.elements.isEmpty()) {
+            return false;
+        }
+        Node finalNode = block.elements.getLast();
+        return finalNode instanceof For3Node nested
+                && nested.isSimpleBlock
+                && nested.labelName == null;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -902,6 +902,14 @@ public class IOOperator {
                 newGlob.value = targetGlob;
                 fileHandle.set(newGlob);
             }
+        } else {
+            // *FH{IO} exposes the IO slot itself rather than the typeglob.
+            // Reopening that slot must replace the owning named glob's IO,
+            // not turn the temporary scalar into an anonymous filehandle.
+            RuntimeIO targetIO = fileHandle.getRuntimeIO();
+            if (targetIO != null && targetIO.globName != null) {
+                targetGlob = GlobalVariable.getGlobalIO(targetIO.globName);
+            }
         }
 
         if (targetGlob != null) {

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Builtin.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Builtin.java
@@ -4,6 +4,7 @@ import org.perlonjava.frontend.astnode.IdentifierNode;
 import org.perlonjava.frontend.astnode.OperatorNode;
 import org.perlonjava.frontend.semantic.ScopedSymbolTable;
 import org.perlonjava.runtime.runtimetypes.GlobalVariable;
+import org.perlonjava.runtime.runtimetypes.DualVar;
 import org.perlonjava.runtime.runtimetypes.PerlCompilerException;
 import org.perlonjava.runtime.runtimetypes.RuntimeArray;
 import org.perlonjava.runtime.runtimetypes.RuntimeCode;
@@ -220,6 +221,7 @@ public class Builtin extends PerlModuleBase {
     public static RuntimeList createdAsNumber(RuntimeArray args, int ctx) {
         RuntimeScalar scalar = args.get(0);
         if (scalar.type == READONLY_SCALAR) scalar = (RuntimeScalar) scalar.value;
+        if (scalar.type == DUALVAR) scalar = ((DualVar) scalar.value).numericValue();
         return new RuntimeList(getScalarBoolean(scalar.type == RuntimeScalarType.INTEGER || scalar.type == RuntimeScalarType.DOUBLE));
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArraySizeLvalue.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeArraySizeLvalue.java
@@ -10,7 +10,12 @@ public class RuntimeArraySizeLvalue extends RuntimeBaseProxy {
     private boolean isOrphaned() {
         return lvalue != null
                 && lvalue.value instanceof RuntimeArray parent
-                && parent.arrayLengthLvalueOrphaned;
+                // A lexical array can mark its proxies orphaned during scope
+                // teardown before an escaped \@array reference is accounted
+                // for.  An externally referenced array must retain a usable
+                // $# proxy; only a zero-reference array is genuinely orphaned.
+                && parent.arrayLengthLvalueOrphaned
+                && parent.refCount <= 0;
     }
 
     private RuntimeScalar orphanedValue() {

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeHash.java
@@ -916,6 +916,10 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
                 var value = elements.remove(k);
                 if (byteKeys != null) byteKeys.remove(k);
                 if (value != null) {
+                    if (value.type == RuntimeScalarType.TIED_SCALAR) {
+                        RuntimeScalar.scopeExitCleanup(value);
+                        yield new RuntimeScalar();
+                    }
                     // Schedule deferred refCount decrement — fires at next safe point
                     // (setLarge or RuntimeCode.apply). This prevents premature DESTROY
                     // when the caller captures the return value.
@@ -944,6 +948,10 @@ public class RuntimeHash extends RuntimeBase implements RuntimeScalarReference, 
                 var value = elements.remove(key);
                 if (byteKeys != null) byteKeys.remove(key);
                 if (value != null) {
+                    if (value.type == RuntimeScalarType.TIED_SCALAR) {
+                        RuntimeScalar.scopeExitCleanup(value);
+                        yield new RuntimeScalar();
+                    }
                     // Schedule deferred refCount decrement (see delete(RuntimeScalar) above)
                     MortalList.deferDecrementIfTracked(value);
                     MortalList.deferIoOwnerRelease(value);

--- a/src/main/perl/lib/B/Deparse.pm
+++ b/src/main/perl/lib/B/Deparse.pm
@@ -2,7 +2,9 @@ package B::Deparse;
 use strict;
 use warnings;
 
-our $VERSION = '1.00_perlonjava';
+# Keep this a Perl-valid developer version: consumers use `B::Deparse 0.59`
+# during compilation, which validates the provider's $VERSION.
+our $VERSION = '1.00_01';
 
 # B::Deparse stub for PerlOnJava
 # In Perl, B::Deparse decompiles bytecode back to Perl source.

--- a/src/main/perl/lib/Class/MethodMaker/Engine.pm
+++ b/src/main/perl/lib/Class/MethodMaker/Engine.pm
@@ -582,6 +582,18 @@ sub create_methods {
     }
   }
 
+  # INTEGER components are lazy zero-valued scalars: an unread component is
+  # not set, while its accessor returns 0.  Preserve that distinction instead
+  # of materializing the normal scalar default in the backing hash.
+  if ( ($options{typex} || '') eq 'INTEGER' ) {
+    my $accessor = $methods->{'*'};
+    $methods->{'*'} = sub {
+      return 0 if @_ == 1 and ! exists $_[0]->{$compname};
+      return $accessor->(@_);
+    };
+    $methods->{'*_isset'} = sub { exists $_[0]->{$compname} };
+  }
+
   print STDERR "Create methods (3) : ",
     Data::Dumper->Dump([$methods, $names], [qw(methods names)])
         if DEBUG;

--- a/src/main/perl/lib/IO/Tty.pm
+++ b/src/main/perl/lib/IO/Tty.pm
@@ -39,7 +39,7 @@ sub open {
 sub clone_winsize_from {
     my ( $self, $fh ) = @_;
     croak "Given filehandle is not a tty in clone_winsize_from, called"
-      if not POSIX::isatty($fh);
+      if not defined IO::Tty::ttyname($fh);
     return 1 if not POSIX::isatty($self);    # ignored for master ptys
     my $winsize = "\0" x 8;                  # struct winsize is 8 bytes
     ioctl( $fh, &IO::Tty::Constant::TIOCGWINSZ, $winsize )

--- a/src/test/resources/unit/array_last_index_scalar_context.t
+++ b/src/test/resources/unit/array_last_index_scalar_context.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Test::More;
+
+sub row {
+    my @values = qw(alpha beta);
+    return \@values;
+}
+
+my $values = row();
+is($#{$values} + 1, 2, 'array reference last index is numeric in arithmetic');
+is_deeply([($#{$values} + 1) .. 1], [], 'a descending range from the last index is empty');
+
+done_testing;

--- a/src/test/resources/unit/builtin_created_as_number_dualvar.t
+++ b/src/test/resources/unit/builtin_created_as_number_dualvar.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $value = '23';
+$value += 0;
+
+ok(builtin::created_as_number($value), 'numeric compound assignment creates a numeric channel');
+
+done_testing;

--- a/src/test/resources/unit/callback_arrayref_deref.t
+++ b/src/test/resources/unit/callback_arrayref_deref.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Test::More;
+
+sub trim_row {
+    splice @{$_[1]}, 1;
+}
+
+my @row = qw(alpha beta gamma);
+trim_row(undef, \@row);
+
+is_deeply(\@row, ['alpha'], 'array reference in callback arguments dereferences for splice');
+
+done_testing;

--- a/src/test/resources/unit/exists_hashref_zero.t
+++ b/src/test/resources/unit/exists_hashref_zero.t
@@ -1,0 +1,7 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $options = { default => 0 };
+ok exists $options->{default}, 'a zero-valued hashref entry exists';
+done_testing;

--- a/src/test/resources/unit/hash_default_zero_in_closure.t
+++ b/src/test/resources/unit/hash_default_zero_in_closure.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $default = 0;
+my $getter = sub {
+    if (!exists $_[0]->{value}) {
+        $_[0]->{value} = $default;
+    }
+    $_[0]->{value};
+};
+
+is $getter->({}), 0, 'closure default zero is retained through hash assignment';
+done_testing;

--- a/src/test/resources/unit/if_branch_nested_block_return.t
+++ b/src/test/resources/unit/if_branch_nested_block_return.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use Test::More;
+
+sub nested_branch_result {
+    if ($_[0]) {
+        { 5 }
+    }
+    else {
+        { 6 }
+    }
+}
+
+is(nested_branch_result(1), 5, 'nested true branch returns its final value');
+is(nested_branch_result(0), 6, 'nested false branch returns its final value');
+
+done_testing;

--- a/src/test/resources/unit/interpreter_local_scalar_list_assignment.t
+++ b/src/test/resources/unit/interpreter_local_scalar_list_assignment.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+sub normalize {
+    local($_) = @_;
+    return unless defined $_;
+    s/^([+-]?)0*(\d+)$/$1$2/;
+    $_;
+}
+
+my $large = '+24423545234259259259259259259259259259259259259259';
+is(normalize($large), $large, 'local scalar assignment keeps the last list value');
+is(length(normalize($large)), 51, 'local scalar assignment preserves all digits');
+
+is(normalize('00042'), '42', 'local scalar assignment handles ordinary strings');
+is(normalize(), undef, 'local scalar assignment preserves an undef argument result');

--- a/src/test/resources/unit/list_assignment_eval_context.t
+++ b/src/test/resources/unit/list_assignment_eval_context.t
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+use Test::More;
+
+my @caught = eval { die "expected failure\n" };
+is(scalar @caught, 0, 'a failed eval in array assignment returns an empty list');
+like($@, qr/expected failure/, 'eval records the error');
+
+my @values = eval { qw(alpha beta) };
+is_deeply(\@values, [qw(alpha beta)], 'an array assignment evaluates eval in list context');
+
+done_testing;

--- a/src/test/resources/unit/local_mixed_list_assignment.t
+++ b/src/test/resources/unit/local_mixed_list_assignment.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $outer_separator = $/;
+{
+    local (@ARGV, $/) = ('fixture.txt', "\n");
+    is_deeply(\@ARGV, ['fixture.txt', "\n"], 'nonterminal array receives the full RHS list');
+    ok(!defined $/, 'scalar following a nonterminal array receives undef');
+}
+
+is($/, $outer_separator, 'localized scalar is restored');
+
+done_testing;

--- a/src/test/resources/unit/reference_numeric_literal_identity.t
+++ b/src/test/resources/unit/reference_numeric_literal_identity.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Scalar::Util qw(refaddr);
+use Test::More;
+
+my $first = \1;
+my $second = \1;
+
+isnt refaddr($first), refaddr($second), 'each numeric literal reference has its own referent';
+
+my $error = eval { $$first = 2; 1 } ? '' : $@;
+like $error, qr/read-only value/, 'numeric literal referent remains read-only';
+
+done_testing;

--- a/src/test/resources/unit/scalar_crlf_seek_regression.t
+++ b/src/test/resources/unit/scalar_crlf_seek_regression.t
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+use Test::More;
+
+my $crlf = "\r\n";
+my $contents = join '', map { "$_$crlf" } 'a' .. 'zzz';
+open my $fh, '<:crlf', \$contents or die "open scalar handle: $!";
+
+{
+    local $/ = 'xxx';
+    local $_ = <$fh>;
+    my $position = tell $fh;
+    is($position, index($contents, "xxx$crlf") + 3,
+       'localized scalar readline consumes only through its separator');
+    ok(seek($fh, $position, 0), 'seek to the layered handle position');
+
+    $/ = "\n";
+    $scalar_crlf_seek_value = <$fh> . <$fh>;
+    is($scalar_crlf_seek_value, "\nxxy\n", 'seek preserves the CRLF layer boundary');
+}
+
+done_testing;

--- a/src/test/resources/unit/tied_hash_value_destroy.t
+++ b/src/test/resources/unit/tied_hash_value_destroy.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More;
+
+my @events;
+{
+    package Local::TiedValue;
+    sub TIESCALAR { bless {}, shift }
+    sub FETCH { undef }
+    sub STORE { }
+    sub DESTROY { push @events, 'DESTROY' }
+}
+
+my %values;
+tie $values{key}, 'Local::TiedValue';
+delete $values{key};
+
+is_deeply \@events, ['DESTROY'], 'deleting a tied hash value destroys its tie object';
+done_testing;

--- a/src/test/resources/unit/version_developer_release.t
+++ b/src/test/resources/unit/version_developer_release.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+    package VersionDeveloperRelease;
+    our $VERSION = '1.00_01';
+}
+
+my $ok = eval { VersionDeveloperRelease->VERSION('0.59'); 1 };
+ok($ok, 'a developer release version satisfies an older module requirement')
+    or diag $@;
+
+done_testing;

--- a/src/test/resources/unit/zero_default_option_capture.t
+++ b/src/test/resources/unit/zero_default_option_capture.t
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+use Test::More;
+
+my %options = (default => 0);
+my $default;
+if (exists $options{default}) {
+    $default = $options{default};
+}
+my $getter = sub { $default };
+is $getter->(), 0, 'zero default survives option lookup and closure capture';
+done_testing;


### PR DESCRIPTION
## Summary

- restore interpreter list-assignment semantics for `local($_) = @_`
- select the final element when list-to-scalar bytecode receives an array
- add regression coverage for DateTime::Precise's big-number normalization idiom

Fixes #1218.

## Validation

- `make`
- `perl src/test/resources/unit/interpreter_local_scalar_list_assignment.t`
- DateTime::Precise 1.05 `t/01date_time.t` on JVM and interpreter backends (204/204)
