### PR TITLE
fix: preserve IO::Async accepted sockets and binary payloads

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,9 +6,9 @@ priorities and future plans.
 
 ## Work in progress
 
-- Preserve IO::Async thread callback results in scalar and list context on
-  both execution backends, and align its notifier-loop refcount expectation
-  with native Perl.
+- Preserve IO::Async thread callback results and accepted listener sockets on
+  both execution backends, retain binary channel payload octets, and align its
+  notifier-loop refcount expectation with native Perl.
 
 - Fix parsing of dense Mo::Inline expressions that use `::` as a bareword.
 

--- a/src/main/java/org/perlonjava/runtime/io/InternalPipeHandle.java
+++ b/src/main/java/org/perlonjava/runtime/io/InternalPipeHandle.java
@@ -190,7 +190,28 @@ public class InternalPipeHandle implements IOHandle {
         }
 
         try {
-            byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
+            // An unlayered Perl handle writes octets, not UTF-8-encoded text.
+            // RuntimeScalar represents byte strings as chars in the 0..255
+            // range, so UTF-8 encoding here expands octets such as 0x8a to
+            // two bytes. That corrupts framed binary protocols (notably
+            // Storable over IO::Async::Channel) because their length prefix
+            // still describes the original octet count.
+            boolean hasWideChars = false;
+            for (int i = 0; i < string.length(); i++) {
+                if (string.charAt(i) > 0xFF) {
+                    hasWideChars = true;
+                    break;
+                }
+            }
+            byte[] bytes;
+            if (hasWideChars) {
+                bytes = string.getBytes(StandardCharsets.UTF_8);
+            } else {
+                bytes = new byte[string.length()];
+                for (int i = 0; i < string.length(); i++) {
+                    bytes[i] = (byte) string.charAt(i);
+                }
+            }
             if (!blocking && inputStream != null) {
                 int free = pipeSize - inputStream.available();
                 if (free <= 0) {

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -2302,6 +2302,7 @@ public class IOOperator {
 
             if (targetGlob != null) {
                 targetGlob.setIO(clientRuntimeIO);
+                targetGlob.acceptedSocket = true;
                 MyVarCleanupStack.retainLiveIoGlobOwners(targetGlob);
                 RuntimeScalar.retainUnstashedIoForDurableSlot(newSocketHandle);
             } else {
@@ -2309,6 +2310,7 @@ public class IOOperator {
                 RuntimeScalar newGlob = new RuntimeScalar();
                 newGlob.type = RuntimeScalarType.GLOBREFERENCE;
                 RuntimeGlob anonGlob = new RuntimeGlob(null).setIO(clientRuntimeIO);
+                anonGlob.acceptedSocket = true;
                 newGlob.value = anonGlob;
                 RuntimeIO.registerGlobForFdRecycling(anonGlob, clientRuntimeIO);
                 RuntimeScalar assignedHandle = newSocketHandle.set(newGlob);

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeGlob.java
@@ -100,6 +100,9 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
     /** Number of scalar wrappers currently pointing at this anonymous IO glob. */
     public int ioHolderCount = 0;
 
+    /** True when this glob's current IO was created by accept(). */
+    public boolean acceptedSocket;
+
     /**
      * Constructor for RuntimeGlob.
      * Initializes a new instance of the RuntimeGlob class with the specified glob name.
@@ -1205,6 +1208,7 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
 
     public RuntimeGlob setIO(RuntimeScalar io) {
         GlobalVariable.markStashEntryVisible(this.globName);
+        acceptedSocket = false;
         // Check if the current IO is the selected handle - if so, update it
         RuntimeIO oldIO = null;
         if (this.IO.value instanceof RuntimeIO) {
@@ -1232,6 +1236,7 @@ public class RuntimeGlob extends RuntimeScalar implements RuntimeScalarReference
 
     public RuntimeGlob setIO(RuntimeIO io) {
         GlobalVariable.markStashEntryVisible(this.globName);
+        acceptedSocket = false;
         // Set the glob name in the RuntimeIO for proper stringification
         io.globName = this.globName;
         // Check if the current IO is the selected handle - if so, update it

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeScalar.java
@@ -1975,6 +1975,8 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
         boolean assignedFromArgumentAlias = RuntimeCode.isCurrentArgumentAlias(value)
                 || (!value.ioOwner
                     && RuntimeCode.isArgumentFrameActive(value.copiedFromArgumentFrame));
+        boolean assignedFromAcceptedSocketArgument = assignedFromArgumentAlias
+                && isAcceptedSocket(value);
         boolean transferDetachedIoOwner = durableIoDestination
                 && this != value
                 && !assignedFromArgumentAlias
@@ -1994,7 +1996,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
                 && isUnstashedIoGlob(newGlob)
                 && hasLiveIo(newGlob)
                 && durableIoDestination
-                && !assignedFromArgumentAlias
+                && (!assignedFromArgumentAlias || assignedFromAcceptedSocketArgument)
                 && !transferDetachedIoOwner) {
             newGlob.ioHolderCount++;
         }
@@ -2099,7 +2101,7 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             value.ioOwner = false;
             this.ioOwner = true;
         } else if (durableIoDestination
-                && !assignedFromArgumentAlias
+                && (!assignedFromArgumentAlias || assignedFromAcceptedSocketArgument)
                 && this != value
                 && value.type == GLOBREFERENCE
                 && value.value instanceof RuntimeGlob assignedGlob
@@ -4066,6 +4068,15 @@ public class RuntimeScalar extends RuntimeBase implements RuntimeScalarReference
             handle = layered.getDelegate();
         }
         return handle instanceof SocketIO socket && !socket.isDatagramSocket();
+    }
+
+    private static boolean isAcceptedSocket(RuntimeScalar scalar) {
+        if (scalar == null || scalar.type != GLOBREFERENCE
+                || !(scalar.value instanceof RuntimeGlob glob)
+                || !glob.acceptedSocket) {
+            return false;
+        }
+        return hasLiveIo(glob) && isSocketIOHandle(((RuntimeIO) glob.getIO().value).ioHandle);
     }
 
     private static boolean isUnstashedIoGlob(RuntimeGlob glob) {

--- a/src/main/perl/lib/PerlOnJava/CpanPatches/IO-Async-0.805/SkipUnsupportedSocketTests.patch
+++ b/src/main/perl/lib/PerlOnJava/CpanPatches/IO-Async-0.805/SkipUnsupportedSocketTests.patch
@@ -9,16 +9,6 @@
  use IO::Async::OS;
  
  use Socket qw(
---- t/05notifier-loop.t.orig
-+++ t/05notifier-loop.t
-@@ -140,6 +140,11 @@
-       '$loop->remove decrements notifiers count' );
- }
- 
--is_refcount( $loop, 2, '$loop has refcount 2 finally' );
-+is_refcount( $loop, 2, '$loop has refcount 2 finally' );
- 
- done_testing;
 --- t/10loop-poll-io.t.orig
 +++ t/10loop-poll-io.t
 @@ -4,5 +4,6 @@

--- a/src/test/resources/unit/accepted_socket_callback_lifetime.t
+++ b/src/test/resources/unit/accepted_socket_callback_lifetime.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use IO::Socket::INET;
+use Test::More;
+
+my $listener = IO::Socket::INET->new(
+    LocalAddr => '127.0.0.1',
+    LocalPort => 0,
+    Listen    => 1,
+    ReuseAddr => 1,
+);
+
+plan skip_all => "loopback listener unavailable: $!" unless $listener;
+plan tests => 3;
+
+my $client = IO::Socket::INET->new(
+    PeerAddr => '127.0.0.1',
+    PeerPort => $listener->sockport,
+) or die "client connect: $!";
+
+accept(my $accepted, $listener) or die "accept: $!";
+
+my $callback_socket;
+sub invoke_callback {
+    my ($callback, $socket) = @_;
+    $callback->($socket);
+}
+
+invoke_callback(sub { $callback_socket = $_[0] }, $accepted);
+undef $accepted;
+
+ok defined fileno($callback_socket),
+    'accepted socket remains open after callback argument assignment';
+is length(getpeername($callback_socket)), 16,
+    'accepted socket retains its IPv4 peer address';
+is length($client->sockname), 16,
+    'connected client remains valid';

--- a/src/test/resources/unit/pipe_storable_binary_roundtrip.t
+++ b/src/test/resources/unit/pipe_storable_binary_roundtrip.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use Test::More;
+use Storable qw(freeze thaw);
+
+# IO::Async::Channel frames Storable data over pipes. Its binary stream can
+# contain high-bit octets, which must remain single octets on an unlayered
+# pipe; otherwise the frame length and payload diverge.
+pipe(my $reader, my $writer) or die "pipe: $!";
+binmode $reader;
+binmode $writer;
+
+my $frozen = freeze([10, 20]);
+print {$writer} pack('I', length $frozen), $frozen or die "write: $!";
+close $writer or die "close writer: $!";
+
+read($reader, my $header, 4) == 4 or die "read header: $!";
+my $length = unpack('I', $header);
+read($reader, my $payload, $length) == $length or die "read payload: $!";
+
+is_deeply(thaw($payload), [10, 20],
+    'binary Storable payload round-trips through a pipe');
+
+done_testing;


### PR DESCRIPTION
## Summary

- preserve accepted socket ownership across callback argument assignment
- preserve binary octets through internal pipes used by IO::Async channels
- add focused accepted-socket and Storable pipe regressions

## Validation

- `make`
- system Perl, JVM, and interpreter runs of both focused regressions
- IO::Async 0.805 listener regression reaches the previously failing peer-address assertion on both backends

The remaining IO::Async listener test process phase is environment-limited by fork resource exhaustion.
