### PR TITLE
WIP: fix inherited UNIVERSAL import arguments

### DIFF
--- a/src/main/java/org/perlonjava/runtime/perlmodule/Universal.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Universal.java
@@ -2,6 +2,7 @@ package org.perlonjava.runtime.perlmodule;
 
 import org.perlonjava.runtime.mro.InheritanceResolver;
 import org.perlonjava.runtime.operators.VersionHelper;
+import org.perlonjava.runtime.operators.WarnDie;
 import org.perlonjava.runtime.runtimetypes.*;
 
 import java.nio.ByteBuffer;
@@ -251,7 +252,26 @@ public class Universal extends PerlModuleBase {
 
     public static RuntimeList importUniversal(RuntimeArray args, int ctx) {
         if (args.size() > 1) {
-            throw new PerlCompilerException("UNIVERSAL does not export anything");
+            String packageName = args.get(0).toString();
+            if ("UNIVERSAL".equals(packageName)) {
+                throw new PerlCompilerException("UNIVERSAL does not export anything");
+            }
+
+            // A package without its own import method inherits UNIVERSAL::import.
+            // Perl treats arguments on that inherited call as a non-fatal
+            // missing-import warning, rather than as an attempted export by
+            // UNIVERSAL itself.  This is particularly important for use_ok()
+            // diagnostics and superclass import forwarding.
+            StringBuilder imported = new StringBuilder();
+            for (int i = 1; i < args.size(); i++) {
+                if (i > 1) imported.append(", ");
+                imported.append('"').append(args.get(i)).append('"');
+            }
+            WarnDie.warn(new RuntimeScalar(
+                    "Attempt to call undefined import method with arguments (" + imported
+                            + ") via package \"" + packageName
+                            + "\" (Perhaps you forgot to load the package?)"),
+                    RuntimeScalarCache.scalarEmptyString);
         }
         return new RuntimeList();
     }

--- a/src/test/resources/unit/universal_import_methods.t
+++ b/src/test/resources/unit/universal_import_methods.t
@@ -9,4 +9,34 @@ my $ok = eval { UNIVERSAL->import('can'); 1 };
 ok(!$ok, 'UNIVERSAL cannot export a requested symbol');
 like($@, qr/^UNIVERSAL does not export anything/, 'UNIVERSAL import error matches Perl');
 
+{
+    package Issue1214::InfoSysFreeDBEntry;
+    package Issue1214::IPCFileSpec;
+    package Issue1214::HTTPRecorder;
+    package Issue1214::FindLibFixture;
+    package Issue1214::DeviceFirmataBase;
+    sub import { shift->SUPER::import(@_) }
+}
+
+my @missing_import_cases = (
+    ['Issue1214::InfoSysFreeDBEntry', 'Loaded InfoSys::FreeDB::Entry'],
+    ['Issue1214::IPCFileSpec', 'devnull'],
+    ['Issue1214::HTTPRecorder', 'Loaded HTTP::Recorder'],
+    ['Issue1214::FindLibFixture', qw(a 1 b 42)],
+    ['Issue1214::DeviceFirmataBase', 'LiquidCrystal_I2C'],
+);
+
+for my $case (@missing_import_cases) {
+    my ($package, @imports) = @$case;
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, shift };
+    my $ok = eval { $package->import(@imports); 1 };
+    is($ok, 1, "$package inherited import with arguments is non-fatal");
+    is($@, '', "$package inherited import leaves no exception");
+    like($warnings[0], qr/^Attempt to call undefined import method with arguments /,
+         "$package inherited import emits Perl's missing-import warning");
+    like($warnings[0], qr/\Qvia package "$package"\E/,
+         "$package warning identifies the missing importer");
+}
+
 done_testing;


### PR DESCRIPTION
Fixes #1214

## WIP

This changes inherited `UNIVERSAL::import` calls with arguments from a fatal
export error to Perl's non-fatal missing-import warning. The direct
`UNIVERSAL->import(...)` error remains unchanged.

Focused coverage includes the import shapes reported for InfoSys::FreeDB,
IPC::Capture, HTTP::Recorder, Find::Lib, and Device::Firmata.

## Validation so far

- `prove src/test/resources/unit/universal_import_methods.t` (system Perl)
- `make`
- JVM and interpreter runs of `universal_import_methods.t`
- cached CPAN test runs: InfoSys::FreeDB 0.92 (55 tests), IPC::Capture 0.06
  (14), HTTP::Recorder 0.07 (3), Find::Lib 1.04 (43), and Device::Firmata
  0.71 (4)
- issue-specific Device::Firmata 0.60 load test and LiquidCrystal_I2C target

Generated with [Codex](https://openai.com/codex/)
