### PR TITLE
fix: load Types::Numbers eval-created subs

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,10 @@ priorities and future plans.
 
 ## Work in progress
 
+- Prevent eval-created named subs from treating lexical variables as
+  same-named constant calls, restoring `Types::Numbers` loading through
+  `Data::Float`.
+
 - Implement undef-aware experimental equality operators (`===`, `!==`, `equ`,
   and `neu`) with lexical warnings and single-evaluation chained comparisons.
 

--- a/src/main/java/org/perlonjava/frontend/analysis/ConstantFoldingVisitor.java
+++ b/src/main/java/org/perlonjava/frontend/analysis/ConstantFoldingVisitor.java
@@ -438,12 +438,17 @@ public class ConstantFoldingVisitor implements Visitor {
             return;
         }
 
-        // Don't fold identifiers under the & sigil operator.
-        // &Name refers to the subroutine itself (e.g., exists(&Errno::EINVAL), \&sub),
-        // not a call. Folding would replace the name with its constant value, breaking
-        // exists/defined checks. Calls with parens (&Name()) are handled separately
-        // in visit(BinaryOperatorNode) via the "(" operator.
-        if ("&".equals(node.operator)) {
+        // Don't fold an identifier used as the name part of a sigiled variable.
+        // $Name, @Name, %Name, *Name, and &Name are variable/CV syntax, not
+        // bare calls to a same-named constant. In particular, folding the
+        // IdentifierNode in `$positive` after a `positive` constant was
+        // installed changes a lexical read into `${constant}`, which fails at
+        // runtime as "Not a SCALAR reference". Calls with parens (&Name())
+        // are handled separately in visit(BinaryOperatorNode) via "(".
+        if (node.operand instanceof IdentifierNode
+                && ("&".equals(node.operator) || "$".equals(node.operator)
+                    || "@".equals(node.operator) || "%".equals(node.operator)
+                    || "*".equals(node.operator))) {
             result = node;
             isConstant = false;
             return;

--- a/src/test/resources/unit/eval_string_named_sub_scalar_comparison.t
+++ b/src/test/resources/unit/eval_string_named_sub_scalar_comparison.t
@@ -1,0 +1,51 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+package Issue1231::DataFloatLike;
+
+# Data::Float defines named classification subs by eval STRING after setting
+# file-scope lexical scalar constants.  The generated sub must retain those
+# scalar cells when its argument is compared to either captured value.
+my @earlier_values = (1, 2, 3);
+my %earlier_options = (mode => 'test');
+my $earlier_scalar = 41;
+my $earlier_scalar_ref = \$earlier_scalar;
+my ($positive, $negative);
+$positive = 1e308 * 1e308;
+$negative = -$positive;
+
+sub _install_constant {
+    my ($name, $value) = @_;
+    no strict 'refs';
+    *{__PACKAGE__ . '::' . $name} = sub () { $value };
+}
+
+_install_constant('eval_string_endpoints_enabled', 1);
+_install_constant('positive', $positive);
+_install_constant('negative', $negative);
+sub eval_string_is_endpoint($);
+
+my $loaded;
+{
+    local $/;
+    my $code = <DATA>;
+    $loaded = eval $code;
+}
+
+Test::More::is($loaded, 1, 'eval STRING installs named sub that captures scalar lexicals');
+Test::More::is($@, '', 'eval STRING reports no error');
+Test::More::ok(eval_string_is_endpoint($positive), 'generated sub compares against positive captured scalar');
+Test::More::ok(eval_string_is_endpoint($negative), 'generated sub compares against negative captured scalar');
+Test::More::ok(!eval_string_is_endpoint(3), 'generated sub rejects a non-captured scalar');
+
+Test::More::done_testing();
+
+__DATA__
+sub eval_string_is_endpoint($) {
+    return undef unless eval_string_endpoints_enabled;
+    my ($value) = @_;
+    return $value == $positive || $value == $negative;
+}
+1;


### PR DESCRIPTION
## Summary

- prevent constant folding from rewriting the identifier portion of sigiled variables
- restore `Data::Float` eval-created named subs and `Types::Numbers` loading
- add a focused regression test and changelog entry

Fixes #1231.

## Validation

- `make`
- `perl src/test/resources/unit/eval_string_named_sub_scalar_comparison.t`
- JVM and interpreter runs of the focused regression
- `jcpan -t Data::Float` — 720 tests passed
- `make check-links`

## Integration note

`jcpan -t DBIx::BatchChunker` gets past the former `Types::Numbers` / `Data::Float` load failure. Its remaining failures are separate DBI/Math::BigInt/XSAccessor issues.

Generated with [Codex](https://openai.com/codex)
