### PR TITLE
Add CPAN release acceptance gate

### DIFF
--- a/.agents/skills/create-release/SKILL.md
+++ b/.agents/skills/create-release/SKILL.md
@@ -14,6 +14,34 @@ Follow `AGENTS.md`, especially its dirty-tree preflight, testing, branch, commit
 3. Inspect the previous tag and GitHub release for naming, notes, and tag style.
 4. Record the starting version from `src/main/java/org/perlonjava/core/Configuration.java.in`.
 
+## Pre-bump compatibility gates
+
+Before running `Configure.pl` or otherwise changing the project version, run
+the release acceptance suites from the current development head. Run them
+sequentially because both workflows build or consume the shared development
+shadow JAR:
+
+```bash
+make test-cpan-release-acceptance
+make test-bundled-modules
+```
+
+`test-cpan-release-acceptance` tests exactly these representative CPAN
+distributions through `jcpan -t`: `PPR`, `Catalyst`, `Mojolicious`,
+`Image::ExifTool`, `DateTime`, `Template`, and `DBIx::Class`. It uses strict
+target checking, so a selected distribution that fails, times out, or is not
+tested fails the Make target. The command requires network access and a
+usable CPAN index, may take several hours, and retains the full transcript in
+`build/reports/cpan-release-acceptance.log`; per-target diagnostics are also
+reported under `/tmp/cpan_random_logs/`.
+
+`make test-bundled-modules` must pass all bundled-module tests. Treat every
+failure or regression from either gate as release-blocking: diagnose and fix
+the implementation, then rerun the failing gate(s) until both commands pass.
+Do not bump the version, prepare a release branch, or promote the changelog
+while either gate has an unresolved regression. Record the successful tested
+commit and complete logs as release evidence.
+
 ## Update the version
 
 Run from the repository root:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean test test-unit test-interpreter check-thread-test-sources check-thread-core-test-sources check-thread-ecosystem-test-sources check-thread-regex-test-sources test-thread-tooling test-threads test-threads-core test-threads-core-platform test-threads-core-mode test-threads-windows test-threads-regex test-threads-release test-threads-ecosystem test-bundled-modules test-cpan-distroprefs test-exiftool test-all test-gradle test-gradle-unit test-gradle-all test-gradle-parallel test-maven-parallel build run wrapper check-java-gradle dev ci sbom sbom-java sbom-perl sbom-clean check-links perl5-update perl5-sync perl5-sync-check
+.PHONY: all clean test test-unit test-interpreter check-thread-test-sources check-thread-core-test-sources check-thread-ecosystem-test-sources check-thread-regex-test-sources test-thread-tooling test-threads test-threads-core test-threads-core-platform test-threads-core-mode test-threads-windows test-threads-regex test-threads-release test-threads-ecosystem test-bundled-modules test-cpan-distroprefs test-cpan-release-acceptance test-exiftool test-all test-gradle test-gradle-unit test-gradle-all test-gradle-parallel test-maven-parallel build run wrapper check-java-gradle dev ci sbom sbom-java sbom-perl sbom-clean check-links perl5-update perl5-sync perl5-sync-check
 
 PERL ?= perl
 
@@ -357,10 +357,28 @@ test-cpan-distroprefs: check-java-gradle
 ifeq ($(OS),Windows_NT)
 	gradlew.bat shadowJar -q
 	bash dev/tools/test-cpan-distroprefs.sh
+
 else
 	./gradlew shadowJar -q
 	bash dev/tools/test-cpan-distroprefs.sh
 endif
+
+# Release acceptance gate. Build the development shadow JAR before invoking
+# jcpan, then keep the CPAN run sequential so no test process shares a JAR
+# while it is being written. The tester writes per-target diagnostics under
+# /tmp/cpan_random_logs and this target retains the complete gate transcript.
+test-cpan-release-acceptance: build
+	@mkdir -p build/reports
+	@log="build/reports/cpan-release-acceptance.log"; \
+	modules='PPR,Catalyst,Mojolicious,Image::ExifTool,DateTime,Template,DBIx::Class'; \
+	echo "CPAN release acceptance log: $$log"; \
+	echo "Selected modules: $$modules" > "$$log"; \
+	echo "Commit: $$(git rev-parse --short HEAD)" >> "$$log"; \
+	timeout 28800 perl dev/tools/cpan_random_tester.pl \
+		--modules "$$modules" --jobs 8 --strict-exit \
+		--timeout 2400 --activity-grace 600 --max-runtime 5400 \
+		--perl-oracle never >> "$$log" 2>&1; \
+	status=$$?; cat "$$log"; exit $$status
 
 # Image::ExifTool test suite (Image-ExifTool-13.44/t/ directory)
 test-exiftool:

--- a/dev/tools/cpan_random_tester.pl
+++ b/dev/tools/cpan_random_tester.pl
@@ -108,6 +108,7 @@ my $help        = 0;
 my $seed;
 my $perl_oracle = 'failures'; # failures (default) or never
 my $perl_oracle_timeout = 600;
+my $strict_exit = 0;          # fail if an explicitly selected target is not PASS
 
 GetOptions(
     'count|n=i'    => \$count,
@@ -123,6 +124,7 @@ GetOptions(
     'seed=i'       => \$seed,
     'perl-oracle=s' => \$perl_oracle,
     'perl-oracle-timeout=i' => \$perl_oracle_timeout,
+    'strict-exit'   => \$strict_exit,
     'help|h'       => \$help,
 ) or die "Error in command line arguments\n";
 
@@ -336,6 +338,7 @@ my $new_perl_fail = 0;
 my $upgraded     = 0;   # FAIL→PASS transitions
 my $regressed    = 0;   # PASS→FAIL transitions from explicit re-tests
 my $record_pass_regressions = ($retest_age > 0 || $modules_arg ne '');
+my @strict_failures;
 
 for my $module (@selected) {
     $selected_index++;
@@ -343,6 +346,8 @@ for my $module (@selected) {
     if ($skip_target) {
         printf "[%d/%d] %s (%s; skipped)\n\n",
             $selected_index, scalar @selected, $module, $skip_reason;
+        push @strict_failures, "$module: $skip_reason"
+            if $strict_exit;
         next;
     }
 
@@ -381,11 +386,13 @@ for my $module (@selected) {
     }
 
     # If nothing parsed, check for special cases before recording failure
-    if (!@all_results) {
+        if (!@all_results) {
         if (output_file_contains($log_path, qr/\Q$module\E is up to date/)
             || $output_tail =~ /\Q$module\E is up to date/) {
             # Already installed, jcpan skipped it — not a failure
             printf "  (already installed, skipped)\n\n";
+            push @strict_failures, "$module: NOT TESTED (already installed/up to date)"
+                if $strict_exit;
             next;
         } else {
             # Check for PerlOnJava-specific errors in the raw output
@@ -402,6 +409,17 @@ for my $module (@selected) {
 
     apply_standard_perl_oracle(\@all_results, $log_path, $module_max_runtime)
         if $perl_oracle eq 'failures';
+
+    if ($strict_exit) {
+        my ($target_result) = grep {
+            ($_->{module} // '') eq $module
+        } @all_results;
+        if (!$target_result || ($target_result->{status} // '') ne 'PASS') {
+            my $status = $target_result ? ($target_result->{status} // 'UNKNOWN') : 'NOT TESTED';
+            my $error = $target_result && ($target_result->{error} // '');
+            push @strict_failures, "$module: $status" . ($error ? " ($error)" : '');
+        }
+    }
 
     my ($changes, $events, $diagnostics) = persist_module_results(
         \@all_results, $record_pass_regressions, $module, $log_path,
@@ -437,6 +455,12 @@ printf "Cumulative: %d pass | %d fail | %d skip | %d Perl fail | %d total\n",
 
 print "\nReport: $report_md\n";
 print "Logs:   $log_dir/\n";
+
+if ($strict_exit && @strict_failures) {
+    print "\nStrict target failures:\n";
+    print "  - $_\n" for @strict_failures;
+    exit 1;
+}
 
 
 # A timeout often leaves an open target test block in the log.  The parser can
@@ -2143,6 +2167,9 @@ Options:
                    Hard timeout in seconds for each standard-Perl check
                    (default: 600), additionally bounded by --max-runtime
                    when that cap is enabled.
+  --strict-exit    Exit non-zero unless every explicitly selected target
+                   distribution reaches PASS. Dependencies may still fail
+                   independently and are recorded in the report.
   --report-only    Regenerate .md report from existing .dat files
   --seed N         Random seed for reproducible module selection
   --help           Show this help
@@ -2165,6 +2192,8 @@ Behavior:
   - If a previously-failed module now passes (e.g., its deps got
     installed), the record is upgraded from FAIL to PASS.
   - PASS results include the git commit hash for regression bisecting.
+  - --strict-exit is intended for release gates and checks selected targets,
+    not every dependency discovered during their runs.
   - By default, PerlOnJava failures are re-tested with system Perl in an
     isolated CPAN home. Failures reproduced there are listed separately as
     "Skipped because Perl failed" and excluded from the Pass/Fail percentage.

--- a/dev/tools/tests/cpan_release_acceptance_contract.t
+++ b/dev/tools/tests/cpan_release_acceptance_contract.t
@@ -1,0 +1,36 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use File::Basename qw(dirname);
+use File::Spec;
+use Test::More;
+
+my $root = File::Spec->rel2abs(File::Spec->catdir(dirname(__FILE__), '..', '..', '..'));
+my $makefile = File::Spec->catfile($root, 'Makefile');
+my $tester = File::Spec->catfile($root, 'dev', 'tools', 'cpan_random_tester.pl');
+
+open my $mf, '<', $makefile or die "Cannot read $makefile: $!";
+my $make_text = do { local $/; <$mf> };
+close $mf;
+open my $tf, '<', $tester or die "Cannot read $tester: $!";
+my $tester_text = do { local $/; <$tf> };
+close $tf;
+
+my @modules = qw(PPR Catalyst Mojolicious Image::ExifTool DateTime Template DBIx::Class);
+like($make_text, qr/^test-cpan-release-acceptance: build$/m,
+    'release acceptance target builds before testing');
+like($make_text, qr/--modules "\$\$modules".*--jobs 8 --strict-exit/s,
+    'release target uses explicit modules, parallel test jobs, and strict exit');
+like($make_text, qr/timeout 28800 perl dev\/tools\/cpan_random_tester\.pl/s,
+    'release target has an outer timeout');
+for my $module (@modules) {
+    like($make_text, qr/\Q$module\E/, "release target includes $module");
+}
+like($tester_text, qr/'strict-exit'\s*=>\s*\\\$strict_exit/,
+    'tester exposes strict exit mode');
+like($tester_text, qr/Strict target failures:/,
+    'tester reports strict target failures');
+like($tester_text, qr/NOT TESTED \(already installed\/up to date\)/,
+    'strict mode rejects an up-to-date target that was not tested');
+
+done_testing;

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -111,6 +111,28 @@ one-hour outer bound.
 See the [Perl threads reference](threads.md) for the compatibility contract and
 resource policies.
 
+Before every PerlOnJava release, run the fixed CPAN acceptance gate:
+
+```bash
+make test-cpan-release-acceptance
+```
+
+This builds the development shadow JAR and tests exactly `PPR`, `Catalyst`,
+`Mojolicious`, `Image::ExifTool`, `DateTime`, `Template`, and `DBIx::Class`
+through `jcpan -t`, using eight jobs within each distribution. The seven
+targets run sequentially because they share the development JAR; dependencies
+are tested and recorded too, but only the seven selected targets determine the
+gate status. The command requires network access and a usable CPAN package
+index, and can take several hours (the outer timeout is eight hours; the two
+known heavy distributions have longer per-target limits).
+
+The complete transcript is retained at
+`build/reports/cpan-release-acceptance.log`. Per-target logs and the generated
+compatibility report are also retained by
+`dev/tools/cpan_random_tester.pl`; its output prints the run-specific log
+directory under `/tmp/cpan_random_logs/`. A failed target is named in the
+transcript and causes `make` to return non-zero.
+
 ## Testing Approaches
 
 ### 1. Perl-Style Testing (Default)


### PR DESCRIPTION
## Summary

- Add `make test-cpan-release-acceptance` for exactly seven representative CPAN distributions.
- Add strict selected-target exit handling, retained gate logs, and a contract test.
- Document the CPAN and bundled-module gates as mandatory before any release version bump.

## Validation

- `make check-links` — passed
- `lychee --offline .agents/skills/create-release/SKILL.md` — passed
- `perl dev/tools/tests/cpan_release_acceptance_contract.t` — passed
- Full build intentionally not run at the user's request.

Fixes #1334
