### PR TITLE
fix: parse dense Mo::Inline double-colon barewords

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,8 @@ priorities and future plans.
 
 ## Work in progress
 
+- Fix parsing of dense Mo::Inline expressions that use `::` as a bareword.
+
 - Preserve UTF-8 HTML octets through HTML::Parser and no-op entity decoding,
   restoring complete Thai text in HTML::Formatter output.
 - Preserve caller-owned array and hash lifetimes across generated coercion

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -1347,7 +1347,9 @@ public class BytecodeInterpreter {
 
                             case Opcodes.COMPARE_NUM, Opcodes.COMPARE_STR, Opcodes.EQ_NUM, Opcodes.NE_NUM,
                                  Opcodes.LT_NUM, Opcodes.GT_NUM, Opcodes.LE_NUM, Opcodes.GE_NUM, Opcodes.EQ_STR,
-                                 Opcodes.NE_STR, Opcodes.NOT, Opcodes.NOT_NO_OVERLOAD -> {
+                                 Opcodes.NE_STR, Opcodes.EQU_STR, Opcodes.NEU_STR,
+                                 Opcodes.STRICT_EQ_NUM, Opcodes.STRICT_NE_NUM,
+                                 Opcodes.NOT, Opcodes.NOT_NO_OVERLOAD -> {
                                 pc = executeComparisons(opcode, bytecode, pc, registers);
                             }
 
@@ -3577,6 +3579,23 @@ public class BytecodeInterpreter {
                 RuntimeScalar s1 = (val1 instanceof RuntimeScalar) ? (RuntimeScalar) val1 : val1.scalar();
                 RuntimeScalar s2 = (val2 instanceof RuntimeScalar) ? (RuntimeScalar) val2 : val2.scalar();
                 registers[rd] = CompareOperators.ne(s1, s2);
+                return pc;
+            }
+
+            case Opcodes.EQU_STR, Opcodes.NEU_STR, Opcodes.STRICT_EQ_NUM, Opcodes.STRICT_NE_NUM -> {
+                int rd = bytecode[pc++];
+                int rs1 = bytecode[pc++];
+                int rs2 = bytecode[pc++];
+                RuntimeBase val1 = registers[rs1];
+                RuntimeBase val2 = registers[rs2];
+                RuntimeScalar s1 = (val1 instanceof RuntimeScalar) ? (RuntimeScalar) val1 : val1.scalar();
+                RuntimeScalar s2 = (val2 instanceof RuntimeScalar) ? (RuntimeScalar) val2 : val2.scalar();
+                registers[rd] = switch (opcode) {
+                    case Opcodes.EQU_STR -> CompareOperators.equ(s1, s2);
+                    case Opcodes.NEU_STR -> CompareOperators.neu(s1, s2);
+                    case Opcodes.STRICT_EQ_NUM -> CompareOperators.strictEqual(s1, s2);
+                    default -> CompareOperators.strictNotEqual(s1, s2);
+                };
                 return pc;
             }
 

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
@@ -8,6 +8,10 @@ import org.perlonjava.runtime.runtimetypes.RuntimeCode;
 import org.perlonjava.runtime.runtimetypes.RuntimeContextType;
 import org.perlonjava.runtime.runtimetypes.RuntimeScalar;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class CompileBinaryOperator {
     static void visitBinaryOperator(BytecodeCompiler bytecodeCompiler, BinaryOperatorNode node) {
         int savedCallerLineOverride = bytecodeCompiler.callerLineTokenOverride;
@@ -29,6 +33,16 @@ public class CompileBinaryOperator {
     private static void visitBinaryOperatorBody(BytecodeCompiler bytecodeCompiler, BinaryOperatorNode node) {
         // Track token index for error reporting
         bytecodeCompiler.currentTokenIndex = node.getIndex();
+
+        // Perl evaluates chained comparisons left-to-right, evaluating each
+        // operand once and stopping as soon as a comparison is false.  The JVM
+        // backend has a dedicated emitter for this shape; keep the bytecode
+        // interpreter backend equivalent instead of compiling the nested AST as
+        // ordinary boolean comparisons.
+        if (isChainedComparison(node)) {
+            compileChainedComparison(bytecodeCompiler, node);
+            return;
+        }
 
         // Handle print/say early (special handling for filehandle)
         if (node.operator.equals("print") || node.operator.equals("say")) {
@@ -796,6 +810,71 @@ public class CompileBinaryOperator {
 
 
         bytecodeCompiler.lastResultReg = rd;
+    }
+
+    private static final List<String> CHAIN_COMPARISON_OPS =
+            Arrays.asList("<", ">", "<=", ">=", "lt", "gt", "le", "ge");
+    private static final List<String> CHAIN_EQUALITY_OPS =
+            Arrays.asList("==", "!=", "===", "!==", "eq", "ne", "equ", "neu");
+
+    private static boolean isChainedComparison(BinaryOperatorNode node) {
+        if (!(node.left instanceof BinaryOperatorNode left)) {
+            return false;
+        }
+        boolean equality = CHAIN_EQUALITY_OPS.contains(node.operator);
+        boolean comparison = CHAIN_COMPARISON_OPS.contains(node.operator);
+        if (!equality && !comparison) {
+            return false;
+        }
+        return (equality && CHAIN_EQUALITY_OPS.contains(left.operator))
+                || (comparison && CHAIN_COMPARISON_OPS.contains(left.operator));
+    }
+
+    private static void compileChainedComparison(BytecodeCompiler bytecodeCompiler,
+                                                  BinaryOperatorNode node) {
+        List<Node> operands = new ArrayList<>();
+        List<String> operators = new ArrayList<>();
+        BinaryOperatorNode current = node;
+        boolean equality = CHAIN_EQUALITY_OPS.contains(node.operator);
+        while (true) {
+            operators.add(0, current.operator);
+            operands.add(0, current.right);
+            if (current.left instanceof BinaryOperatorNode left
+                    && ((equality && CHAIN_EQUALITY_OPS.contains(left.operator))
+                        || (!equality && CHAIN_COMPARISON_OPS.contains(left.operator)))) {
+                current = left;
+            } else {
+                operands.add(0, current.left);
+                break;
+            }
+        }
+
+        int resultReg = bytecodeCompiler.allocateOutputRegister();
+        bytecodeCompiler.compileNode(operands.get(0), -1, RuntimeContextType.SCALAR);
+        int leftReg = bytecodeCompiler.lastResultReg;
+        List<Integer> falseJumpPositions = new ArrayList<>();
+
+        for (int i = 0; i < operators.size(); i++) {
+            bytecodeCompiler.compileNode(operands.get(i + 1), -1, RuntimeContextType.SCALAR);
+            int rightReg = bytecodeCompiler.lastResultReg;
+            int comparisonReg = CompileBinaryOperatorHelper.compileBinaryOperatorSwitch(
+                    bytecodeCompiler, operators.get(i), leftReg, rightReg, node.getIndex());
+            bytecodeCompiler.emitAliasWithTarget(resultReg, comparisonReg);
+
+            if (i + 1 < operators.size()) {
+                bytecodeCompiler.emit(bytecodeCompiler.gotoIfFalseOpcode());
+                bytecodeCompiler.emitReg(resultReg);
+                falseJumpPositions.add(bytecodeCompiler.bytecode.size());
+                bytecodeCompiler.emitInt(0);
+            }
+            leftReg = rightReg;
+        }
+
+        int endPc = bytecodeCompiler.bytecode.size();
+        for (int patchPosition : falseJumpPositions) {
+            bytecodeCompiler.patchIntOffset(patchPosition, endPc);
+        }
+        bytecodeCompiler.lastResultReg = resultReg;
     }
 
     private static boolean isDirectScalarLvalue(Node node) {

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperatorHelper.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperatorHelper.java
@@ -195,6 +195,30 @@ public class CompileBinaryOperatorHelper {
                 bytecodeCompiler.emitReg(rs1);
                 bytecodeCompiler.emitReg(rs2);
             }
+            case "equ" -> {
+                bytecodeCompiler.emit(Opcodes.EQU_STR);
+                bytecodeCompiler.emitReg(rd);
+                bytecodeCompiler.emitReg(rs1);
+                bytecodeCompiler.emitReg(rs2);
+            }
+            case "neu" -> {
+                bytecodeCompiler.emit(Opcodes.NEU_STR);
+                bytecodeCompiler.emitReg(rd);
+                bytecodeCompiler.emitReg(rs1);
+                bytecodeCompiler.emitReg(rs2);
+            }
+            case "===" -> {
+                bytecodeCompiler.emit(Opcodes.STRICT_EQ_NUM);
+                bytecodeCompiler.emitReg(rd);
+                bytecodeCompiler.emitReg(rs1);
+                bytecodeCompiler.emitReg(rs2);
+            }
+            case "!==" -> {
+                bytecodeCompiler.emit(Opcodes.STRICT_NE_NUM);
+                bytecodeCompiler.emitReg(rd);
+                bytecodeCompiler.emitReg(rs1);
+                bytecodeCompiler.emitReg(rs2);
+            }
             case "lt", "gt", "le", "ge" -> {
                 // String comparisons using COMPARE_STR (like cmp)
                 // cmp returns: -1 if $a lt $b, 0 if equal, 1 if $a gt $b

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -252,6 +252,18 @@ public class Opcodes {
      */
     public static final short NE_STR = 38;
 
+    /** Defined string equality: equ. */
+    public static final short EQU_STR = 547;
+
+    /** Defined string inequality: neu. */
+    public static final short NEU_STR = 548;
+
+    /** Defined numeric equality: ===. */
+    public static final short STRICT_EQ_NUM = 552;
+
+    /** Defined numeric inequality: !==. */
+    public static final short STRICT_NE_NUM = 553;
+
     // =================================================================
     // LOGICAL OPERATORS (39-41)
     // =================================================================

--- a/src/main/java/org/perlonjava/backend/jvm/EmitBinaryOperatorNode.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitBinaryOperatorNode.java
@@ -83,7 +83,8 @@ public class EmitBinaryOperatorNode {
 
             // Comparison operators (chained)
             case "<", ">", "<=", ">=", "lt", "gt", "le", "ge",
-                 "==", "!=", "eq", "ne" -> EmitOperatorChained.emitChainedComparison(emitterVisitor, node);
+                 "==", "!=", "===", "!==", "eq", "ne", "equ", "neu" ->
+                    EmitOperatorChained.emitChainedComparison(emitterVisitor, node);
 
             // Binary operators
             case "%", "&", "&.", "binary&", "*", "**", "+", "-", "/",

--- a/src/main/java/org/perlonjava/backend/jvm/EmitOperatorChained.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitOperatorChained.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public class EmitOperatorChained {
     public static final String[] CHAIN_COMPARISON_OP = new String[]{"<", ">", "<=", ">=", "lt", "gt", "le", "ge"};
-    public static final String[] CHAIN_EQUALITY_OP = new String[]{"==", "!=", "eq", "ne"};
+    public static final String[] CHAIN_EQUALITY_OP = new String[]{"==", "!=", "===", "!==", "eq", "ne", "equ", "neu"};
 
     static public void emitChainedComparison(EmitterVisitor emitterVisitor, BinaryOperatorNode node) {
         EmitterVisitor scalarVisitor =

--- a/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
@@ -37,7 +37,8 @@ public class ParseInfix {
     private static final List<String> NON_CHAINABLE_RELATIONAL_OPS = List.of("isa");
 
     // Chainable equality operators (can chain with each other)
-    private static final List<String> CHAINABLE_EQUALITY_OPS = Arrays.asList("==", "!=", "eq", "ne");
+    private static final List<String> CHAINABLE_EQUALITY_OPS =
+            Arrays.asList("==", "!=", "===", "!==", "eq", "ne", "equ", "neu");
 
     // Chainable relational operators (can chain with each other)
     private static final List<String> CHAINABLE_RELATIONAL_OPS = Arrays.asList("<", ">", "<=", ">=", "lt", "gt", "le", "ge");
@@ -59,17 +60,7 @@ public class ParseInfix {
         Node right;
 
         if (ParserTables.INFIX_OP.contains(token.text)) {
-            String operator = switch (token.text) {
-                // Perl 5.44's undef-aware comparison operators currently share
-                // the established numeric/string comparison execution paths.
-                // Preserve their precedence and parseability while the runtime
-                // comparison implementation remains centralized.
-                case "===" -> "==";
-                case "!==" -> "!=";
-                case "equ" -> "eq";
-                case "neu" -> "ne";
-                default -> token.text;
-            };
+            String operator = token.text;
 
             // Check if left operand is a DECLARED REFERENCE (my \$a, our \@arr, etc.)
             // Most operators cannot be applied to declared references

--- a/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
@@ -374,6 +374,14 @@ public class ParsePrimary {
                         return new StringNode("::" + identifierName, parser.tokenIndex);
                     }
                 }
+                // In an expression such as `$pkg.::.':E'`, Perl treats `::`
+                // as a bareword string.  This spelling is emitted by
+                // Mo::Inline and is especially common inside braced hash
+                // dereferences.  It is not a package-qualified subroutine
+                // when the following token is the concatenation operator.
+                if (nextToken2.text.equals(".")) {
+                    return new StringNode("::", parser.tokenIndex);
+                }
                 throw new PerlCompilerException(parser.tokenIndex, "syntax error", parser.ctx.errorUtil);
 
             case "\\":

--- a/src/main/java/org/perlonjava/frontend/parser/ParserTables.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParserTables.java
@@ -113,6 +113,7 @@ public class ParserTables {
         CORE_PROTOTYPES.put("endservent", "");
         CORE_PROTOTYPES.put("eof", ";*");
         CORE_PROTOTYPES.put("eq", null);
+        CORE_PROTOTYPES.put("equ", null);
         CORE_PROTOTYPES.put("eval", null);
         CORE_PROTOTYPES.put("evalbytes", "_");
         CORE_PROTOTYPES.put("exec", null);
@@ -195,6 +196,7 @@ public class ParserTables {
         CORE_PROTOTYPES.put("msgsnd", "$$$");
         CORE_PROTOTYPES.put("my", null);
         CORE_PROTOTYPES.put("ne", null);
+        CORE_PROTOTYPES.put("neu", null);
         CORE_PROTOTYPES.put("next", null);
         CORE_PROTOTYPES.put("no", null);
         CORE_PROTOTYPES.put("not", "$;");

--- a/src/main/java/org/perlonjava/runtime/operators/CompareOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/CompareOperators.java
@@ -565,6 +565,53 @@ public class CompareOperators {
     }
 
     /**
+     * Defined string equality ({@code equ}).  Unlike {@code eq}, undef is a
+     * value in its own right: two undefs compare equal, while undef and any
+     * defined value compare unequal without producing an uninitialized warning.
+     */
+    public static RuntimeScalar equ(RuntimeScalar arg1, RuntimeScalar arg2) {
+        boolean defined1 = arg1.getDefinedBoolean();
+        boolean defined2 = arg2.getDefinedBoolean();
+        if (!defined1 || !defined2) {
+            return getScalarBoolean(defined1 == defined2);
+        }
+        return eq(arg1, arg2);
+    }
+
+    /** Defined string inequality ({@code neu}), the inverse of {@code equ}. */
+    public static RuntimeScalar neu(RuntimeScalar arg1, RuntimeScalar arg2) {
+        boolean defined1 = arg1.getDefinedBoolean();
+        boolean defined2 = arg2.getDefinedBoolean();
+        if (!defined1 || !defined2) {
+            return getScalarBoolean(defined1 != defined2);
+        }
+        return ne(arg1, arg2);
+    }
+
+    /**
+     * Defined numeric equality ({@code ===}).  It has the same overload
+     * behavior as {@code ==}, but does not coerce undef or warn about it.
+     */
+    public static RuntimeScalar strictEqual(RuntimeScalar arg1, RuntimeScalar arg2) {
+        boolean defined1 = arg1.getDefinedBoolean();
+        boolean defined2 = arg2.getDefinedBoolean();
+        if (!defined1 || !defined2) {
+            return getScalarBoolean(defined1 == defined2);
+        }
+        return equalTo(arg1, arg2);
+    }
+
+    /** Defined numeric inequality ({@code !==}), the inverse of {@code ===}. */
+    public static RuntimeScalar strictNotEqual(RuntimeScalar arg1, RuntimeScalar arg2) {
+        boolean defined1 = arg1.getDefinedBoolean();
+        boolean defined2 = arg2.getDefinedBoolean();
+        if (!defined1 || !defined2) {
+            return getScalarBoolean(defined1 != defined2);
+        }
+        return notEqualTo(arg1, arg2);
+    }
+
+    /**
      * Throws a Perl-5-style "Operation '<op>': no method found" error when
      * the overloaded package on either side does not permit fallback
      * autogeneration (fallback=undef or missing). Called by string- and

--- a/src/main/java/org/perlonjava/runtime/operators/CompareOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/CompareOperators.java
@@ -570,6 +570,8 @@ public class CompareOperators {
      * defined value compare unequal without producing an uninitialized warning.
      */
     public static RuntimeScalar equ(RuntimeScalar arg1, RuntimeScalar arg2) {
+        arg1 = fetchDefinedComparisonOperand(arg1);
+        arg2 = fetchDefinedComparisonOperand(arg2);
         boolean defined1 = arg1.getDefinedBoolean();
         boolean defined2 = arg2.getDefinedBoolean();
         if (!defined1 || !defined2) {
@@ -580,6 +582,8 @@ public class CompareOperators {
 
     /** Defined string inequality ({@code neu}), the inverse of {@code equ}. */
     public static RuntimeScalar neu(RuntimeScalar arg1, RuntimeScalar arg2) {
+        arg1 = fetchDefinedComparisonOperand(arg1);
+        arg2 = fetchDefinedComparisonOperand(arg2);
         boolean defined1 = arg1.getDefinedBoolean();
         boolean defined2 = arg2.getDefinedBoolean();
         if (!defined1 || !defined2) {
@@ -593,6 +597,8 @@ public class CompareOperators {
      * behavior as {@code ==}, but does not coerce undef or warn about it.
      */
     public static RuntimeScalar strictEqual(RuntimeScalar arg1, RuntimeScalar arg2) {
+        arg1 = fetchDefinedComparisonOperand(arg1);
+        arg2 = fetchDefinedComparisonOperand(arg2);
         boolean defined1 = arg1.getDefinedBoolean();
         boolean defined2 = arg2.getDefinedBoolean();
         if (!defined1 || !defined2) {
@@ -603,12 +609,24 @@ public class CompareOperators {
 
     /** Defined numeric inequality ({@code !==}), the inverse of {@code ===}. */
     public static RuntimeScalar strictNotEqual(RuntimeScalar arg1, RuntimeScalar arg2) {
+        arg1 = fetchDefinedComparisonOperand(arg1);
+        arg2 = fetchDefinedComparisonOperand(arg2);
         boolean defined1 = arg1.getDefinedBoolean();
         boolean defined2 = arg2.getDefinedBoolean();
         if (!defined1 || !defined2) {
             return getScalarBoolean(defined1 != defined2);
         }
         return notEqualTo(arg1, arg2);
+    }
+
+    /**
+     * Fetch a tied operand once before the definedness check and subsequent
+     * comparison.  Calling {@code getDefinedBoolean()} on the tied wrapper and
+     * then passing that same wrapper to the ordinary comparison would invoke
+     * FETCH twice.
+     */
+    private static RuntimeScalar fetchDefinedComparisonOperand(RuntimeScalar arg) {
+        return arg.type == RuntimeScalarType.TIED_SCALAR ? arg.tiedFetch() : arg;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/operators/OperatorHandler.java
+++ b/src/main/java/org/perlonjava/runtime/operators/OperatorHandler.java
@@ -120,6 +120,10 @@ public record OperatorHandler(String className, String methodName, int methodTyp
         put("<=>", "spaceship", "org/perlonjava/runtime/operators/CompareOperators");
         put("eq", "eq", "org/perlonjava/runtime/operators/CompareOperators");
         put("ne", "ne", "org/perlonjava/runtime/operators/CompareOperators");
+        put("equ", "equ", "org/perlonjava/runtime/operators/CompareOperators");
+        put("neu", "neu", "org/perlonjava/runtime/operators/CompareOperators");
+        put("===", "strictEqual", "org/perlonjava/runtime/operators/CompareOperators");
+        put("!==", "strictNotEqual", "org/perlonjava/runtime/operators/CompareOperators");
         put("lt", "lt", "org/perlonjava/runtime/operators/CompareOperators");
         put("le", "le", "org/perlonjava/runtime/operators/CompareOperators");
         put("gt", "gt", "org/perlonjava/runtime/operators/CompareOperators");

--- a/src/main/perl/lib/CPAN/Meta.pm
+++ b/src/main/perl/lib/CPAN/Meta.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 package CPAN::Meta;
 
-our $VERSION = '2.150013';
+our $VERSION = '2.150015';
 
 #pod =head1 SYNOPSIS
 #pod
@@ -649,7 +649,7 @@ CPAN::Meta - the distribution metadata for a CPAN dist
 
 =head1 VERSION
 
-version 2.150013
+version 2.150015
 
 =head1 SYNOPSIS
 
@@ -1038,7 +1038,7 @@ Adam Kennedy <adamk@cpan.org>
 
 =head1 CONTRIBUTORS
 
-=for stopwords Ansgar Burchardt Avar Arnfjord Bjarmason Benjamin Noggle Christopher J. Madsen Chuck Adams Cory G Watson Damyan Ivanov Dan Book Eric Wilhelm Graham Knop Gregor Hermann Karen Etheridge Kenichi Ishigaki Kent Fredric Ken Williams Lars Dieckow Leon Timmermans majensen Mark Fowler Matt S Trout Michael G. Schwern Mohammad Anwar mohawk2 moznion Niko Tyni Olaf Alders Olivier Mengué Philippe Bruhat (BooK) Randy Sims Ricardo Signes Tomohiro Hosaka
+=for stopwords Ansgar Burchardt Avar Arnfjord Bjarmason Benjamin Noggle Christopher J. Madsen Chuck Adams Cory G Watson Damyan Ivanov Dan Book Eric Wilhelm Graham Knop Gregor Hermann James E Keenan Karen Etheridge Kenichi Ishigaki Kent Fredric Ken Williams Lars Dieckow Leon Timmermans majensen Mark Fowler Matt S Trout Michael G. Schwern Mohammad Anwar mohawk2 moznion Niko Tyni Olaf Alders Olivier Mengué Philippe Bruhat (BooK) Randy Sims Ricardo Signes Tomohiro Hosaka
 
 =over 4
 
@@ -1085,6 +1085,10 @@ Graham Knop <haarg@haarg.org>
 =item *
 
 Gregor Hermann <gregoa@debian.org>
+
+=item *
+
+James E Keenan <jkeenan@cpan.org>
 
 =item *
 

--- a/src/main/perl/lib/CPAN/Meta/Converter.pm
+++ b/src/main/perl/lib/CPAN/Meta/Converter.pm
@@ -3,12 +3,11 @@ use strict;
 use warnings;
 package CPAN::Meta::Converter;
 
-our $VERSION = '2.150013';
+our $VERSION = '2.150015';
 
 #pod =head1 SYNOPSIS
 #pod
-#pod   my $struct = decode_json_file('META.json');
-#pod
+#pod   my $struct = Parse::CPAN::Meta->load_file('META.json');
 #pod   my $cmc = CPAN::Meta::Converter->new( $struct );
 #pod
 #pod   my $new_struct = $cmc->convert( version => "2" );
@@ -24,7 +23,7 @@ our $VERSION = '2.150013';
 #pod =cut
 
 use CPAN::Meta::Validator;
-use CPAN::Meta::Requirements;
+use CPAN::Meta::Requirements 2.145;
 use Parse::CPAN::Meta 1.4400 ();
 
 # To help ExtUtils::MakeMaker bootstrap CPAN::Meta::Requirements on perls
@@ -392,12 +391,7 @@ sub _clean_version {
   my $v = eval { version->new($element) };
   # XXX check defined $v and not just $v because version objects leak memory
   # in boolean context -- dagolden, 2012-02-03
-  if ( defined $v ) {
-    return _is_qv($v) ? $v->normal : $element;
-  }
-  else {
-    return 0;
-  }
+  return defined $v ? $v->stringify : 0;
 }
 
 sub _bad_version_hook {
@@ -1513,12 +1507,11 @@ CPAN::Meta::Converter - Convert CPAN distribution metadata structures
 
 =head1 VERSION
 
-version 2.150013
+version 2.150015
 
 =head1 SYNOPSIS
 
-  my $struct = decode_json_file('META.json');
-
+  my $struct = Parse::CPAN::Meta->load_file('META.json');
   my $cmc = CPAN::Meta::Converter->new( $struct );
 
   my $new_struct = $cmc->convert( version => "2" );

--- a/src/main/perl/lib/CPAN/Meta/Feature.pm
+++ b/src/main/perl/lib/CPAN/Meta/Feature.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 package CPAN::Meta::Feature;
 
-our $VERSION = '2.150013';
+our $VERSION = '2.150015';
 
 use CPAN::Meta::Prereqs;
 
@@ -77,7 +77,7 @@ CPAN::Meta::Feature - an optional feature provided by a CPAN distribution
 
 =head1 VERSION
 
-version 2.150013
+version 2.150015
 
 =head1 DESCRIPTION
 

--- a/src/main/perl/lib/CPAN/Meta/History.pm
+++ b/src/main/perl/lib/CPAN/Meta/History.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 package CPAN::Meta::History;
 
-our $VERSION = '2.150013';
+our $VERSION = '2.150015';
 
 1;
 
@@ -22,7 +22,7 @@ CPAN::Meta::History - history of CPAN Meta Spec changes
 
 =head1 VERSION
 
-version 2.150013
+version 2.150015
 
 =head1 DESCRIPTION
 

--- a/src/main/perl/lib/CPAN/Meta/History/Meta_1_2.pod
+++ b/src/main/perl/lib/CPAN/Meta/History/Meta_1_2.pod
@@ -653,7 +653,7 @@ Add proposal for C<auto_regenerate> field.
 
 =item *
 
-Add C<index> field as a compliment to L</no_index>
+Add C<index> field as a complement to L</no_index>
 
 =item *
 

--- a/src/main/perl/lib/CPAN/Meta/History/Meta_1_3.pod
+++ b/src/main/perl/lib/CPAN/Meta/History/Meta_1_3.pod
@@ -682,7 +682,7 @@ Add proposal for C<auto_regenerate> field.
 
 =item *
 
-Add C<index> field as a compliment to L</no_index>
+Add C<index> field as a complement to L</no_index>
 
 =item *
 

--- a/src/main/perl/lib/CPAN/Meta/History/Meta_1_4.pod
+++ b/src/main/perl/lib/CPAN/Meta/History/Meta_1_4.pod
@@ -696,7 +696,7 @@ Add proposal for C<auto_regenerate> field.
 
 =item *
 
-Add C<index> field as a compliment to L</no_index>
+Add C<index> field as a complement to L</no_index>
 
 =item *
 

--- a/src/main/perl/lib/CPAN/Meta/Merge.pm
+++ b/src/main/perl/lib/CPAN/Meta/Merge.pm
@@ -4,7 +4,7 @@ use warnings;
 
 package CPAN::Meta::Merge;
 
-our $VERSION = '2.150013';
+our $VERSION = '2.150015';
 
 use Carp qw/croak/;
 use Scalar::Util qw/blessed/;
@@ -252,7 +252,7 @@ CPAN::Meta::Merge - Merging CPAN Meta fragments
 
 =head1 VERSION
 
-version 2.150013
+version 2.150015
 
 =head1 SYNOPSIS
 

--- a/src/main/perl/lib/CPAN/Meta/Prereqs.pm
+++ b/src/main/perl/lib/CPAN/Meta/Prereqs.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 package CPAN::Meta::Prereqs;
 
-our $VERSION = '2.150013';
+our $VERSION = '2.150015';
 
 #pod =head1 DESCRIPTION
 #pod
@@ -326,7 +326,7 @@ CPAN::Meta::Prereqs - a set of distribution prerequisites by phase and type
 
 =head1 VERSION
 
-version 2.150013
+version 2.150015
 
 =head1 DESCRIPTION
 

--- a/src/main/perl/lib/CPAN/Meta/Spec.pm
+++ b/src/main/perl/lib/CPAN/Meta/Spec.pm
@@ -8,7 +8,7 @@ use strict;
 use warnings;
 package CPAN::Meta::Spec;
 
-our $VERSION = '2.150013';
+our $VERSION = '2.150015';
 
 1;
 
@@ -29,7 +29,7 @@ CPAN::Meta::Spec - specification for CPAN distribution metadata
 
 =head1 VERSION
 
-version 2.150013
+version 2.150015
 
 =head1 SYNOPSIS
 

--- a/src/main/perl/lib/CPAN/Meta/Validator.pm
+++ b/src/main/perl/lib/CPAN/Meta/Validator.pm
@@ -3,12 +3,11 @@ use strict;
 use warnings;
 package CPAN::Meta::Validator;
 
-our $VERSION = '2.150013';
+our $VERSION = '2.150015';
 
 #pod =head1 SYNOPSIS
 #pod
-#pod   my $struct = decode_json_file('META.json');
-#pod
+#pod   my $struct = Parse::CPAN::Meta->load_file('META.json');
 #pod   my $cmv = CPAN::Meta::Validator->new( $struct );
 #pod
 #pod   unless ( $cmv->is_valid ) {
@@ -996,12 +995,11 @@ CPAN::Meta::Validator - validate CPAN distribution metadata structures
 
 =head1 VERSION
 
-version 2.150013
+version 2.150015
 
 =head1 SYNOPSIS
 
-  my $struct = decode_json_file('META.json');
-
+  my $struct = Parse::CPAN::Meta->load_file('META.json');
   my $cmv = CPAN::Meta::Validator->new( $struct );
 
   unless ( $cmv->is_valid ) {

--- a/src/main/perl/lib/Parse/CPAN/Meta.pm
+++ b/src/main/perl/lib/Parse/CPAN/Meta.pm
@@ -4,7 +4,7 @@ use warnings;
 package Parse::CPAN::Meta;
 # ABSTRACT: Parse META.yml and META.json CPAN metadata files
 
-our $VERSION = '2.150013';
+our $VERSION = '2.150015';
 
 use Exporter;
 use Carp 'croak';
@@ -169,7 +169,7 @@ Parse::CPAN::Meta - Parse META.yml and META.json CPAN metadata files
 
 =head1 VERSION
 
-version 2.150013
+version 2.150015
 
 =head1 SYNOPSIS
 

--- a/src/main/perl/lib/Pod/perldelta.pod
+++ b/src/main/perl/lib/Pod/perldelta.pod
@@ -32,15 +32,15 @@ here, but most should go in the L</Performance Enhancements> section.
 Four new operators have been added, which are similar to the regular equality operators except for their handling of C<undef>. Whereas the regular operators treat C<undef> as equal to the empty string or the number zero, these operators consider C<undef> to be a distinct value, equal to itself, but unequal to any defined value.
 
     if( $x equ $y ) {
-     # $x and $y are both undef, or
-     # $x and $y are both defined and equal
-     ...
+      # $x and $y are both undef, or
+      # $x and $y are both defined and equal
+      ...
     }
 
 This is approximately equal to the following, except that it is more efficient and avoids duplicate evaluation of operands or fetching of tied scalar values:
 
     if( (!defined $x and !defined $y) or
-        (defined $x and defined $y and $x eq $y) ) {
+      (defined $x and defined $y and $x eq $y) ) {
       ...
     }
 
@@ -434,7 +434,37 @@ manager will later use a regex to expand these into links.
 
 =item *
 
-XXX
+Since 5.28.0, the numeric value of a string would sometimes not get reset
+after the string was assigned to as part of a string concatenation. It
+required the following circumstances to all be present for the bug to
+manifest:
+
+=over
+
+=item *
+
+the string variable must be zero length and have just been used in numeric
+context, e.g. C<$s = ""; $n = $s + 1;>
+
+=item *
+
+then the variable must be the target of a string concatenation and also
+be used on the RHS, e.g.C<$s = "9$s";>
+
+=item *
+
+then if the string is used in numeric context again, the bug caused the
+old numeric value of 0 to be returned, rather than numifying the new
+string value and returning 9.
+
+=back
+
+[GH #24763]
+
+=item *
+
+Parsing an invalid signature that gives a slurpy parameter a default value no
+longer crashes when parser debugging is enabled.  [GH #24691]
 
 =item *
 

--- a/src/main/perl/lib/Pod/perlexperiment.pod
+++ b/src/main/perl/lib/Pod/perlexperiment.pod
@@ -226,6 +226,15 @@ taken as a literal character.
 The ticket for this experiment is
 L<[perl #23945]|https://github.com/Perl/perl5/issues/24209>.
 
+=item Value Magic in Magic v2
+
+Introduced in Perl 5.45.3.
+
+See L<perlapi/struct ScalarValueMagicFunctions> for the mechanism.
+
+The ticket for this experiment is
+L<[perl #24735]|https://github.com/Perl/perl5/issues/24735>.
+
 =back
 
 =head2 Accepted features

--- a/src/main/perl/lib/Pod/perlop.pod
+++ b/src/main/perl/lib/Pod/perlop.pod
@@ -650,7 +650,7 @@ Each of these four operators has a variant whose name is one character longer,
 which has different behaviour to the base operator when either (or both) of
 its arguments is C<undef>. These operators, called the I<undef-aware equality
 operators>, consider that C<undef> is equal to another C<undef> but not equal
-to any defined value - even the number zero or the empty string. Furtheremore,
+to any defined value - even the number zero or the empty string. Furthermore,
 these operators will not invoke warnings when invoked on undefined values,
 even when their base counterparts would. (Though other warnings are still
 possible, such as C<===> warning about non-numerical values).

--- a/src/main/perl/lib/Pod/perlreguts.pod
+++ b/src/main/perl/lib/Pod/perlreguts.pod
@@ -1048,9 +1048,21 @@ regop. An even more aggressive form of this is that a branch
 sequence of the form C<EXACT BRANCH ... EXACT> can be converted into a
 C<TRIE-EXACT> regop.
 
-All of this occurs in the routine C<study_chunk()> which uses a special
-structure C<scan_data_t> to store the analysis that it has performed, and
-does the "peep-hole" optimisations as it goes.
+=head4 study_chunk()
+
+All of the optimisations described above occur in the routine
+C<study_chunk()>, which is called from C<Perl_re_op_compile()> after
+C<reg()> is done. It uses a special structure C<scan_data_t> to store the
+analysis that it has performed, and does the "peep-hole" optimisations as
+it goes, in-place.
+
+The basic structure of C<study_chunk()> is recursive. By default it will
+linearly process all nodes until it reaches the node specified by the
+C<last> parameter, or an C<END> node if earlier. But when it encounters a
+sub-pattern such the 'A' in quantifiers like C<(A)+> or C<(A){1,5}>, it
+will recurse into that sub-pattern, with C<last> set to the end of that
+sub-pattern. Similarly for a branch such as C<A|B|C>, it will recurse for
+each sub-pattern A,B and C.
 
 The code involved in C<study_chunk()> is extremely cryptic. Be careful. :-)
 
@@ -1121,6 +1133,224 @@ basically a giant switch statement that implements a state machine, where
 the possible states are the regops themselves, plus a number of additional
 intermediate and failure states. A few of the states are implemented as
 subroutines but the bulk are inline code.
+
+=head3 The super-linear cache
+
+"Insanity is doing the same thing over and over again and expecting
+different results."
+
+Under some circumstances with quantifiers, it is possible for an NFA
+engine to encounter a combinatorial explosion of backtracking. The
+super-linear cache (SLC) is intended to avoid this happening under some
+circumstances.
+
+Consider this simple example:
+
+    ("a" x 20) =~ /^ ( (aa?) ){5,100} [bc] /x;
+
+(This example works just the same using C<*> rather than C<{5,100}>, but
+the latter form is used here as it will shortly help illuminate an issue
+with non-infinite ranges.)
+
+This pattern will eventually fail, since the string doesn't include a 'b'
+or 'c' character (this example uses a character class to stop intuit
+rejecting it immediately). But early on in execution the quantifier will
+have iterated 10 times, each time consuming 'aa'. So at that point the
+entire input string can be thought of as having been consumed in this
+fashion:
+
+    (aa)(aa)(aa)(aa)(aa)(aa)(aa)(aa)(aa)(aa)
+
+Then the character class fails and the pattern starts backtracking. The
+last C<aa?> is retried, this time consuming a single character, and an
+11th iteration can proceed, resulting in:
+
+    (aa)(aa)(aa)(aa)(aa)(aa)(aa)(aa)(aa)(a)(a)
+
+before again failing the character class. The backtracking continues until
+every possible permutation of 'a' and 'aa' in each iteration is tried,
+which may take a long time.
+
+Staying with this example, consider that after much iterating and
+backtracking, the engine may have reached this state:
+
+    (aa)(a)(a)
+
+where it has consumed four characters using three iterations. The rest of
+the match at this point can be thought of as the equivalent of:
+
+    ("a" x 16) =~ /^ ( (aa?) ){2,97} [bc] /x;
+
+Running this will eventually fail, and after backtracking to the
+C<(aa)(a)(a)> state, it backtracks further and tries further permutations,
+after which it will eventually reach this state:
+
+    (a)(aa)(a)
+
+In a similar fashion to the previous state, the rest of the match at this
+point is equivalent to:
+
+    ("a" x 16) =~ /^ ( (aa?) ){2,97} [bc] /x;
+
+But hold on: we know that this particular sub-match failed earlier on; so
+running the exact same match again must also fail. So, in principle, after
+the first set of backtracking back to the C<(aa)(a)(a)> state, we could
+record in a cache somewhere that the match failed for that particular
+quantifier when starting from string position 4 and with between 2 and 97
+iterations left. Then the next time the same quantifier finds itself at
+the same string position and with the same number of iterations left, it
+knows that it can fail itself immediately and backtrack, rather than
+pushing on and (eventually) failing again.
+
+This is the essence of the SLC.
+
+There are several caveats to to this in order to make a system which is
+both practical and logically correct (i.e. without false cache failures).
+
+=over
+
+=item *
+
+The obvious objection at this point is that recording a whole bunch of
+(quantifier-id, current string position, min iterations left, max
+iterations left) tuples will be extremely expensive in memory.
+
+We can reduce this complexity by using the SLC only on quantifiers which
+have a maximum of infinity (such as C<*>, C<+>, C<({5,}>), and make the
+quantifiers only use the cache after the minimum number of iterations has
+already been satisfied. Under these two conditions, the remaining number
+of iterations will always have a min of 0 and a max of infinity, so we
+don't need to record the min and max values any more.
+
+With this simplification, we just need to record a single bit of
+information ("failed already") for every (quantifier-id, current string
+position) tuple. We can achieve this by allocating a single bit array
+whose size is equal to the string length multiplied by the number of
+candidate quantifiers in the pattern. So for example when matching a 1
+Mbyte string against a pattern like C</(...)*(...)*/> which has two
+quantifiers, 2 million bits must be allocated.
+
+To avoid a potentially large malloc() for every match that has been marked
+as suitable for a SLC, a countdown is initiated the first time a candidate
+C<WHILEM> node is reached; only after (string length) multiplied by
+(number of participating C<WHILEM> nodes) iterations is the cache actually
+allocated and initialised. This crude heuristic is an indication that the
+match has gone super-linear.
+
+=item *
+
+The SLC is only used for quantifiers on I<variable-length> sub-patterns,
+i.e. those which are compiled to a C<CURLYX>/C<WHILEM> node pair.
+Quantifiers with simpler sub-patterns are less likely to exhibit
+exponential behaviour.
+
+=item *
+
+Non-regular pattern items such as backreferences (C<\g{1}>) and evals
+(C<(??{...})/>) break the assumption that running the same rest-of-pattern
+from the same position will give the same result each time. If these occur
+in the rest-of-pattern, the cache is reset. This is currently done at
+runtime.
+
+=item *
+
+Nested quantifiers can sometimes the break the assumption that running the
+rest-of-pattern from the same string position will always give the same
+result. To understand this issue, first consider a non-nested quantifier
+pattern, such as
+
+    / A (B)+ C /x
+
+where each capital letter represents an entire sub-pattern: for example,
+'A' might represent C<(pq)?rs>.
+
+During execution, A will have consumed some characters, then a number of
+iterations of the quantified sub-pattern B will have consumed some more
+characters, then the rest-of-pattern (in this case C) will be attempted,
+starting at string position p say. If C subsequently fails, then the
+engine backtracks to the quantifier, which marks in the cache that running
+the rest-of-pattern from position p will always fail. Subsequent attempts
+might see A consuming a different number of characters and the quantifier
+might iterate a different number of times, but if the quantifier is
+ever about to run the rest-of-pattern again from position p, the cache can
+be used to fail immediately, rather than running and failing C again.
+
+Now consider a nested pattern such as
+
+    / A ((B)+){2,5} C /x
+
+Here, the inner quantifier doesn't know how many times the outer
+quantifier has already iterated, nor that what's to the right of it can
+now vary depending on that iteration count. The rest-of-pattern after an
+inner quantifier run (from the viewpoint of that inner quantifier), rather
+than always being just C as in the non-nested example above, is now
+instead equivalent to
+
+    / ... ((B)+){1,4} C /x   # after the first  outer iteration
+    / ... ((B)+){0,3} C /x   # after the second outer iteration
+    / ... ((B)+){0,2} C /x   # after the third  outer iteration
+    etc
+
+This violates the assumption that the rest-of-pattern is always the same
+sub-pattern and that what's to the right will always pass or fail in the
+same way from the same string position.
+
+For it to be safe to use the cache in a nested quantifier, the rule is
+that the outer quantifier's still-to-go minimum and maximum values must
+both remain constant on the second, third, etc., iterations. Since such
+values normally count down until they reach zero or remain at infinity,
+a minimum can only be be 0 or 1, and a maximum must be 0, 1 or infinity.
+This effectively means that any outer quantifier other than C<?,*,+>
+disqualifies nested quantifiers from participating in the cache.
+
+[DAPM 2026: I suspect that this restriction is too severe, and that an
+outer quantifier like C<{1,5}> is safe. But I have neither been able to
+prove this to my satisfaction, nor able to find a counter-example. But my
+strong suspicion is that the outer must iterate at least twice (so is at
+minimum C<{2,...}>) so that the first iteration can fail and mark the
+cache, then the second incorrectly fail due to the cache.]
+
+There are some tests for nested quantifiers in F<t/re/re_tests> under the
+heading 'RT #79152'.
+
+=item *
+
+The number of cache-participating C<WHILEM> nodes is stored in the upper 4
+bits of each C<WHILEM>'s C<FLAGS()> field, while the identity of the
+particular C<WHILEM> (used as part of the index into the bit cache) is
+stored in the lower 4 bits. This means that a pattern can have a maximum
+of 16 participating C<WHILEM>s. If the flags field is zero, it indicates
+that this C<WHILEM> node won't participate in the cache mechanism.
+
+=back
+
+The runtime state of the SLC is mainly stored in various fields of the
+C<reginfo> struct, which is initialised at the start of a match.
+
+A pointer to the cache is stored in C<< reginfo->info_aux.poscache >>,
+which will be freed when matching ends (the aux structure is guaranteed to
+be freed even on abnormal termination), and its size is recorded in
+C<< reginfo->poscache_size >>.
+
+If zero, C<< reginfo->poscache_maxiter >> indicates that the SLC countdown
+has not yet been triggered (i.e. no candidate C<WHILEM> node has been
+executed yet), or that it has been subsequently disabled again. Otherwise,
+its (positive) value is used for two different purposes: what value to
+start an initial (or reset) countdown from; and the size to C<alloc()> the
+cache, in bits. Currently these values are the same, but in principle they
+needn't be.
+
+C<< reginfo->poscache_iter >> only has meaning if C<poscache_maxiter> is
+non-zero. In that case, it represents a countdown initialised from
+C<poscache_maxiter>. If it reaches 1, the cache is malloced/realloced if
+necessary, and then zeroed. When it reaches 0, the cache is used.
+
+The C<CACHEsayNO> macro is used at runtime in various places as a
+replacement for C<sayNO> to set a fail bit in the cache while popping the
+current state. The C<ST.cache_offset> and C<ST.cache_mask> fields are set
+by the current C<WHILEM> to the address in the cache of the byte and bit
+corresponding to the current match state. These are used by C<CACHEsayNO>
+to mark the cache during a subsequent unwinding.
 
 =head1 MISCELLANEOUS
 

--- a/src/main/perl/lib/Pod/perlsub.pod
+++ b/src/main/perl/lib/Pod/perlsub.pod
@@ -2163,9 +2163,6 @@ associated with it.  If such an attribute list is present, it is
 broken up at space or colon boundaries and treated as though a
 C<use attributes> had been seen.  See L<attributes> for details
 about what attributes are currently supported.
-Unlike the limitation with the obsolescent C<use attrs>, the
-C<sub : ATTRLIST> syntax works to associate the attributes with
-a pre-declaration, and not just with a subroutine definition.
 
 The attributes must be valid as simple identifier names (without any
 punctuation other than the '_' character).  They may have a parameter

--- a/src/main/perl/lib/Test/Builder.pm
+++ b/src/main/perl/lib/Test/Builder.pm
@@ -4,7 +4,7 @@ use 5.006;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Scalar::Util qw/blessed reftype weaken/;
 
@@ -261,8 +261,8 @@ sub child {
 
 sub finalize {
     my $self = shift;
-    my $ok = 1;
-    ($ok) = @_ if @_;
+    my $end_hub = 1;
+    ($end_hub) = @_ if @_;
 
     my $st_ctx = $self->ctx;
     my $chub = $self->{Hub} || return $st_ctx->release;
@@ -284,7 +284,7 @@ sub finalize {
     delete $ctx->hub->meta(__PACKAGE__, {})->{child};
 
     $chub->finalize($trace->snapshot(hid => $chub->hid, nested => $chub->nested), 1)
-        if $ok
+        if $end_hub
         && $chub->count
         && !$chub->no_ending
         && !$chub->ended;
@@ -396,6 +396,12 @@ sub subtest {
         $err = "Subtest ended with exit code $code" if $code;
     }
 
+    # Record the exception inside the subtest so it fails and says why. The
+    # exception is still rethrown below, this only stops the subtest reporting
+    # success for code that never finished.
+    $st_ctx->send_event('Exception', error => $err)
+        if !$ok && defined($err);
+
     my $st_hub  = $st_ctx->hub;
     my $plan  = $st_hub->plan;
     my $count = $st_hub->count;
@@ -405,7 +411,7 @@ sub subtest {
         $st_ctx->diag('No tests run!');
     }
 
-    $child->finalize($st_ctx->trace);
+    $child->finalize;
 
     $ctx->release;
 

--- a/src/main/perl/lib/Test/Builder/Formatter.pm
+++ b/src/main/perl/lib/Test/Builder/Formatter.pm
@@ -2,7 +2,7 @@ package Test::Builder::Formatter;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Test2::Formatter::TAP; our @ISA = qw(Test2::Formatter::TAP) }
 

--- a/src/main/perl/lib/Test/Builder/Module.pm
+++ b/src/main/perl/lib/Test/Builder/Module.pm
@@ -7,7 +7,7 @@ use Test::Builder;
 require Exporter;
 our @ISA = qw(Exporter);
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 =head1 NAME

--- a/src/main/perl/lib/Test/Builder/Tester.pm
+++ b/src/main/perl/lib/Test/Builder/Tester.pm
@@ -1,7 +1,7 @@
 package Test::Builder::Tester;
 
 use strict;
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test::Builder;
 use Symbol;

--- a/src/main/perl/lib/Test/Builder/Tester/Color.pm
+++ b/src/main/perl/lib/Test/Builder/Tester/Color.pm
@@ -1,7 +1,7 @@
 package Test::Builder::Tester::Color;
 
 use strict;
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 require Test::Builder::Tester;
 

--- a/src/main/perl/lib/Test/Builder/TodoDiag.pm
+++ b/src/main/perl/lib/Test/Builder/TodoDiag.pm
@@ -2,7 +2,7 @@ package Test::Builder::TodoDiag;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Test2::Event::Diag; our @ISA = qw(Test2::Event::Diag) }
 

--- a/src/main/perl/lib/Test/More.pm
+++ b/src/main/perl/lib/Test/More.pm
@@ -17,7 +17,7 @@ sub _carp {
     return warn @_, " at $file line $line\n";
 }
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test::Builder::Module;
 our @ISA    = qw(Test::Builder::Module);
@@ -795,6 +795,10 @@ considered a skip.
   };
 
 Returns true if the subtest passed, false otherwise.
+
+If the code dies, the subtest fails and the exception is reported inside it.
+The exception is then rethrown, so it still reaches your test file and ends it
+the way any other uncaught exception would.
 
 Due to how subtests work, you may omit a plan if you desire.  This adds an
 implicit C<done_testing()> to the end of your subtest.  The following two

--- a/src/main/perl/lib/Test/Simple.pm
+++ b/src/main/perl/lib/Test/Simple.pm
@@ -4,7 +4,7 @@ use 5.006;
 
 use strict;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test::Builder::Module;
 our @ISA    = qw(Test::Builder::Module);

--- a/src/main/perl/lib/Test/Tester.pm
+++ b/src/main/perl/lib/Test/Tester.pm
@@ -16,7 +16,7 @@ use Test::Tester::Delegate;
 
 require Exporter;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 our @EXPORT = qw( run_tests check_tests check_test cmp_results show_space );
 our @ISA = qw( Exporter );

--- a/src/main/perl/lib/Test/Tester/Capture.pm
+++ b/src/main/perl/lib/Test/Tester/Capture.pm
@@ -2,7 +2,7 @@ use strict;
 
 package Test::Tester::Capture;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 use Test::Builder;

--- a/src/main/perl/lib/Test/Tester/CaptureRunner.pm
+++ b/src/main/perl/lib/Test/Tester/CaptureRunner.pm
@@ -3,7 +3,7 @@ use strict;
 
 package Test::Tester::CaptureRunner;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 use Test::Tester::Capture;

--- a/src/main/perl/lib/Test/Tester/Delegate.pm
+++ b/src/main/perl/lib/Test/Tester/Delegate.pm
@@ -3,7 +3,7 @@ use warnings;
 
 package Test::Tester::Delegate;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Scalar::Util();
 

--- a/src/main/perl/lib/Test/use/ok.pm
+++ b/src/main/perl/lib/Test/use/ok.pm
@@ -1,7 +1,7 @@
 package Test::use::ok;
 use 5.005;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 __END__

--- a/src/main/perl/lib/Test2.pm
+++ b/src/main/perl/lib/Test2.pm
@@ -2,7 +2,7 @@ package Test2;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 1;

--- a/src/main/perl/lib/Test2/API.pm
+++ b/src/main/perl/lib/Test2/API.pm
@@ -10,7 +10,7 @@ BEGIN {
     $ENV{TEST2_ACTIVE} = 1;
 }
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 my $INST;
@@ -1213,7 +1213,7 @@ It will execute the codeblock, intercepting any generated events in the
 process. It will return an array reference with all the generated event
 objects. All events should be subclasses of L<Test2::Event>.
 
-As of version 1.302178 the events array that is returned is blssed as an
+As of version 1.302178 the events array that is returned is blessed as an
 L<Test2::API::InterceptResult> instance. L<Test2::API::InterceptResult>
 Provides a helpful interface for filtering and/or inspecting the events list
 overall, or individual events within the list.

--- a/src/main/perl/lib/Test2/API/Breakage.pm
+++ b/src/main/perl/lib/Test2/API/Breakage.pm
@@ -2,7 +2,7 @@ package Test2::API::Breakage;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 use Test2::Util qw/pkg_to_file/;

--- a/src/main/perl/lib/Test2/API/Context.pm
+++ b/src/main/perl/lib/Test2/API/Context.pm
@@ -2,7 +2,7 @@ package Test2::API::Context;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 use Carp qw/confess croak/;

--- a/src/main/perl/lib/Test2/API/Instance.pm
+++ b/src/main/perl/lib/Test2/API/Instance.pm
@@ -2,7 +2,7 @@ package Test2::API::Instance;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 our @CARP_NOT = qw/Test2::API Test2::API::Instance Test2::IPC::Driver Test2::Formatter/;
 use Carp qw/confess carp/;

--- a/src/main/perl/lib/Test2/API/InterceptResult.pm
+++ b/src/main/perl/lib/Test2/API/InterceptResult.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Scalar::Util qw/blessed/;
 use Test2::Util  qw/pkg_to_file/;

--- a/src/main/perl/lib/Test2/API/InterceptResult/Event.pm
+++ b/src/main/perl/lib/Test2/API/InterceptResult/Event.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use List::Util   qw/first/;
 use Test2::Util  qw/pkg_to_file/;
@@ -907,7 +907,7 @@ Returns an empty list if no assertion is present.
 
 =item $bool = $event->has_subtest
 
-True if a subetest is present in this event.
+True if a subtest is present in this event.
 
 =item $undef_or_hashref = $event->the_subtest
 

--- a/src/main/perl/lib/Test2/API/InterceptResult/Facet.pm
+++ b/src/main/perl/lib/Test2/API/InterceptResult/Facet.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Facet;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN {
     require Test2::EventFacet;

--- a/src/main/perl/lib/Test2/API/InterceptResult/Hub.pm
+++ b/src/main/perl/lib/Test2/API/InterceptResult/Hub.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Test2::Hub; our @ISA = qw(Test2::Hub) }
 use Test2::Util::HashBase;

--- a/src/main/perl/lib/Test2/API/InterceptResult/Squasher.pm
+++ b/src/main/perl/lib/Test2/API/InterceptResult/Squasher.pm
@@ -2,7 +2,7 @@ package Test2::API::InterceptResult::Squasher;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 use List::Util qw/first/;

--- a/src/main/perl/lib/Test2/API/Stack.pm
+++ b/src/main/perl/lib/Test2/API/Stack.pm
@@ -2,7 +2,7 @@ package Test2::API::Stack;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 use Test2::Hub();

--- a/src/main/perl/lib/Test2/AsyncSubtest.pm
+++ b/src/main/perl/lib/Test2/AsyncSubtest.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Test2::IPC;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 our @CARP_NOT = qw/Test2::Util::HashBase/;
 

--- a/src/main/perl/lib/Test2/AsyncSubtest/Event/Attach.pm
+++ b/src/main/perl/lib/Test2/AsyncSubtest/Event/Attach.pm
@@ -2,7 +2,7 @@ package Test2::AsyncSubtest::Event::Attach;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use base 'Test2::Event';
 use Test2::Util::HashBase qw/id/;

--- a/src/main/perl/lib/Test2/AsyncSubtest/Event/Detach.pm
+++ b/src/main/perl/lib/Test2/AsyncSubtest/Event/Detach.pm
@@ -2,7 +2,7 @@ package Test2::AsyncSubtest::Event::Detach;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use base 'Test2::Event';
 use Test2::Util::HashBase qw/id/;

--- a/src/main/perl/lib/Test2/AsyncSubtest/Formatter.pm
+++ b/src/main/perl/lib/Test2/AsyncSubtest/Formatter.pm
@@ -2,7 +2,7 @@ package Test2::AsyncSubtest::Formatter;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 die "Should not load this anymore";
 

--- a/src/main/perl/lib/Test2/AsyncSubtest/Hub.pm
+++ b/src/main/perl/lib/Test2/AsyncSubtest/Hub.pm
@@ -2,7 +2,7 @@ package Test2::AsyncSubtest::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use base 'Test2::Hub::Subtest';
 use Test2::Util::HashBase qw/ast_ids ast/;

--- a/src/main/perl/lib/Test2/Bundle.pm
+++ b/src/main/perl/lib/Test2/Bundle.pm
@@ -2,7 +2,7 @@ package Test2::Bundle;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Bundle/Extended.pm
+++ b/src/main/perl/lib/Test2/Bundle/Extended.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Test2::V0;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN {
     push @Test2::Bundle::Extended::ISA => 'Test2::V0';

--- a/src/main/perl/lib/Test2/Bundle/More.pm
+++ b/src/main/perl/lib/Test2/Bundle/More.pm
@@ -2,7 +2,7 @@ package Test2::Bundle::More;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Plugin::ExitSummary;
 

--- a/src/main/perl/lib/Test2/Bundle/Simple.pm
+++ b/src/main/perl/lib/Test2/Bundle/Simple.pm
@@ -2,7 +2,7 @@ package Test2::Bundle::Simple;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Plugin::ExitSummary;
 

--- a/src/main/perl/lib/Test2/Compare.pm
+++ b/src/main/perl/lib/Test2/Compare.pm
@@ -2,7 +2,7 @@ package Test2::Compare;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Scalar::Util qw/blessed/;
 use Test2::Util qw/try/;
@@ -57,6 +57,8 @@ sub build {
     my ($ok, $err) = try { $code->($build); 1 };
     pop @BUILD;
     die $err unless $ok;
+
+    $build->verify_build;
 
     return $build;
 }
@@ -245,7 +247,9 @@ passed in is different from the current global.
 =item build($class, sub { ... })
 
 Run the provided codeblock with a new instance of C<$class> as the current
-build. Returns the new build.
+build. Returns the new build. Once the codeblock has run, C<verify_build> is
+called on the new build, so a class that rejects a combination of build
+directives can throw from there.
 
 =item $check = convert($thing)
 

--- a/src/main/perl/lib/Test2/Compare/Array.pm
+++ b/src/main/perl/lib/Test2/Compare/Array.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/inref meta ending items order for_each/;
 
@@ -104,6 +104,16 @@ sub add_filter {
 sub add_for_each {
     my $self = shift;
     push @{$self->{+FOR_EACH}} => @_;
+}
+
+sub verify_build {
+    my $self = shift;
+
+    return unless @{$self->{+FOR_EACH}};
+    return unless $self->{+ENDING};
+    return if keys %{$self->{+ITEMS}};
+
+    $self->throw_build_error("'end' with no items specified requires an empty array, which discards the 'all_items' checks; use 'etc' instead of 'end' to check every item without bounding the array");
 }
 
 sub deltas {

--- a/src/main/perl/lib/Test2/Compare/Bag.pm
+++ b/src/main/perl/lib/Test2/Compare/Bag.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/ending meta items for_each/;
 
@@ -52,6 +52,16 @@ sub add_item {
 sub add_for_each {
     my $self = shift;
     push @{$self->{+FOR_EACH}} => @_;
+}
+
+sub verify_build {
+    my $self = shift;
+
+    return unless @{$self->{+FOR_EACH}};
+    return unless $self->{+ENDING};
+    return if @{$self->{+ITEMS}};
+
+    $self->throw_build_error("'end' with no items specified requires an empty bag, which discards the 'all_items' checks; use 'etc' instead of 'end' to check every item without bounding the bag");
 }
 
 sub deltas {
@@ -109,9 +119,6 @@ sub deltas {
         my @checks = map { $convert->($_) } @for_each;
 
         for my $idx (0..$#list) {
-            # All items are matched if we have conditions for all items
-            delete $unmatched{$idx};
-
             my $val = $list[$idx];
 
             for my $check (@checks) {

--- a/src/main/perl/lib/Test2/Compare/Base.pm
+++ b/src/main/perl/lib/Test2/Compare/Base.pm
@@ -2,7 +2,7 @@ package Test2::Compare::Base;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/confess croak/;
 use Scalar::Util qw/blessed/;
@@ -68,6 +68,19 @@ sub delta_class { 'Test2::Compare::Delta' }
 
 sub deltas { () }
 sub got_lines { () }
+
+sub verify_build { }
+
+sub throw_build_error {
+    my $self = shift;
+    my ($msg) = @_;
+
+    my $file  = $self->file || 'unknown file';
+    my $lines = $self->lines;
+    my $line  = $lines && @$lines ? $lines->[0] : 0;
+
+    die "$msg at $file line $line.\n";
+}
 
 sub stringify_got { 0 }
 
@@ -206,6 +219,18 @@ checks are done in C<< $check->deltas() >>.
 =item $name = $check->name
 
 Get the name of the check.
+
+=item $check->verify_build()
+
+Called on every check built by a builder block once the block has run. This
+base class does nothing; a subclass may override it to reject a combination of
+build directives that cannot do anything useful, and should use
+C<< $check->throw_build_error($msg) >> to report the problem.
+
+=item $check->throw_build_error($msg)
+
+Throw an exception reporting C<$msg> against the file and line of the builder
+block the check came from.
 
 =item $display = $check->render
 

--- a/src/main/perl/lib/Test2/Compare/Bool.pm
+++ b/src/main/perl/lib/Test2/Compare/Bool.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/src/main/perl/lib/Test2/Compare/Custom.pm
+++ b/src/main/perl/lib/Test2/Compare/Custom.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/code name operator stringify_got/;
 

--- a/src/main/perl/lib/Test2/Compare/DeepRef.pm
+++ b/src/main/perl/lib/Test2/Compare/DeepRef.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/src/main/perl/lib/Test2/Compare/Delta.pm
+++ b/src/main/perl/lib/Test2/Compare/Delta.pm
@@ -2,7 +2,7 @@ package Test2::Compare::Delta;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw{verified id got chk children dne exception note};
 

--- a/src/main/perl/lib/Test2/Compare/Event.pm
+++ b/src/main/perl/lib/Test2/Compare/Event.pm
@@ -8,7 +8,7 @@ use Test2::Compare::EventMeta();
 
 use base 'Test2::Compare::Object';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/etype/;
 

--- a/src/main/perl/lib/Test2/Compare/EventMeta.pm
+++ b/src/main/perl/lib/Test2/Compare/EventMeta.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Meta';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase;
 

--- a/src/main/perl/lib/Test2/Compare/Float.pm
+++ b/src/main/perl/lib/Test2/Compare/Float.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 our $DEFAULT_TOLERANCE = 1e-08;
 

--- a/src/main/perl/lib/Test2/Compare/Hash.pm
+++ b/src/main/perl/lib/Test2/Compare/Hash.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/inref meta ending items order for_each_key for_each_val/;
 
@@ -85,6 +85,16 @@ sub add_for_each_key {
 sub add_for_each_val {
     my $self = shift;
     push @{$self->{+FOR_EACH_VAL}} => @_;
+}
+
+sub verify_build {
+    my $self = shift;
+
+    return unless @{$self->{+FOR_EACH_KEY}} || @{$self->{+FOR_EACH_VAL}};
+    return unless $self->{+ENDING};
+    return if keys %{$self->{+ITEMS}};
+
+    $self->throw_build_error("'end' with no fields specified requires an empty hash, which discards the 'all_keys' and 'all_values' checks; use 'etc' instead of 'end' to check every key and value without bounding the hash");
 }
 
 sub deltas {

--- a/src/main/perl/lib/Test2/Compare/Isa.pm
+++ b/src/main/perl/lib/Test2/Compare/Isa.pm
@@ -7,7 +7,7 @@ use Scalar::Util qw/blessed/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/src/main/perl/lib/Test2/Compare/Meta.pm
+++ b/src/main/perl/lib/Test2/Compare/Meta.pm
@@ -7,7 +7,7 @@ use Test2::Compare::Isa();
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/items/;
 

--- a/src/main/perl/lib/Test2/Compare/Negatable.pm
+++ b/src/main/perl/lib/Test2/Compare/Negatable.pm
@@ -2,7 +2,7 @@ package Test2::Compare::Negatable;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 require overload;
 require Test2::Util::HashBase;

--- a/src/main/perl/lib/Test2/Compare/Number.pm
+++ b/src/main/perl/lib/Test2/Compare/Number.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/input mode/;
 

--- a/src/main/perl/lib/Test2/Compare/Object.pm
+++ b/src/main/perl/lib/Test2/Compare/Object.pm
@@ -8,7 +8,7 @@ use Test2::Compare::Meta();
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/calls meta refcheck ending/;
 

--- a/src/main/perl/lib/Test2/Compare/OrderedSubset.pm
+++ b/src/main/perl/lib/Test2/Compare/OrderedSubset.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/inref items/;
 

--- a/src/main/perl/lib/Test2/Compare/Pattern.pm
+++ b/src/main/perl/lib/Test2/Compare/Pattern.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/pattern stringify_got/;
 

--- a/src/main/perl/lib/Test2/Compare/Ref.pm
+++ b/src/main/perl/lib/Test2/Compare/Ref.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/src/main/perl/lib/Test2/Compare/Regex.pm
+++ b/src/main/perl/lib/Test2/Compare/Regex.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/src/main/perl/lib/Test2/Compare/Scalar.pm
+++ b/src/main/perl/lib/Test2/Compare/Scalar.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/item/;
 

--- a/src/main/perl/lib/Test2/Compare/Set.pm
+++ b/src/main/perl/lib/Test2/Compare/Set.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/checks _reduction/;
 

--- a/src/main/perl/lib/Test2/Compare/String.pm
+++ b/src/main/perl/lib/Test2/Compare/String.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/input/;
 

--- a/src/main/perl/lib/Test2/Compare/Undef.pm
+++ b/src/main/perl/lib/Test2/Compare/Undef.pm
@@ -6,7 +6,7 @@ use Carp qw/confess/;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase;
 

--- a/src/main/perl/lib/Test2/Compare/Wildcard.pm
+++ b/src/main/perl/lib/Test2/Compare/Wildcard.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Compare::Base';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/expect/;
 

--- a/src/main/perl/lib/Test2/Env.pm
+++ b/src/main/perl/lib/Test2/Env.pm
@@ -2,7 +2,7 @@ package Test2::Env;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Event.pm
+++ b/src/main/perl/lib/Test2/Event.pm
@@ -2,7 +2,7 @@ package Test2::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Scalar::Util qw/blessed reftype/;
 use Carp qw/croak/;

--- a/src/main/perl/lib/Test2/Event/Bail.pm
+++ b/src/main/perl/lib/Test2/Event/Bail.pm
@@ -2,7 +2,7 @@ package Test2::Event::Bail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/Event/Diag.pm
+++ b/src/main/perl/lib/Test2/Event/Diag.pm
@@ -2,7 +2,7 @@ package Test2::Event::Diag;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/Event/Encoding.pm
+++ b/src/main/perl/lib/Test2/Event/Encoding.pm
@@ -2,7 +2,7 @@ package Test2::Event::Encoding;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/Test2/Event/Exception.pm
+++ b/src/main/perl/lib/Test2/Event/Exception.pm
@@ -2,7 +2,7 @@ package Test2::Event::Exception;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/Event/Fail.pm
+++ b/src/main/perl/lib/Test2/Event/Fail.pm
@@ -2,7 +2,7 @@ package Test2::Event::Fail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::EventFacet::Info;
 

--- a/src/main/perl/lib/Test2/Event/Generic.pm
+++ b/src/main/perl/lib/Test2/Event/Generic.pm
@@ -5,7 +5,7 @@ use warnings;
 use Carp qw/croak/;
 use Scalar::Util qw/reftype/;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }
 use Test2::Util::HashBase;

--- a/src/main/perl/lib/Test2/Event/Note.pm
+++ b/src/main/perl/lib/Test2/Event/Note.pm
@@ -2,7 +2,7 @@ package Test2::Event::Note;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/Event/Ok.pm
+++ b/src/main/perl/lib/Test2/Event/Ok.pm
@@ -2,7 +2,7 @@ package Test2::Event::Ok;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/Event/Pass.pm
+++ b/src/main/perl/lib/Test2/Event/Pass.pm
@@ -2,7 +2,7 @@ package Test2::Event::Pass;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::EventFacet::Info;
 

--- a/src/main/perl/lib/Test2/Event/Plan.pm
+++ b/src/main/perl/lib/Test2/Event/Plan.pm
@@ -2,7 +2,7 @@ package Test2::Event::Plan;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/Event/Skip.pm
+++ b/src/main/perl/lib/Test2/Event/Skip.pm
@@ -2,7 +2,7 @@ package Test2::Event::Skip;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 BEGIN { require Test2::Event::Ok; our @ISA = qw(Test2::Event::Ok) }

--- a/src/main/perl/lib/Test2/Event/Subtest.pm
+++ b/src/main/perl/lib/Test2/Event/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Event::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Test2::Event::Ok; our @ISA = qw(Test2::Event::Ok) }
 use Test2::Util::HashBase qw{subevents buffered subtest_id subtest_uuid start_stamp stop_stamp};

--- a/src/main/perl/lib/Test2/Event/TAP/Version.pm
+++ b/src/main/perl/lib/Test2/Event/TAP/Version.pm
@@ -2,7 +2,7 @@ package Test2::Event::TAP::Version;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/Test2/Event/V2.pm
+++ b/src/main/perl/lib/Test2/Event/V2.pm
@@ -2,7 +2,7 @@ package Test2::Event::V2;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Scalar::Util qw/reftype/;
 use Carp qw/croak/;

--- a/src/main/perl/lib/Test2/Event/Waiting.pm
+++ b/src/main/perl/lib/Test2/Event/Waiting.pm
@@ -2,7 +2,7 @@ package Test2::Event::Waiting;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }

--- a/src/main/perl/lib/Test2/EventFacet.pm
+++ b/src/main/perl/lib/Test2/EventFacet.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/-details/;
 use Carp qw/croak/;

--- a/src/main/perl/lib/Test2/EventFacet/About.pm
+++ b/src/main/perl/lib/Test2/EventFacet/About.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::About;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -package -no_display -uuid -eid };

--- a/src/main/perl/lib/Test2/EventFacet/Amnesty.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Amnesty.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Amnesty;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub is_list { 1 }
 

--- a/src/main/perl/lib/Test2/EventFacet/Assert.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Assert.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Assert;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -pass -no_debug -number };

--- a/src/main/perl/lib/Test2/EventFacet/Control.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Control.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Control;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -global -terminate -halt -has_callback -encoding -phase };

--- a/src/main/perl/lib/Test2/EventFacet/Error.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Error.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Error;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub facet_key { 'errors' }
 sub is_list { 1 }

--- a/src/main/perl/lib/Test2/EventFacet/Hub.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Hub.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub is_list { 1 }
 sub facet_key { 'hubs' }

--- a/src/main/perl/lib/Test2/EventFacet/Info.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Info.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Info;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub is_list { 1 }
 

--- a/src/main/perl/lib/Test2/EventFacet/Info/Table.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Info/Table.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Info::Table;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/confess/;
 

--- a/src/main/perl/lib/Test2/EventFacet/Meta.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Meta.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Meta;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 

--- a/src/main/perl/lib/Test2/EventFacet/Parent.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Parent.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Parent;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/confess/;
 

--- a/src/main/perl/lib/Test2/EventFacet/Plan.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Plan.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Plan;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 use Test2::Util::HashBase qw{ -count -skip -none };

--- a/src/main/perl/lib/Test2/EventFacet/Render.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Render.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Render;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub is_list { 1 }
 

--- a/src/main/perl/lib/Test2/EventFacet/Trace.pm
+++ b/src/main/perl/lib/Test2/EventFacet/Trace.pm
@@ -2,7 +2,7 @@ package Test2::EventFacet::Trace;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Test2::EventFacet; our @ISA = qw(Test2::EventFacet) }
 

--- a/src/main/perl/lib/Test2/Formatter.pm
+++ b/src/main/perl/lib/Test2/Formatter.pm
@@ -2,7 +2,7 @@ package Test2::Formatter;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 my %ADDED;

--- a/src/main/perl/lib/Test2/Formatter/TAP.pm
+++ b/src/main/perl/lib/Test2/Formatter/TAP.pm
@@ -2,7 +2,7 @@ package Test2::Formatter::TAP;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util qw/clone_io/;
 

--- a/src/main/perl/lib/Test2/Handle.pm
+++ b/src/main/perl/lib/Test2/Handle.pm
@@ -2,7 +2,7 @@ package Test2::Handle;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 require Carp;
 require Test2::Util;
@@ -45,7 +45,7 @@ sub _HANDLE_INCLUDE {
 
     my $line = __LINE__ + 3;
     $self->{+IMPORT} = eval <<"    EOT" or die $@;
-#line $line ${ \__FILE__ }
+#line $line "${ \__FILE__ }"
         package $ns;
         sub {
             my (\$module, \$caller, \@imports) = \@_;
@@ -251,11 +251,11 @@ namespace.
 
 =item $inst = $class->import()
 
-Used to create a C<T2()> sub in your namsepace at import.
+Used to create a C<T2()> sub in your namespace at import.
 
 =item $inst->init()
 
-Internally used to intialize and validate the handle object.
+Internally used to initialize and validate the handle object.
 
 =item AUTOLOAD
 

--- a/src/main/perl/lib/Test2/Hub.pm
+++ b/src/main/perl/lib/Test2/Hub.pm
@@ -2,7 +2,7 @@ package Test2::Hub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 use Carp qw/carp croak confess/;

--- a/src/main/perl/lib/Test2/Hub/Interceptor.pm
+++ b/src/main/perl/lib/Test2/Hub/Interceptor.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Interceptor;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 use Test2::Hub::Interceptor::Terminator();

--- a/src/main/perl/lib/Test2/Hub/Interceptor/Terminator.pm
+++ b/src/main/perl/lib/Test2/Hub/Interceptor/Terminator.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Interceptor::Terminator;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 1;

--- a/src/main/perl/lib/Test2/Hub/Subtest.pm
+++ b/src/main/perl/lib/Test2/Hub/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Hub::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Test2::Hub; our @ISA = qw(Test2::Hub) }
 use Test2::Util::HashBase qw/nested exit_code manual_skip_all/;

--- a/src/main/perl/lib/Test2/IPC.pm
+++ b/src/main/perl/lib/Test2/IPC.pm
@@ -2,7 +2,7 @@ package Test2::IPC;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 use Test2::API::Instance;

--- a/src/main/perl/lib/Test2/IPC/Driver.pm
+++ b/src/main/perl/lib/Test2/IPC/Driver.pm
@@ -2,7 +2,7 @@ package Test2::IPC::Driver;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 use Carp qw/confess/;

--- a/src/main/perl/lib/Test2/IPC/Driver/Files.pm
+++ b/src/main/perl/lib/Test2/IPC/Driver/Files.pm
@@ -2,7 +2,7 @@ package Test2::IPC::Driver::Files;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Test2::IPC::Driver; our @ISA = qw(Test2::IPC::Driver) }
 

--- a/src/main/perl/lib/Test2/Manual.pm
+++ b/src/main/perl/lib/Test2/Manual.pm
@@ -2,7 +2,7 @@ package Test2::Manual;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/API.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/API.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::API;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/Context.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/Context.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::Context;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/EndToEnd.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/EndToEnd.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::EndToEnd;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/Event.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/Event.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/Hubs.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/Hubs.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::Hubs;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/IPC.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/IPC.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::IPC;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Anatomy/Utilities.pm
+++ b/src/main/perl/lib/Test2/Manual/Anatomy/Utilities.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Anatomy::Utilities;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Concurrency.pm
+++ b/src/main/perl/lib/Test2/Manual/Concurrency.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Concurrency;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Contributing.pm
+++ b/src/main/perl/lib/Test2/Manual/Contributing.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Contributing;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Testing.pm
+++ b/src/main/perl/lib/Test2/Manual/Testing.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Testing/Introduction.pm
+++ b/src/main/perl/lib/Test2/Manual/Testing/Introduction.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing::Introduction;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 
@@ -36,10 +36,10 @@ This is all the boilerplate you need.
 
 =over 4
 
-=item use Test2::V1 -ipP;
+=item C<use Test2::V1 -ipP;>
 
 This loads a collection of testing tools that will be described later in the
-tutorial. See L<Test2::V1> for more details, but for starters '-ipP' is a good
+tutorial. See L<Test2::V1> for more details, but for starters C<-ipP> is a good
 set of import flags.
 
 If you do not like importing a ton of symbols or enabling pragmas/plugins all

--- a/src/main/perl/lib/Test2/Manual/Testing/Migrating.pm
+++ b/src/main/perl/lib/Test2/Manual/Testing/Migrating.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing::Migrating;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Testing/Planning.pm
+++ b/src/main/perl/lib/Test2/Manual/Testing/Planning.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing::Planning;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Testing/Todo.pm
+++ b/src/main/perl/lib/Test2/Manual/Testing/Todo.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Testing::Todo;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Tooling;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/FirstTool.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/FirstTool.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::FirstTool;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Formatter.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Formatter.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Formatter;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Nesting.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Nesting.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Tooling::Nesting;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Plugin/TestExit.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Plugin/TestExit.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Plugin::TestExit;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Plugin/TestingDone.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Plugin/TestingDone.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Plugin::TestingDone;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Plugin/ToolCompletes.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Plugin/ToolCompletes.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Plugin::ToolCompletes;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Plugin/ToolStarts.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Plugin/ToolStarts.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::Plugin::ToolStarts;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Subtest.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Tooling::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/TestBuilder.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/TestBuilder.pm
@@ -1,6 +1,6 @@
 package Test2::Manual::Tooling::TestBuilder;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Manual/Tooling/Testing.pm
+++ b/src/main/perl/lib/Test2/Manual/Tooling/Testing.pm
@@ -2,7 +2,7 @@ package Test2::Manual::Tooling::Testing;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Mock.pm
+++ b/src/main/perl/lib/Test2/Mock.pm
@@ -2,7 +2,7 @@ package Test2::Mock;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak confess/;
 our @CARP_NOT = (__PACKAGE__);

--- a/src/main/perl/lib/Test2/Plugin.pm
+++ b/src/main/perl/lib/Test2/Plugin.pm
@@ -2,7 +2,7 @@ package Test2::Plugin;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Plugin/BailOnFail.pm
+++ b/src/main/perl/lib/Test2/Plugin/BailOnFail.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::BailOnFail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::API qw/test2_add_callback_context_release/;
 
@@ -46,6 +46,21 @@ diagnostics they may need.
     T2->ok(1, "pass");
     T2->ok(0, "fail");
     T2->ok(1, "Will not run");
+
+=head1 FORKED AND ASYNC SUBTESTS
+
+This plugin acts on the pass/fail state of the hub in the process that is
+running, and a process that does not own its hub never sees that state. A
+forked subtest sends its events to the process that owns the hub instead of
+recording them locally, so inside one the hub reports no tests and no
+failures no matter what happened.
+
+A failure inside a forked subtest therefore does not bail there. It bails in
+the owning process once that subtest is finished and its events have been
+merged, by which point sibling subtests have run whatever they were going to
+run. Their output is not suppressed, and there is no way to suppress it from
+here: a process cannot receive events for a hub it does not own, so it cannot
+be told that a sibling failed.
 
 =head1 SOURCE
 

--- a/src/main/perl/lib/Test2/Plugin/DieOnFail.pm
+++ b/src/main/perl/lib/Test2/Plugin/DieOnFail.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::DieOnFail;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::API qw/test2_add_callback_context_release/;
 
@@ -44,6 +44,19 @@ This gives the tools the ability to output any extra diagnostics they may need.
     T2->ok(1, "pass");
     T2->ok(0, "fail");
     T2->ok(1, "Will not run");
+
+=head1 FORKED AND ASYNC SUBTESTS
+
+This plugin acts on the pass/fail state of the hub in the process that is
+running, and a process that does not own its hub never sees that state. A
+forked subtest sends its events to the process that owns the hub instead of
+recording them locally, so inside one the hub reports no tests and no
+failures no matter what happened.
+
+A failure inside a forked subtest therefore does not throw there. It throws in
+the owning process once that subtest is finished and its events have been
+merged, by which point sibling subtests have run whatever they were going to
+run.
 
 =head1 SOURCE
 

--- a/src/main/perl/lib/Test2/Plugin/ExitSummary.pm
+++ b/src/main/perl/lib/Test2/Plugin/ExitSummary.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::ExitSummary;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::API qw/test2_add_callback_exit/;
 

--- a/src/main/perl/lib/Test2/Plugin/SRand.pm
+++ b/src/main/perl/lib/Test2/Plugin/SRand.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::SRand;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/carp/;
 

--- a/src/main/perl/lib/Test2/Plugin/Times.pm
+++ b/src/main/perl/lib/Test2/Plugin/Times.pm
@@ -10,7 +10,7 @@ use Test2::API qw{
 
 use Time::HiRes qw/time/;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 my $ADDED_HOOK = 0;
 my $START;

--- a/src/main/perl/lib/Test2/Plugin/UTF8.pm
+++ b/src/main/perl/lib/Test2/Plugin/UTF8.pm
@@ -2,7 +2,7 @@ package Test2::Plugin::UTF8;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/Test2/Require.pm
+++ b/src/main/perl/lib/Test2/Require.pm
@@ -2,7 +2,7 @@ package Test2::Require;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::API qw/context/;
 use Carp qw/croak/;

--- a/src/main/perl/lib/Test2/Require/AuthorTesting.pm
+++ b/src/main/perl/lib/Test2/Require/AuthorTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub skip {
     my $class = shift;

--- a/src/main/perl/lib/Test2/Require/AutomatedTesting.pm
+++ b/src/main/perl/lib/Test2/Require/AutomatedTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub skip {
     my $class = shift;

--- a/src/main/perl/lib/Test2/Require/EnvVar.pm
+++ b/src/main/perl/lib/Test2/Require/EnvVar.pm
@@ -5,7 +5,7 @@ use warnings;
 use Carp qw/confess/;
 use base 'Test2::Require';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub skip {
     my $class = shift;

--- a/src/main/perl/lib/Test2/Require/ExtendedTesting.pm
+++ b/src/main/perl/lib/Test2/Require/ExtendedTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub skip {
     my $class = shift;

--- a/src/main/perl/lib/Test2/Require/Fork.pm
+++ b/src/main/perl/lib/Test2/Require/Fork.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util qw/CAN_FORK/;
 

--- a/src/main/perl/lib/Test2/Require/Module.pm
+++ b/src/main/perl/lib/Test2/Require/Module.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util qw/pkg_to_file/;
 

--- a/src/main/perl/lib/Test2/Require/NonInteractiveTesting.pm
+++ b/src/main/perl/lib/Test2/Require/NonInteractiveTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub skip {
     my $class = shift;

--- a/src/main/perl/lib/Test2/Require/Perl.pm
+++ b/src/main/perl/lib/Test2/Require/Perl.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util qw/pkg_to_file/;
 use Scalar::Util qw/reftype/;

--- a/src/main/perl/lib/Test2/Require/RealFork.pm
+++ b/src/main/perl/lib/Test2/Require/RealFork.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util qw/CAN_REALLY_FORK/;
 

--- a/src/main/perl/lib/Test2/Require/ReleaseTesting.pm
+++ b/src/main/perl/lib/Test2/Require/ReleaseTesting.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use base 'Test2::Require';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub skip {
     my $class = shift;

--- a/src/main/perl/lib/Test2/Require/Threads.pm
+++ b/src/main/perl/lib/Test2/Require/Threads.pm
@@ -4,7 +4,7 @@ use warnings;
 
 BEGIN { require Test2::Require; our @ISA = qw(Test2::Require) }
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util qw/CAN_THREAD/;
 

--- a/src/main/perl/lib/Test2/Suite.pm
+++ b/src/main/perl/lib/Test2/Suite.pm
@@ -2,7 +2,7 @@ package Test2::Suite;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Todo.pm
+++ b/src/main/perl/lib/Test2/Todo.pm
@@ -9,7 +9,7 @@ use Test2::API qw/test2_stack/;
 
 use overload '""' => \&reason, fallback => 1;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub init {
     my $self = shift;

--- a/src/main/perl/lib/Test2/Tools.pm
+++ b/src/main/perl/lib/Test2/Tools.pm
@@ -2,7 +2,7 @@ package Test2::Tools;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/Tools/AsyncSubtest.pm
+++ b/src/main/perl/lib/Test2/Tools/AsyncSubtest.pm
@@ -2,7 +2,7 @@ package Test2::Tools::AsyncSubtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::IPC;
 use Test2::AsyncSubtest;
@@ -86,7 +86,7 @@ other events are also being generated.
 
 =head1 SYNOPSIS
 
-    use Test2::Bundle::Extended;
+    use Test2::V0;
     use Test2::Tools::AsyncSubtest;
 
     my $ast1 = async_subtest local => sub {

--- a/src/main/perl/lib/Test2/Tools/Basic.pm
+++ b/src/main/perl/lib/Test2/Tools/Basic.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Basic;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 use Test2::API qw/context/;
@@ -104,7 +104,9 @@ sub skip_all {
 sub done_testing {
     my $ctx = context();
     $ctx->hub->finalize($ctx->trace, 1);
+    my $count = $ctx->hub->count;
     $ctx->release;
+    return $count;
 }
 
 sub bail_out {
@@ -201,6 +203,8 @@ tests are run.
 
 Used to mark the end of testing. This is a safe way to have a dynamic or
 unknown number of tests.
+
+Returns the number of assertions that were made, which is 0 when none were.
 
 =item bail_out($reason)
 

--- a/src/main/perl/lib/Test2/Tools/Class.pm
+++ b/src/main/perl/lib/Test2/Tools/Class.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Class;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::API qw/context/;
 use Test2::Util::Ref qw/render_ref/;

--- a/src/main/perl/lib/Test2/Tools/ClassicCompare.pm
+++ b/src/main/perl/lib/Test2/Tools/ClassicCompare.pm
@@ -2,7 +2,7 @@ package Test2::Tools::ClassicCompare;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 our @EXPORT = qw/is is_deeply isnt like unlike cmp_ok/;
 use base 'Exporter';

--- a/src/main/perl/lib/Test2/Tools/Compare.pm
+++ b/src/main/perl/lib/Test2/Tools/Compare.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Compare;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 use Scalar::Util qw/reftype/;
@@ -1341,6 +1341,13 @@ Enforce that no keys are found in the hash other than those specified. This is
 essentially the C<use strict> of a hash check. This can be used anywhere in the
 hash builder, though typically it is placed at the end.
 
+C<all_keys()> and C<all_values()> do not specify any fields, so they do not
+keep C<end()> from rejecting a key. Using either or both together with
+C<end()> in a builder that specifies no fields throws an exception once the
+builder block finishes: such a check can only match an empty hash, which
+discards the C<all_keys()> and C<all_values()> checks. Use C<etc()> to check
+every key or value without limiting which keys the hash may have.
+
 =item etc()
 
 Ignore any extra keys found in the hash. This is the opposite of C<end()>.
@@ -1436,6 +1443,13 @@ block, and can call it any number of times with any number of arguments.
 Enforce that there are no indexes after the last one specified. This will not
 force checking of skipped indexes.
 
+C<all_items()> does not specify any indexes, so it does not keep C<end()> from
+rejecting an item. Using it together with C<end()> in a builder that specifies
+no items throws an exception once the builder block finishes: such a check can
+only match an empty array, which discards the C<all_items()> checks. Use
+C<etc()> to check every item without limiting how many items the array may
+have.
+
 =item etc()
 
 Ignore any extra items found in the array. This is the opposite of C<end()>.
@@ -1489,7 +1503,14 @@ block, and can call it any number of times with any number of arguments.
 
 =item end()
 
-Enforce that there are no more items after the last one specified.
+Enforce that the array contains no items other than the ones specified.
+
+C<all_items()> does not specify any items, so it does not keep C<end()> from
+rejecting an item. Using it together with C<end()> in a builder that specifies
+no items throws an exception once the builder block finishes: such a check can
+only match an empty array, which discards the C<all_items()> checks. Use
+C<etc()> to check every item without limiting how many items the array may
+have.
 
 =item etc()
 

--- a/src/main/perl/lib/Test2/Tools/Defer.pm
+++ b/src/main/perl/lib/Test2/Tools/Defer.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Defer;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/Test2/Tools/Encoding.pm
+++ b/src/main/perl/lib/Test2/Tools/Encoding.pm
@@ -8,7 +8,7 @@ use Test2::API qw/test2_stack/;
 
 use base 'Exporter';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 our @EXPORT = qw/set_encoding/;
 

--- a/src/main/perl/lib/Test2/Tools/Event.pm
+++ b/src/main/perl/lib/Test2/Tools/Event.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Event;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util qw/pkg_to_file/;
 

--- a/src/main/perl/lib/Test2/Tools/Exception.pm
+++ b/src/main/perl/lib/Test2/Tools/Exception.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Exception;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/carp/;
 use Test2::API qw/context test2_add_pending_diag test2_clear_pending_diags/;

--- a/src/main/perl/lib/Test2/Tools/Exports.pm
+++ b/src/main/perl/lib/Test2/Tools/Exports.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Exports;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak carp/;
 use Test2::API qw/context/;

--- a/src/main/perl/lib/Test2/Tools/GenTemp.pm
+++ b/src/main/perl/lib/Test2/Tools/GenTemp.pm
@@ -3,7 +3,7 @@ package Test2::Tools::GenTemp;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use File::Temp qw/tempdir/;
 use File::Spec;

--- a/src/main/perl/lib/Test2/Tools/Grab.pm
+++ b/src/main/perl/lib/Test2/Tools/Grab.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Grab;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::Grabber;
 use Test2::EventFacet::Trace();

--- a/src/main/perl/lib/Test2/Tools/Mock.pm
+++ b/src/main/perl/lib/Test2/Tools/Mock.pm
@@ -11,7 +11,7 @@ use Test2::Mock();
 
 use base 'Exporter';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 our @CARP_NOT = (__PACKAGE__, 'Test2::Mock');
 our @EXPORT = qw/mock mocked/;

--- a/src/main/perl/lib/Test2/Tools/Ref.pm
+++ b/src/main/perl/lib/Test2/Tools/Ref.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Ref;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Scalar::Util qw/reftype refaddr/;
 use Test2::API qw/context/;

--- a/src/main/perl/lib/Test2/Tools/Refcount.pm
+++ b/src/main/perl/lib/Test2/Tools/Refcount.pm
@@ -13,7 +13,7 @@ use Test2::API qw(context release);
 use Scalar::Util qw( weaken refaddr );
 use B qw( svref_2object );
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 our @EXPORT = qw(
    is_refcount

--- a/src/main/perl/lib/Test2/Tools/Spec.pm
+++ b/src/main/perl/lib/Test2/Tools/Spec.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Spec;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 use Test2::Workflow qw/parse_args build current_build root_build init_root build_stack/;
@@ -301,7 +301,7 @@ supports isolation and/or concurrency via forking or threads.
 
 =head1 SYNOPSIS
 
-    use Test2::Bundle::Extended;
+    use Test2::V0;
     use Test2::Tools::Spec;
 
     describe foo => sub {
@@ -580,7 +580,7 @@ Same as:
 Sometimes you want to apply default attributes to all C<tests()> or C<case()>
 blocks. This can be done, and is lexical to your describe or package root!
 
-    use Test2::Bundle::Extended;
+    use Test2::V0;
     use Test2::Tools::Spec ':ALL';
 
     # All 'tests' blocks after this declaration will have C<<iso => 1>> by default

--- a/src/main/perl/lib/Test2/Tools/Subtest.pm
+++ b/src/main/perl/lib/Test2/Tools/Subtest.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Subtest;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::API qw/context run_subtest/;
 use Test2::Util qw/try/;

--- a/src/main/perl/lib/Test2/Tools/Target.pm
+++ b/src/main/perl/lib/Test2/Tools/Target.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Target;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/Test2/Tools/Tester.pm
+++ b/src/main/perl/lib/Test2/Tools/Tester.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Tester;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 use Test2::Util::Ref qw/rtype/;

--- a/src/main/perl/lib/Test2/Tools/Tiny.pm
+++ b/src/main/perl/lib/Test2/Tools/Tiny.pm
@@ -10,7 +10,7 @@ use Test2::API qw/context run_subtest test2_stack/;
 use Test2::Hub::Interceptor();
 use Test2::Hub::Interceptor::Terminator();
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 BEGIN { require Exporter; our @ISA = qw(Exporter) }
 our @EXPORT = qw{
@@ -208,7 +208,9 @@ sub plan {
 sub done_testing {
     my $ctx = context();
     $ctx->done_testing;
+    my $count = $ctx->hub->count;
     $ctx->release;
+    return $count;
 }
 
 sub warnings(&) {
@@ -363,6 +365,8 @@ Set the plan.
 =item done_testing()
 
 Set the plan to the current test count.
+
+Returns the number of assertions that were made, which is 0 when none were.
 
 =item $warnings = warnings { ... }
 

--- a/src/main/perl/lib/Test2/Tools/Warnings.pm
+++ b/src/main/perl/lib/Test2/Tools/Warnings.pm
@@ -2,7 +2,7 @@ package Test2::Tools::Warnings;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/carp/;
 use Test2::API qw/context test2_add_pending_diag/;

--- a/src/main/perl/lib/Test2/Util.pm
+++ b/src/main/perl/lib/Test2/Util.pm
@@ -2,7 +2,7 @@ package Test2::Util;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Config qw/%Config/;
 use Carp qw/croak/;

--- a/src/main/perl/lib/Test2/Util/ExternalMeta.pm
+++ b/src/main/perl/lib/Test2/Util/ExternalMeta.pm
@@ -2,7 +2,7 @@ package Test2::Util::ExternalMeta;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 
 use Carp qw/croak/;

--- a/src/main/perl/lib/Test2/Util/Facets2Legacy.pm
+++ b/src/main/perl/lib/Test2/Util/Facets2Legacy.pm
@@ -2,7 +2,7 @@ package Test2::Util::Facets2Legacy;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak confess/;
 use Scalar::Util qw/blessed/;

--- a/src/main/perl/lib/Test2/Util/Grabber.pm
+++ b/src/main/perl/lib/Test2/Util/Grabber.pm
@@ -2,7 +2,7 @@ package Test2::Util::Grabber;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Hub::Interceptor();
 use Test2::EventFacet::Trace();

--- a/src/main/perl/lib/Test2/Util/Guard.pm
+++ b/src/main/perl/lib/Test2/Util/Guard.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use Carp qw(confess);
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub new {
     confess "Can't create a Test2::Util::Guard in void context" unless (defined wantarray);

--- a/src/main/perl/lib/Test2/Util/HashBase.pm
+++ b/src/main/perl/lib/Test2/Util/HashBase.pm
@@ -2,7 +2,7 @@ package Test2::Util::HashBase;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 #################################################################
 #                                                               #

--- a/src/main/perl/lib/Test2/Util/Importer.pm
+++ b/src/main/perl/lib/Test2/Util/Importer.pm
@@ -2,7 +2,7 @@ package Test2::Util::Importer;
 use strict; no strict 'refs';
 use warnings; no warnings 'once';
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 my %SIG_TO_SLOT = (
     '&' => 'CODE',

--- a/src/main/perl/lib/Test2/Util/Ref.pm
+++ b/src/main/perl/lib/Test2/Util/Ref.pm
@@ -2,7 +2,7 @@ package Test2::Util::Ref;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Scalar::Util qw/reftype blessed refaddr/;
 

--- a/src/main/perl/lib/Test2/Util/Sig.pm
+++ b/src/main/perl/lib/Test2/Util/Sig.pm
@@ -2,7 +2,7 @@ package Test2::Util::Sig;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use POSIX();
 use Test2::Util qw/try IS_WIN32/;

--- a/src/main/perl/lib/Test2/Util/Stash.pm
+++ b/src/main/perl/lib/Test2/Util/Stash.pm
@@ -2,7 +2,7 @@ package Test2::Util::Stash;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 use B;

--- a/src/main/perl/lib/Test2/Util/Sub.pm
+++ b/src/main/perl/lib/Test2/Util/Sub.pm
@@ -2,7 +2,7 @@ package Test2::Util::Sub;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak carp/;
 use B();

--- a/src/main/perl/lib/Test2/Util/Table.pm
+++ b/src/main/perl/lib/Test2/Util/Table.pm
@@ -2,7 +2,7 @@ package Test2::Util::Table;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use base 'Term::Table';
 

--- a/src/main/perl/lib/Test2/Util/Table/Cell.pm
+++ b/src/main/perl/lib/Test2/Util/Table/Cell.pm
@@ -2,7 +2,7 @@ package Test2::Util::Table::Cell;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use base 'Term::Table::Cell';
 

--- a/src/main/perl/lib/Test2/Util/Table/LineBreak.pm
+++ b/src/main/perl/lib/Test2/Util/Table/LineBreak.pm
@@ -2,7 +2,7 @@ package Test2::Util::Table::LineBreak;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use base 'Term::Table::LineBreak';
 

--- a/src/main/perl/lib/Test2/Util/Term.pm
+++ b/src/main/perl/lib/Test2/Util/Term.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Term::Table::Util qw/term_size USE_GCS USE_TERM_READKEY uni_length/;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::Importer 'Test2::Util::Importer' => 'import';
 our @EXPORT_OK = qw/term_size USE_GCS USE_TERM_READKEY uni_length/;

--- a/src/main/perl/lib/Test2/Util/Times.pm
+++ b/src/main/perl/lib/Test2/Util/Times.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use List::Util qw/sum/;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 our @EXPORT_OK = qw/render_bench render_duration/;
 use base 'Exporter';

--- a/src/main/perl/lib/Test2/Util/Trace.pm
+++ b/src/main/perl/lib/Test2/Util/Trace.pm
@@ -6,7 +6,7 @@ use strict;
 
 our @ISA = ('Test2::EventFacet::Trace');
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 1;
 

--- a/src/main/perl/lib/Test2/V0.pm
+++ b/src/main/perl/lib/Test2/V0.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Test2::Util::Importer;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/Test2/V1.pm
+++ b/src/main/perl/lib/Test2/V1.pm
@@ -2,7 +2,7 @@ package Test2::V1;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 
@@ -320,7 +320,7 @@ thrown.
 =item C<!EXPORT_NAME>
 
 You can prefix an export name with C<!> to exclude it at import time. This is
-really only usedul when combined with C<-import> or C<-i>.
+really only useful when combined with C<-import> or C<-i>.
 
 =item C<< EXPORT_NAME => { -as => "ALT_NAME" } >>
 
@@ -360,8 +360,8 @@ C<my_ok()>
 
 =head1 PRAGMAS AND PLUGINS
 
-B<NO PRAGMAS ARE ENABLED BY DEFAULT>
-B<ONLY THE EXIT SUMMARY PLUGIN IS STILL ENABLED BY DEFAULT>
+B<NO PRAGMAS ARE ENABLED BY DEFAULT.>
+B<ONLY THE EXIT SUMMARY PLUGIN IS STILL ENABLED BY DEFAULT.>
 
 This is a significant departure from L<Test2::V0>.
 
@@ -369,7 +369,7 @@ You can enable all of these with the C<-pP> argument, which is short for
 C<-plugins, -pragmas>. C<P> is short for plugins, and C<p> is short for
 pragmas. When using the single-letter form they may both be together following
 a single dash, and can be in any order. They may also be combined with C<i> to
-bring in all imports. C<-p> or C<-P> ont heir own are also perfectly valid.
+bring in all imports. C<-p> or C<-P> on their own are also perfectly valid.
 
 =over 4
 
@@ -434,7 +434,7 @@ See L<Test2::Env> for a list of meaningful environment variables.
 
 =head1 API FUNCTIONS
 
-See L<Test2::API> for these
+See L<Test2::API> for these.
 
 =over 4
 
@@ -487,10 +487,10 @@ can have additional tools added to it.
 
 Note that you MAY override original tools such as ok(), note(), etc. by
 importing different copies this way. The first time you do this there should be
-no warnings or errors. If you pull in multiple tools of the same name an
+no warnings or errors. If you pull in multiple tools of the same name, a
 redefine warning is likely.
 
-This also effects exports:
+This also affects exports:
 
     use Test2::V1 -import, -include => ['Data::Dumper'];
 
@@ -532,7 +532,7 @@ Used to allow the handle to stomp on an existing namespace (NOT RECOMMENDED).
 Set the base class from which functions should be inherited. Normally this is
 set to L<Test2::V1::Base>.
 
-Another interesting use case is to have multiple handles that use eachothers
+Another interesting use case is to have multiple handles that use each other's
 namespaces as base classes:
 
     use Test2::V1;
@@ -552,7 +552,7 @@ namespaces as base classes:
 
 =head2 OVERRIDING INCLUDED TOOLS WITH ALTERNATES
 
-Lets say you want to use the L<Test2::Warnings> version of C<warning()>,
+Let's say you want to use the L<Test2::Warnings> version of C<warning()>,
 C<warnings()> instead of the L<Test2::Tools::Warnings> versions, and also
 wanted to import everything else L<Test2::Warnings> provides.
 
@@ -1047,11 +1047,11 @@ scripts, but they can get in the way in many cases.
 Many people would put custom strict/warnings settings at the top of their
 tests, only to have them wiped out when they use L<Test2::V0>.
 
-=item Assumptions of UTF8
+=item Assumptions of UTF-8
 
 Occasionally you do not want this assumption. The way it impacts all your
 regular and test handles, as well as how your source is read, can be a problem
-if you are not working with UTF8, or have other plans entirly.
+if you are not working with UTF-8, or have other plans entirely.
 
 =item Huge default set of exports, which can grow
 
@@ -1063,16 +1063,16 @@ a point not to break/remove exports, but there is no such commitment about
 adding new ones.
 
 Now the only default export is C<T2()> which gives you a handle where all the
-tools we expose are provided as methods. You can also use the L<T2> module (Not
+tools we expose are provided as methods. You can also use the L<T2> module (not
 bundled with Test-Simple) for use with an identical number of keystrokes, which
-allow you to leverage the prototypes on the original tool subroutines.
+allows you to leverage the prototypes on the original tool subroutines.
 
 =back
 
 =head1 SOURCE
 
 The source code repository for Test2-Suite can be found at
-F<https://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -1097,6 +1097,6 @@ Copyright Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>.
 
 =cut

--- a/src/main/perl/lib/Test2/V1/Base.pm
+++ b/src/main/perl/lib/Test2/V1/Base.pm
@@ -2,7 +2,7 @@ package Test2::V1::Base;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::API qw/intercept context/;
 

--- a/src/main/perl/lib/Test2/V1/Handle.pm
+++ b/src/main/perl/lib/Test2/V1/Handle.pm
@@ -2,7 +2,7 @@ package Test2::V1::Handle;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 sub DEFAULT_HANDLE_BASE { 'Test2::V1::Base' }
 

--- a/src/main/perl/lib/Test2/Workflow.pm
+++ b/src/main/perl/lib/Test2/Workflow.pm
@@ -2,7 +2,7 @@ package Test2::Workflow;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 our @EXPORT_OK = qw/parse_args current_build build root_build init_root build_stack/;
 use base 'Exporter';

--- a/src/main/perl/lib/Test2/Workflow/BlockBase.pm
+++ b/src/main/perl/lib/Test2/Workflow/BlockBase.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::BlockBase;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Util::HashBase qw/code frame _info _lines/;
 use Test2::Util::Sub qw/sub_info/;

--- a/src/main/perl/lib/Test2/Workflow/Build.pm
+++ b/src/main/perl/lib/Test2/Workflow/Build.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Build;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::Workflow::Task::Group;
 

--- a/src/main/perl/lib/Test2/Workflow/Runner.pm
+++ b/src/main/perl/lib/Test2/Workflow/Runner.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Runner;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::API();
 use Test2::Todo();

--- a/src/main/perl/lib/Test2/Workflow/Task.pm
+++ b/src/main/perl/lib/Test2/Workflow/Task.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Task;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Test2::API();
 use Test2::Event::Exception();

--- a/src/main/perl/lib/Test2/Workflow/Task/Action.pm
+++ b/src/main/perl/lib/Test2/Workflow/Task/Action.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Task::Action;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use base 'Test2::Workflow::Task';
 use Test2::Util::HashBase qw/around/;

--- a/src/main/perl/lib/Test2/Workflow/Task/Group.pm
+++ b/src/main/perl/lib/Test2/Workflow/Task/Group.pm
@@ -2,7 +2,7 @@ package Test2::Workflow::Task::Group;
 use strict;
 use warnings;
 
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use Carp qw/croak/;
 

--- a/src/main/perl/lib/ok.pm
+++ b/src/main/perl/lib/ok.pm
@@ -1,5 +1,5 @@
 package ok;
-our $VERSION = '1.302222';
+our $VERSION = '1.302225';
 
 use strict;
 use Test::More ();

--- a/src/test/resources/unit/defined_comparison_operators.t
+++ b/src/test/resources/unit/defined_comparison_operators.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+my ($a, $b);
+
+print "1..8\n";
+print "ok 1 - equ compares defined strings\n" if 'abc' equ 'abc';
+print "ok 2 - equ distinguishes different strings\n" if !('abc' equ 'def');
+print "ok 3 - equ considers two undefs equal\n" if !defined($a) && !defined($b) && ($a equ $b);
+print "ok 4 - equ distinguishes undef from empty string\n" if !($a equ '');
+print "ok 5 - neu is the inverse of equ\n" if 'abc' neu 'def';
+print "ok 6 - strict numeric equality compares numbers\n" if 123 === 123;
+print "ok 7 - strict numeric equality considers two undefs equal\n" if $a === $b;
+print "ok 8 - strict numeric inequality distinguishes undef and zero\n" if $a !== 0;

--- a/src/test/resources/unit/defined_comparison_operators.t
+++ b/src/test/resources/unit/defined_comparison_operators.t
@@ -1,8 +1,10 @@
 use strict;
 use warnings;
 my ($a, $b);
+my $calls = 0;
+sub chain_value { ++$calls; $_[0] }
 
-print "1..8\n";
+print "1..11\n";
 print "ok 1 - equ compares defined strings\n" if 'abc' equ 'abc';
 print "ok 2 - equ distinguishes different strings\n" if !('abc' equ 'def');
 print "ok 3 - equ considers two undefs equal\n" if !defined($a) && !defined($b) && ($a equ $b);
@@ -11,3 +13,8 @@ print "ok 5 - neu is the inverse of equ\n" if 'abc' neu 'def';
 print "ok 6 - strict numeric equality compares numbers\n" if 123 === 123;
 print "ok 7 - strict numeric equality considers two undefs equal\n" if $a === $b;
 print "ok 8 - strict numeric inequality distinguishes undef and zero\n" if $a !== 0;
+print "ok 9 - equ chains\n" if ('abc' equ 'abc' equ 'abc');
+print "ok 10 - mixed strict equality chains\n" if (123 === 123 == 123);
+my $chain_result = chain_value(0) equ chain_value(1) equ chain_value(1);
+print "ok 11 - chains short-circuit after false\n"
+    if $calls == 2 && !$chain_result;

--- a/src/test/resources/unit/mo_inline_double_colon_bareword.t
+++ b/src/test/resources/unit/mo_inline_double_colon_bareword.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+no strict 'subs';
+
+my $package = 'TestML::Base';
+my %values = ($package . ':::E' => 'loaded');
+
+print "1..1\n";
+print "ok 1 - a double-colon bareword concatenates inside a braced hash lookup\n"
+    if $values{$package.::.':E'} eq 'loaded';


### PR DESCRIPTION
## Summary

Fixes #1217.

TestML::Base 0.54 uses dense Mo::Inline-generated code containing `::` as a
bareword between concatenation operators inside a braced hash dereference.
The parser treated this as an invalid leading package-qualified name and
reported a missing closing brace. Parse `::` as the bareword string in this
context.

## Validation

- System Perl regression test
- JVM backend regression test
- Interpreter backend regression test
- TestML::Base 0.54 module load on both backends
- Full `make` gate after rebase: passed
