### PR TITLE
fix: restore MooX::Options list context and dynamic glob localization

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,12 @@ priorities and future plans.
 
 ## Work in progress
 
+- Make an absent `maybe::next::method` return an empty list in list context,
+  restoring MooX::Options metadata and command-line parsing.
+
+- Support `local *$globref` dynamic typeglob localization, including its IO
+  slot, so Test::Trap and Test::Spec can load their temporary-handle helpers.
+
 - Fixed large dynamic named-subexpression grammars hanging during regex compilation.
 
 - Preserve Data::Dumper's pure-Perl numeric-string behavior for

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -4857,6 +4857,20 @@ public class BytecodeCompiler implements Visitor {
                 lastResultReg = rd;
                 return;
             }
+            // local *$globref - localize the glob referenced by a scalar.
+            if (node.operand instanceof OperatorNode sigilOp4
+                    && sigilOp4.operator.equals("*")
+                    && sigilOp4.operand instanceof OperatorNode refOp
+                    && refOp.operator.equals("$")) {
+                compileNode(refOp, -1, RuntimeContextType.SCALAR);
+                int globRefReg = lastResultReg;
+                int rd = allocateOutputRegister();
+                emit(Opcodes.LOCAL_GLOB_REF);
+                emitReg(rd);
+                emitReg(globRefReg);
+                lastResultReg = rd;
+                return;
+            }
             // local @{expr} / local %{expr} - localize a dynamic array/hash by name
             // Implemented by localizing the typeglob (covers the array/hash slot)
             if (node.operand instanceof OperatorNode sigilOp4
@@ -5811,7 +5825,7 @@ public class BytecodeCompiler implements Visitor {
     void emit(short opcode) {
         // Track if any localization opcodes are emitted (including defer blocks which use DVM)
         if (opcode == Opcodes.LOCAL_SCALAR || opcode == Opcodes.LOCAL_ARRAY ||
-                opcode == Opcodes.LOCAL_HASH || opcode == Opcodes.LOCAL_GLOB ||
+                opcode == Opcodes.LOCAL_HASH || opcode == Opcodes.LOCAL_GLOB || opcode == Opcodes.LOCAL_GLOB_REF ||
                 opcode == Opcodes.PUSH_LOCAL_VARIABLE || opcode == Opcodes.LOCAL_SCALAR_SAVE_LEVEL ||
                 opcode == Opcodes.PUSH_DEFER || opcode == Opcodes.PUSH_CANCEL
                 || opcode == Opcodes.SAVE_REGEX_STATE) {
@@ -5827,7 +5841,7 @@ public class BytecodeCompiler implements Visitor {
     void emitWithToken(short opcode, int tokenIndex) {
         // Track if any localization opcodes are emitted (including defer blocks which use DVM)
         if (opcode == Opcodes.LOCAL_SCALAR || opcode == Opcodes.LOCAL_ARRAY ||
-                opcode == Opcodes.LOCAL_HASH || opcode == Opcodes.LOCAL_GLOB ||
+                opcode == Opcodes.LOCAL_HASH || opcode == Opcodes.LOCAL_GLOB || opcode == Opcodes.LOCAL_GLOB_REF ||
                 opcode == Opcodes.PUSH_LOCAL_VARIABLE || opcode == Opcodes.LOCAL_SCALAR_SAVE_LEVEL ||
                 opcode == Opcodes.PUSH_DEFER || opcode == Opcodes.PUSH_CANCEL
                 || opcode == Opcodes.SAVE_REGEX_STATE) {

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -2880,6 +2880,10 @@ public class BytecodeInterpreter {
                                 pc = InlineOpcodeHandler.executeLocalGlobDynamic(bytecode, pc, registers);
                             }
 
+                            case Opcodes.LOCAL_GLOB_REF -> {
+                                pc = InlineOpcodeHandler.executeLocalGlobRef(bytecode, pc, registers);
+                            }
+
                             case Opcodes.GET_LOCAL_LEVEL -> {
                                 int rd = bytecode[pc++];
                                 registers[rd] = new RuntimeScalar(

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -1861,6 +1861,12 @@ public class Disassemble {
                         sb.append("LOCAL_GLOB_DYNAMIC r").append(lgdRd).append(" = pushLocalVariable(glob r").append(lgdNameReg).append(")\n");
                         break;
                     }
+                    case Opcodes.LOCAL_GLOB_REF: {
+                        int lgrRd = interpretedCode.bytecode[pc++];
+                        int lgrRefReg = interpretedCode.bytecode[pc++];
+                        sb.append("LOCAL_GLOB_REF r").append(lgrRd).append(" = pushLocalVariable(*r").append(lgrRefReg).append(")\\n");
+                        break;
+                    }
                     case Opcodes.GET_LOCAL_LEVEL:
                         sb.append("GET_LOCAL_LEVEL r").append(interpretedCode.bytecode[pc++]).append("\n");
                         break;

--- a/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/InlineOpcodeHandler.java
@@ -1572,6 +1572,14 @@ public class InlineOpcodeHandler {
         return pc;
     }
 
+    public static int executeLocalGlobRef(int[] bytecode, int pc, RuntimeBase[] registers) {
+        int rd = bytecode[pc++];
+        int globRefReg = bytecode[pc++];
+        RuntimeGlob glob = registers[globRefReg].scalar().globDeref();
+        registers[rd] = DynamicVariableManager.pushLocalVariable(glob);
+        return pc;
+    }
+
     public static int executeGetLocalLevel(int[] bytecode, int pc, RuntimeBase[] registers) {
         int rd = bytecode[pc++];
         registers[rd] = new RuntimeScalar(DynamicVariableManager.getLocalLevel());

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -1001,6 +1001,13 @@ public class Opcodes {
     public static final short LOCAL_GLOB_DYNAMIC = 387;
 
     /**
+     * Localize a typeglob through a glob reference: rd = pushLocalVariable(*rs).
+     * Used for: local *$globref
+     * Format: LOCAL_GLOB_REF rd rs
+     */
+    public static final short LOCAL_GLOB_REF = 549;
+
+    /**
      * Flip-flop operator: rd = ScalarFlipFlopOperator.evaluate(flipFlopId, rs1, rs2)
      * flipFlopId is a unique per-call-site int constant.
      * Format: FLIP_FLOP rd flipFlopId rs1 rs2 isExclusive

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/NextMethod.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/NextMethod.java
@@ -229,7 +229,11 @@ public class NextMethod {
             if (DEBUG_NEXT_METHOD) {
                 System.out.println("DEBUG: maybe::next::method caught exception: " + e.getMessage());
             }
-            return scalarUndef.getList();
+            // `maybe::next::method` is equivalent to an optional method call.
+            // With no next method, Perl returns an empty list in list context
+            // (rather than a list containing undef).  The distinction matters
+            // when callers append its result to a key/value list.
+            return new RuntimeList();
         }
     }
 

--- a/src/test/resources/unit/local_globref_dynamic.t
+++ b/src/test/resources/unit/local_globref_dynamic.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use File::Temp qw(tempfile);
+use Test::More;
+
+$Issue1305::FH = 'outer scalar slot';
+my $globref = \*Issue1305::FH;
+my ($tempfile_handle, $filename) = tempfile();
+close $tempfile_handle;
+
+{
+    local *$globref;
+    is($Issue1305::FH, undef, 'localized glob starts with a fresh scalar slot');
+    $Issue1305::FH = 'inner scalar slot';
+
+    open *$globref, '>', $filename or die "open $filename: $!";
+    print {$globref} "localized IO slot\n" or die "print $filename: $!";
+    close *$globref or die "close $filename: $!";
+
+    is($Issue1305::FH, 'inner scalar slot', 'localized glob retains its scalar slot');
+}
+
+is($Issue1305::FH, 'outer scalar slot', 'original glob is restored after the dynamic scope');
+open my $reader, '<', $filename or die "read $filename: $!";
+is(<$reader>, "localized IO slot\n", 'open through the localized glob reference writes to its IO slot');
+close $reader;
+unlink $filename;
+
+done_testing;

--- a/src/test/resources/unit/maybe_next_list_context.t
+++ b/src/test/resources/unit/maybe_next_list_context.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+use MRO::Compat ();
+
+{
+    package Issue1307::Options;
+
+    sub option_data {
+        my ($class) = @_;
+        return $class->maybe::next::method, module => { format => 's' };
+    }
+}
+
+my @option_data = Issue1307::Options->option_data;
+is_deeply(
+    \@option_data,
+    [ module => { format => 's' } ],
+    'maybe::next::method contributes no list element when no next method exists',
+);
+
+done_testing;


### PR DESCRIPTION
## Summary

- Return an empty list for an absent `maybe::next::method` call, preventing a leading `undef` from corrupting MooX::Options option metadata (#1307).
- Add bytecode-interpreter support for `local *$globref`, allowing Test::Trap temporary-handle setup and unblocking Test::Spec loading (#1305).

## Validation

- `make`
- `prove src/test/resources/unit/maybe_next_list_context.t`
- `prove src/test/resources/unit/local_globref_dynamic.t`
- JVM and interpreter focused regressions
- JVM and interpreter MooX::Options `new_with_options` reproduction
- JVM and interpreter `Test::Trap::Builder::TempFile` load
- `jcpan -t Test::Spec`: 17 previously load-blocked test programs now run; two unrelated warning/strict-diagnostic programs remain.
- `make check-links`

## UAT

Please exercise applications that use MooX::Options, particularly command-line `new_with_options` flows. The current checkout will be rebuilt and launch-verified before handoff.
