### PR TITLE
fix: preserve Data::Dumper behavior after Perl5 sync

### DIFF
--- a/dev/import-perl5/patches/Data-Dumper.pm.patch
+++ b/dev/import-perl5/patches/Data-Dumper.pm.patch
@@ -1,11 +1,16 @@
 --- perl5/dist/Data-Dumper/Dumper.pm
 +++ src/main/perl/lib/Data/Dumper.pm
-@@ -580,7 +580,9 @@
+@@ -580,7 +580,14 @@
        $out .= sprintf "v%vd", $val;
      }
      # \d here would treat "1\x{660}" as a safe decimal number
 -    elsif ($val =~ /^(?:0|-?[1-9][0-9]{0,8})\z/) { # safe decimal number
-+    elsif (defined &Data::Dumper::_perlonjava_numified_safe_decimal
++    # Test::Differences explicitly selects Data::Dumper's pure-Perl renderer.
++    # That renderer has always used the safe-decimal fallback below, which
++    # renders numeric-looking strings without quotes.  Keep that behavior in
++    # Useperl mode; otherwise use PerlOnJava's scalar-aware hook so an
++    # untouched string remains distinguishable from a numeric scalar.
++    elsif ((!$s->{useperl} && defined &Data::Dumper::_perlonjava_numified_safe_decimal)
 +       ? Data::Dumper::_perlonjava_numified_safe_decimal($val)
 +       : $val =~ /^(?:0|-?[1-9][0-9]{0,8})\z/) {
        $out .= $val;

--- a/src/main/perl/lib/Data/Dumper.pm
+++ b/src/main/perl/lib/Data/Dumper.pm
@@ -580,12 +580,7 @@ sub _dump {
       $out .= sprintf "v%vd", $val;
     }
     # \d here would treat "1\x{660}" as a safe decimal number
-    # Test::Differences explicitly selects Data::Dumper's pure-Perl renderer.
-    # That renderer has always used the safe-decimal fallback below, which
-    # renders numeric-looking strings without quotes.  Keep that behavior in
-    # Useperl mode; otherwise use PerlOnJava's scalar-aware hook so an
-    # untouched string remains distinguishable from a numeric scalar.
-    elsif ((!$s->{useperl} && defined &Data::Dumper::_perlonjava_numified_safe_decimal)
+    elsif (defined &Data::Dumper::_perlonjava_numified_safe_decimal
        ? Data::Dumper::_perlonjava_numified_safe_decimal($val)
        : $val =~ /^(?:0|-?[1-9][0-9]{0,8})\z/) {
       $out .= $val;

--- a/src/main/perl/lib/Data/Dumper.pm
+++ b/src/main/perl/lib/Data/Dumper.pm
@@ -580,7 +580,12 @@ sub _dump {
       $out .= sprintf "v%vd", $val;
     }
     # \d here would treat "1\x{660}" as a safe decimal number
-    elsif (defined &Data::Dumper::_perlonjava_numified_safe_decimal
+    # Test::Differences explicitly selects Data::Dumper's pure-Perl renderer.
+    # That renderer has always used the safe-decimal fallback below, which
+    # renders numeric-looking strings without quotes.  Keep that behavior in
+    # Useperl mode; otherwise use PerlOnJava's scalar-aware hook so an
+    # untouched string remains distinguishable from a numeric scalar.
+    elsif ((!$s->{useperl} && defined &Data::Dumper::_perlonjava_numified_safe_decimal)
        ? Data::Dumper::_perlonjava_numified_safe_decimal($val)
        : $val =~ /^(?:0|-?[1-9][0-9]{0,8})\z/) {
       $out .= $val;

--- a/src/main/perl/lib/Pod/Man.pm
+++ b/src/main/perl/lib/Pod/Man.pm
@@ -12,7 +12,7 @@
 # Modules and declarations
 ##############################################################################
 
-package Pod::Man v6.1.0;
+package Pod::Man v6.1.1;
 
 use 5.012;
 use parent qw(Pod::Simple);

--- a/src/main/perl/lib/Pod/ParseLink.pm
+++ b/src/main/perl/lib/Pod/ParseLink.pm
@@ -11,7 +11,7 @@
 # Modules and declarations
 ##############################################################################
 
-package Pod::ParseLink v6.1.0;
+package Pod::ParseLink v6.1.1;
 
 use 5.012;
 use warnings;

--- a/src/main/perl/lib/Pod/Text.pm
+++ b/src/main/perl/lib/Pod/Text.pm
@@ -12,7 +12,7 @@
 # Modules and declarations
 ##############################################################################
 
-package Pod::Text v6.1.0;
+package Pod::Text v6.1.1;
 
 use 5.012;
 use parent qw(Pod::Simple);
@@ -248,6 +248,17 @@ sub wrap {
     my $output = '';
     my $spaces = ' ' x $$self{MARGIN};
     my $width = $$self{opt_width} - $$self{MARGIN};
+
+    # Pathological margins make wrapping impossible.  In this case, complain
+    # to the user and reset the margin to 0.
+    if ($width <= 0) {
+        my $error = 'Margin is wider than the output width';
+        $self->whine($self->line_count(), $error);
+        $spaces = q{};
+        $width = $self->{opt_width};
+    }
+
+    # Perform the wrapping.
     while (length > $width) {
         if (s/^([^\n]{0,$width})[ \t\n]+// || s/^([^\n]{$width})//) {
             $output .= $spaces . $1 . "\n";
@@ -1171,6 +1182,13 @@ and the input file it was given could not be opened.
 (F) The quote specification given (the C<quotes> option to the
 constructor) was invalid.  A quote specification must be either one
 character long or an even number (greater than one) characters long.
+
+=item Margin is wider than the output width
+
+(W) The requested margin width, determined from the sum of indentations
+requested by C<=over> and the baseline indentation for text, is equal to or
+wider than the desired output width specified with C<width>.  The text will
+be formatted as if the margin was set to zero.
 
 =item POD document had syntax errors
 

--- a/src/main/perl/lib/Pod/Text/Color.pm
+++ b/src/main/perl/lib/Pod/Text/Color.pm
@@ -10,7 +10,7 @@
 # Modules and declarations
 ##############################################################################
 
-package Pod::Text::Color v6.1.0;
+package Pod::Text::Color v6.1.1;
 
 use 5.012;
 use parent qw(Pod::Text);
@@ -84,6 +84,15 @@ sub wrap {
     my $output = q{};
     my $spaces = q{ } x $self->{MARGIN};
     my $width = $self->{opt_width} - $self->{MARGIN};
+
+    # Pathological margins make wrapping impossible. In this case, complain to
+    # the user and reset the margin to 0.
+    if ($width <= 0) {
+        my $error = 'Margin is wider than the output width';
+        $self->whine($self->line_count(), $error);
+        $spaces = q{};
+        $width = $self->{opt_width};
+    }
 
     # Matches a single escape sequence.
     my $code = qr{ (?: \e\[ [\d;]+ m ) }xms;
@@ -204,7 +213,7 @@ Russ Allbery <rra@cpan.org>.
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright 1999, 2001, 2004, 2006, 2008, 2009, 2018-2019, 2022, 2024 Russ
+Copyright 1999, 2001, 2004, 2006, 2008, 2009, 2018-2019, 2022, 2024, 2026 Russ
 Allbery <rra@cpan.org>
 
 This program is free software; you may redistribute it and/or modify it

--- a/src/main/perl/lib/Pod/Text/Overstrike.pm
+++ b/src/main/perl/lib/Pod/Text/Overstrike.pm
@@ -17,7 +17,7 @@
 # Modules and declarations
 ##############################################################################
 
-package Pod::Text::Overstrike v6.1.0;
+package Pod::Text::Overstrike v6.1.1;
 
 use 5.012;
 use parent qw(Pod::Text);
@@ -103,14 +103,29 @@ sub wrap {
     my $output = '';
     my $spaces = ' ' x $$self{MARGIN};
     my $width = $$self{opt_width} - $$self{MARGIN};
+
+    # Pathological margins make wrapping impossible. In this case, complain to
+    # the user and reset the margin to 0.
+    if ($width <= 0) {
+        my $error = 'Margin is wider than the output width';
+        $self->whine($self->line_count(), $error);
+        $spaces = q{};
+        $width = $self->{opt_width};
+    }
+
+    # This regex represents a single character, that's possibly underlined or
+    # in bold (in which case, it's three characters; the character, a
+    # backspace, and a character).  Use [^\n] rather than . to protect against
+    # odd settings of $*.
+    my $char = '(?:[^\n][\b])?[^\n]';
+
+    # Perform the wrapping.  After we find a break point, remove any
+    # underlined or bold spaces left over in the input text after the break
+    # point.
     while (length > $width) {
-        # This regex represents a single character, that's possibly underlined
-        # or in bold (in which case, it's three characters; the character, a
-        # backspace, and a character).  Use [^\n] rather than . to protect
-        # against odd settings of $*.
-        my $char = '(?:[^\n][\b])?[^\n]';
         if (s/^((?>$char){0,$width})(?:\Z|[ \t\n]+)//) {
             $output .= $spaces . $1 . "\n";
+            s/^(?:[\b][ _])?(?:[ ][\b][ ])*//;
         } else {
             last;
         }
@@ -198,7 +213,7 @@ created by Russ Allbery <rra@cpan.org>.  Subsequently updated by Russ Allbery.
 
 Copyright 2000 Joe Smith <Joe.Smith@inwap.com>
 
-Copyright 2001, 2004, 2008, 2014, 2018-2019, 2022, 2024 Russ Allbery
+Copyright 2001, 2004, 2008, 2014, 2018-2019, 2022, 2024, 2026 Russ Allbery
 <rra@cpan.org>
 
 This program is free software; you may redistribute it and/or modify it

--- a/src/main/perl/lib/Pod/Text/Termcap.pm
+++ b/src/main/perl/lib/Pod/Text/Termcap.pm
@@ -10,7 +10,7 @@
 # Modules and declarations
 ##############################################################################
 
-package Pod::Text::Termcap v6.1.0;
+package Pod::Text::Termcap v6.1.1;
 
 use 5.012;
 use parent qw(Pod::Text);
@@ -147,6 +147,15 @@ sub wrap {
         return $self->SUPER::wrap($_);
     }
 
+    # Pathological margins make wrapping impossible. In this case, complain to
+    # the user and reset the margin to 0.
+    if ($width <= 0) {
+        my $error = 'Margin is wider than the output width';
+        $self->whine($self->line_count(), $error);
+        $spaces = q{};
+        $width = $self->{opt_width};
+    }
+
     # $code matches a single special sequence.  $char matches any number of
     # special sequences preceding a single character other than a newline.
     # $shortchar matches some sequence of $char ending in codes followed by
@@ -263,7 +272,7 @@ Russ Allbery <rra@cpan.org>
 =head1 COPYRIGHT AND LICENSE
 
 Copyright 1999, 2001-2002, 2004, 2006, 2008-2009, 2014-2015, 2018-2019, 2022,
-2024 Russ Allbery <rra@cpan.org>
+2024, 2026 Russ Allbery <rra@cpan.org>
 
 This program is free software; you may redistribute it and/or modify it
 under the same terms as Perl itself.

--- a/src/main/perl/lib/Pod/perldelta.pod
+++ b/src/main/perl/lib/Pod/perldelta.pod
@@ -159,6 +159,14 @@ Specifically, any of the following single subscripts
 
 XXX
 
+=item *
+
+The regular expression trie optimizer has been reworked to compile trie
+transitions as octets.  Large alternations can now avoid work that previously
+grew with both the number of alternatives and the amount of text skipped
+before a match, while preserving the existing matching semantics for native
+and UTF-8 strings.
+
 =back
 
 =head1 Modules and Pragmata
@@ -416,7 +424,28 @@ well.
 
 =item *
 
+During regex compilation, C<S_reg> will attempt to flatten nested BRANCH
+structures, in an attempt to give the TRIE optimizer more alternations
+to consider. The intent is that patterns that were previously compiled
+into two or more adjacent TRIE nodes might now get compiled into a single
+(or at least, fewer) TRIE node(s).
+
+=item *
+
 XXX
+
+=item *
+
+The regular expression compiler's TRIE implementation has been changed to use
+the octets of the UTF-8 representation of the pattern in its internal table
+structures. Previous versions used a trie based on code points, which had
+various side effects that required additional complexity, especially because
+of Unicode's potentially very large alphabet. By switching to an octet-based
+representation, a large amount of this complexity could be removed, making
+the new code faster, easier to maintain, and easier to prove correct.
+
+Most users should not notice this change, except perhaps a slight performance
+improvement.
 
 =back
 

--- a/src/main/perl/lib/Pod/perldiag.pod
+++ b/src/main/perl/lib/Pod/perldiag.pod
@@ -8566,7 +8566,7 @@ indicates that incorrect results are being obtained.  You should examine
 your code to determine how a wide character is getting to an operation
 that doesn't handle them.
 
-=item Wide character (U+%X) in %s
+=item Wide character (U+%X) in %s under a non-UTF-8 locale
 
 (W locale) While in a single-byte locale (I<i.e.>, a non-UTF-8
 one), a multi-byte character was encountered.   Perl considers this

--- a/src/main/perl/lib/Pod/perlreguts.pod
+++ b/src/main/perl/lib/Pod/perlreguts.pod
@@ -374,19 +374,12 @@ LNBREAK          none       generic newline pattern
 
 # Trie Related
 #
-# Behave the same as A|LIST|OF|WORDS would. The '..C' variants have inline
-# charclass data (ascii only), the 'C' store it in the structure.
+# Behave the same as A|LIST|OF|WORDS would. Trie data is stored in a shared
+# trie structure.
 TRIE             trie 1     Match many EXACT(F[ALU]?)? at once.
                             flags==type
-TRIEC            trie       Same as TRIE, but with embedded charclass
-                 charclass  data
 AHOCORASICK      trie 1     Aho Corasick stclass. flags==type
-AHOCORASICKC     trie       Same as AHOCORASICK, but with embedded
-                 charclass  charclass data
 LTRIE            trie 2     Same as TRIE, but with longjump support
-LTRIEC           trie       Same as TRIEC, but with longjump support
-                 charclass_
-                 trie
 
 # Do nothing types
 NOTHING          no         Match empty string.
@@ -1351,6 +1344,12 @@ current state. The C<ST.cache_offset> and C<ST.cache_mask> fields are set
 by the current C<WHILEM> to the address in the cache of the byte and bit
 corresponding to the current match state. These are used by C<CACHEsayNO>
 to mark the cache during a subsequent unwinding.
+
+The initial cache allocation countdown can be adjusted via
+C<PL_re_superlinear_cache_delay>, which is settable via
+C<${^RE_SUPERLINEAR_CACHE_DELAY}> or, on perls built with
+C<-DPERL_RE_SUPERLINEAR_CACHE_DELAY>, via the environment variable
+C<$PERL_RE_SUPERLINEAR_CACHE_DELAY>.
 
 =head1 MISCELLANEOUS
 

--- a/src/main/perl/lib/Pod/perlrun.pod
+++ b/src/main/perl/lib/Pod/perlrun.pod
@@ -1377,6 +1377,21 @@ in a variety of ways:
 
   $ 3>foo3 PERL_MEM_LOG=3m perl ...
 
+=item PERL_RE_SUPERLINEAR_CACHE_DELAY
+X<PERL_RE_SUPERLINEAR_CACHE_DELAY>
+
+Setting this environment variable to the value C<NNN> causes an effect
+roughly equivalent to including this code at the start of the program:
+
+    BEGIN { ${^RE_SUPERLINEAR_CACHE_DELAY} = NNN; }
+
+See L<perlvar/"${^RE_SUPERLINEAR_CACHE_DELAY}"> for details.
+
+Note that this environment variable is only honoured if the perl
+interpreter has been built with the C<PERL_RE_SUPERLINEAR_CACHE_DELAY>
+define: see F<INSTALL>.
+
+
 =item PERL_ROOT (specific to the VMS port)
 X<PERL_ROOT>
 

--- a/src/main/perl/lib/Pod/perlvar.pod
+++ b/src/main/perl/lib/Pod/perlvar.pod
@@ -669,6 +669,45 @@ between the variants.
 
 This variable was added in Perl 5.003.
 
+=item ${^RE_SUPERLINEAR_CACHE_DELAY}
+
+Added in Perl 5.46.0.
+
+This integer-valued variable allows the initial countdown delay in the
+regex engine's super-linear cache mechanism to be adjusted for testing and
+debugging purposes. It is not intended for production code, and its
+semantics may change without notice.
+
+When matching a complex pattern with much backtracking, after a certain
+number of iterations a cache is allocated to detect backtracks to the same
+position and state. The countdown is intended so that the cache isn't
+wastefully allocated for every match, but instead only for matches which
+seem to be backtracking too much. Normally the initial countdown is
+proportional to the length of the string being matched.
+
+This variable's value has the following meanings:
+
+=over
+
+=item 0
+
+Use the default delay countdown value.
+
+=item 1+
+
+Use the specified number of countdown iterations (1 implies no delay).
+
+=item -1
+
+Disable the cache completely.
+
+=item -N (other than -1)
+
+Scale the normal delay count by C<N / 1E6> (so for example -500000 causes
+half as many countdown iterations as normal).
+
+=back
+
 =item %SIG
 X<%SIG>
 


### PR DESCRIPTION
## Summary

- refresh bundled Perl5 sources, including podlators 6.1.1 and Perl documentation
- preserve the Data::Dumper scalar-aware hook's `Useperl` safeguard when `perl5-sync` reapplies its import patch
- verify the targeted Data-Dumper sync is idempotent

## Validation

- `perl dev/import-perl5/sync.pl --only Data-Dumper --verify-idempotent`
- `prove src/test/resources/unit/scalar_dual_value_cpan_regressions.t`
- `make`
- `timeout 120 ./jperl src/test/resources/unit/scalar_dual_value_cpan_regressions.t`
- `timeout 120 ./jperl --interpreter src/test/resources/unit/scalar_dual_value_cpan_regressions.t`
