### PR TITLE
fix: bind foreach hash reference aliases

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,9 @@ priorities and future plans.
 
 ## Work in progress
 
+- Bind `for \\%hash (@hashrefs)` loop variables to each referenced hash on
+  both execution backends, restoring constant-sub core-test coverage.
+
 - Restore parser diagnostics for malformed quoted-string escapes,
   overlong identifiers, invalid typed loop declarations, and version-control
   conflict markers; accept Unicode identifiers in normal Unicode-string `eval`

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -6575,6 +6575,11 @@ public class BytecodeCompiler implements Visitor {
 
         // Determine if this is a global loop variable (e.g. $_).
         String globalLoopVarName = null;
+        Node globalLoopVariableNode = node.variable;
+        if (globalLoopVariableNode instanceof OperatorNode referenceOp
+                && referenceOp.operator.equals("\\")) {
+            globalLoopVariableNode = referenceOp.operand;
+        }
         if (node.needsArrayOfAlias && node.variable instanceof OperatorNode varOp
                 && varOp.operator.equals("$") && varOp.operand instanceof IdentifierNode idNode) {
             globalLoopVarName = NameNormalizer.normalizeVariableName(idNode.name, getCurrentPackage());
@@ -6598,6 +6603,22 @@ public class BytecodeCompiler implements Visitor {
             if (entry != null && "our".equals(entry.decl())) {
                 String perlPackage = entry.perlPackage() != null ? entry.perlPackage() : getCurrentPackage();
                 globalLoopVarName = NameNormalizer.normalizeVariableName(idNode1.name, perlPackage);
+            }
+        }
+        // `for \\%name (...)` and `for \\@name (...)` can alias package
+        // aggregates too. The leading reference operator used to hide these
+        // from the global-variable check, leaving the body to read an
+        // unrelated package slot.
+        if (globalLoopVarName == null && globalLoopVariableNode instanceof OperatorNode sigilOp
+                && (sigilOp.operator.equals("$") || sigilOp.operator.equals("@") || sigilOp.operator.equals("%"))
+                && sigilOp.operand instanceof IdentifierNode idNode) {
+            String varName = sigilOp.operator + idNode.name;
+            SymbolTable.SymbolEntry entry = symbolTable.getSymbolEntry(varName);
+            if (entry == null || "our".equals(entry.decl())) {
+                String perlPackage = entry != null && entry.perlPackage() != null
+                        ? entry.perlPackage()
+                        : getCurrentPackage();
+                globalLoopVarName = NameNormalizer.normalizeVariableName(idNode.name, perlPackage);
             }
         }
 
@@ -6638,7 +6659,7 @@ public class BytecodeCompiler implements Visitor {
         List<Integer> multiVarRegs = new ArrayList<>();
         List<String> lexicalLoopVarNames = new ArrayList<>();
         OperatorNode referenceAliasedVariable = null;
-        if (globalLoopVarName == null && node.variable instanceof OperatorNode referenceOp
+        if (node.variable instanceof OperatorNode referenceOp
                 && referenceOp.operator.equals("\\")
                 && referenceOp.operand instanceof OperatorNode sigilOp
                 && (sigilOp.operator.equals("$") || sigilOp.operator.equals("@")
@@ -6719,11 +6740,29 @@ public class BytecodeCompiler implements Visitor {
             emitReg(varReg);
         }
 
+        // A global aggregate reference alias replaces a package slot for the
+        // duration of the loop. Save that slot explicitly; scalar localization
+        // cannot restore %name or @name.
+        int savedGlobalReferenceLoopVarReg = -1;
+        if (referenceAliasedVariable != null && globalLoopVarName != null) {
+            savedGlobalReferenceLoopVarReg = allocateRegister();
+            int nameIdx = addToStringPool(globalLoopVarName);
+            if (referenceAliasedVariable.operator.equals("$")) {
+                emit(Opcodes.LOAD_GLOBAL_SCALAR);
+            } else if (referenceAliasedVariable.operator.equals("@")) {
+                emit(Opcodes.LOAD_GLOBAL_ARRAY);
+            } else {
+                emit(Opcodes.LOAD_GLOBAL_HASH);
+            }
+            emitReg(savedGlobalReferenceLoopVarReg);
+            emit(nameIdx);
+        }
+
         // Step 3b: For global loop variable: emit LOCAL_SCALAR_SAVE_LEVEL.
         // This atomically saves getLocalLevel() into levelReg (pre-push), then calls makeLocal.
         // POP_LOCAL_LEVEL(levelReg) after the loop correctly restores $_ for any nesting depth.
         int levelReg = -1;
-        if (globalLoopVarName != null) {
+        if (globalLoopVarName != null && referenceAliasedVariable == null) {
             levelReg = allocateRegister();
             int nameIdx = addToStringPool(globalLoopVarName);
             emit(Opcodes.LOCAL_SCALAR_SAVE_LEVEL);
@@ -6793,7 +6832,7 @@ public class BytecodeCompiler implements Visitor {
         String normalizedGlobalLoopSourceName = globalLoopVarName == null
                 ? null
                 : "$" + globalLoopVarName;
-        if (normalizedGlobalLoopSourceName != null) {
+        if (normalizedGlobalLoopSourceName != null && referenceAliasedVariable == null) {
             pushForeachGlobalAliasRegister(normalizedGlobalLoopSourceName, varReg);
         }
         try {
@@ -6824,7 +6863,7 @@ public class BytecodeCompiler implements Visitor {
                 }
             }
         } finally {
-            if (normalizedGlobalLoopSourceName != null) {
+            if (normalizedGlobalLoopSourceName != null && referenceAliasedVariable == null) {
                 popForeachGlobalAliasRegister(normalizedGlobalLoopSourceName);
             }
             for (String varName : lexicalLoopVarNames) {
@@ -6909,6 +6948,22 @@ public class BytecodeCompiler implements Visitor {
                 emitReg(varReg);
                 emitReg(referenceReg);
             }
+            if (globalLoopVarName != null) {
+                int nameIdx = addToStringPool(globalLoopVarName);
+                if (referenceAliasedVariable.operator.equals("$")) {
+                    emit(Opcodes.ALIAS_GLOBAL_SCALAR);
+                    emit(nameIdx);
+                    emitReg(varReg);
+                } else if (referenceAliasedVariable.operator.equals("@")) {
+                    emit(Opcodes.ALIAS_GLOBAL_ARRAY);
+                    emit(nameIdx);
+                    emitReg(varReg);
+                } else if (referenceAliasedVariable.operator.equals("%")) {
+                    emit(Opcodes.ALIAS_GLOBAL_HASH);
+                    emit(nameIdx);
+                    emitReg(varReg);
+                }
+            }
             emit(Opcodes.GOTO);
             emitInt(bodyStartPc);
         } else if (globalLoopVarName != null) {
@@ -6948,6 +7003,18 @@ public class BytecodeCompiler implements Visitor {
             emit(Opcodes.ALIAS);
             emitReg(varReg);
             emitReg(savedLexicalLoopVarReg);
+        }
+        if (savedGlobalReferenceLoopVarReg >= 0) {
+            int nameIdx = addToStringPool(globalLoopVarName);
+            if (referenceAliasedVariable.operator.equals("$")) {
+                emit(Opcodes.ALIAS_GLOBAL_SCALAR);
+            } else if (referenceAliasedVariable.operator.equals("@")) {
+                emit(Opcodes.ALIAS_GLOBAL_ARRAY);
+            } else {
+                emit(Opcodes.ALIAS_GLOBAL_HASH);
+            }
+            emit(nameIdx);
+            emitReg(savedGlobalReferenceLoopVarReg);
         }
 
         // Step 12: Patch all last/next/redo jumps

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -810,6 +810,20 @@ public class BytecodeInterpreter {
                                         registers[scalarReg].getFirst());
                             }
 
+                            case Opcodes.ALIAS_GLOBAL_ARRAY -> {
+                                int nameIdx = bytecode[pc++];
+                                int arrayReg = bytecode[pc++];
+                                GlobalVariable.aliasGlobalArray(code.stringPool[nameIdx],
+                                        (RuntimeArray) registers[arrayReg]);
+                            }
+
+                            case Opcodes.ALIAS_GLOBAL_HASH -> {
+                                int nameIdx = bytecode[pc++];
+                                int hashReg = bytecode[pc++];
+                                GlobalVariable.aliasGlobalHash(code.stringPool[nameIdx],
+                                        (RuntimeHash) registers[hashReg]);
+                            }
+
                             case Opcodes.LOAD_CONST -> {
                                 // Load from constant pool: rd = constants[index]
                                 int rd = bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Disassemble.java
@@ -230,6 +230,18 @@ public class Disassemble {
                         sb.append("ALIAS_GLOBAL_SCALAR ").append(interpretedCode.stringPool[globalAliasNameIdx])
                                 .append(" <- r").append(src).append("\n");
                         break;
+                    case Opcodes.ALIAS_GLOBAL_ARRAY:
+                        int globalArrayAliasNameIdx = interpretedCode.bytecode[pc++];
+                        src = interpretedCode.bytecode[pc++];
+                        sb.append("ALIAS_GLOBAL_ARRAY ").append(interpretedCode.stringPool[globalArrayAliasNameIdx])
+                                .append(" <- r").append(src).append("\n");
+                        break;
+                    case Opcodes.ALIAS_GLOBAL_HASH:
+                        int globalHashAliasNameIdx = interpretedCode.bytecode[pc++];
+                        src = interpretedCode.bytecode[pc++];
+                        sb.append("ALIAS_GLOBAL_HASH ").append(interpretedCode.stringPool[globalHashAliasNameIdx])
+                                .append(" <- r").append(src).append("\n");
+                        break;
                     case Opcodes.ASSIGN_LEXICAL_SCALAR:
                         rd = interpretedCode.bytecode[pc++];
                         src = interpretedCode.bytecode[pc++];

--- a/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/Opcodes.java
@@ -2533,6 +2533,12 @@ public class Opcodes {
     /** Release the most recently retained chained method invocant. Format: no operands. */
     public static final short RELEASE_METHOD_INVOCANT = 531;
 
+    /** Alias a package array slot to an array register. Format: nameStringIdx arrayReg. */
+    public static final short ALIAS_GLOBAL_ARRAY = 550;
+
+    /** Alias a package hash slot to a hash register. Format: nameStringIdx hashReg. */
+    public static final short ALIAS_GLOBAL_HASH = 551;
+
     /**
      * Resolve a statically named CODE reference at runtime. This preserves the
      * current CV snapshot while allowing an earlier runtime glob assignment in

--- a/src/main/java/org/perlonjava/backend/jvm/EmitForeach.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitForeach.java
@@ -126,10 +126,17 @@ public class EmitForeach {
 
         int scopeIndex = emitterVisitor.ctx.symbolTable.enterScope();
 
-        // Check if the variable is global
+        // Check if the variable is global. Reference-alias loop variables
+        // retain their sigil inside a leading backslash.
         boolean loopVariableIsGlobal = false;
         String globalVarName = null;
-        if (variableNode instanceof OperatorNode opNode && opNode.operator.equals("$")) {
+        Node globalVariableNode = variableNode;
+        if (globalVariableNode instanceof OperatorNode referenceOp
+                && referenceOp.operator.equals("\\")) {
+            globalVariableNode = referenceOp.operand;
+        }
+        if (globalVariableNode instanceof OperatorNode opNode
+                && (opNode.operator.equals("$") || opNode.operator.equals("@") || opNode.operator.equals("%"))) {
             if (opNode.operand instanceof IdentifierNode idNode) {
                 String varName = opNode.operator + idNode.name;
                 SymbolTable.SymbolEntry entry = emitterVisitor.ctx.symbolTable.getSymbolEntry(varName);
@@ -139,9 +146,10 @@ public class EmitForeach {
                             ? entry.perlPackage()
                             : emitterVisitor.ctx.symbolTable.getCurrentPackage();
                     globalVarName = NameNormalizer.normalizeVariableName(idNode.name, perlPackage);
-                } else if (entry == null) {
+                } else if (entry == null || idNode.name.equals("_")) {
                     loopVariableIsGlobal = true;
-                    globalVarName = idNode.name;
+                    globalVarName = NameNormalizer.normalizeVariableName(
+                            idNode.name, emitterVisitor.ctx.symbolTable.getCurrentPackage());
                 }
             }
         }
@@ -261,7 +269,11 @@ public class EmitForeach {
                     if (CompilerOptions.DEBUG_ENABLED) emitterVisitor.ctx.logDebug("FOR1 ref-alias: saved local var " + varName + " to index " + savedValueIndex);
                 } else {
                     // Global variable - save its current value
-                    String globalName = ((IdentifierNode) innerOp.operand).name;
+                    String globalName = globalVarName != null
+                            ? globalVarName
+                            : NameNormalizer.normalizeVariableName(
+                                    ((IdentifierNode) innerOp.operand).name,
+                                    emitterVisitor.ctx.symbolTable.getCurrentPackage());
                     mv.visitLdcInsn(globalName);
 
                     if (innerOp.operator.equals("$")) {
@@ -541,24 +553,25 @@ public class EmitForeach {
 
                 if (isReferenceAliasing && actualVariable instanceof OperatorNode innerOp) {
                     if (innerOp.operator.equals("@")) {
-                        // Array: use setGlobalArray
+                        // Replace the package array slot for this iteration.
                         mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                                 "org/perlonjava/runtime/runtimetypes/GlobalVariable",
-                                "setGlobalArray",
+                                "aliasGlobalArray",
                                 "(Ljava/lang/String;Lorg/perlonjava/runtime/runtimetypes/RuntimeArray;)V",
                                 false);
                     } else if (innerOp.operator.equals("%")) {
-                        // Hash: use setGlobalHash
+                        // Replace the package hash slot for this iteration.
                         mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                                 "org/perlonjava/runtime/runtimetypes/GlobalVariable",
-                                "setGlobalHash",
+                                "aliasGlobalHash",
                                 "(Ljava/lang/String;Lorg/perlonjava/runtime/runtimetypes/RuntimeHash;)V",
                                 false);
                     } else {
-                        // Scalar: use aliasGlobalVariable (original behavior)
+                        // Scalar: replace the package scalar slot for this
+                        // iteration, then restore it after the loop.
                         mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                                 "org/perlonjava/runtime/runtimetypes/GlobalVariable",
-                                "aliasForeachGlobalVariable",
+                                "aliasGlobalVariable",
                                 "(Ljava/lang/String;Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)V",
                                 false);
                     }
@@ -730,26 +743,30 @@ public class EmitForeach {
                     if (CompilerOptions.DEBUG_ENABLED) emitterVisitor.ctx.logDebug("FOR1 ref-alias: restored local var " + varName + " from index " + savedValueIndex);
                 } else {
                     // Global variable - restore it
-                    String globalName = ((IdentifierNode) innerOp.operand).name;
+                    String globalName = globalVarName != null
+                            ? globalVarName
+                            : NameNormalizer.normalizeVariableName(
+                                    ((IdentifierNode) innerOp.operand).name,
+                                    emitterVisitor.ctx.symbolTable.getCurrentPackage());
                     mv.visitLdcInsn(globalName);
                     mv.visitInsn(Opcodes.SWAP);
 
                     if (innerOp.operator.equals("$")) {
                         mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                                 "org/perlonjava/runtime/runtimetypes/GlobalVariable",
-                                "setGlobalVariable",
-                                "(Ljava/lang/String;Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)V",
+                                "aliasGlobalVariable",
+                                "(Ljava/lang/String;Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)V",
                                 false);
                     } else if (innerOp.operator.equals("@")) {
                         mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                                 "org/perlonjava/runtime/runtimetypes/GlobalVariable",
-                                "setGlobalArray",
+                                "aliasGlobalArray",
                                 "(Ljava/lang/String;Lorg/perlonjava/runtime/runtimetypes/RuntimeArray;)V",
                                 false);
                     } else if (innerOp.operator.equals("%")) {
                         mv.visitMethodInsn(Opcodes.INVOKESTATIC,
                                 "org/perlonjava/runtime/runtimetypes/GlobalVariable",
-                                "setGlobalHash",
+                                "aliasGlobalHash",
                                 "(Ljava/lang/String;Lorg/perlonjava/runtime/runtimetypes/RuntimeHash;)V",
                                 false);
                     }

--- a/src/test/resources/unit/refaliasing_containers.t
+++ b/src/test/resources/unit/refaliasing_containers.t
@@ -17,4 +17,32 @@ my %source_hash = (alpha => 1);
 $source_hash{beta} = 2;
 is($target_hash{beta}, 2, 'hash refaliasing shares the source hash');
 
+my @hashrefs = (
+    { name => 'first', count => 1 },
+    { name => 'second', count => 2 },
+);
+my @seen;
+for \%_ (@hashrefs) {
+    push @seen, $_{name};
+    $_{count}++;
+}
+is_deeply(\@seen, [qw(first second)],
+    'foreach hash reference aliases the global loop hash on every iteration');
+is_deeply(\@hashrefs, [
+    { name => 'first', count => 2 },
+    { name => 'second', count => 3 },
+], 'writes through a foreach hash reference alias mutate each source hash');
+
+our @loop_array;
+my @arrayrefs = ([1], [2]);
+my @array_seen;
+for \@loop_array (@arrayrefs) {
+    push @array_seen, $loop_array[0];
+    $loop_array[0]++;
+}
+is_deeply(\@array_seen, [1, 2],
+    'foreach array reference aliases rebind on every iteration');
+is_deeply(\@arrayrefs, [[2], [3]],
+    'writes through a foreach array reference alias mutate each source array');
+
 done_testing;


### PR DESCRIPTION
## Summary

- bind `for \\%hash (@hashrefs)` to the referenced package hash on JVM and interpreter backends
- restore aggregate slots after the loop and cover analogous array aliasing
- add permanent regression coverage and release notes

Fixes #1343.

## Validation

- `perl src/test/resources/unit/refaliasing_containers.t`
- `./jperl src/test/resources/unit/refaliasing_containers.t`
- `./jperl --interpreter src/test/resources/unit/refaliasing_containers.t`
- `make`

Generated with [Codex](https://openai.com/codex)
