### PR TITLE
WIP: Address issue #1269 Perl compatibility failures

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,9 @@ priorities and future plans.
 
 ## Work in progress
 
+- Make key/value hash slices supply writable values when used as a `foreach`
+  source, matching Perl on both execution backends.
+
 - Bind `for \\%hash (@hashrefs)` loop variables to each referenced hash on
   both execution backends, restoring constant-sub core-test coverage.
 

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeCompiler.java
@@ -136,6 +136,9 @@ public class BytecodeCompiler implements Visitor {
     // older symbol-table register that must not be used while the loop alias
     // is installed. A stack preserves nested loops over the same name.
     private final Map<String, Deque<Integer>> foreachGlobalAliasRegisters = new HashMap<>();
+    // A key/value hash slice is special when it supplies a foreach source:
+    // Perl aliases only its values, not its (temporary) keys.
+    private boolean compilingForeachList;
     // Source information
     final String sourceName;
     final int sourceLine;
@@ -2562,7 +2565,10 @@ public class BytecodeCompiler implements Visitor {
         }
 
         int rd = allocateOutputRegister();
-        emit(Opcodes.HASH_KEYVALUE_SLICE);
+        // In a foreach source, %hash{...} supplies the same writable values
+        // as @hash{...}.  Iterating its alternating key/value list would try
+        // to modify the read-only key literals before it reaches a value.
+        emit(compilingForeachList ? Opcodes.HASH_SLICE : Opcodes.HASH_KEYVALUE_SLICE);
         emitReg(rd);
         emitReg(hashReg);
         emitReg(keysListReg);
@@ -6631,7 +6637,12 @@ public class BytecodeCompiler implements Visitor {
                 && lastIndexOp.operator.equals("$#")) {
             compileNode(lastIndexOp, -1, RuntimeContextType.LVALUE);
         } else {
-            compileNode(node.list, -1, RuntimeContextType.LIST);
+            compilingForeachList = true;
+            try {
+                compileNode(node.list, -1, RuntimeContextType.LIST);
+            } finally {
+                compilingForeachList = false;
+            }
         }
         int listReg = lastResultReg;
 

--- a/src/main/java/org/perlonjava/backend/jvm/Dereference.java
+++ b/src/main/java/org/perlonjava/backend/jvm/Dereference.java
@@ -779,7 +779,9 @@ public class Dereference {
                 emitterVisitor.ctx.mv.visitVarInsn(Opcodes.ALOAD, keyListSlot);
 
                 // Call the appropriate method based on operation
-                String methodName = hashOperation.equals("delete") ? "deleteKeyValueSlice" : "getKeyValueSlice";
+                String methodName = hashOperation.equals("delete") ? "deleteKeyValueSlice"
+                        : Boolean.TRUE.equals(node.getAnnotation("foreachSource"))
+                                ? "getSlice" : "getKeyValueSlice";
                 emitterVisitor.ctx.mv.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "org/perlonjava/runtime/runtimetypes/RuntimeHash",
                         methodName, "(Lorg/perlonjava/runtime/runtimetypes/RuntimeList;)Lorg/perlonjava/runtime/runtimetypes/RuntimeList;", false);
 

--- a/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitBlock.java
@@ -287,7 +287,12 @@ public class EmitBlock {
             // actual array live; foreachAliasIterator snapshots other list
             // expressions when the loop is emitted.
             int tempArrayIndex = emitterVisitor.ctx.symbolTable.allocateLocalVariable();
-            forNode.list.accept(emitterVisitor.with(RuntimeContextType.LIST));
+            forNode.list.setAnnotation("foreachSource", true);
+            try {
+                forNode.list.accept(emitterVisitor.with(RuntimeContextType.LIST));
+            } finally {
+                forNode.list.setAnnotation("foreachSource", false);
+            }
             mv.visitVarInsn(Opcodes.ASTORE, tempArrayIndex);
 
             // Mark the For1Node to use the pre-evaluated array

--- a/src/main/java/org/perlonjava/backend/jvm/EmitForeach.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitForeach.java
@@ -119,7 +119,15 @@ public class EmitForeach {
         // In Perl, the list in a foreach is always evaluated once in the enclosing scope.
         int preEvalListLocal = -1;
         if (node.preEvaluatedArrayIndex < 0) {
-            node.list.accept(emitterVisitor.with(RuntimeContextType.LIST));
+            // A key/value hash slice used as a foreach source supplies its
+            // values only.  Keep this marker narrowly scoped to emission so
+            // ordinary %hash{...} expressions still return key/value pairs.
+            node.list.setAnnotation("foreachSource", true);
+            try {
+                node.list.accept(emitterVisitor.with(RuntimeContextType.LIST));
+            } finally {
+                node.list.setAnnotation("foreachSource", false);
+            }
             preEvalListLocal = emitterVisitor.ctx.symbolTable.allocateLocalVariable();
             mv.visitVarInsn(Opcodes.ASTORE, preEvalListLocal);
         }

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/DiamondIO.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/DiamondIO.java
@@ -225,6 +225,17 @@ public class DiamondIO {
             argvName.set(originalFileName);
         }
 
+        // In ordinary diamond mode, '-' always denotes the current STDIN
+        // handle.  It is not a path that in-place editing may rename; after a
+        // nested local @ARGV loop, the outer reader can legitimately resume
+        // from this synthetic fallback entry.
+        if ("-".equals(originalFileName) && !state.doubleDiamond) {
+            state.currentReader = getGlobalIO("main::STDIN").getRuntimeIO();
+            state.stdinReader = state.currentReader;
+            getGlobalIO("main::ARGV").set(state.currentReader);
+            return state.currentReader != null;
+        }
+
         // Check if in-place editing is enabled (either via -i switch or $^I variable)
         boolean isInPlaceEnabled = state.inPlaceEdit;
         String extension = state.inPlaceExtension;

--- a/src/test/resources/unit/kv_hash_slice_foreach.t
+++ b/src/test/resources/unit/kv_hash_slice_foreach.t
@@ -1,0 +1,11 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+
+my %hash = (a => 1, b => 2, c => 3);
+$_++ for %hash{'b', 'c'};
+
+is_deeply(\%hash, {a => 1, b => 3, c => 4},
+    'foreach aliases the values of a key/value hash slice');
+is(join('|', %hash{'b', 'c'}), 'b|3|c|4',
+    'ordinary key/value slice still returns alternating keys and values');


### PR DESCRIPTION
Relates to #1269.

This WIP tracks focused Perl 5 compatibility fixes from the identified high-yield core-test failures. Each behavior change will have a project-owned regression test and validation on both PerlOnJava backends.
