### PR TITLE
fix(require): preserve @INC hook generator state

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,9 @@ priorities and future plans.
 
 ## Work in progress
 
+- Pass state returned beside an `@INC` hook generator to each generator call,
+  restoring stateful module source loading on both execution backends.
+
 - Make an absent `maybe::next::method` return an empty list in list context,
   restoring MooX::Options metadata and command-line parsing.
 

--- a/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/ModuleOperators.java
@@ -1158,7 +1158,12 @@ public class ModuleOperators {
             sourceSub = (RuntimeCode) third.value;
         }
 
-        state = values.get(3);
+        // A generator is returned as (\&generator, $state), whereas a
+        // filehandle filter uses (\$prefix?, $fh, \&filter, $state).  The
+        // state slot therefore depends on which source form the hook chose.
+        // Reading only slot 3 drops generator state and makes every call see
+        // undef for $_[1].
+        state = sourceSub != null && filehandle == null ? values.get(1) : values.get(3);
 
         if (filehandle != null) {
             String body = readIncHookFilehandle(filehandle, sourceSub, state);
@@ -1229,10 +1234,15 @@ public class ModuleOperators {
 
     private static RuntimeArray incHookFilterArgs(RuntimeScalar state) {
         RuntimeArray args = new RuntimeArray();
-        args.push(new RuntimeScalar(0));
+        // @_ aliases the hook-returned state; it does not take a new durable
+        // container ownership of it.  RuntimeArray.push() retains reference
+        // values, which leaked one state reference for every generator call
+        // (including calls that die before returning).
+        args.elements.add(new RuntimeScalar(0));
         if (state != null) {
-            args.push(state);
+            args.elements.add(state);
         }
+        args.elementsAliased = true;
         return args;
     }
 

--- a/src/test/resources/unit/inc_hook_generator_state.t
+++ b/src/test/resources/unit/inc_hook_generator_state.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+use Test::More tests => 10;
+
+my $state = {
+    chunks => [
+        "package IncHook::GeneratorState;\nsub value { 42 }\n",
+        "1;\n",
+    ],
+    calls => 0,
+};
+
+my $hook = sub {
+    my ($self, $file) = @_;
+    return unless $file eq 'IncHook/GeneratorState.pm';
+
+    return (sub {
+        my ($placeholder, $generator_state) = @_;
+        is($placeholder, 0, 'generator receives the required placeholder argument');
+        is($generator_state, $state, 'generator receives state returned after its coderef');
+        ++$generator_state->{calls};
+        $_ = shift @{ $generator_state->{chunks} } // '';
+        return length $_;
+    }, $state);
+};
+
+# The generator receives this by alias through @_ on each call; loading the
+# module must not retain an extra state reference after those calls return.
+my $initial_state_refcount = &Internals::SvREFCNT($state) + 1;
+
+{
+    local @INC = ($hook, @INC);
+    ok(eval { require IncHook::GeneratorState; 1 }, 'require loads source from generator')
+        or diag $@;
+}
+
+is($state->{calls}, 3, 'generator consumes both chunks and observes EOF');
+is(IncHook::GeneratorState::value(), 42, 'generated module was compiled and loaded');
+is(&Internals::SvREFCNT($state) + 1, $initial_state_refcount,
+    'generator state is not retained after loading');


### PR DESCRIPTION
## Summary

- preserve state returned beside an `@INC` hook source generator
- add regression coverage validated on system Perl, JVM, and interpreter backends
- record the compatibility fix in the changelog

## Validation

- `make`
- `make check-links`
- `timeout 60 perl src/test/resources/unit/inc_hook_generator_state.t`
- `timeout 90 ./jperl src/test/resources/unit/inc_hook_generator_state.t`
- `timeout 90 ./jperl --interpreter src/test/resources/unit/inc_hook_generator_state.t`
