### PR TITLE
fix: preserve Perl full folds across adjacent classes

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,9 @@ priorities and future plans.
 
 ## Work in progress
 
+- Restore Perl full case-fold matching across adjacent character classes,
+  including literal-delimited and evaluated regex patterns.
+
 - Make key/value hash slices supply writable values when used as a `foreach`
   source, matching Perl on both execution backends.
 

--- a/src/test/resources/unit/regex_full_casefold.t
+++ b/src/test/resources/unit/regex_full_casefold.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use utf8;
-use Test::More tests => 8;
+use Test::More tests => 12;
 
 ok("ss" =~ /^\x{00DF}$/iu, 'sharp s pattern matches its full fold');
 ok("\x{00DF}" =~ /^ss$/iu, 'full fold pattern matches sharp s');
@@ -11,6 +11,15 @@ ok("\x{017F}\x{017F}" =~ /^\x{00DF}$/iu,
 ok("st" =~ /^[\x{FB06}]$/iu, 'full fold works from a character class');
 ok("\x{FB06}" =~ /^st$/iu, 'ligature matches the reverse full fold');
 ok("\x{FB03}" =~ /^ffi$/iu, 'three-character full fold is expanded');
+ok("\x{00DF}" =~ /^[s][s]$/iu,
+    'reverse full fold crosses adjacent character classes');
+ok(":\x{00DF}:" =~ /:[s][s]:/iu,
+    'reverse full fold crosses classes beside literal delimiters');
+my $eval_subject = ":\x{00DF}:";
+my $eval_fold = q[$eval_subject =~ /:[s][s]:/iu];
+ok(eval $eval_fold, 'reverse full fold survives evaluated regex source');
+ok("\x{00DF}" !~ /^[s]$/iu,
+    'reverse full fold does not make one class consume two characters');
 
 ok("\x{00DF}" =~ /^ss$/ia, '/a permits Unicode-to-ASCII case folds');
 ok("\x{00DF}" !~ /^ss$/iaa, '/aa forbids Unicode-to-ASCII case folds');

--- a/third_party/joni/src/org/joni/Analyser.java
+++ b/third_party/joni/src/org/joni/Analyser.java
@@ -69,6 +69,7 @@ import org.joni.exception.SyntaxException;
 import org.joni.exception.ValueException;
 
 final class Analyser extends Parser {
+    private boolean perlReverseFoldClassSequenceExpanded;
     private Map<Node, Integer> recursiveHeadResults;
     private Map<Node, Integer> recursiveNonHeadResults;
 
@@ -2932,6 +2933,7 @@ final class Analyser extends Parser {
                 }
                 prev = lin.value;
             } while ((lin = lin.tail) != null);
+            node = addPerlReverseFoldClassSequences((ListNode)node);
             break;
 
         case NodeType.ALT:
@@ -3183,6 +3185,263 @@ final class Analyser extends Parser {
         } // restart: while
     }
 
+    private Node addPerlReverseFoldClassSequences(ListNode sequence) {
+        if (!syntax.op2OptionPerl() || Option.isPerlAsciiStrict(regex.options)
+                || Option.isPerlBytePattern(regex.options)) return sequence;
+
+        ListNode previous = null;
+        for (ListNode start = sequence; start != null;
+                previous = start, start = start.tail) {
+            if (!isReverseFoldClassAtom(start.value)) continue;
+            Node[] classes = new Node[3];
+            ListNode cursor = start;
+            int count = 0;
+            while (cursor != null && count < classes.length
+                    && isReverseFoldClassAtom(cursor.value)) {
+                classes[count] = cursor.value;
+                count++;
+                cursor = cursor.tail;
+            }
+            if (count < 2) continue;
+            ListNode replacementStart = start;
+            int replacementCount = count;
+            int prefix = -1;
+            if (previous != null && previous.value instanceof StringNode prefixNode
+                    && prefixNode.isAmbig() && prefixNode.length(enc) == 1) {
+                prefix = enc.mbcToCode(prefixNode.bytes, prefixNode.p, prefixNode.end);
+                if (PerlCaseFold.simpleFoldClassLength(prefix) == 0) {
+                    replacementStart = previous;
+                    replacementCount++;
+                } else {
+                    prefix = -1;
+                }
+            }
+            ListNode alternatives = null;
+            int candidateCount = 0;
+            for (int mappingIndex = 0;
+                    mappingIndex < PerlCaseFold.fullMappingCount(); mappingIndex++) {
+                int source = PerlCaseFold.fullSourceAt(mappingIndex);
+                int length = PerlCaseFold.fullFoldLength(source);
+                if (length < 2 || length > count || length > 3) continue;
+                boolean matches = true;
+                for (int index = 0; index < length; index++) {
+                    int codePoint = PerlCaseFold.fullFoldCodePoint(source, index);
+                    if (!reverseFoldClassAccepts(classes[index], codePoint)) {
+                        matches = false;
+                        break;
+                    }
+                }
+                if (!matches) continue;
+                    StringNode candidate = new StringNode();
+                    if (prefix >= 0) candidate.catCode(prefix, enc);
+                    candidate.catCode(source, enc);
+                    candidate.setRaw();
+                    Node candidateBranch = appendReverseFoldClassSuffix(
+                            candidate, classes[length - 1]);
+                    if (alternatives == null) alternatives = newAlt(candidateBranch, null);
+                    else {
+                        ListNode tail = alternatives;
+                        while (tail.tail != null) tail = tail.tail;
+                        tail.setTail(newAlt(candidateBranch, null));
+                    }
+                if (++candidateCount >= 256) break;
+                if (candidateCount >= 256) break;
+            }
+            for (int sequenceIndex = 0;
+                    candidateCount < 256
+                    && sequenceIndex < PerlCaseFold.reverseFullFoldSequenceCount();
+                    sequenceIndex++) {
+                int length = PerlCaseFold.reverseFullFoldSequenceLengthAt(sequenceIndex);
+                if (length < 2 || length > count || length > 3) continue;
+                int[] fold = new int[length];
+                boolean matches = true;
+                for (int index = 0; index < length; index++) {
+                    fold[index] = PerlCaseFold.reverseFullFoldSequenceCodePointAt(
+                            sequenceIndex, index);
+                    if (!reverseFoldClassAccepts(classes[index], fold[index])) {
+                        matches = false;
+                        break;
+                    }
+                }
+                if (!matches) continue;
+                int sourceCount = PerlCaseFold.reverseFullFoldSourceCount(
+                        fold, 0, length);
+                for (int sourceIndex = 0;
+                        sourceIndex < sourceCount
+                        && candidateCount < 256;
+                        sourceIndex++) {
+                    int source = PerlCaseFold.reverseFullFoldSourceAt(
+                            fold, 0, length, sourceIndex);
+                    StringNode candidate = new StringNode();
+                    if (prefix >= 0) candidate.catCode(prefix, enc);
+                    candidate.catCode(source, enc);
+                    candidate.setRaw();
+                    Node candidateBranch = appendReverseFoldClassSuffix(
+                            candidate, classes[length - 1]);
+                    if (alternatives == null) alternatives = newAlt(candidateBranch, null);
+                    else {
+                        ListNode tail = alternatives;
+                        while (tail.tail != null) tail = tail.tail;
+                        tail.setTail(newAlt(candidateBranch, null));
+                    }
+                    candidateCount++;
+                }
+            }
+            if (alternatives == null) continue;
+
+            ListNode original = null;
+            ListNode originalTail = null;
+            cursor = replacementStart;
+            for (int index = 0; index < replacementCount; index++, cursor = cursor.tail) {
+                ListNode part = newList(cursor.value, null);
+                if (original == null) original = part;
+                else originalTail.setTail(part);
+                originalTail = part;
+            }
+            // Put the fixed-width reverse-fold candidates first while
+            // retaining a well-formed ALT chain for the original branches.
+            ListNode branch;
+            if (prefix < 0) {
+                branch = newAlt(original, alternatives);
+            } else {
+                branch = alternatives;
+                while (alternatives.tail != null) alternatives = alternatives.tail;
+                alternatives.setTail(newAlt(original, null));
+            }
+            replacementStart.setValue(branch);
+            replacementStart.tail = cursor;
+            if (prefix >= 0) {
+                perlReverseFoldClassSequenceExpanded = true;
+                disablePerlReverseFoldClassOptimization(sequence);
+            }
+            return sequence;
+        }
+        return sequence;
+    }
+
+    private Node reverseFoldClassCore(Node node) {
+        if (node instanceof CClassNode cc) return !cc.isNot() ? cc : null;
+        if (node instanceof StringNode string) {
+            return isReverseFoldStringAtom(string) ? string : null;
+        }
+        if (node instanceof QuantifierNode quantifier) {
+            return quantifier.lower == 1 && quantifier.upper == 1
+                    ? reverseFoldClassCore(quantifier.target) : null;
+        }
+        if (node instanceof ListNode list && node.getType() == NodeType.ALT) {
+            do {
+                Node core = reverseFoldClassCore(list.value);
+                if (core != null) return core;
+            } while ((list = list.tail) != null);
+        }
+        if (node instanceof ListNode list && node.getType() == NodeType.LIST) {
+            return reverseFoldClassCore(list.value);
+        }
+        return null;
+    }
+
+    private boolean isReverseFoldClassAtom(Node node) {
+        return reverseFoldClassCore(node) != null;
+    }
+
+    private boolean reverseFoldClassAccepts(Node node, int codePoint) {
+        Node classCore = reverseFoldClassCore(node);
+        if (classCore instanceof CClassNode cc) {
+            return !cc.isNot() && (cc.isCodeInCC(enc, codePoint)
+                    || cc.isCodeInCCLength(2, codePoint));
+        }
+        if (node instanceof CClassNode cc) {
+            return !cc.isNot() && (cc.isCodeInCC(enc, codePoint)
+                    || cc.isCodeInCCLength(2, codePoint));
+        }
+        if (node instanceof StringNode string
+                && isReverseFoldStringAtom(string)) {
+            int literal = enc.mbcToCode(string.bytes, string.p, string.end);
+            if (literal == codePoint) return true;
+            int foldLength = PerlCaseFold.simpleFoldClassLength(literal);
+            for (int index = 0; index < foldLength; index++) {
+                if (PerlCaseFold.simpleFoldClassCodePoint(literal, index)
+                        == codePoint) return true;
+            }
+        }
+        if (node instanceof QuantifierNode quantifier) {
+            return quantifier.lower == 1 && quantifier.upper == 1
+                    && reverseFoldClassAccepts(quantifier.target, codePoint);
+        }
+        if (node instanceof ListNode list && node.getType() == NodeType.ALT) {
+            do {
+                if (reverseFoldClassAccepts(list.value, codePoint)) return true;
+            } while ((list = list.tail) != null);
+        }
+        if (node instanceof ListNode list && node.getType() == NodeType.LIST) {
+            return reverseFoldClassAccepts(list.value, codePoint);
+        }
+        return false;
+    }
+
+    private boolean isReverseFoldStringAtom(StringNode string) {
+        if (!string.isAmbig() || string.length(enc) < 1) return false;
+        return string.length(enc) >= 1;
+    }
+
+    private Node appendReverseFoldClassSuffix(Node candidate, Node node) {
+        if (node instanceof ListNode alternatives
+                && node.getType() == NodeType.ALT) {
+            Node fallback = null;
+            do {
+                if (alternatives.value instanceof StringNode) {
+                    fallback = alternatives.value;
+                    continue;
+                }
+                Node result = appendReverseFoldClassSuffix(
+                        candidate, alternatives.value);
+                if (result != candidate) return result;
+            } while ((alternatives = alternatives.tail) != null);
+            return fallback == null ? candidate
+                    : appendReverseFoldClassSuffix(candidate, fallback);
+        }
+        Node core = reverseFoldClassCore(node);
+        if (node instanceof StringNode string && core != null
+                && string.length(enc) > 1) {
+            int firstLength = enc.length(string.bytes, string.p, string.end);
+            ((StringNode)candidate).catBytes(string.bytes,
+                    string.p + firstLength, string.end);
+            return candidate;
+        }
+        if (core == null || !(node instanceof ListNode list)
+                || node.getType() != NodeType.LIST || list.tail == null) {
+            return candidate;
+        }
+        if (!(list.tail.value instanceof StringNode suffix)
+                || list.tail.tail != null) return candidate;
+        return candidate;
+    }
+
+    private void disablePerlReverseFoldClassOptimization(Node node) {
+        switch (node.getType()) {
+        case NodeType.LIST:
+        case NodeType.ALT:
+            ListNode list = (ListNode)node;
+            do {
+                disablePerlReverseFoldClassOptimization(list.value);
+            } while ((list = list.tail) != null);
+            break;
+        case NodeType.STR:
+            ((StringNode)node).setDontGetOptInfo();
+            break;
+        case NodeType.CCLASS:
+            CClassNode cclass = (CClassNode)node;
+            cclass.markDebugOptimizationUnsafe();
+            cclass.markPerlReverseFoldOptimizationUnsafe();
+            break;
+        case NodeType.QTFR:
+            disablePerlReverseFoldClassOptimization(((QuantifierNode)node).target);
+            break;
+        default:
+            break;
+        }
+    }
+
     /** A runtime pattern callout has unknown width, so zero is not proof of emptiness. */
     private boolean containsDynamicCallout(Node node) {
         if (node instanceof CalloutNode callout && callout.dynamic) return true;
@@ -3294,6 +3553,10 @@ final class Analyser extends Parser {
 
         case NodeType.CCLASS: {
             CClassNode cc = (CClassNode)node;
+            if (cc.isPerlReverseFoldOptimizationUnsafe()) {
+                opt.length.set(enc.minLength(), enc.maxLength());
+                break;
+            }
             /* no need to check ignore case. (setted in setup_tree()) */
             if (cc.hasDeferredProperties()) {
                 // The unresolved class still consumes exactly one character,
@@ -3633,7 +3896,8 @@ final class Analyser extends Parser {
             regex.anchorDmax = opt.length.max;
         }
 
-        if (opt.exb.length > 0 || opt.exm.length > 0) {
+        if (!perlReverseFoldClassSequenceExpanded
+                && (opt.exb.length > 0 || opt.exm.length > 0)) {
             opt.exb.select(opt.exm, enc);
             if (opt.map.value > 0 && opt.exb.compare(opt.map) > 0) {
                 // !goto set_map;!
@@ -3646,7 +3910,7 @@ final class Analyser extends Parser {
                 regex.setOptimizeExactInfo(opt.exb);
                 regex.setSubAnchor(opt.exb.anchor);
             }
-        } else if (opt.map.value > 0) {
+        } else if (!perlReverseFoldClassSequenceExpanded && opt.map.value > 0) {
             // !set_map:!
             regex.setOptimizeMapInfo(opt.map);
             regex.setSubAnchor(opt.map.anchor);

--- a/third_party/joni/src/org/joni/PerlCaseFold.java
+++ b/third_party/joni/src/org/joni/PerlCaseFold.java
@@ -72,6 +72,14 @@ final class PerlCaseFold {
         return PerlUnicodeCaseFoldData.fullFoldCodePoint(source, index);
     }
 
+    static int fullMappingCount() {
+        return PerlUnicodeCaseFoldData.fullMappingCount();
+    }
+
+    static int fullSourceAt(int mappingIndex) {
+        return PerlUnicodeCaseFoldData.fullSourceAt(mappingIndex);
+    }
+
     static int simpleFoldClassLength(int codePoint) {
         return PerlUnicodeCaseFoldData.simpleFoldClassLength(codePoint);
     }
@@ -88,6 +96,27 @@ final class PerlCaseFold {
                                        int sourceIndex) {
         return PerlUnicodeCaseFoldData.reverseFullFoldSourceAt(
                 sequence, offset, length, sourceIndex);
+    }
+
+    static int reverseFullFoldSequenceCount() {
+        return PerlUnicodeCaseFoldData.reverseFullFoldSequenceCount();
+    }
+
+    static int reverseFullFoldSequenceLengthAt(int sequenceIndex) {
+        return PerlUnicodeCaseFoldData.reverseFullFoldSequenceLengthAt(sequenceIndex);
+    }
+
+    static int reverseFullFoldSequenceCodePointAt(int sequenceIndex, int index) {
+        return PerlUnicodeCaseFoldData.reverseFullFoldSequenceCodePointAt(
+                sequenceIndex, index);
+    }
+
+    static int reverseFullFoldSequenceSourceCount(int sequenceIndex) {
+        return PerlUnicodeCaseFoldData.reverseSourceCountAt(sequenceIndex);
+    }
+
+    static int reverseFullFoldSequenceSourceAt(int sequenceIndex, int sourceIndex) {
+        return PerlUnicodeCaseFoldData.reverseSourceAt(sequenceIndex, sourceIndex);
     }
 
     static boolean isMultiFoldComponent(int codePoint) {

--- a/third_party/joni/src/org/joni/PerlUnicodeCaseFoldData.java
+++ b/third_party/joni/src/org/joni/PerlUnicodeCaseFoldData.java
@@ -305,19 +305,15 @@ final class PerlUnicodeCaseFoldData {
         TURKIC_SOURCES = decodeDeltaList(TURKIC_DATA, TURKIC_SOURCE_COUNT);
     }
 
-    static int fullMappingCount() {
-        return FULL_SOURCES.length;
-    }
-
-    static int fullSourceAt(int mappingIndex) {
-        return FULL_SOURCES[mappingIndex];
-    }
-
     static int fullFoldLength(int source) {
         int mappingIndex = Arrays.binarySearch(FULL_SOURCES, source);
         return mappingIndex < 0 ? 0
                 : FULL_OFFSETS[mappingIndex + 1] - FULL_OFFSETS[mappingIndex];
     }
+
+    static int fullMappingCount() { return FULL_SOURCES.length; }
+
+    static int fullSourceAt(int mappingIndex) { return FULL_SOURCES[mappingIndex]; }
 
     static int fullFoldCodePoint(int source, int foldIndex) {
         int mappingIndex = Arrays.binarySearch(FULL_SOURCES, source);
@@ -393,6 +389,18 @@ final class PerlUnicodeCaseFoldData {
     static int reverseFullFoldSourceCount(int[] sequence, int offset, int length) {
         int sequenceIndex = findReverseSequence(sequence, offset, length);
         return sequenceIndex < 0 ? 0 : reverseSourceCountAt(sequenceIndex);
+    }
+
+    static int reverseFullFoldSequenceCount() { return REVERSE_SEQUENCE_COUNT; }
+
+    static int reverseFullFoldSequenceLengthAt(int sequenceIndex) {
+        return REVERSE_SEQUENCE_OFFSETS[sequenceIndex + 1]
+                - REVERSE_SEQUENCE_OFFSETS[sequenceIndex];
+    }
+
+    static int reverseFullFoldSequenceCodePointAt(int sequenceIndex, int index) {
+        return REVERSE_SEQUENCE_CODE_POINTS[
+                REVERSE_SEQUENCE_OFFSETS[sequenceIndex] + index];
     }
 
     static int reverseFullFoldSourceAt(int[] sequence, int offset, int length,

--- a/third_party/joni/src/org/joni/ast/CClassNode.java
+++ b/third_party/joni/src/org/joni/ast/CClassNode.java
@@ -134,6 +134,7 @@ public final class CClassNode extends Node {
     private boolean positiveNonUnicodeWarningProperty;
     private boolean debugCaseFolded;
     private boolean debugOptimizationSafe = true;
+    private boolean perlReverseFoldOptimizationUnsafe;
     private boolean debugHighUnbounded;
     private CClassNode propertyFoldMask;
     private List<CharacterPropertyResolver.DeferredProperty> deferredProperties;
@@ -850,6 +851,14 @@ public final class CClassNode extends Node {
         debugOptimizationSafe = false;
     }
 
+    public void markPerlReverseFoldOptimizationUnsafe() {
+        perlReverseFoldOptimizationUnsafe = true;
+    }
+
+    public boolean isPerlReverseFoldOptimizationUnsafe() {
+        return perlReverseFoldOptimizationUnsafe;
+    }
+
     private List<DebugRange> rawEncodedDebugRanges(long minimum, long maximum) {
         if (mbuf == null) return List.of();
         List<DebugRange> ranges = new ArrayList<>();
@@ -1532,7 +1541,7 @@ public final class CClassNode extends Node {
     }
 
     // onig_is_code_in_cc_len
-    boolean isCodeInCCLength(int encLength, int code) {
+    public boolean isCodeInCCLength(int encLength, int code) {
         boolean found;
 
         if (encLength > 1 || code >= BitSet.SINGLE_BYTE_SIZE) {


### PR DESCRIPTION
Restore reverse multi-character case folding for adjacent character classes, including delimiter and evaluated-regex forms, while preserving existing exact-fold optimizer contracts. Add focused regression coverage.

Generated with [Codex](https://openai.com/codex)