### PR TITLE
fix(format): reduce core write.t failures

### DIFF
--- a/dev/design/comp-parser-pr1333-handoff.md
+++ b/dev/design/comp-parser-pr1333-handoff.md
@@ -1,0 +1,110 @@
+# `comp/parser.t` PR #1333 handoff
+
+Date: 2026-09-10  
+Branch: `fix/issue-1269-core-suite-write`  
+PR: #1333
+
+## Current state
+
+PR #1333 previously reduced the `comp/parser.t` regression from 195 to 9
+failures. The last focused run was:
+
+```sh
+cd perl5_t/t && timeout 300 ../../jperl comp/parser.t
+```
+
+It reported 9 failing assertions (the test program itself exits zero). The
+latest full validation, recorded in
+`/tmp/make-parser-interpolation-expression-rebase.log`, completed successfully
+(`BUILD SUCCESSFUL`, exit 0).
+
+The current worktree contains uncommitted investigation changes. Do not use
+stash, reset, restore, or clean. Preserve them with the repository pre-flight
+procedure before switching branches or rebasing.
+
+## Remaining failures
+
+| Assertions | Scenario | Actual result | Expected result |
+| --- | --- | --- | --- |
+| 153–156 | `#line` directive with tab or many spaces and no filename | `KASHPRITZA`, line 1 | `parser.t`, lines 17 and 19 |
+| 183–186 | `caller` inside two interpolated heredocs | lines 1/4 in a prior `#line` filename | lines 537/538/540/541 |
+| 189 | `caller` inside multiline `qq` interpolation | line 1 | line 25 |
+
+The relevant core-test block is near `perl5_t/t/comp/parser.t:720`.
+
+## Changes currently in the worktree
+
+| File | Change | Evidence |
+| --- | --- | --- |
+| `ErrorMessageUtil.java` | Parse `#line` directives more strictly: require a separator after the number, retain an unterminated quote through the physical newline, and reject malformed bare/glued filenames. | Fixed core assertions 167–172. |
+| `Whitespace.java` | Mirror that directive validation while the parser consumes source. | Fixed the same directive/caller cases. |
+| `CoreOperatorResolver.java` | Resolve direct `__LINE__` and `__FILE__` from the indexed, directive-aware source mapping. | Covered by the focused regression test. |
+| `ByteCodeSourceMapper.java` | Refresh the file/line coordinate of existing parse-time mappings while preserving package/subroutine information. | No demonstrated effect on the final 9 failures; reassess. |
+| `ParseHeredoc.java` | Give interpolated heredocs a directive-aware logical source line. | No demonstrated effect on the final 9 failures. |
+| `StringSegmentParser.java` | Rebase nested interpolation AST token indices recursively. | No demonstrated effect on the final 9 failures; likely insufficient or on the wrong mapping path. |
+| `src/test/resources/unit/line_directive_core_operators.t` | New focused, permanent regression coverage (18 assertions) for malformed `#line` directives and core operators/caller mapping. | Validated with system Perl before implementation; JVM coverage passed before the latest unproven interpolation experiments. |
+
+The first three rows are the confirmed fix. The last three Java changes are
+active experiments and should be retained only if the next investigation proves
+their use. If removing them, do so by an explicit patch after preserving the
+worktree; never use `git restore` on this dirty checkout.
+
+## Mapping architecture and likely root cause
+
+Nested interpolation is parsed with a fresh token stream whose indices begin at
+zero. Its runtime debug metadata is then interpreted through the outer source
+map, so line-number token indices such as 0 or 4 resolve to the outer file's
+earliest/previous mapping. This explains both the inherited `KASHPRITZA`
+filename and physical lines 1/4.
+
+The attempted AST index rebasing in `StringSegmentParser` did not alter the
+observed output. That suggests the debug line emitted at runtime is either not
+using the rebased node index or is being resolved through another source-map
+path. A robust fix will likely carry an explicit logical source coordinate
+(file and line), rather than reinterpret an inner token index as an outer one.
+
+Useful code paths:
+
+- `StringDoubleQuoted.java` creates the nested parser and sets
+  `parser.baseLineNumber` from `rawStr.sourceLine`.
+- `StringSegmentParser.parseVariableInterpolation` constructs nested
+  interpolation expressions.
+- `ParseHeredoc.interpolateString` creates the `ParsedString` source location.
+- `EmitSubroutine.java` calls
+  `ByteCodeSourceMapper.setDebugInfoLineNumber` using
+  `callerLineCallSiteIndex`.
+- `EmitBlock.java`, `ParseBlock.java`, and `StatementCopline.java` propagate
+  statement start/call-site indices.
+- `ByteCodeSourceMapper.parseStackTraceElement` resolves the JVM line number
+  with a `TreeMap.floorEntry` source mapping.
+
+## Recommended continuation
+
+1. Snapshot the dirty worktree before any checkout, rebase, or experiment.
+2. Instrument or trace the exact `tokenIndex` supplied to
+   `setDebugInfoLineNumber` for assertion 189 and one heredoc assertion. Trace
+   its node/statement origin as well as the matching `floorEntry` result.
+3. Identify the emission site for nested interpolation and add a source-location
+   override that survives from the nested parser to bytecode debug metadata.
+   Do not rely solely on `baseLineNumber`: it currently does not correct the
+   emitted caller coordinate.
+4. First make assertion 189 report `parser.t:25`; then verify the heredoc pairs
+   report 537/538 and 540/541. The no-filename directive failures may share the
+   `floorEntry` issue, so rerun all of `comp/parser.t` after each mapping change.
+5. Keep and run `line_directive_core_operators.t` on system Perl and both JVM
+   and interpreter backends for any new regression coverage. Add a permanent
+   focused test for nested interpolation source coordinates before declaring the
+   fix complete.
+6. Run `make` from an immutable checkout before pushing. Wrap every `jperl`
+   invocation with `timeout` and capture all test output to a file.
+
+## Existing committed PR work
+
+The branch already contains these pushed commits:
+
+- `546fdccaf fix(runtime): preserve Unicode regex captures in interpolation`
+- `e38f2634e fix(parser): reject semicolons in unprototyped calls`
+- `a070695a7 fix(parser): reject aggregate regex mutations`
+- `513239777 fix(parser): retain malformed braced interpolation context`
+
+The source-map experiments described above are not committed or pushed.

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -178,6 +178,16 @@ both commits.
   - Files: `ParsePrimary.java`,
     `src/test/resources/unit/core_qualified_subroutine_name.t`.
 
+- [x] Phase 13: empty-brace indirect method invocants (2026-09-10)
+  - Parse `{}` following an unknown indirect method name as a hash-reference
+    invocant instead of an empty statement block.
+  - Added `unit/indirect_method_empty_hash_invocant.t`, validated with system
+    Perl 5.42.2 and both PerlOnJava backends (1/1).
+  - `comp/parser.t` changed from 28 to 27 explicit JVM Not OK records,
+    repairing assertion 115 without observed new failures.
+  - Files: `SubroutineParser.java`,
+    `src/test/resources/unit/indirect_method_empty_hash_invocant.t`.
+
 ### Next steps
 
 1. Diagnose the remaining `comp/parser.t` groups, beginning with the

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -27,11 +27,12 @@ both commits.
 
 ## Progress tracking
 
-### Current status: Phase 2 in progress — remaining `op/write.t` format clusters
+### Current status: Phase 3 in progress — remaining `op/write.t` format clusters
 
 | Cluster | Representative assertion | Owner | Baseline | Fixed | New failures | Blocked delta | PR | Next step |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
 | `formline` multiline fields | `swrite("1^*2 3@*4", "N", "N")` | Codex | 489 explicit JVM Not OK records in `op/write.t` | 216 | 0 observed | 0 | Pending | Commit the validated batch, then classify remaining format clusters separately |
+| Unicode-string `eval` identifiers | `comp/parser.t` tests 67–76 | Codex | 60 explicit JVM Not OK records in `comp/parser.t` | 10 | 0 observed | 0 | #1333 | Preserve Unicode source semantics for normal `eval`; keep byte-source validation exclusive to `evalbytes` |
 | format declaration expressions | `HASH`/`HASH2`/`BLOCK` after TAP 581 | Unassigned | Pending full output grouping | — | — | — | #1234 remains open | Keep separate from multiline field mechanics |
 | file-test overload/FETCH | `op/filetest.t`, `op/tie_fetch_count.t` | Unassigned | Not reproduced | — | — | — | — | Coordinate shared evaluation changes before implementation |
 
@@ -59,17 +60,25 @@ both commits.
   - Files: `RuntimeFormat.java`, `IOOperator.java`,
     `src/test/resources/unit/formline_multiline_fields.t`.
 
+- [x] Phase 2: Unicode-string `eval` identifier parsing (2026-09-10)
+  - Normal `eval` of an upgraded Unicode string no longer inherits byte-source
+    identifier rejection from an enclosing scope without `use utf8`; `evalbytes`
+    remains byte-source validated.
+  - Added `unit/unicode_identifier_length.t`, validated with system Perl 5.42.2
+    and both PerlOnJava backends (2/2).
+  - `comp/parser.t` changed from 60 to 50 explicit JVM Not OK records, repairing
+    assertions 67–76 without introducing observed failures.
+  - Files: `IdentifierParser.java`,
+    `src/test/resources/unit/unicode_identifier_length.t`.
+
 ### Next steps
 
-1. Commit the completed `formline` batch after a terminal full `make` gate and
-   Markdown link check; the last full gate was interrupted only after it
-   exceeded the previous successful duration with no additional output.
-2. Recover the remaining complete `op/write.t` groups and choose the next
+1. Recover the remaining complete `op/write.t` groups and choose the next
    independently proven root cause; do not count formatting-output changes as
    repaired assertions unless their TAP assertions become `ok`.
-3. Run the same validated core runner on the pinned baseline and candidate
+2. Run the same validated core runner on the pinned baseline and candidate
    commit before making suite-wide delta claims.
-4. Proceed to the next independently proven cluster; do not fold #1234's
+3. Proceed to the next independently proven cluster; do not fold #1234's
    executable expression work into this change.
 
 ### Open questions

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -139,6 +139,16 @@ both commits.
   - Files: `ParsePrimary.java`,
     `src/test/resources/unit/unknown_filetest_diagnostic.t`.
 
+- [x] Phase 9: `read` buffer lvalue validation (2026-09-10)
+  - Reject a bareword supplied to a scalar-reference prototype slot as a
+    constant item, so `read` cannot use it as a mutable buffer.
+  - Added `unit/read_constant_buffer_diagnostic.t`, validated with system Perl
+    5.42.2 and both PerlOnJava backends (1/1).
+  - `comp/parser.t` changed from 32 to 31 explicit JVM Not OK records,
+    repairing assertion 12 without observed new failures.
+  - Files: `PrototypeArgs.java`,
+    `src/test/resources/unit/read_constant_buffer_diagnostic.t`.
+
 ### Next steps
 
 1. Diagnose the remaining `comp/parser.t` groups, beginning with the

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -27,7 +27,7 @@ both commits.
 
 ## Progress tracking
 
-### Current status: Phase 6 in progress — remaining parser and `op/write.t` clusters
+### Current status: Phase 15 in progress — remaining parser and `op/write.t` clusters
 
 | Cluster | Representative assertion | Owner | Baseline | Fixed | New failures | Blocked delta | PR | Next step |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
@@ -197,6 +197,17 @@ both commits.
     repairing assertion 2 without observed new failures.
   - Files: `StringSegmentParser.java`,
     `src/test/resources/unit/substitution_empty_braced_interpolation.t`.
+
+- [x] Phase 15: Unicode capture interpolation in evaluated substitutions (2026-09-10)
+  - Materialize live regex-capture proxies before string-context concatenation
+    decides byte versus UTF-8 provenance, and preserve that provenance through
+    the case-conversion operators used by quoted replacement escapes.
+  - Added `unit/regex_unicode_word_boundary.t`, validated with system Perl
+    5.42.2 and both PerlOnJava backends (7/7).
+  - `comp/parser.t` changed from 26 to 25 explicit JVM Not OK records,
+    repairing assertion 139 without observed new failures.
+  - Files: `StringOperators.java`,
+    `src/test/resources/unit/regex_unicode_word_boundary.t`.
 
 ### Next steps
 

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -159,6 +159,15 @@ both commits.
   - Files: `OperatorParser.java`,
     `src/test/resources/unit/undef_constant_item_diagnostic.t`.
 
+- [x] Phase 11: list-assignment bareword validation (2026-09-10)
+  - Reject bareword constant items used directly as list-assignment targets.
+  - Added `unit/list_assignment_constant_item_diagnostic.t`, validated with
+    system Perl 5.42.2 and both PerlOnJava backends (1/1).
+  - `comp/parser.t` changed from 30 to 29 explicit JVM Not OK records,
+    repairing assertion 9 without observed new failures.
+  - Files: `ParseInfix.java`,
+    `src/test/resources/unit/list_assignment_constant_item_diagnostic.t`.
+
 ### Next steps
 
 1. Diagnose the remaining `comp/parser.t` groups, beginning with the

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -128,6 +128,17 @@ both commits.
   - Files: `IdentifierParser.java`,
     `src/test/resources/unit/quoted_subroutine_name.t`.
 
+- [x] Phase 8: unknown filetest operator diagnostics (2026-09-10)
+  - Recognize a one-letter unary-minus fallback as a subroutine only when its
+    code reference is actually defined; a probe no longer autovivifies an
+    undefined code slot and masks an invalid filetest operator.
+  - Added `unit/unknown_filetest_diagnostic.t`, validated with system Perl
+    5.42.2 and both PerlOnJava backends (2/2).
+  - `comp/parser.t` changed from 33 to 32 explicit JVM Not OK records,
+    repairing assertion 44 without observed new failures.
+  - Files: `ParsePrimary.java`,
+    `src/test/resources/unit/unknown_filetest_diagnostic.t`.
+
 ### Next steps
 
 1. Diagnose the remaining `comp/parser.t` groups, beginning with the

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -168,6 +168,16 @@ both commits.
   - Files: `ParseInfix.java`,
     `src/test/resources/unit/list_assignment_constant_item_diagnostic.t`.
 
+- [x] Phase 12: `CORE::` qualified subroutine names (2026-09-10)
+  - Defer explicit CORE-builtin dispatch when a further `::` or deprecated
+    quote package separator continues the name.
+  - Added `unit/core_qualified_subroutine_name.t`, validated with system Perl
+    5.42.2 and both PerlOnJava backends (2/2).
+  - `comp/parser.t` changed from 29 to 28 explicit JVM Not OK records,
+    repairing assertions 85 and 86 without observed new failures.
+  - Files: `ParsePrimary.java`,
+    `src/test/resources/unit/core_qualified_subroutine_name.t`.
+
 ### Next steps
 
 1. Diagnose the remaining `comp/parser.t` groups, beginning with the

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -27,13 +27,14 @@ both commits.
 
 ## Progress tracking
 
-### Current status: Phase 4 in progress — remaining parser and `op/write.t` clusters
+### Current status: Phase 5 in progress — remaining parser and `op/write.t` clusters
 
 | Cluster | Representative assertion | Owner | Baseline | Fixed | New failures | Blocked delta | PR | Next step |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
 | `formline` multiline fields | `swrite("1^*2 3@*4", "N", "N")` | Codex | 489 explicit JVM Not OK records in `op/write.t` | 216 | 0 observed | 0 | Pending | Commit the validated batch, then classify remaining format clusters separately |
 | Unicode-string `eval` identifiers | `comp/parser.t` tests 67–76 | Codex | 60 explicit JVM Not OK records in `comp/parser.t` | 10 | 0 observed | 0 | #1333 | Preserve Unicode source semantics for normal `eval`; keep byte-source validation exclusive to `evalbytes` |
 | parser structural diagnostics | `comp/parser.t` tests 3, 5, 6, 121–129 | Codex | 50 explicit JVM Not OK records in `comp/parser.t` | 12 | 0 observed | 0 | #1333 | Diagnose unfinished quoted escapes and merge-conflict markers before generic parse reduction |
+| bare identifier capacity | `comp/parser.t` test 113 | Codex | 38 explicit JVM Not OK records in `comp/parser.t` | 1 | 0 observed | 0 | #1333 | Apply Perl's identifier byte limit to bareword parser terms |
 | format declaration expressions | `HASH`/`HASH2`/`BLOCK` after TAP 581 | Unassigned | Pending full output grouping | — | — | — | #1234 remains open | Keep separate from multiline field mechanics |
 | file-test overload/FETCH | `op/filetest.t`, `op/tie_fetch_count.t` | Unassigned | Not reproduced | — | — | — | — | Coordinate shared evaluation changes before implementation |
 
@@ -84,6 +85,16 @@ both commits.
     repairing assertions 3, 5, 6, and 121–129 without observed new failures.
   - Files: `StringSegmentParser.java`, `Lexer.java`, `LexerTokenType.java`,
     `Parser.java`, `ParsePrimary.java`, and the two focused unit tests.
+
+- [x] Phase 4: bare identifier capacity validation (2026-09-10)
+  - Applied the existing Perl identifier byte capacity to non-sigil identifier
+    terms as well as complex variable identifiers.
+  - Added `unit/bare_identifier_length.t`, validated with system Perl 5.42.2
+    and both PerlOnJava backends (1/1).
+  - `comp/parser.t` changed from 38 to 37 explicit JVM Not OK records,
+    repairing assertion 113 without observed new failures.
+  - Files: `ParsePrimary.java`,
+    `src/test/resources/unit/bare_identifier_length.t`.
 
 ### Next steps
 

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -27,7 +27,7 @@ both commits.
 
 ## Progress tracking
 
-### Current status: Phase 15 in progress — remaining parser and `op/write.t` clusters
+### Current status: Phase 16 in progress — remaining parser and `op/write.t` clusters
 
 | Cluster | Representative assertion | Owner | Baseline | Fixed | New failures | Blocked delta | PR | Next step |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
@@ -208,6 +208,16 @@ both commits.
     repairing assertion 139 without observed new failures.
   - Files: `StringOperators.java`,
     `src/test/resources/unit/regex_unicode_word_boundary.t`.
+
+- [x] Phase 16: semicolon diagnostics in unprototyped calls (2026-09-10)
+  - Reject a semicolon left inside a parenthesized unprototyped call as a
+    syntax error rather than misreporting an extra argument.
+  - Added `unit/unprototyped_call_semicolon_diagnostic.t`, validated with
+    system Perl 5.42.2 and both PerlOnJava backends (1/1).
+  - `comp/parser.t` changed from 25 to 24 explicit JVM Not OK records,
+    repairing assertion 13 without observed new failures.
+  - Files: `PrototypeArgs.java`,
+    `src/test/resources/unit/unprototyped_call_semicolon_diagnostic.t`.
 
 ### Next steps
 

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -188,6 +188,16 @@ both commits.
   - Files: `SubroutineParser.java`,
     `src/test/resources/unit/indirect_method_empty_hash_invocant.t`.
 
+- [x] Phase 14: empty braced substitution interpolation (2026-09-10)
+  - Reject `${}` in an `s///` replacement rather than accepting it as an empty
+    scalar interpolation and allowing the following malformed regex syntax.
+  - Added `unit/substitution_empty_braced_interpolation.t`, validated with
+    system Perl 5.42.2 and both PerlOnJava backends (1/1).
+  - `comp/parser.t` changed from 27 to 26 explicit JVM Not OK records,
+    repairing assertion 2 without observed new failures.
+  - Files: `StringSegmentParser.java`,
+    `src/test/resources/unit/substitution_empty_braced_interpolation.t`.
+
 ### Next steps
 
 1. Diagnose the remaining `comp/parser.t` groups, beginning with the

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -27,7 +27,7 @@ both commits.
 
 ## Progress tracking
 
-### Current status: Phase 5 in progress — remaining parser and `op/write.t` clusters
+### Current status: Phase 6 in progress — remaining parser and `op/write.t` clusters
 
 | Cluster | Representative assertion | Owner | Baseline | Fixed | New failures | Blocked delta | PR | Next step |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
@@ -35,6 +35,7 @@ both commits.
 | Unicode-string `eval` identifiers | `comp/parser.t` tests 67–76 | Codex | 60 explicit JVM Not OK records in `comp/parser.t` | 10 | 0 observed | 0 | #1333 | Preserve Unicode source semantics for normal `eval`; keep byte-source validation exclusive to `evalbytes` |
 | parser structural diagnostics | `comp/parser.t` tests 3, 5, 6, 121–129 | Codex | 50 explicit JVM Not OK records in `comp/parser.t` | 12 | 0 observed | 0 | #1333 | Diagnose unfinished quoted escapes and merge-conflict markers before generic parse reduction |
 | bare identifier capacity | `comp/parser.t` test 113 | Codex | 38 explicit JVM Not OK records in `comp/parser.t` | 1 | 0 observed | 0 | #1333 | Apply Perl's identifier byte limit to bareword parser terms |
+| typed loop declarations | `comp/parser.t` test 114 | Codex | 37 explicit JVM Not OK records in `comp/parser.t` | 1 | 0 observed | 0 | #1333 | Reject unloaded class types in `for my Type $var` declarations during parsing |
 | format declaration expressions | `HASH`/`HASH2`/`BLOCK` after TAP 581 | Unassigned | Pending full output grouping | — | — | — | #1234 remains open | Keep separate from multiline field mechanics |
 | file-test overload/FETCH | `op/filetest.t`, `op/tie_fetch_count.t` | Unassigned | Not reproduced | — | — | — | — | Coordinate shared evaluation changes before implementation |
 
@@ -95,6 +96,16 @@ both commits.
     repairing assertion 113 without observed new failures.
   - Files: `ParsePrimary.java`,
     `src/test/resources/unit/bare_identifier_length.t`.
+
+- [x] Phase 5: typed loop declaration validation (2026-09-10)
+  - Validate the class type immediately for a lexical loop declaration rather
+    than treating its type name as a bare loop expression.
+  - Added `unit/typed_for_declaration.t`, validated with system Perl 5.42.2
+    and both PerlOnJava backends (1/1).
+  - `comp/parser.t` changed from 37 to 36 explicit JVM Not OK records,
+    repairing assertion 114 without observed new failures.
+  - Files: `OperatorParser.java`,
+    `src/test/resources/unit/typed_for_declaration.t`.
 
 ### Next steps
 

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -27,12 +27,13 @@ both commits.
 
 ## Progress tracking
 
-### Current status: Phase 3 in progress — remaining `op/write.t` format clusters
+### Current status: Phase 4 in progress — remaining parser and `op/write.t` clusters
 
 | Cluster | Representative assertion | Owner | Baseline | Fixed | New failures | Blocked delta | PR | Next step |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
 | `formline` multiline fields | `swrite("1^*2 3@*4", "N", "N")` | Codex | 489 explicit JVM Not OK records in `op/write.t` | 216 | 0 observed | 0 | Pending | Commit the validated batch, then classify remaining format clusters separately |
 | Unicode-string `eval` identifiers | `comp/parser.t` tests 67–76 | Codex | 60 explicit JVM Not OK records in `comp/parser.t` | 10 | 0 observed | 0 | #1333 | Preserve Unicode source semantics for normal `eval`; keep byte-source validation exclusive to `evalbytes` |
+| parser structural diagnostics | `comp/parser.t` tests 3, 5, 6, 121–129 | Codex | 50 explicit JVM Not OK records in `comp/parser.t` | 12 | 0 observed | 0 | #1333 | Diagnose unfinished quoted escapes and merge-conflict markers before generic parse reduction |
 | format declaration expressions | `HASH`/`HASH2`/`BLOCK` after TAP 581 | Unassigned | Pending full output grouping | — | — | — | #1234 remains open | Keep separate from multiline field mechanics |
 | file-test overload/FETCH | `op/filetest.t`, `op/tie_fetch_count.t` | Unassigned | Not reproduced | — | — | — | — | Coordinate shared evaluation changes before implementation |
 
@@ -70,6 +71,19 @@ both commits.
     assertions 67–76 without introducing observed failures.
   - Files: `IdentifierParser.java`,
     `src/test/resources/unit/unicode_identifier_length.t`.
+
+- [x] Phase 3: structural parser diagnostics (2026-09-10)
+  - Diagnose unterminated braced `\\x` and `\\o` quoted-string escapes and
+    brace-less quoted-string `\\N` escapes without indexing beyond end of input.
+  - Tokenize seven-character merge-conflict markers at source-line start and
+    report the specific Perl diagnostic before surrounding statement reduction.
+  - Added `unit/string_escape_diagnostics.t` (3/3) and
+    `unit/conflict_marker_diagnostics.t` (9/9), each validated with system Perl
+    5.42.2 and both PerlOnJava backends.
+  - `comp/parser.t` changed from 50 to 38 explicit JVM Not OK records,
+    repairing assertions 3, 5, 6, and 121–129 without observed new failures.
+  - Files: `StringSegmentParser.java`, `Lexer.java`, `LexerTokenType.java`,
+    `Parser.java`, `ParsePrimary.java`, and the two focused unit tests.
 
 ### Next steps
 

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -27,7 +27,7 @@ both commits.
 
 ## Progress tracking
 
-### Current status: Phase 16 in progress — remaining parser and `op/write.t` clusters
+### Current status: Phase 17 in progress — remaining parser and `op/write.t` clusters
 
 | Cluster | Representative assertion | Owner | Baseline | Fixed | New failures | Blocked delta | PR | Next step |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
@@ -218,6 +218,16 @@ both commits.
     repairing assertion 13 without observed new failures.
   - Files: `PrototypeArgs.java`,
     `src/test/resources/unit/unprototyped_call_semicolon_diagnostic.t`.
+
+- [x] Phase 17: aggregate regex-mutation diagnostics (2026-09-10)
+  - Reject substitutions and transliterations bound directly to arrays or
+    hashes, while retaining scalarized non-mutating match behavior.
+  - Added `unit/aggregate_regex_mutation_diagnostic.t`, validated with system
+    Perl 5.42.2 and both PerlOnJava backends (2/2).
+  - `comp/parser.t` changed from 24 to 14 explicit JVM Not OK records,
+    repairing assertions 59 and 88–96 without observed new failures.
+  - Files: `ParseInfix.java`,
+    `src/test/resources/unit/aggregate_regex_mutation_diagnostic.t`.
 
 ### Next steps
 

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -107,15 +107,25 @@ both commits.
   - Files: `OperatorParser.java`,
     `src/test/resources/unit/typed_for_declaration.t`.
 
+- [x] Phase 6: `keys` lvalue scalar context (2026-09-10)
+  - Compile `keys %hash` in lvalue consumers as its scalar count, and copy a
+    read-only count to a mutable temporary for operations such as `substr`.
+  - Added `unit/keys_lvalue_context.t`, validated with system Perl 5.42.2 and
+    both PerlOnJava backends (2/2).
+  - `comp/parser.t` changed from 36 to 34 explicit JVM Not OK records,
+    repairing assertions 130 and 132 without observed new failures.
+  - Files: `CompileOperator.java`,
+    `src/test/resources/unit/keys_lvalue_context.t`.
+
 ### Next steps
 
-1. Recover the remaining complete `op/write.t` groups and choose the next
+1. Diagnose the remaining `comp/parser.t` groups, beginning with the
+   compile-error cleanup and `#line` source-location assertions.
+2. Recover the remaining complete `op/write.t` groups and choose the next
    independently proven root cause; do not count formatting-output changes as
    repaired assertions unless their TAP assertions become `ok`.
-2. Run the same validated core runner on the pinned baseline and candidate
+3. Run the same validated core runner on the pinned baseline and candidate
    commit before making suite-wide delta claims.
-3. Proceed to the next independently proven cluster; do not fold #1234's
-   executable expression work into this change.
 
 ### Open questions
 

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -27,7 +27,7 @@ both commits.
 
 ## Progress tracking
 
-### Current status: Phase 17 in progress — remaining parser and `op/write.t` clusters
+### Current status: Phase 18 in progress — remaining parser and `op/write.t` clusters
 
 | Cluster | Representative assertion | Owner | Baseline | Fixed | New failures | Blocked delta | PR | Next step |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
@@ -229,10 +229,21 @@ both commits.
   - Files: `ParseInfix.java`,
     `src/test/resources/unit/aggregate_regex_mutation_diagnostic.t`.
 
+- [x] Phase 18: malformed braced-interpolation diagnostics (2026-09-10)
+  - Preserve a nested expression's concrete syntax error instead of replacing
+    it with an EOF-only missing-bracket diagnostic during braced-variable
+    recovery.
+  - Added `unit/malformed_braced_interpolation_diagnostic.t`, validated with
+    system Perl 5.42.2 and both PerlOnJava backends (1/1).
+  - `comp/parser.t` changed from 14 to 13 explicit JVM Not OK records,
+    repairing assertion 135 without observed new failures.
+  - Files: `Variable.java`,
+    `src/test/resources/unit/malformed_braced_interpolation_diagnostic.t`.
+
 ### Next steps
 
-1. Diagnose the remaining `comp/parser.t` groups, beginning with the
-   compile-error cleanup and `#line` source-location assertions.
+1. Diagnose the remaining `comp/parser.t` `#line` and heredoc source-location
+   assertions.
 2. Recover the remaining complete `op/write.t` groups and choose the next
    independently proven root cause; do not count formatting-output changes as
    repaired assertions unless their TAP assertions become `ok`.

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -117,6 +117,17 @@ both commits.
   - Files: `CompileOperator.java`,
     `src/test/resources/unit/keys_lvalue_context.t`.
 
+- [x] Phase 7: quote-qualified subroutine declarations (2026-09-10)
+  - Treat a leading deprecated quote in a subroutine declaration as the
+    package separator before the first component, without inventing a `main::`
+    component that stores the declaration under the wrong name.
+  - Added `unit/quoted_subroutine_name.t`, validated with system Perl 5.42.2
+    and both PerlOnJava backends (1/1).
+  - `comp/parser.t` changed from 34 to 33 explicit JVM Not OK records,
+    repairing assertion 104 without observed new failures.
+  - Files: `IdentifierParser.java`,
+    `src/test/resources/unit/quoted_subroutine_name.t`.
+
 ### Next steps
 
 1. Diagnose the remaining `comp/parser.t` groups, beginning with the

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -149,6 +149,16 @@ both commits.
   - Files: `PrototypeArgs.java`,
     `src/test/resources/unit/read_constant_buffer_diagnostic.t`.
 
+- [x] Phase 10: `undef` bareword validation (2026-09-10)
+  - Reject a bareword operand to `undef` as a constant item before the
+    compiler can treat it as an rvalue expression.
+  - Added `unit/undef_constant_item_diagnostic.t`, validated with system Perl
+    5.42.2 and both PerlOnJava backends (1/1).
+  - `comp/parser.t` changed from 31 to 30 explicit JVM Not OK records,
+    repairing assertion 11 without observed new failures.
+  - Files: `OperatorParser.java`,
+    `src/test/resources/unit/undef_constant_item_diagnostic.t`.
+
 ### Next steps
 
 1. Diagnose the remaining `comp/parser.t` groups, beginning with the

--- a/dev/design/core-suite-failure-reduction.md
+++ b/dev/design/core-suite-failure-reduction.md
@@ -1,0 +1,80 @@
+# Core-suite failure reduction
+
+Issue: [#1269](https://github.com/fglock/PerlOnJava/issues/1269)
+
+## Goal
+
+Reduce reported core-suite `not ok` assertions by at least 1,000 from a
+pinned, comparable baseline without masking failures, increasing error files
+or timeouts, or introducing unexplained regressions.
+
+## Pinned baseline
+
+The handoff baseline is `test_20260910_120000_1328.log`, captured on
+2026-09-10: 587 files, 4,046 reported Not OK, 371 blocked tests (already
+included in that count), 21 error files, and no timeouts.  Its TAP totals have
+a known discrepancy and must not be used as a percentage calculation until
+runner accounting has been audited.
+
+Current work starts from commit `c4b9814f35eaccb39c7341b4084c02613565edee`.
+The complete local JVM reproduction of `perl5_t/t/op/write.t` is retained in
+`/tmp/issue-1269-write-baseline-jvm.log`: 605 executed of 636 planned, with
+489 explicit `not ok` records.  It was run with `timeout 600 ../../jperl
+op/write.t` from `perl5_t/t` on macOS Darwin 25.6.0 / arm64 using system Perl
+5.42.2 for oracle tests.  Before a suite-wide comparison, record the runner
+revision, source/JAR hashes, Perl-suite revision, and full per-file output for
+both commits.
+
+## Progress tracking
+
+### Current status: Phase 2 in progress — remaining `op/write.t` format clusters
+
+| Cluster | Representative assertion | Owner | Baseline | Fixed | New failures | Blocked delta | PR | Next step |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| `formline` multiline fields | `swrite("1^*2 3@*4", "N", "N")` | Codex | 489 explicit JVM Not OK records in `op/write.t` | 216 | 0 observed | 0 | Pending | Commit the validated batch, then classify remaining format clusters separately |
+| format declaration expressions | `HASH`/`HASH2`/`BLOCK` after TAP 581 | Unassigned | Pending full output grouping | — | — | — | #1234 remains open | Keep separate from multiline field mechanics |
+| file-test overload/FETCH | `op/filetest.t`, `op/tie_fetch_count.t` | Unassigned | Not reproduced | — | — | — | — | Coordinate shared evaluation changes before implementation |
+
+### Completed phases
+
+- [x] Phase 0: baseline recovery and classification (2026-09-10)
+  - Reproduced `op/write.t` with complete JVM output rather than a truncated
+    historical failure tail.
+  - Classified tests 128–397 as a shared `formline` `^*`/`@*` field parsing,
+    argument consumption, and tied-FETCH cluster.
+  - Confirmed #1234 is a separate write-time executable-format-expression
+    pipeline and is not assumed to explain this cluster.
+  - Files: this document; `/tmp/issue-1269-write-baseline-jvm.log` (untracked
+    evidence).
+
+- [x] Phase 1: `formline` multiline field materialization (2026-09-10)
+  - Parsed supplied `formline` pictures rather than constructing an empty
+    field list; fixed field-sigil positioning; expanded aggregate operands in
+    the `$@` list context; and materialized tied operands once for both output
+    and taint observation.
+  - Added `unit/formline_multiline_fields.t`, validated with system Perl 5.42.2
+    and on both PerlOnJava backends (4/4).
+  - `op/write.t` changed from 489 to 273 explicit JVM Not OK records (216
+    repaired assertions); interpreter output has the same 273-record count.
+  - Files: `RuntimeFormat.java`, `IOOperator.java`,
+    `src/test/resources/unit/formline_multiline_fields.t`.
+
+### Next steps
+
+1. Commit the completed `formline` batch after a terminal full `make` gate and
+   Markdown link check; the last full gate was interrupted only after it
+   exceeded the previous successful duration with no additional output.
+2. Recover the remaining complete `op/write.t` groups and choose the next
+   independently proven root cause; do not count formatting-output changes as
+   repaired assertions unless their TAP assertions become `ok`.
+3. Run the same validated core runner on the pinned baseline and candidate
+   commit before making suite-wide delta claims.
+4. Proceed to the next independently proven cluster; do not fold #1234's
+   executable expression work into this change.
+
+### Open questions
+
+- `^*` continuation, mutation, and `~~` semantics remain separate from the
+  narrow `formline` literal-field/one-FETCH repair.
+- The historical suite aggregate needs runner-accounting reconciliation before
+  it can be used as an authoritative percentage.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,8 @@ priorities and future plans.
 
 ## Work in progress
 
+- Accept Unicode identifiers in normal Unicode-string `eval` calls.
+
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.
 

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,9 +6,9 @@ priorities and future plans.
 
 ## Work in progress
 
-- Restore parser diagnostics for malformed quoted-string escapes and
-  version-control conflict markers, and accept Unicode identifiers in normal
-  Unicode-string `eval` calls.
+- Restore parser diagnostics for malformed quoted-string escapes,
+  overlong identifiers, and version-control conflict markers; accept Unicode
+  identifiers in normal Unicode-string `eval` calls.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -14,7 +14,8 @@ priorities and future plans.
   diagnose unknown one-letter filetest operators and constant `read` or
   `undef` operands and bareword list-assignment targets; preserve qualified
   subroutine names that begin with `CORE::`; and parse empty braces as an
-  indirect-method hash-reference invocant.
+  indirect-method hash-reference invocant; reject empty braced interpolation
+  in substitution replacements.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -17,8 +17,9 @@ priorities and future plans.
   indirect-method hash-reference invocant; reject empty braced interpolation
   in substitution replacements; and preserve Unicode capture provenance during
   interpolated evaluated substitutions; reject semicolons within
-  parenthesized unprototyped calls; and reject aggregate substitutions and
-  transliterations that lack a mutable scalar target.
+  parenthesized unprototyped calls; reject aggregate substitutions and
+  transliterations that lack a mutable scalar target; and retain the original
+  syntax diagnostic and context for malformed braced interpolation.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -12,7 +12,8 @@ priorities and future plans.
   calls; evaluate `keys %hash` as a scalar temporary in lvalue consumers; and
   retain subroutine prototypes for deprecated quote-qualified declarations and
   diagnose unknown one-letter filetest operators and constant `read` or
-  `undef` operands and bareword list-assignment targets.
+  `undef` operands and bareword list-assignment targets; preserve qualified
+  subroutine names that begin with `CORE::`.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -10,7 +10,8 @@ priorities and future plans.
   overlong identifiers, invalid typed loop declarations, and version-control
   conflict markers; accept Unicode identifiers in normal Unicode-string `eval`
   calls; evaluate `keys %hash` as a scalar temporary in lvalue consumers; and
-  retain subroutine prototypes for deprecated quote-qualified declarations.
+  retain subroutine prototypes for deprecated quote-qualified declarations and
+  diagnose unknown one-letter filetest operators.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -11,7 +11,8 @@ priorities and future plans.
   conflict markers; accept Unicode identifiers in normal Unicode-string `eval`
   calls; evaluate `keys %hash` as a scalar temporary in lvalue consumers; and
   retain subroutine prototypes for deprecated quote-qualified declarations and
-  diagnose unknown one-letter filetest operators and constant `read` buffers.
+  diagnose unknown one-letter filetest operators and constant `read` or
+  `undef` operands.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -9,7 +9,8 @@ priorities and future plans.
 - Restore parser diagnostics for malformed quoted-string escapes,
   overlong identifiers, invalid typed loop declarations, and version-control
   conflict markers; accept Unicode identifiers in normal Unicode-string `eval`
-  calls; and evaluate `keys %hash` as a scalar temporary in lvalue consumers.
+  calls; evaluate `keys %hash` as a scalar temporary in lvalue consumers; and
+  retain subroutine prototypes for deprecated quote-qualified declarations.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -15,7 +15,8 @@ priorities and future plans.
   `undef` operands and bareword list-assignment targets; preserve qualified
   subroutine names that begin with `CORE::`; and parse empty braces as an
   indirect-method hash-reference invocant; reject empty braced interpolation
-  in substitution replacements.
+  in substitution replacements; and preserve Unicode capture provenance during
+  interpolated evaluated substitutions.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -16,7 +16,8 @@ priorities and future plans.
   subroutine names that begin with `CORE::`; and parse empty braces as an
   indirect-method hash-reference invocant; reject empty braced interpolation
   in substitution replacements; and preserve Unicode capture provenance during
-  interpolated evaluated substitutions.
+  interpolated evaluated substitutions; reject semicolons within
+  parenthesized unprototyped calls.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -9,7 +9,7 @@ priorities and future plans.
 - Restore parser diagnostics for malformed quoted-string escapes,
   overlong identifiers, invalid typed loop declarations, and version-control
   conflict markers; accept Unicode identifiers in normal Unicode-string `eval`
-  calls.
+  calls; and evaluate `keys %hash` as a scalar temporary in lvalue consumers.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -13,7 +13,8 @@ priorities and future plans.
   retain subroutine prototypes for deprecated quote-qualified declarations and
   diagnose unknown one-letter filetest operators and constant `read` or
   `undef` operands and bareword list-assignment targets; preserve qualified
-  subroutine names that begin with `CORE::`.
+  subroutine names that begin with `CORE::`; and parse empty braces as an
+  indirect-method hash-reference invocant.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -12,7 +12,7 @@ priorities and future plans.
   calls; evaluate `keys %hash` as a scalar temporary in lvalue consumers; and
   retain subroutine prototypes for deprecated quote-qualified declarations and
   diagnose unknown one-letter filetest operators and constant `read` or
-  `undef` operands.
+  `undef` operands and bareword list-assignment targets.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -7,8 +7,9 @@ priorities and future plans.
 ## Work in progress
 
 - Restore parser diagnostics for malformed quoted-string escapes,
-  overlong identifiers, and version-control conflict markers; accept Unicode
-  identifiers in normal Unicode-string `eval` calls.
+  overlong identifiers, invalid typed loop declarations, and version-control
+  conflict markers; accept Unicode identifiers in normal Unicode-string `eval`
+  calls.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -17,7 +17,8 @@ priorities and future plans.
   indirect-method hash-reference invocant; reject empty braced interpolation
   in substitution replacements; and preserve Unicode capture provenance during
   interpolated evaluated substitutions; reject semicolons within
-  parenthesized unprototyped calls.
+  parenthesized unprototyped calls; and reject aggregate substitutions and
+  transliterations that lack a mutable scalar target.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,7 +6,9 @@ priorities and future plans.
 
 ## Work in progress
 
-- Accept Unicode identifiers in normal Unicode-string `eval` calls.
+- Restore parser diagnostics for malformed quoted-string escapes and
+  version-control conflict markers, and accept Unicode identifiers in normal
+  Unicode-string `eval` calls.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -11,7 +11,7 @@ priorities and future plans.
   conflict markers; accept Unicode identifiers in normal Unicode-string `eval`
   calls; evaluate `keys %hash` as a scalar temporary in lvalue consumers; and
   retain subroutine prototypes for deprecated quote-qualified declarations and
-  diagnose unknown one-letter filetest operators.
+  diagnose unknown one-letter filetest operators and constant `read` buffers.
 
 - Identify PerlOnJava, its copyright, and its dual-license terms in
   `jperl -v` output while retaining the standard Perl text.

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -1668,10 +1668,24 @@ public class CompileOperator {
         int hashReg = bc.lastResultReg;
         int rd = bc.allocateOutputRegister();
         bc.emit(Opcodes.HASH_KEYS); bc.emitReg(rd); bc.emitReg(hashReg);
-        if (bc.currentCallContext == RuntimeContextType.SCALAR) {
+        // keys is not itself an assignable aggregate.  In the lvalue contexts
+        // reached by `keys %h .= ...` and `substr keys %h, ...`, Perl uses its
+        // scalar count result rather than passing the key RuntimeArray through
+        // to the assignment operator.
+        if (bc.currentCallContext == RuntimeContextType.SCALAR
+                || bc.currentCallContext == RuntimeContextType.LVALUE) {
             int scalarReg = bc.allocateRegister();
             bc.emit(Opcodes.ARRAY_SIZE); bc.emitReg(scalarReg); bc.emitReg(rd);
-            bc.lastResultReg = scalarReg;
+            if (bc.currentCallContext == RuntimeContextType.LVALUE) {
+                // ARRAY_SIZE may return a RuntimeScalarReadOnly count.  An
+                // lvalue consumer such as substr must receive its mutable
+                // temporary copy, just as it does for other scalar results.
+                int lvalueReg = bc.allocateRegister();
+                bc.emit(Opcodes.ALIAS); bc.emitReg(lvalueReg); bc.emitReg(scalarReg);
+                bc.lastResultReg = lvalueReg;
+            } else {
+                bc.lastResultReg = scalarReg;
+            }
         } else { bc.lastResultReg = rd; }
     }
 

--- a/src/main/java/org/perlonjava/backend/jvm/ByteCodeSourceMapper.java
+++ b/src/main/java/org/perlonjava/backend/jvm/ByteCodeSourceMapper.java
@@ -213,15 +213,10 @@ public class ByteCodeSourceMapper {
         // an entry already exists from parse-time, we should preserve it entirely.
         LineInfo existingEntry = info.tokenToLineInfo.get(tokenIndex);
         if (existingEntry != null) {
-            // Parse-time package/subroutine state is authoritative, but its
-            // mutable #line cursor can be stale after later directives.  Refresh
-            // the source coordinates from the token-indexed directive map.
-            var sourceLoc = ctx.errorUtil.getSourceLocationAccurate(tokenIndex);
-            info.tokenToLineInfo.put(tokenIndex, new LineInfo(
-                    sourceLoc.lineNumber(),
-                    existingEntry.packageNameId(),
-                    existingEntry.subroutineNameId(),
-                    getOrCreateFileId(sourceLoc.fileName())));
+            // Parse-time location state is authoritative.  In particular, the
+            // mutable #line cursor may have advanced to a later directive by
+            // emission time, whereas this token's recorded entry preserves its
+            // original logical file and line for caller()/warn/die.
             return;
         }
         

--- a/src/main/java/org/perlonjava/backend/jvm/ByteCodeSourceMapper.java
+++ b/src/main/java/org/perlonjava/backend/jvm/ByteCodeSourceMapper.java
@@ -22,6 +22,10 @@ public class ByteCodeSourceMapper {
         final Map<String, Integer> fileNameToId = new HashMap<>();
         final ArrayList<String> subroutineNamePool = new ArrayList<>();
         final Map<String, Integer> subroutineNameToId = new HashMap<>();
+        // JVM line-number entries are unsigned shorts. Reserve the high end for
+        // logical locations from nested quoted-source parsers, whose local token
+        // indices cannot safely be interpreted in the outer source map.
+        int nextSyntheticLineNumber = 60_000;
 
         void clear() {
             sourceFiles.clear();
@@ -31,6 +35,7 @@ public class ByteCodeSourceMapper {
             fileNameToId.clear();
             subroutineNamePool.clear();
             subroutineNameToId.clear();
+            nextSyntheticLineNumber = 60_000;
         }
 
         /** Copy immutable source-location metadata into an ithread runtime. */
@@ -42,6 +47,7 @@ public class ByteCodeSourceMapper {
             target.fileNameToId.putAll(fileNameToId);
             target.subroutineNamePool.addAll(subroutineNamePool);
             target.subroutineNameToId.putAll(subroutineNameToId);
+            target.nextSyntheticLineNumber = nextSyntheticLineNumber;
             sourceFiles.forEach((fileId, source) -> {
                 SourceFileInfo copy = new SourceFileInfo(source.fileId);
                 copy.tokenToLineInfo.putAll(source.tokenToLineInfo);
@@ -130,6 +136,40 @@ public class ByteCodeSourceMapper {
     }
 
     /**
+     * Emits a debug location whose logical source coordinate is independent of
+     * the enclosing file's token stream. This is required for code parsed from
+     * interpolated strings and heredocs: their lexer indices begin at zero.
+     */
+    static void setDebugInfoSourceLocation(EmitterContext ctx, String sourceFileName,
+                                           int sourceLineNumber) {
+        State state = state();
+        int fileId = getOrCreateFileId(ctx.compilerOptions.fileName);
+        SourceFileInfo info = state.sourceFiles.computeIfAbsent(fileId, SourceFileInfo::new);
+        int syntheticLineNumber = state.nextSyntheticLineNumber;
+        while (syntheticLineNumber > 0 && info.tokenToLineInfo.containsKey(syntheticLineNumber)) {
+            syntheticLineNumber--;
+        }
+        if (syntheticLineNumber <= 0) {
+            throw new IllegalStateException("exhausted synthetic source-location line numbers");
+        }
+        state.nextSyntheticLineNumber = syntheticLineNumber - 1;
+
+        String subroutineName = ctx.symbolTable.getCurrentSubroutine();
+        if (subroutineName == null) {
+            subroutineName = "";
+        }
+        info.tokenToLineInfo.put(syntheticLineNumber, new LineInfo(
+                sourceLineNumber,
+                getOrCreatePackageId(ctx.symbolTable.getCurrentPackage()),
+                getOrCreateSubroutineId(subroutineName),
+                getOrCreateFileId(sourceFileName)));
+
+        Label thisLabel = new Label();
+        ctx.mv.visitLabel(thisLabel);
+        ctx.mv.visitLineNumber(syntheticLineNumber, thisLabel);
+    }
+
+    /**
      * Saves the source location information for a given token index.
      * This method maps a token index to its corresponding line number
      * and package context in the source file, storing this information
@@ -173,7 +213,15 @@ public class ByteCodeSourceMapper {
         // an entry already exists from parse-time, we should preserve it entirely.
         LineInfo existingEntry = info.tokenToLineInfo.get(tokenIndex);
         if (existingEntry != null) {
-            // Entry already exists from parse-time - preserve it entirely
+            // Parse-time package/subroutine state is authoritative, but its
+            // mutable #line cursor can be stale after later directives.  Refresh
+            // the source coordinates from the token-indexed directive map.
+            var sourceLoc = ctx.errorUtil.getSourceLocationAccurate(tokenIndex);
+            info.tokenToLineInfo.put(tokenIndex, new LineInfo(
+                    sourceLoc.lineNumber(),
+                    existingEntry.packageNameId(),
+                    existingEntry.subroutineNameId(),
+                    getOrCreateFileId(sourceLoc.fileName())));
             return;
         }
         
@@ -186,26 +234,6 @@ public class ByteCodeSourceMapper {
         int lineNumber = sourceLoc.lineNumber();
         String sourceFileName = sourceLoc.fileName();
         int packageId = getOrCreatePackageId(ctx.symbolTable.getCurrentPackage());
-        
-        // FIX: If current sourceFile equals original file (no #line active in emit context),
-        // check for a nearby parse-time entry that has a #line-adjusted filename.
-        // This handles the case where parse-time captured the #line directive but
-        // emit-time has a different tokenIndex and stale errorUtil without #line state.
-        if (sourceFileName != null && sourceFileName.equals(ctx.compilerOptions.fileName)) {
-            // Look for nearby entry (within 50 tokens) that has #line-adjusted filename
-            var nearbyEntry = info.tokenToLineInfo.floorEntry(tokenIndex);
-            if (nearbyEntry != null && (tokenIndex - nearbyEntry.getKey()) < 50) {
-                String nearbySourceFile = state.fileNamePool.get(nearbyEntry.getValue().sourceFileNameId());
-                if (!nearbySourceFile.equals(ctx.compilerOptions.fileName)) {
-                    // Nearby entry has #line-adjusted filename - inherit it
-                    sourceFileName = nearbySourceFile;
-                    // Also use the nearby entry's line number calculation for consistency
-                    // (the #line directive affects line numbering)
-                    lineNumber = nearbyEntry.getValue().lineNumber() + 
-                        (ctx.errorUtil.getLineNumber(tokenIndex) - ctx.errorUtil.getLineNumber(nearbyEntry.getKey()));
-                }
-            }
-        }
         
         int sourceFileNameId = getOrCreateFileId(sourceFileName);
 
@@ -278,74 +306,6 @@ public class ByteCodeSourceMapper {
         int lineNumber = lineInfo.lineNumber();
         String packageName = state.packageNamePool.get(lineInfo.packageNameId());
         
-        // FIX: If the found entry's sourceFile equals the original file (no #line applied),
-        // check for nearby entries that have a #line-adjusted filename.
-        // This handles entries stored before the #line directive was processed.
-        if (sourceFileName != null && sourceFileName.equals(element.getFileName())) {
-            // First, check LOWER entries (in case #line was applied before this code)
-            // Find the first entry with a #line-adjusted filename to calculate the offset
-            var lowerEntry = info.tokenToLineInfo.lowerEntry(entry.getKey());
-            int lineOffset = 0;
-            boolean foundLineDirective = false;
-            
-            while (lowerEntry != null && (entry.getKey() - lowerEntry.getKey()) < 300) {
-                String lowerSourceFile = state.fileNamePool.get(lowerEntry.getValue().sourceFileNameId());
-                if (!lowerSourceFile.equals(element.getFileName())) {
-                    // Found an entry with #line-adjusted filename
-                    // Calculate the offset: the difference between the original line and the #line-adjusted line
-                    // We need to find where the #line directive was applied
-                    foundLineDirective = true;
-                    sourceFileName = lowerSourceFile;
-                    
-                    // The offset is calculated as: original_line_at_directive - adjusted_line_at_directive
-                    // For this entry: tokenIndex gives us a rough position
-                    // Use the original line number (lineNumber variable) adjusted by the difference
-                    // between the #line position and the current position
-                    
-                    // Simple approach: use the #line entry's adjusted line + offset based on original lines
-                    // The original entry has line=19 (physical line in eval), the #line entry has line=2 (adjusted)
-                    // at tokenIndex=24. The physical line at tokenIndex=24 would have been around line 3-4.
-                    // So the offset is roughly: physical_line_at_directive - adjusted_line_at_directive = 3-4 - 2 = 1-2
-                    
-                    // Better: use the relationship between the found entry and the #line entry
-                    // entry.line = 19 (physical), lowerEntry.line = 2 (adjusted), lowerEntry.tokenIndex = 24
-                    // Assume token distance roughly correlates to line distance
-                    int tokenDistFromLineDirective = entry.getKey() - lowerEntry.getKey();
-                    // The #line-adjusted line at lowerEntry + extrapolation
-                    // Estimate ~6 tokens per line for typical Perl code (based on empirical testing)
-                    int estimatedExtraLines = tokenDistFromLineDirective / 6;
-                    lineNumber = lowerEntry.getValue().lineNumber() + estimatedExtraLines;
-                    
-                    packageName = state.packageNamePool.get(lowerEntry.getValue().packageNameId());
-                    break;
-                }
-                // This lower entry still has the original file, keep looking
-                lowerEntry = info.tokenToLineInfo.lowerEntry(lowerEntry.getKey());
-            }
-            
-            // If still not found, check HIGHER entries (in case #line is applied after this code)
-            if (!foundLineDirective) {
-                int currentKey = entry.getKey();
-                var higherEntry = info.tokenToLineInfo.higherEntry(currentKey);
-                while (higherEntry != null && (higherEntry.getKey() - entry.getKey()) < 50) {
-                    String higherSourceFile = state.fileNamePool.get(higherEntry.getValue().sourceFileNameId());
-                    if (!higherSourceFile.equals(element.getFileName())) {
-                        // Higher entry has #line-adjusted filename - use it
-                        sourceFileName = higherSourceFile;
-                        lineNumber = higherEntry.getValue().lineNumber() - 
-                            (higherEntry.getKey() - entry.getKey());  // Approximate adjustment
-                        if (lineNumber < 1) lineNumber = 1;
-                        packageName = state.packageNamePool.get(higherEntry.getValue().packageNameId());
-                        break;
-                    }
-                    // This higher entry still has the original file, keep looking
-                    currentKey = higherEntry.getKey();
-                    higherEntry = info.tokenToLineInfo.higherEntry(currentKey);
-                }
-            }
-        }
-        
-
         // Retrieve subroutine name
         String subroutineName = state.subroutineNamePool.get(lineInfo.subroutineNameId());
         // If subroutine name is empty string (main code), convert to null

--- a/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitSubroutine.java
@@ -1077,7 +1077,14 @@ public class EmitSubroutine {
                         ? emitterVisitor.ctx.javaClassInfo.callerLineTokenOverride
                         : callerLineCallSiteIndex(node,
                                 emitterVisitor.ctx.javaClassInfo.statementTokenIndex));
-        if (callSiteIndex > 0) {
+        Object interpolatedSourceLine = node.getAnnotation("stringInterpolationSourceLine");
+        Object interpolatedSourceFile = node.getAnnotation("stringInterpolationSourceFile");
+        if (interpolatedSourceLine instanceof Integer sourceLine
+                && sourceLine > 0
+                && interpolatedSourceFile instanceof String sourceFile) {
+            ByteCodeSourceMapper.setDebugInfoSourceLocation(
+                    emitterVisitor.ctx, sourceFile, sourceLine);
+        } else if (callSiteIndex > 0) {
             ByteCodeSourceMapper.setDebugInfoLineNumber(emitterVisitor.ctx, callSiteIndex);
         }
 

--- a/src/main/java/org/perlonjava/frontend/lexer/Lexer.java
+++ b/src/main/java/org/perlonjava/frontend/lexer/Lexer.java
@@ -147,6 +147,12 @@ public class Lexer {
             return null;
         }
 
+        if (isConflictMarkerAtLineStart()) {
+            String marker = input.substring(position, position + 7);
+            position += 7;
+            return new LexerToken(LexerTokenType.CONFLICT_MARKER, marker);
+        }
+
         char current = input.charAt(position);
         int currentCp = getCurrentCodePoint();
 
@@ -195,6 +201,25 @@ public class Lexer {
             }
             return new LexerToken(LexerTokenType.STRING, input.substring(start, position));
         }
+    }
+
+    private boolean isConflictMarkerAtLineStart() {
+        if (position > 0 && input.charAt(position - 1) != '\n') {
+            return false;
+        }
+        if (position + 7 > length) {
+            return false;
+        }
+        char marker = input.charAt(position);
+        if (marker != '<' && marker != '=' && marker != '>') {
+            return false;
+        }
+        for (int i = 1; i < 7; i++) {
+            if (input.charAt(position + i) != marker) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public LexerToken consumeWhitespace() {

--- a/src/main/java/org/perlonjava/frontend/lexer/LexerTokenType.java
+++ b/src/main/java/org/perlonjava/frontend/lexer/LexerTokenType.java
@@ -51,10 +51,16 @@ public enum LexerTokenType {
     STRING,
 
     /**
+     * A seven-character version-control conflict marker at the start of a
+     * source line.  It needs a dedicated token so the parser can issue Perl's
+     * specific diagnostic instead of interpreting it as operators.
+     */
+    CONFLICT_MARKER,
+
+    /**
      * Represents the end-of-file (EOF) marker, which indicates that the lexer
      * has reached the end of the input source. This is used to signal that no
      * more tokens are available.
      */
     EOF
 }
-

--- a/src/main/java/org/perlonjava/frontend/parser/CoreOperatorResolver.java
+++ b/src/main/java/org/perlonjava/frontend/parser/CoreOperatorResolver.java
@@ -67,13 +67,15 @@ public class CoreOperatorResolver {
                     }
                     lineNumber = parser.baseLineNumber + newlineCount;
                 } else {
-                    lineNumber = parser.ctx.errorUtil.getLineNumber(parser.tokenIndex);
+                    lineNumber = parser.ctx.errorUtil
+                            .getSourceLocationAccurate(sourceIndex).lineNumber();
                 }
                 yield new NumberNode(Integer.toString(lineNumber), parser.tokenIndex);
             }
             case "__FILE__" -> {
                 handleEmptyParentheses(parser);
-                yield new StringNode(parser.ctx.errorUtil.getFileName(), parser.tokenIndex);
+                yield new StringNode(parser.ctx.errorUtil
+                        .getSourceLocationAccurate(sourceIndex).fileName(), parser.tokenIndex);
             }
             case "__PACKAGE__" -> {
                 handleEmptyParentheses(parser);

--- a/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
@@ -200,15 +200,15 @@ public class IdentifierParser {
             }
         }
 
-        // In `no utf8` mode (or `evalbytes`), Perl still allows many non-ASCII bytes as length-1 variables,
-        // but it must reject whitespace-like bytes and format/control bytes. Additionally, for length-2+
-        // identifiers, non-ASCII bytes are not allowed.
+        // A normal eval of a Unicode string has Unicode source semantics even
+        // when its enclosing scope did not enable `use utf8`.  Only evalbytes
+        // treats its input as byte source and therefore rejects non-ASCII
+        // characters in multi-character identifiers.
         boolean utf8Enabled = parser.ctx.symbolTable.isStrictOptionEnabled(Strict.HINT_UTF8)
                 && !parser.ctx.compilerOptions.isEvalbytes;
-
-        if (!utf8Enabled && token.type == LexerTokenType.IDENTIFIER) {
+        if (parser.ctx.compilerOptions.isEvalbytes && token.type == LexerTokenType.IDENTIFIER) {
             // The Lexer may have greedily consumed non-ASCII identifier parts into a single IDENTIFIER token.
-            // Under `no utf8` / `evalbytes`, those are not allowed for length-2+ variables.
+            // Under evalbytes, those are not allowed for length-2+ variables.
             String id = token.text;
             if (id.length() > 1) {
                 for (int i = 0; i < id.length(); ) {

--- a/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/IdentifierParser.java
@@ -647,10 +647,10 @@ public class IdentifierParser {
         // Track if we're at the start of the identifier
         boolean isFirstToken = true;
 
-        // Handle leading ' (old-style package separator meaning main::)
+        // A leading quote is the deprecated package separator before the first
+        // component, not an empty `main` package component.  Thus
+        // `sub 'Hello'_he_said` declares `Hello::_he_said`.
         if (isFirstToken && token.text.equals("'")) {
-            // Leading ' means main:: (e.g., 'Hello'_he_said means main::Hello::_he_said)
-            variableName.append("::");  // Leading :: means main::
             parser.tokenIndex++;
             token = parser.tokens.get(parser.tokenIndex);
             nextToken = parser.tokens.get(parser.tokenIndex + 1);

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -556,6 +556,9 @@ public class OperatorParser {
                         || "(".equals(afterType.text);
                 if (followedBySigil) {
                     // Unambiguously a type annotation (followed by a variable sigil or paren list)
+                    if (parser.parsingForLoopVariable && !GlobalVariable.isPackageLoaded(packageName)) {
+                        parser.throwCleanError("No such class " + packageName);
+                    }
                     varType = packageName;
                 } else if (GlobalVariable.isPackageLoaded(packageName)) {
                     varType = packageName;

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -1061,6 +1061,14 @@ public class OperatorParser {
             return new OperatorNode(token.text, null, currentIndex);
         }
 
+        // `undef foo` targets a bareword constant, not a scalar slot.  It
+        // bypasses ordinary prototype parsing, so reject it here before the
+        // compiler treats the identifier as an rvalue expression.
+        if (operand.elements.size() == 1
+                && operand.elements.getFirst() instanceof IdentifierNode) {
+            parser.throwError("Can't modify constant item in undef operator");
+        }
+
         return new OperatorNode(token.text, operand, currentIndex);
     }
 

--- a/src/main/java/org/perlonjava/frontend/parser/ParseHeredoc.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseHeredoc.java
@@ -282,7 +282,12 @@ public class ParseHeredoc {
     private static Node interpolateString(Parser parser, String string, int newlineIndex, boolean preprocessBracedBackslashQuotes) {
         ArrayList<String> buffers = new ArrayList<>();
         buffers.add(string);
-        StringParser.ParsedString rawStr = new StringParser.ParsedString(newlineIndex, newlineIndex, buffers, ' ', ' ', ' ', ' ');
+        int sourceLine = parser.ctx.errorUtil.getSourceLocationAccurate(newlineIndex).lineNumber();
+        StringParser.ParsedString rawStr = new StringParser.ParsedString(newlineIndex, sourceLine, buffers, ' ', ' ', ' ', ' ');
+        // The constructor's second argument is the next token index, not a
+        // logical source line. The interpolated token stream itself begins
+        // after this newline, so its first token advances the base line.
+        rawStr.sourceLine = sourceLine;
 
         // When interpolating heredoc content, create a new heredoc context
         // to avoid processing parent heredocs in the wrong context

--- a/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
@@ -205,6 +205,7 @@ public class ParseInfix {
             // Validate that state variables are not initialized in list context
             if (operator.equals("=")) {
                 validateNoStateInListAssignment(parser, left);
+                validateConstantItemListLvalue(parser, left);
                 validateKnownSubroutineLvalue(parser, left);
             }
 
@@ -832,6 +833,18 @@ public class ParseInfix {
                     parser.tokenIndex,
                     "Initialization of state variables in list currently forbidden",
                     parser.ctx.errorUtil);
+        }
+    }
+
+    /** Reject bareword constants used as slots in a list assignment. */
+    private static void validateConstantItemListLvalue(Parser parser, Node left) {
+        if (!(left instanceof ListNode listNode)) {
+            return;
+        }
+        for (Node element : listNode.elements) {
+            if (element instanceof IdentifierNode) {
+                parser.throwError("Can't modify constant item in list assignment");
+            }
         }
     }
 

--- a/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
@@ -223,6 +223,7 @@ public class ParseInfix {
 
             if (operator.equals("=~") || operator.equals("!~")) {
                 warnAggregateRegexBinding(parser, left, right, operatorIndex);
+                rejectAggregateRegexMutation(parser, left, right);
             }
 
             BinaryOperatorNode node = new BinaryOperatorNode(operator, left, right, parser.tokenIndex);
@@ -581,6 +582,37 @@ public class ParseInfix {
                 WarnDie.warn(text, location);
             }
         }
+    }
+
+    /**
+     * A bare aggregate may be scalarized for a non-mutating match, but Perl
+     * rejects substitutions and transliterations because they require a
+     * mutable scalar target.  Diagnose this during parsing so later compile
+     * activity (such as a following use) cannot replace the real error.
+     */
+    private static void rejectAggregateRegexMutation(Parser parser, Node left,
+                                                     Node right) {
+        if (!(right instanceof OperatorNode regexOperator)
+                || !(regexOperator.operator.equals("replaceRegex")
+                    || regexOperator.operator.equals("tr")
+                    || regexOperator.operator.equals("transliterate"))) {
+            return;
+        }
+        if (!(left instanceof OperatorNode aggregate)
+                || !(aggregate.operator.equals("@") || aggregate.operator.equals("%"))
+                || !(aggregate.operand instanceof IdentifierNode identifier)) {
+            return;
+        }
+
+        String kind = aggregate.operator.equals("@") ? "array" : "hash";
+        var entry = parser.ctx.symbolTable.getSymbolEntry(
+                aggregate.operator + identifier.name);
+        boolean lexical = entry != null
+                && ("my".equals(entry.decl()) || "state".equals(entry.decl()));
+        parser.throwError("Can't modify " + (lexical ? "private " : "")
+                + kind + (lexical ? "" : " dereference")
+                + " in " + (regexOperator.operator.equals("replaceRegex")
+                        ? "substitution (s///)" : "transliteration (tr///)"));
     }
 
     /**

--- a/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
@@ -7,6 +7,8 @@ import org.perlonjava.frontend.semantic.SymbolTable;
 import org.perlonjava.runtime.perlmodule.Strict;
 import org.perlonjava.runtime.runtimetypes.*;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.perlonjava.frontend.parser.ParserNodeUtils.scalarUnderscore;
 import static org.perlonjava.frontend.parser.TokenUtils.peek;
 import static org.perlonjava.runtime.runtimetypes.GlobalVariable.existsGlobalCodeRef;
@@ -72,6 +74,9 @@ public class ParsePrimary {
         switch (token.type) {
             case IDENTIFIER:
                 // Handle identifiers: variables, subroutines, keywords, etc.
+                if (token.text.getBytes(StandardCharsets.UTF_8).length >= 1020) {
+                    parser.throwCleanError("Identifier too long");
+                }
                 return parseIdentifier(parser, startIndex, token, operator);
             case NUMBER:
                 // Handle numeric literals (integers, floats, hex, octal, binary)

--- a/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
@@ -481,8 +481,11 @@ public class ParsePrimary {
                         // Check if there's a function with this name
                         String functionName = nextToken.text;
                         String fullName = parser.ctx.symbolTable.getCurrentPackage() + "::" + functionName;
-                        RuntimeScalar codeRef = GlobalVariable.getGlobalCodeRef(fullName);
-                        if (codeRef.getDefinedBoolean()) {
+                        // Do not autovivify a CV while probing: an undefined
+                        // CODE slot is truthy as a RuntimeScalar but is not a
+                        // callable subroutine, so `-F 1` must remain the
+                        // invalid-filetest syntax rather than `-F(1)`.
+                        if (GlobalVariable.isGlobalCodeRefDefined(fullName)) {
                             // There's a function with this name, treat as regular unary minus
                             // Don't do anything special here, just fall through to regular unary minus handling
                         } else {

--- a/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
@@ -152,6 +152,15 @@ public class ParsePrimary {
             TokenUtils.consume(parser);  // consume "::"
             token = TokenUtils.consume(parser); // consume the actual operator
             operator = token.text;
+            // CORE::print::helper and CORE::foo'bar are ordinary qualified
+            // subroutine names, not explicit calls to CORE::print or
+            // CORE::foo.  Let the subroutine-name parser consume all package
+            // components before deciding whether a CORE builtin was named.
+            String followingNameToken = parser.tokens.get(parser.tokenIndex).text;
+            if (followingNameToken.equals("::") || followingNameToken.equals("'")) {
+                parser.tokenIndex = startIndex;
+                return SubroutineParser.parseSubroutineCall(parser, false);
+            }
         }
 
         // IMPORTANT: Check for lexical subs AFTER CORE::, but before checking for quote-like operators!

--- a/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParsePrimary.java
@@ -85,6 +85,9 @@ public class ParsePrimary {
             case EOF:
                 // Handle end of input gracefully
                 return null;
+            case CONFLICT_MARKER:
+                throw new PerlCompilerException(startIndex,
+                        "Version control conflict marker", parser.ctx.errorUtil);
             default:
                 // Any other token type is a syntax error
                 throw new PerlCompilerException(parser.tokenIndex, "syntax error", parser.ctx.errorUtil);

--- a/src/main/java/org/perlonjava/frontend/parser/Parser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/Parser.java
@@ -206,6 +206,16 @@ public class Parser {
      * @return The root node of the parsed AST.
      */
     public Node parse() {
+        // Perl recognizes a seven-character merge-conflict marker before it
+        // attempts to reduce the surrounding statement.  Doing this as a
+        // lexical diagnostic is important for input such as "$_\n<<<<<<<":
+        // the incomplete preceding expression must not mask the marker.
+        for (int i = 0; i < tokens.size(); i++) {
+            if (tokens.get(i).type == LexerTokenType.CONFLICT_MARKER) {
+                throw new PerlCompilerException(i,
+                        "Version control conflict marker", ctx.errorUtil);
+            }
+        }
         if (tokens.get(tokenIndex).text.equals("=")) {
             // looks like pod: insert a newline to trigger pod parsing
             tokens.addFirst(new LexerToken(LexerTokenType.NEWLINE, "\n"));

--- a/src/main/java/org/perlonjava/frontend/parser/Parser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/Parser.java
@@ -87,6 +87,10 @@ public class Parser {
     // re-tokenized string content and __LINE__ should use this as the base line,
     // counting newlines from the inner token list to offset from it.
     public int baseLineNumber = 0;
+    // Logical file paired with baseLineNumber for re-tokenized quoted strings.
+    // Nested interpolation has token indices local to the string, so runtime
+    // caller() metadata must carry this coordinate explicitly.
+    public String baseSourceFileName = null;
     // Source-line offsets are indexed once by token identity. String parsing used
     // to rescan every preceding token for every quote-like operator, which made
     // large generated Perl data files (notably CPAN CHECKSUMS) quadratic to parse.

--- a/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
+++ b/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
@@ -373,6 +373,9 @@ public class PrototypeArgs {
             }
 
             if (!TokenUtils.peek(parser).text.equals(")")) {
+                if (prototype == null && TokenUtils.peek(parser).text.equals(";")) {
+                    parser.throwError("syntax error");
+                }
                 throwTooManyArgumentsError(parser);
             }
             TokenUtils.consume(parser, LexerTokenType.OPERATOR, ")");

--- a/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
+++ b/src/main/java/org/perlonjava/frontend/parser/PrototypeArgs.java
@@ -1230,6 +1230,17 @@ public class PrototypeArgs {
             // The unary + is used for disambiguation but should be transparent for prototypes
             referenceArg = unwrapUnaryPlus(referenceArg, refType);
 
+            // A bare identifier has no scalar slot to reference.  In
+            // particular, read($buffer, FILE, 1) must reject FILE as a
+            // constant item rather than treating it as a mutable \$ buffer.
+            if (refType == '$' && referenceArg instanceof IdentifierNode) {
+                String operatorName = parser.ctx.symbolTable.getCurrentSubroutine();
+                if (operatorName == null || operatorName.isEmpty()) {
+                    operatorName = "operator";
+                }
+                parser.throwError("Can't modify constant item in " + operatorName);
+            }
+
             // Handle my(@array) and my(%hash) for backslash prototypes.
             // When my(@bar) is parsed, it creates OperatorNode("my", ListNode(OperatorNode("@")))
             // but \my(@bar) should produce an ARRAYREFERENCE, same as \my @bar.

--- a/src/main/java/org/perlonjava/frontend/parser/SpecialBlockParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SpecialBlockParser.java
@@ -248,6 +248,9 @@ public class SpecialBlockParser {
      */
     static RuntimeList runSpecialBlock(Parser parser, String blockPhase, Node block, int contextType) {
         int tokenIndex = parser.tokenIndex;
+        LineDirectiveLocation callerLocation = blockPhase.equals("BEGIN")
+                ? lineDirectiveLocation(parser, block.getIndex(), tokenIndex)
+                : null;
 
         // Create AST nodes for setting up the capture variables and package declaration
         List<Node> nodes = new ArrayList<>();
@@ -376,14 +379,12 @@ public class SpecialBlockParser {
 
         if (blockPhase.equals("BEGIN")) {
             // BEGIN - execute immediately
-            nodes.add(
-                    new BinaryOperatorNode(
-                            "->",
-                            anonSub,
-                            new ListNode(tokenIndex),
-                            tokenIndex
-                    )
-            );
+            BinaryOperatorNode invokeBegin = new BinaryOperatorNode(
+                    "->",
+                    anonSub,
+                    new ListNode(tokenIndex),
+                    tokenIndex);
+            nodes.add(invokeBegin);
         } else {
             // Not BEGIN - return a sub to execute later
             nodes.add(anonSub);
@@ -425,8 +426,8 @@ public class SpecialBlockParser {
             ErrorMessageUtil.SourceLocation loc = parser.ctx.errorUtil.getSourceLocationAccurate(tokenIndex);
             CallerStack.push(
                     parser.ctx.symbolTable.getCurrentPackage(),
-                    loc.fileName(),
-                    loc.lineNumber());
+                    callerLocation != null ? callerLocation.fileName() : loc.fileName(),
+                    callerLocation != null ? callerLocation.lineNumber() : loc.lineNumber());
             try {
                 // Deferred phasers must return the anonymous CODE value to the
                 // parser so it can be queued.  Compiling that wrapper in VOID
@@ -510,5 +511,44 @@ public class SpecialBlockParser {
         }
 
         return result;
+    }
+
+    /**
+     * BEGIN executes only after its complete body has been parsed.  A #line
+     * directive in that body therefore supplies the COP seen by caller(), even
+     * when the wrapper invocation is emitted at the closing brace.  Return the
+     * first token on the last such directive's following line, whose source
+     * mapping carries the requested logical location.
+     */
+    private static LineDirectiveLocation lineDirectiveLocation(Parser parser, int start, int end) {
+        LineDirectiveLocation result = null;
+        for (int i = Math.max(0, start); i < Math.min(end, parser.tokens.size()); i++) {
+            var token = parser.tokens.get(i);
+            if (!token.text.equals("#")) {
+                continue;
+            }
+            int cursor = i + 1;
+            while (cursor < end && parser.tokens.get(cursor).type == LexerTokenType.WHITESPACE) cursor++;
+            if (cursor >= end || !parser.tokens.get(cursor).text.equals("line")) continue;
+            cursor++;
+            while (cursor < end && parser.tokens.get(cursor).type == LexerTokenType.WHITESPACE) cursor++;
+            if (cursor >= end) continue;
+            int lineNumber;
+            try {
+                lineNumber = Integer.parseInt(parser.tokens.get(cursor).text);
+            } catch (NumberFormatException ignored) {
+                continue;
+            }
+            while (cursor < end && parser.tokens.get(cursor).type != LexerTokenType.NEWLINE) cursor++;
+            if (cursor + 1 < end) {
+                int locationToken = cursor + 1;
+                var location = parser.ctx.errorUtil.getSourceLocationAccurate(locationToken);
+                result = new LineDirectiveLocation(location.fileName(), lineNumber, locationToken);
+            }
+        }
+        return result;
+    }
+
+    private record LineDirectiveLocation(String fileName, int lineNumber, int tokenIndex) {
     }
 }

--- a/src/main/java/org/perlonjava/frontend/parser/StringDoubleQuoted.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringDoubleQuoted.java
@@ -239,6 +239,8 @@ public class StringDoubleQuoted extends StringSegmentParser {
         // returns the correct line from the original source, not the inner token list.
         // Use rawStr.index (position of opening delimiter in outer token list).
         parser.baseLineNumber = rawStr.sourceLine;
+        parser.baseSourceFileName = ctx.errorUtil
+                .getSourceLocationAccurate(rawStr.index).fileName();
 
         // Create and run the double-quoted string parser with original token offset tracking
         var doubleQuotedParser = new StringDoubleQuoted(ctx, tokens, parser,

--- a/src/main/java/org/perlonjava/frontend/parser/StringParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringParser.java
@@ -347,7 +347,11 @@ public class StringParser {
         }
         ParsedString parsed = new ParsedString(index, tokPos, buffers, startDelim, endDelim,
                 secondBufferStartDelim, secondBufferEndDelim);
-        parsed.sourceLine = parser != null ? parser.sourceLineAt(index) : 1;
+        parsed.sourceLine = parser == null
+                ? 1
+                : (parser.baseLineNumber > 0
+                        ? parser.sourceLineAt(index)
+                        : parser.ctx.errorUtil.getSourceLocationAccurate(index).lineNumber());
         return parsed;
     }
 

--- a/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
@@ -349,6 +349,16 @@ public abstract class StringSegmentParser {
         if (TokenUtils.peek(parser).text.equals("{")) {
             // Handle block-like interpolation: ${...} or @{...}
 
+            // `${}` is accepted as an empty interpolation in ordinary
+            // double-quoted strings, but it is a syntax error in an s///
+            // replacement.  Parsing it as an empty scalar here would let the
+            // malformed replacement consume the following regex unchecked.
+            if ("$".equals(sigil) && isRegexReplacement
+                    && parser.tokenIndex + 1 < parser.tokens.size()
+                    && parser.tokens.get(parser.tokenIndex + 1).text.equals("}")) {
+                throw new PerlCompilerException(tokenIndex, "syntax error", ctx.errorUtil);
+            }
+
             // Check if this is an @{[...]} construct (array reference interpolation)
             if (isArray) {
                 int savedIndex = parser.tokenIndex;

--- a/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
@@ -1504,7 +1504,7 @@ public abstract class StringSegmentParser {
             chr = TokenUtils.peekChar(parser);
 
             // Skip leading whitespace
-            while (Character.isWhitespace(chr.charAt(0)) && !"}".equals(chr)) {
+            while (!chr.isEmpty() && Character.isWhitespace(chr.charAt(0)) && !"}".equals(chr)) {
                 TokenUtils.consumeChar(parser);
                 chr = TokenUtils.peekChar(parser);
             }
@@ -1529,6 +1529,10 @@ public abstract class StringSegmentParser {
                 } else {
                     break;
                 }
+            }
+
+            if (chr.isEmpty()) {
+                parser.throwError("Missing right brace on \\x{}");
             }
 
             // Skip trailing non-digits
@@ -1587,7 +1591,7 @@ public abstract class StringSegmentParser {
             chr = TokenUtils.peekChar(parser);
 
             // Skip leading whitespace
-            while (Character.isWhitespace(chr.charAt(0)) && !"}".equals(chr)) {
+            while (!chr.isEmpty() && Character.isWhitespace(chr.charAt(0)) && !"}".equals(chr)) {
                 TokenUtils.consumeChar(parser);
                 chr = TokenUtils.peekChar(parser);
             }
@@ -1612,6 +1616,10 @@ public abstract class StringSegmentParser {
                 } else {
                     break;
                 }
+            }
+
+            if (chr.isEmpty()) {
+                parser.throwError("Missing right brace on \\o{}");
             }
 
             // Skip trailing non-digits
@@ -1673,8 +1681,12 @@ public abstract class StringSegmentParser {
     void handleUnicodeNameEscape() {
         if (!"{".equals(TokenUtils.peekChar(parser))) {
             // In a regex, plain \N is Perl's non-newline atom. Keep the escape
-            // intact for the regex backend; quoted strings still treat it as N.
-            appendToCurrentSegment(isRegex ? "\\N" : "N");
+            // intact for the regex backend. In quoted strings, \N requires
+            // braces to introduce a Unicode character name.
+            if (!isRegex) {
+                parser.throwError("Missing braces on \\N{}");
+            }
+            appendToCurrentSegment("\\N");
             return;
         }
 

--- a/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StringSegmentParser.java
@@ -509,7 +509,41 @@ public abstract class StringSegmentParser {
             hashAccess.setAnnotation("stringInterpolationHashName", "$" + hashName.name);
         }
 
+        // Expressions inside ${...} are parsed from a nested token stream, whose
+        // indices start at zero.  Their executable blocks nevertheless belong to
+        // this quoted source, so rebase their debug positions to the outer token
+        // stream before bytecode emission uses them for caller()/warn/die.
+        rebaseNode(operand, tokenIndex);
         addStringSegment(operand);
+    }
+
+    private void rebaseNode(Node node, int offset) {
+        if (node instanceof AbstractNode abstractNode) {
+            int innerIndex = abstractNode.getIndex();
+            if (parser.baseLineNumber > 0 && innerIndex >= 0) {
+                abstractNode.setAnnotation("stringInterpolationSourceLine",
+                        parser.sourceLineAt(innerIndex));
+                if (parser.baseSourceFileName != null) {
+                    abstractNode.setAnnotation("stringInterpolationSourceFile",
+                            parser.baseSourceFileName);
+                }
+            }
+            abstractNode.setIndex(abstractNode.getIndex() + offset);
+            Object statementStart = abstractNode.getAnnotation("statementStartIndex");
+            if (statementStart instanceof Integer index) {
+                abstractNode.setAnnotation("statementStartIndex", index + offset);
+            }
+        }
+        if (node instanceof BinaryOperatorNode binary) {
+            rebaseNode(binary.left, offset);
+            rebaseNode(binary.right, offset);
+        } else if (node instanceof OperatorNode operator) {
+            rebaseNode(operator.operand, offset);
+        } else if (node instanceof BlockNode block) {
+            for (Node element : block.elements) rebaseNode(element, offset);
+        } else if (node instanceof ListNode list) {
+            for (Node element : list.elements) rebaseNode(element, offset);
+        }
     }
 
     /**

--- a/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/SubroutineParser.java
@@ -574,14 +574,23 @@ public class SubroutineParser {
 
                     // Consume the opening brace
                     TokenUtils.consume(parser, LexerTokenType.OPERATOR, "{");
-                    // Parse the block as an expression - it will be evaluated at runtime
-                    // to determine the invocant (class/object) for the method call
-                    Node blockExpr = ParseBlock.parseBlock(parser);
-                    if (peek(parser).type == LexerTokenType.EOF) {
-                        parser.throwMissingRightCurlyOrSquareBracketError();
+                    // An empty brace pair is a hash-reference invocant, not
+                    // an empty statement block.  Thus `method {} {...}` must
+                    // report an unblessed reference rather than undef.
+                    Node blockExpr;
+                    if (peek(parser).text.equals("}")) {
+                        TokenUtils.consume(parser, LexerTokenType.OPERATOR, "}");
+                        blockExpr = new HashLiteralNode(List.of(), currentIndex);
+                    } else {
+                        // Parse the block as an expression - it will be evaluated at runtime
+                        // to determine the invocant (class/object) for the method call
+                        blockExpr = ParseBlock.parseBlock(parser);
+                        if (peek(parser).type == LexerTokenType.EOF) {
+                            parser.throwMissingRightCurlyOrSquareBracketError();
+                        }
+                        // Consume the closing brace
+                        TokenUtils.consume(parser, LexerTokenType.OPERATOR, "}");
                     }
-                    // Consume the closing brace
-                    TokenUtils.consume(parser, LexerTokenType.OPERATOR, "}");
                     
                     // Parse any additional arguments after the block.
                     ListNode arguments = consumeArgsWithPrototype(parser, "@");

--- a/src/main/java/org/perlonjava/frontend/parser/Variable.java
+++ b/src/main/java/org/perlonjava/frontend/parser/Variable.java
@@ -1300,7 +1300,7 @@ public class Variable {
             // raised while parsing the braced expression itself: doing so
             // turns malformed code such as @{if(0){sub d{]]] into a misleading
             // EOF-only "Missing right curly" error.
-            if (!"Missing closing brace in variable interpolation".equals(e.getMessage())) {
+            if (!e.getMessage().startsWith("Missing closing brace in variable interpolation")) {
                 // ErrorMessageUtil deliberately omits a leading "{" from its
                 // generic context window.  Here that brace is the malformed
                 // braced-interpolation expression itself, immediately followed

--- a/src/main/java/org/perlonjava/frontend/parser/Variable.java
+++ b/src/main/java/org/perlonjava/frontend/parser/Variable.java
@@ -1009,6 +1009,7 @@ public class Variable {
      * @throws PerlCompilerException if the braced expression is malformed or unterminated
      */
     public static Node parseBracedVariable(Parser parser, String sigil, boolean isStringInterpolation) {
+        int bracedExpressionStart = parser.tokenIndex;
         int startLineNumber = parser.ctx.errorUtil.getLineNumber(parser.tokenIndex - 1); // Save line number before peek() side effects
         TokenUtils.consume(parser); // Consume the '{'
 
@@ -1293,6 +1294,32 @@ public class Variable {
                 // fall through to return the full block as the dereference target
             }
             return new OperatorNode(sigil, block, parser.tokenIndex);
+        } catch (PerlCompilerException e) {
+            // An actual omitted closing brace is normalized below for Perl's
+            // traditional diagnostic.  Do not hide a concrete syntax error
+            // raised while parsing the braced expression itself: doing so
+            // turns malformed code such as @{if(0){sub d{]]] into a misleading
+            // EOF-only "Missing right curly" error.
+            if (!"Missing closing brace in variable interpolation".equals(e.getMessage())) {
+                // ErrorMessageUtil deliberately omits a leading "{" from its
+                // generic context window.  Here that brace is the malformed
+                // braced-interpolation expression itself, immediately followed
+                // by `]`, so preserve the compact Perl diagnostic context.
+                if (hasMalformedBracedInterpolation(parser, bracedExpressionStart)) {
+                    var location = parser.ctx.errorUtil
+                            .getSourceLocationAccurate(bracedExpressionStart);
+                    throw new PerlCompilerException("syntax error at "
+                            + location.fileName() + " line " + location.lineNumber()
+                            + ", near \"{]\"\n");
+                }
+                throw e;
+            }
+            // Fall through to the historical unterminated-brace diagnostic.
+            String fileName = parser.ctx.errorUtil.getFileName();
+            String multiLineError = "Missing right curly or square bracket at " + fileName + " line " + startLineNumber + ", at end of line\n" +
+                    "syntax error at " + fileName + " line " + startLineNumber + ", at EOF\n" +
+                    "Execution of " + fileName + " aborted due to compilation errors.\n";
+            throw new PerlParserException(multiLineError);
         } catch (Exception e) {
             // Use the saved line number from before peek() side effects
             String fileName = parser.ctx.errorUtil.getFileName();
@@ -1304,6 +1331,19 @@ public class Variable {
             parser.insideBracedDereference = savedInsideBracedDereference;
             parser.parsingTakeReference = savedParsingTakeReference;
         }
+    }
+
+    private static boolean hasMalformedBracedInterpolation(Parser parser, int start) {
+        for (int i = start + 1; i + 1 < parser.tokens.size(); i++) {
+            if (parser.tokens.get(i).type == LexerTokenType.EOF) {
+                return false;
+            }
+            if ("{".equals(parser.tokens.get(i).text)
+                    && parser.tokens.get(i + 1).text.startsWith("]")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/org/perlonjava/frontend/parser/Whitespace.java
+++ b/src/main/java/org/perlonjava/frontend/parser/Whitespace.java
@@ -133,11 +133,10 @@ public class Whitespace {
             try {
                 int lineNumber = Integer.parseInt(lineNumberStr);
                 tokenIndex++;
+                boolean validDirective = true;
 
-                // Update the context (ErrorMessageUtil instance) with the new line number
-                parser.ctx.errorUtil.setLineNumber(lineNumber - 1);
-                parser.ctx.errorUtil.setTokenIndex(tokenIndex - 1);
-
+                boolean separatedFromLineNumber = tokenIndex < tokens.size()
+                        && tokens.get(tokenIndex).type == LexerTokenType.WHITESPACE;
                 // Skip optional whitespace before filename
                 while (tokenIndex < tokens.size() && tokens.get(tokenIndex).type == LexerTokenType.WHITESPACE) {
                     tokenIndex++;
@@ -146,7 +145,10 @@ public class Whitespace {
                 if (tokenIndex < tokens.size() && tokens.get(tokenIndex).type == LexerTokenType.OPERATOR && tokens.get(tokenIndex).text.equals("\"")) {
                     tokenIndex++; // Skip opening quote
                     StringBuilder filenameBuilder = new StringBuilder();
-                    while (tokenIndex < tokens.size() && !(tokens.get(tokenIndex).type == LexerTokenType.OPERATOR && tokens.get(tokenIndex).text.equals("\""))) {
+                    while (tokenIndex < tokens.size()
+                            && tokens.get(tokenIndex).type != LexerTokenType.NEWLINE
+                            && !(tokens.get(tokenIndex).type == LexerTokenType.OPERATOR
+                            && tokens.get(tokenIndex).text.equals("\""))) {
                         filenameBuilder.append(tokens.get(tokenIndex).text);
                         tokenIndex++;
                     }
@@ -156,8 +158,13 @@ public class Whitespace {
 
                         // Update the context (ErrorMessageUtil instance) with the new file name
                         parser.ctx.errorUtil.setFileName(filename);
+                    } else if (!filenameBuilder.isEmpty()) {
+                        // Perl treats an unterminated quoted filename as the
+                        // filename through the end of this physical line.
+                        parser.ctx.errorUtil.setFileName("\"" + filenameBuilder);
                     }
-                } else if (tokenIndex < tokens.size() && isUnquotedLineFilenameToken(tokens.get(tokenIndex))) {
+                } else if (separatedFromLineNumber && tokenIndex < tokens.size()
+                        && isUnquotedLineFilenameToken(tokens.get(tokenIndex))) {
                     // Unquoted filename: #line N filename
                     // Perl allows unquoted filenames such as lib/Foo/Bar.pm.
                     StringBuilder filenameBuilder = new StringBuilder();
@@ -167,8 +174,32 @@ public class Whitespace {
                     }
                     String filename = filenameBuilder.toString();
                     if (!filename.isEmpty()) {
-                        parser.ctx.errorUtil.setFileName(filename);
+                        // A bare filename must consume the directive's entire
+                        // remainder.  A second word makes the directive a
+                        // comment, leaving the preceding logical location intact.
+                        int remainder = tokenIndex;
+                        while (remainder < tokens.size()
+                                && tokens.get(remainder).type == LexerTokenType.WHITESPACE) {
+                            remainder++;
+                        }
+                        if (remainder < tokens.size()
+                                && tokens.get(remainder).type != LexerTokenType.NEWLINE
+                                && tokens.get(remainder).type != LexerTokenType.EOF) {
+                            validDirective = false;
+                        } else {
+                            parser.ctx.errorUtil.setFileName(filename);
+                        }
                     }
+                } else if (!separatedFromLineNumber && tokenIndex < tokens.size()
+                        && tokens.get(tokenIndex).type != LexerTokenType.NEWLINE
+                        && tokens.get(tokenIndex).type != LexerTokenType.EOF) {
+                    validDirective = false;
+                }
+
+                if (validDirective) {
+                    // The directive applies to its following source line.
+                    parser.ctx.errorUtil.setLineNumber(lineNumber - 1);
+                    parser.ctx.errorUtil.setTokenIndex(tokenIndex - 1);
                 }
             } catch (NumberFormatException e) {
                 // Handle the error if the line number is not valid

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -1936,7 +1936,10 @@ public class IOOperator {
         // Create arguments list for format processing
         RuntimeList formatArgs = new RuntimeList();
         for (int i = 1; i < args.length; i++) {
-            formatArgs.add(args[i]);
+            // The formline prototype is $@.  A supplied @_ (or any other
+            // aggregate) is list-valued here, not the aggregate's scalar
+            // element count.
+            formatArgs.addFlattened(args[i]);
         }
 
         // For complex format templates with @ or ^ fields, use RuntimeFormat
@@ -1946,11 +1949,6 @@ public class IOOperator {
             // Create a temporary RuntimeFormat to process the template
             RuntimeFormat tempFormat = new RuntimeFormat("FORMLINE_TEMP", formatTemplate);
 
-            // Parse the format template as picture lines
-            List<FormatLine> lines = new ArrayList<>();
-            lines.add(new PictureLine(formatTemplate, new ArrayList<>(), formatTemplate, 0));
-            tempFormat.setCompiledLines(lines);
-
             // Execute the format and get the result
             String formattedOutput = tempFormat.execute(formatArgs);
 
@@ -1958,9 +1956,7 @@ public class IOOperator {
             RuntimeScalar accumulator = getGlobalVariable(GlobalContext.encodeSpecialVar("A"));
             boolean resultTainted = accumulator.isTainted() || picture.isTainted()
                     || picture.formatPictureTainted;
-            for (int i = 1; i < args.length; i++) {
-                resultTainted |= args[i].scalar().isTainted();
-            }
+            resultTainted |= tempFormat.isLastExecutionTainted();
             String currentValue = accumulator.toString();
             accumulator.set(currentValue + formattedOutput);
             accumulator.tainted = resultTainted;

--- a/src/main/java/org/perlonjava/runtime/operators/StringOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/StringOperators.java
@@ -295,6 +295,9 @@ public class StringOperators {
     }
 
     private static RuntimeScalar lcfirstUnpropagated(RuntimeScalar runtimeScalar) {
+        if (runtimeScalar instanceof ScalarSpecialVariable) {
+            runtimeScalar = new RuntimeScalar(runtimeScalar);
+        }
         if (runtimeScalar.type == RuntimeScalarType.BYTE_STRING) {
             return lcfirstBytes(runtimeScalar);
         }
@@ -336,6 +339,9 @@ public class StringOperators {
     }
 
     private static RuntimeScalar ucUnpropagated(RuntimeScalar runtimeScalar) {
+        if (runtimeScalar instanceof ScalarSpecialVariable) {
+            runtimeScalar = new RuntimeScalar(runtimeScalar);
+        }
         if (runtimeScalar.type == RuntimeScalarType.BYTE_STRING) {
             return uppercaseBytesAsciiOnly(runtimeScalar);
         }
@@ -369,6 +375,9 @@ public class StringOperators {
     }
 
     private static RuntimeScalar ucfirstUnpropagated(RuntimeScalar runtimeScalar) {
+        if (runtimeScalar instanceof ScalarSpecialVariable) {
+            runtimeScalar = new RuntimeScalar(runtimeScalar);
+        }
         if (runtimeScalar.type == RuntimeScalarType.BYTE_STRING) {
             return ucfirstBytes(runtimeScalar);
         }
@@ -1073,6 +1082,13 @@ public class StringOperators {
     }
 
     private static RuntimeScalar stringifyForStringContext(RuntimeScalar scalar) {
+        // Regex captures are live proxy scalars.  String context must
+        // materialize their current value before deciding whether a
+        // concatenation is byte-backed or UTF-8; otherwise `"$1"` loses the
+        // capture's Unicode provenance.
+        if (scalar instanceof ScalarSpecialVariable) {
+            scalar = new RuntimeScalar(scalar);
+        }
         return RuntimeScalarType.blessedId(scalar) != 0 ? Overload.stringify(scalar) : scalar;
     }
 

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/ErrorMessageUtil.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/ErrorMessageUtil.java
@@ -646,6 +646,8 @@ public class ErrorMessageUtil {
         if (lineNumber < 0) return null;
 
         index++;
+        boolean separatedFromLineNumber = index < tokens.size()
+                && tokens.get(index).type == LexerTokenType.WHITESPACE;
         while (index < tokens.size()
                 && tokens.get(index).type == LexerTokenType.WHITESPACE) {
             index++;
@@ -657,6 +659,7 @@ public class ErrorMessageUtil {
             index++;
             StringBuilder filename = new StringBuilder();
             while (index < tokens.size()
+                    && tokens.get(index).type != LexerTokenType.NEWLINE
                     && !(tokens.get(index).type == LexerTokenType.OPERATOR
                     && tokens.get(index).text.equals("\""))) {
                 filename.append(tokens.get(index).text);
@@ -667,8 +670,12 @@ public class ErrorMessageUtil {
                     && tokens.get(index).text.equals("\"")
                     && !filename.isEmpty()) {
                 directiveFile = filename.toString();
+            } else if (!filename.isEmpty()) {
+                // Perl accepts a missing closing quote as part of the logical
+                // filename rather than scanning into a following source line.
+                directiveFile = "\"" + filename;
             }
-        } else if (index < tokens.size()
+        } else if (separatedFromLineNumber && index < tokens.size()
                 && isUnquotedLineFilenameToken(tokens.get(index))) {
             StringBuilder filename = new StringBuilder();
             while (index < tokens.size()
@@ -677,6 +684,22 @@ public class ErrorMessageUtil {
                 index++;
             }
             if (!filename.isEmpty()) directiveFile = filename.toString();
+            // A bare filename consumes the directive's entire remainder.  A
+            // second word makes the directive malformed rather than silently
+            // changing the logical file to its first word.
+            while (index < tokens.size()
+                    && tokens.get(index).type == LexerTokenType.WHITESPACE) {
+                index++;
+            }
+            if (index < tokens.size()
+                    && tokens.get(index).type != LexerTokenType.NEWLINE
+                    && tokens.get(index).type != LexerTokenType.EOF) {
+                return null;
+            }
+        } else if (!separatedFromLineNumber && index < tokens.size()
+                && tokens.get(index).type != LexerTokenType.NEWLINE
+                && tokens.get(index).type != LexerTokenType.EOF) {
+            return null;
         }
         return new ParsedLineDirective(lineNumber, directiveFile);
     }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeFormat.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/RuntimeFormat.java
@@ -31,6 +31,11 @@ public class RuntimeFormat extends RuntimeScalar implements RuntimeScalarReferen
     // Whether the format has been compiled
     private boolean isCompiled = false;
 
+    // Taint observed while materializing arguments for the latest execution.
+    // Kept with the materialized values so callers do not fetch tied operands
+    // a second time merely to calculate output provenance.
+    private boolean lastExecutionTainted;
+
     /**
      * Constructor for RuntimeFormat.
      * Initializes a new instance of the RuntimeFormat class with the specified format name.
@@ -307,8 +312,17 @@ public class RuntimeFormat extends RuntimeScalar implements RuntimeScalarReferen
 
         StringBuilder output = new StringBuilder();
         List<RuntimeScalar> argList = new ArrayList<>();
+        lastExecutionTainted = false;
         for (RuntimeBase element : args.elements) {
-            argList.add(element.scalar());
+            RuntimeScalar value = element.scalar();
+            if (value.type == RuntimeScalarType.TIED_SCALAR) {
+                // A format field consumes the value, not its tied lvalue.
+                // Fetch it once here so formatting and taint propagation use
+                // the same scalar snapshot.
+                value = value.tiedFetch();
+            }
+            argList.add(value);
+            lastExecutionTainted |= value.isTainted();
         }
         int argIndex = 0;
 
@@ -360,6 +374,11 @@ public class RuntimeFormat extends RuntimeScalar implements RuntimeScalarReferen
         return output.toString();
     }
 
+    /** Returns taint observed while materializing the most recent arguments. */
+    public boolean isLastExecutionTainted() {
+        return lastExecutionTainted;
+    }
+
     /**
      * Execute a picture line with its corresponding argument line.
      *
@@ -394,6 +413,13 @@ public class RuntimeFormat extends RuntimeScalar implements RuntimeScalarReferen
                     lineArgs.add(new RuntimeScalar("<eval_error>"));
                 }
             }
+        } else {
+            // formline() supplies its field values directly rather than as a
+            // following format argument line.  Retain those RuntimeScalar
+            // instances so tied values are fetched once when formatted.
+            for (int i = startIndex; i < args.size(); i++) {
+                lineArgs.add(args.get(i));
+            }
         }
 
         // Process each field in the picture line
@@ -417,7 +443,10 @@ public class RuntimeFormat extends RuntimeScalar implements RuntimeScalarReferen
             String formattedValue = field.formatValue(fieldValue);
             result.append(formattedValue);
 
-            lastPos = field.startPosition + field.width;
+            // width describes the picture characters after the leading @ or
+            // ^.  Advance past the sigil too, otherwise the final field
+            // character is copied back into the formatted output.
+            lastPos = field.startPosition + field.width + 1;
         }
 
         // Add any remaining literal text

--- a/src/test/resources/unit/aggregate_regex_mutation_diagnostic.t
+++ b/src/test/resources/unit/aggregate_regex_mutation_diagnostic.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $substitution = eval q{my @items; @items =~ s/a/b/};
+like($@, qr/Can't modify private array in substitution/, 'lexical array substitution is rejected');
+
+my $match = eval q{my @items; @items =~ m/a/};
+is($@, '', 'non-mutating aggregate match remains valid');
+
+done_testing;

--- a/src/test/resources/unit/bare_identifier_length.t
+++ b/src/test/resources/unit/bare_identifier_length.t
@@ -1,0 +1,11 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+my $identifier = 'F' x 1020;
+eval $identifier;
+like $@, qr/^Identifier too long at /,
+    'a bare identifier at Perl identifier capacity is rejected';
+
+done_testing;

--- a/src/test/resources/unit/conflict_marker_diagnostics.t
+++ b/src/test/resources/unit/conflict_marker_diagnostics.t
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+no strict 'vars';
+
+for my $marker (map { $_ x 7 } qw(< = >)) {
+    for my $source (
+        $marker,
+        "\$_\n$marker",
+        "\n\$_ =\n$marker",
+    ) {
+        eval $source;
+        like $@, qr/^Version control conflict marker at \(eval \d+\) line \d+, near "\Q$marker\E"/,
+            "conflict marker $marker is diagnosed";
+    }
+}
+
+done_testing;

--- a/src/test/resources/unit/core_qualified_subroutine_name.t
+++ b/src/test/resources/unit/core_qualified_subroutine_name.t
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+{
+    no warnings;
+    sub CORE'print'foo { 43 }
+    sub CORE'foo'bar { 43 }
+
+    is CORE::print::foo, 43,
+        'qualified CORE::print::foo is not a CORE::print call';
+    is scalar eval q{CORE::foo'bar}, 43,
+        'quote-qualified CORE package subroutine is not rejected as a keyword';
+}
+
+done_testing;

--- a/src/test/resources/unit/formline_multiline_fields.t
+++ b/src/test/resources/unit/formline_multiline_fields.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+    local $^A = '';
+    my $picture = '1^*2 3@*4';
+    my $fill = 'N';
+    my $all = "N\nMoo!";
+    formline $picture, $fill, $all;
+    is($^A, "1N2 3N\nMoo!4", 'formline formats ^* and @* fields instead of copying their pictures');
+}
+
+sub render_formline {
+    my $picture = shift;
+    local $^A = '';
+    formline $picture, @_;
+    return $^A;
+}
+
+{
+    my $picture = '1^*2 3@*4';
+    my $fill = 'N';
+    my $all = "N\nMoo!";
+    is(render_formline($picture, $fill, $all), "1N2 3N\nMoo!4",
+        'formline expands @_ arguments in list context');
+}
+
+{
+    package FormlineFetchProbe;
+    sub TIESCALAR { bless { value => $_[1], fetches => 0 }, $_[0] }
+    sub FETCH { ++$_[0]{fetches}; $_[0]{value} }
+    sub STORE { $_[0]{value} = $_[1] }
+
+    package main;
+    tie my $value, 'FormlineFetchProbe', "N\nMoo!";
+    my $probe = tied $value;
+    local $^A = '';
+    my $picture = '3@*4';
+    formline $picture, $value;
+    is($^A, "3N\nMoo!4", 'formline supplies a tied value to @*');
+    is($probe->{fetches}, 1, 'formline fetches a supplied tied value once');
+}
+
+done_testing;

--- a/src/test/resources/unit/indirect_method_empty_hash_invocant.t
+++ b/src/test/resources/unit/indirect_method_empty_hash_invocant.t
@@ -1,0 +1,10 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+eval q{method {} { $_, undef }};
+like $@, qr/^Can't call method "method" on unblessed reference at /,
+    'empty braces in indirect method syntax form a hash-reference invocant';
+
+done_testing;

--- a/src/test/resources/unit/keys_lvalue_context.t
+++ b/src/test/resources/unit/keys_lvalue_context.t
@@ -1,0 +1,13 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+our %h;
+eval 'keys(%h) .= "00"';
+is $@, '', 'keys compound string assignment uses scalar context';
+
+eval 'substr keys(%h), 0, = 3';
+is $@, '', 'keys used as a substr lvalue argument uses scalar context';
+
+done_testing;

--- a/src/test/resources/unit/line_directive_core_operators.t
+++ b/src/test/resources/unit/line_directive_core_operators.t
@@ -45,6 +45,16 @@ is($caller_line, 73, 'caller honors a bare #line filename number');
 is($caller_file, 'KASHPRITZA', 'filename-less tab-separated #line retains the previous filename');
 is($caller_line, 77, 'filename-less tab-separated #line updates caller line');
 
+{
+    package LineDirectiveBeginCaller;
+    BEGIN {
+        my ($package, $file, $line) = caller;
+        ::is($file, 'begin-logical-source.pm', 'caller in BEGIN retains a later #line filename');
+        ::is($line, 12345, 'caller in BEGIN retains a later #line number');
+#line 12345 "begin-logical-source.pm"
+    }
+}
+
 #line 81 "unterminated-line-directive
 #line 85 invalid filename
 ($caller_file, $caller_line) = caller_location();

--- a/src/test/resources/unit/line_directive_core_operators.t
+++ b/src/test/resources/unit/line_directive_core_operators.t
@@ -1,0 +1,59 @@
+use strict;
+use warnings;
+use Test::More;
+
+#line	17 "logical-source.pm"
+is(__FILE__, 'logical-source.pm', '__FILE__ honors a tab-separated #line directive');
+is(__LINE__, 18, '__LINE__ advances from a tab-separated #line directive');
+
+sub caller_location {
+    return (caller)[1, 2];
+}
+
+sub caller_location_with_prototype ($$$) {
+    return (caller)[1, 2];
+}
+
+#line	23
+my ($caller_file, $caller_line) = caller_location();
+is($caller_file, 'logical-source.pm', 'filename-less tab-separated #line retains the prior filename');
+is($caller_line, 23, 'filename-less tab-separated #line updates caller line');
+($caller_file, $caller_line) = caller_location_with_prototype(1, 2, 3);
+is($caller_file, 'logical-source.pm', 'prototyped caller retains a filename-less directive filename');
+is($caller_line, 26, 'prototyped caller retains a filename-less directive line');
+
+#line	41 "caller-logical-source.pm"
+($caller_file, $caller_line) = caller_location();
+is($caller_file, 'caller-logical-source.pm', 'caller honors a tab-separated #line filename');
+is($caller_line, 41, 'caller honors a tab-separated #line number');
+
+#line 100 "later-logical-source.pm"
+my $later_marker = 1;
+
+#line                                                                        71
+($caller_file, $caller_line) = caller_location();
+is($caller_file, 'later-logical-source.pm', 'caller retains the preceding #line filename');
+is($caller_line, 71, 'caller honors a space-only #line directive');
+
+#line 73 KASHPRITZA
+($caller_file, $caller_line) = caller_location();
+is($caller_file, 'KASHPRITZA', 'caller honors a bare #line filename');
+is($caller_line, 73, 'caller honors a bare #line filename number');
+
+#line	77
+($caller_file, $caller_line) = caller_location();
+is($caller_file, 'KASHPRITZA', 'filename-less tab-separated #line retains the previous filename');
+is($caller_line, 77, 'filename-less tab-separated #line updates caller line');
+
+#line 81 "unterminated-line-directive
+#line 85 invalid filename
+($caller_file, $caller_line) = caller_location();
+is($caller_file, '"unterminated-line-directive', 'malformed bare filename preserves the preceding directive filename');
+is($caller_line, 82, 'malformed bare filename preserves the preceding directive line sequence');
+
+#line 91seven
+($caller_file, $caller_line) = caller_location();
+is($caller_file, '"unterminated-line-directive', 'glued #line number preserves the preceding directive filename');
+is($caller_line, 87, 'glued #line number preserves the preceding directive line sequence');
+
+done_testing;

--- a/src/test/resources/unit/list_assignment_constant_item_diagnostic.t
+++ b/src/test/resources/unit/list_assignment_constant_item_diagnostic.t
@@ -1,0 +1,12 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+our $value;
+no strict 'subs';
+eval q{ ($value, bareword) = (1, 2); };
+like $@, qr/^Can't modify constant item in list assignment/,
+    'list assignment rejects a bareword constant item';
+
+done_testing;

--- a/src/test/resources/unit/malformed_braced_interpolation_diagnostic.t
+++ b/src/test/resources/unit/malformed_braced_interpolation_diagnostic.t
@@ -7,4 +7,8 @@ my $error = $@;
 like($error, qr/^syntax error at \(eval \d+\) line 1, near "\{\]"/,
     'malformed braced interpolation retains its syntax context');
 
+eval '${';
+like($@, qr/syntax error at \(eval \d+\) line 1/,
+    'unterminated braced interpolation retains a syntax error diagnostic');
+
 done_testing;

--- a/src/test/resources/unit/malformed_braced_interpolation_diagnostic.t
+++ b/src/test/resources/unit/malformed_braced_interpolation_diagnostic.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use Test::More;
+
+eval 'm(@{if(0){sub d{]]])}return';
+my $error = $@;
+like($error, qr/^syntax error at \(eval \d+\) line 1, near "\{\]"/,
+    'malformed braced interpolation retains its syntax context');
+
+done_testing;

--- a/src/test/resources/unit/quoted_subroutine_name.t
+++ b/src/test/resources/unit/quoted_subroutine_name.t
@@ -1,0 +1,14 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+{
+    no warnings qw(syntax deprecated);
+    sub 'Hello'_he_said (_);
+}
+
+is prototype('Hello::_he_said'), '_',
+    'leading quote declares the intended package subroutine';
+
+done_testing;

--- a/src/test/resources/unit/read_constant_buffer_diagnostic.t
+++ b/src/test/resources/unit/read_constant_buffer_diagnostic.t
@@ -1,0 +1,12 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+our $buffer;
+no strict 'subs';
+eval q{ read($buffer, FILE, 1); };
+like $@, qr/^Can't modify constant item in read /,
+    'read rejects a bareword buffer as a constant item';
+
+done_testing;

--- a/src/test/resources/unit/regex_unicode_word_boundary.t
+++ b/src/test/resources/unit/regex_unicode_word_boundary.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+
+my $word = 'über';
+ok($word =~ /^\büber\b$/, 'Unicode letter is enclosed by word boundaries');
+ok($word =~ /ü\Bber/, 'Unicode letters have no internal word boundary');
+ok($word =~ /^\w+$/, 'Unicode letter remains a word character');
+ok($word !~ /(?a:^\büber\b$)/, 'ASCII mode retains ASCII-only word boundaries');
+
+my %lower_to_upper = eval q[use utf8;
+    my %lower_to_upper = ('über maus' => 'Über Maus');
+    return %lower_to_upper;
+];
+my ($title) = keys %lower_to_upper;
+ok($title =~ /^\büber\b/, 'returned UTF-8 hash key has a leading word boundary');
+ok($title =~ /ü\Bber/, 'returned UTF-8 hash key has no internal word boundary');
+$title =~ s/\b(.*?)\b/$1 eq uc $1 ? $1 : "\u\L$1"/ge;
+is($title, $lower_to_upper{'über maus'},
+        'Unicode word boundaries drive evaluated substitution');
+
+done_testing;

--- a/src/test/resources/unit/string_escape_diagnostics.t
+++ b/src/test/resources/unit/string_escape_diagnostics.t
@@ -1,0 +1,16 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+for my $case (
+    [ q!"\x{"!, qr/^Missing right brace on \\x/, 'unclosed braced hex escape' ],
+    [ q!"\o{"!, qr/^Missing right brace on \\o/, 'unclosed braced octal escape' ],
+    [ q!"\Nfoo"!, qr/^Missing braces on \\N/, 'Unicode name escape requires braces' ],
+) {
+    my ($source, $expected, $name) = @$case;
+    eval $source;
+    like $@, $expected, $name;
+}
+
+done_testing;

--- a/src/test/resources/unit/substitution_empty_braced_interpolation.t
+++ b/src/test/resources/unit/substitution_empty_braced_interpolation.t
@@ -1,0 +1,10 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+eval q{{s//${}/; //}};
+like $@, qr/syntax error/,
+    'empty braced interpolation is invalid in a substitution replacement';
+
+done_testing;

--- a/src/test/resources/unit/typed_for_declaration.t
+++ b/src/test/resources/unit/typed_for_declaration.t
@@ -1,0 +1,10 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+eval 'for my Missing::Loop::Type $item (1) {}';
+like $@, qr/^No such class Missing::Loop::Type at /,
+    'unknown type in a lexical for declaration is rejected during compilation';
+
+done_testing;

--- a/src/test/resources/unit/undef_constant_item_diagnostic.t
+++ b/src/test/resources/unit/undef_constant_item_diagnostic.t
@@ -1,0 +1,11 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+no strict 'subs';
+eval q{ undef foo; };
+like $@, qr/^Can't modify constant item in undef operator /,
+    'undef rejects a bareword constant item';
+
+done_testing;

--- a/src/test/resources/unit/unicode_identifier_length.t
+++ b/src/test/resources/unit/unicode_identifier_length.t
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+# A normal eval of an upgraded string has Unicode source semantics even when
+# the enclosing file did not enable `use utf8`.
+no strict 'vars';
+my $unicode_identifier = "\x{104B0}";
+
+eval "\$$unicode_identifier";
+is $@, '', 'Unicode eval accepts a scalar identifier';
+
+eval "*$unicode_identifier";
+is $@, '', 'Unicode eval accepts a typeglob identifier';
+
+done_testing;

--- a/src/test/resources/unit/unknown_filetest_diagnostic.t
+++ b/src/test/resources/unit/unknown_filetest_diagnostic.t
@@ -1,0 +1,13 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+eval q{ my $x = -F 1; };
+like $@, qr/(?i:syntax|parse) error .* near "F 1"/,
+    'unknown one-letter filetest reports a syntax error';
+
+eval q{ sub F { 42 } -F 1 };
+is $@, '', 'defined F remains a unary-minus subroutine call';
+
+done_testing;

--- a/src/test/resources/unit/unprototyped_call_semicolon_diagnostic.t
+++ b/src/test/resources/unit/unprototyped_call_semicolon_diagnostic.t
@@ -1,0 +1,8 @@
+use strict;
+use warnings;
+use Test::More;
+
+my $error = eval q{sub { f1(f2();) }};
+like($@, qr/syntax error/, 'semicolon inside an unprototyped call is a syntax error');
+
+done_testing;


### PR DESCRIPTION
## Summary

- Fix `formline` parsing and aggregate argument expansion for `^*` / `@*` fields.
- Materialize tied operands once, preserving the expected FETCH count.
- Reduce `perl5_t/t/op/write.t` explicit Not OK records from 489 to 273 on both JVM and interpreter (216 repaired assertions).
- Add a progress ledger for the #1269 failure-reduction effort.

## Validation

- `perl src/test/resources/unit/formline_multiline_fields.t` — pass (system Perl)
- `./jperl src/test/resources/unit/formline_multiline_fields.t` — pass
- `./jperl --interpreter src/test/resources/unit/formline_multiline_fields.t` — pass
- `perl5_t/t/op/write.t` — 273 explicit Not OK records on both backends, down from 489
- `make check-links` — pass

## Known gate status

Repeated full `make` attempts stalled in CPU-bound unit shards without further output; the checkout-specific workers were terminated after the gate exceeded the earlier successful duration. This PR remains draft until a terminal full gate is available.

Related to #1269

Generated with [Codex](https://openai.com/codex)
