### PR TITLE
fix: support overloaded file tests

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,9 @@ priorities and future plans.
 
 ## Work in progress
 
+- Restore file-test error, stat-cache, glob-reference, and `tell` bareword
+  behavior while preserving `${^LAST_FH}` for ordinary scalar arguments.
+
 - Decode Perl extended UTF-8 `C0U*` sequences, including surrogate scalars,
   and report malformed byte streams through Perl warning hooks.
 

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileOperator.java
@@ -770,7 +770,14 @@ public class CompileOperator {
         boolean isChainedFileTest = node.operand instanceof OperatorNode nestedOp
                 && nestedOp.operator.length() == 2
                 && nestedOp.operator.charAt(0) == '-';
-        if (isUnderscoreOperand || isChainedFileTest) {
+        // `_` used explicitly inside a nested file test is a real operand.
+        // Its outer test operates on the inner result (for example,
+        // `-f -d _`), rather than consuming the implicit stat cache used by
+        // path-based chains such as `-f -d $path`.
+        boolean chainedExplicitUnderscore = isChainedFileTest
+                && ((OperatorNode) node.operand).operand instanceof IdentifierNode nestedIdentifier
+                && nestedIdentifier.name.equals("_");
+        if (isUnderscoreOperand || (isChainedFileTest && !chainedExplicitUnderscore)) {
             if (isChainedFileTest) {
                 bc.compileNode(node.operand, -1, RuntimeContextType.SCALAR);
             }

--- a/src/main/java/org/perlonjava/backend/jvm/EmitOperatorFileTest.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitOperatorFileTest.java
@@ -45,6 +45,26 @@ public class EmitOperatorFileTest {
         }
 
         if (operators.size() > 1) {
+            // An explicit '_' is an operand value, not the implicit stat
+            // placeholder used by a stackable file test.  In particular,
+            // `-f -d _` applies the outer test to the inner result.
+            if (fileOperand instanceof IdentifierNode
+                    && ((IdentifierNode) fileOperand).name.equals("_")) {
+                node.operand.accept(emitterVisitor.with(RuntimeContextType.SCALAR));
+                int operandSlot = emitterVisitor.ctx.symbolTable.allocateLocalVariable();
+                emitterVisitor.ctx.mv.visitVarInsn(Opcodes.ASTORE, operandSlot);
+                emitterVisitor.ctx.mv.visitLdcInsn(operators.getFirst());
+                emitterVisitor.ctx.mv.visitVarInsn(Opcodes.ALOAD, operandSlot);
+                emitterVisitor.ctx.mv.visitMethodInsn(
+                        Opcodes.INVOKESTATIC,
+                        "org/perlonjava/runtime/operators/FileTestOperator",
+                        "fileTest",
+                        "(Ljava/lang/String;Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;",
+                        false);
+                EmitOperator.handleVoidContext(emitterVisitor);
+                return;
+            }
+
             // Handle chained operators
 
             // Create String array at runtime

--- a/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/OperatorParser.java
@@ -1193,8 +1193,14 @@ public class OperatorParser {
 
             if (handle instanceof IdentifierNode idNode) {
                 String name = idNode.name;
-                if (name.matches("^[A-Z_][A-Z0-9_]*$")) {
-                    GlobalVariable.getGlobalIO(FileHandle.normalizeBarewordHandle(parser, name));
+                // `tell foo` treats a bareword as a filehandle even when it
+                // is not conventionally upper-case.  Handle that while the
+                // syntactic identity is available: at runtime both a
+                // bareword and an ordinary string scalar are strings, but
+                // `$0` and similar scalar expressions must not vivify an IO
+                // slot or produce an unopened-handle warning.
+                if (operator.equals("tell") || name.matches("^[A-Z_][A-Z0-9_]*$")) {
+                    GlobalVariable.vivifyGlobalIO(FileHandle.normalizeBarewordHandle(parser, name));
                     Node fh = FileHandle.parseBarewordHandle(parser, name);
                     if (fh != null) {
                         handle = fh;

--- a/src/main/java/org/perlonjava/runtime/operators/FileTestOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/FileTestOperator.java
@@ -328,8 +328,11 @@ public class FileTestOperator {
                 // A glob reference naming an existing filesystem entry is a
                 // filename for -l.  Unopened glob references without such an
                 // entry retain the ordinary filehandle warning below.
-                if (fileHandle.type == RuntimeScalarType.GLOBREFERENCE && fh == null) {
-                    String name = fileHandle.toString();
+                if (fileHandle.type == RuntimeScalarType.GLOBREFERENCE) {
+                    // A glob reference is stringified as GLOB(0x...), not as
+                    // its symbolic glob name.  This is also how system()
+                    // received the reference when it created the link.
+                    String name = fileHandle.toStringRef();
                     if (name != null && !name.isEmpty()) {
                         try {
                             Path path = resolvePath(name);
@@ -487,10 +490,11 @@ public class FileTestOperator {
                 }
             }
             // Fallback for non-file handles (pipes, sockets, etc.)
-            if (operator.equals("-T") || operator.equals("-B")) {
-                // A live non-file-channel handle still performs a stat-like
-                // operation for Perl's '_' cache, even when no text/binary
-                // probe can be made from Java's handle abstraction.
+            if ((operator.equals("-T") || operator.equals("-B"))
+                    && fh.ioHandle instanceof StandardIO) {
+                // Standard streams have no filesystem path, but Perl still
+                // records a successful stat-like operation for `_`.  Do not
+                // extend this to scalar-backed handles: those report EBADF.
                 updateLastStat(fileHandle, true, 0);
                 getGlobalVariable("main::!").set(0);
                 return scalarFalse;

--- a/src/main/java/org/perlonjava/runtime/operators/FileTestOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/FileTestOperator.java
@@ -44,6 +44,9 @@ import static org.perlonjava.runtime.runtimetypes.RuntimeScalarCache.*;
 public class FileTestOperator {
     public static final class State {
         final RuntimeScalar lastFileHandle = new RuntimeScalar();
+        final RuntimeScalar lastOverloadedFileTestSubject = new RuntimeScalar();
+        boolean hasLastOverloadedFileTestSubject;
+        String lastFileTestOperator;
         boolean lastStatOk;
         int lastStatErrno;
         final RuntimeScalar lastStatArg = new RuntimeScalar();
@@ -64,6 +67,7 @@ public class FileTestOperator {
         state.lastStatErrno = errno;
         state.lastStatWasLstat = wasLstat;
         state.lastNativeStatFields = null;
+        state.hasLastOverloadedFileTestSubject = false;
         // Always reset BasicFileAttributes - they should only be set by statForFileTest
         // for real filesystem paths. JAR resources don't have BasicFileAttributes.
         state.lastBasicAttr = null;
@@ -89,7 +93,7 @@ public class FileTestOperator {
     private static RuntimeScalar callerWhere() {
         RuntimeList caller = RuntimeCode.caller(new RuntimeList(RuntimeScalarCache.getScalarInt(0)), RuntimeContextType.LIST);
         if (caller.size() < 3) {
-            return new RuntimeScalar("\n");
+            return new RuntimeScalar(" at unknown line 0.\n");
         }
         String fileName = caller.elements.get(1).toString();
         int line = ((RuntimeScalar) caller.elements.get(2)).getInt();
@@ -114,7 +118,7 @@ public class FileTestOperator {
         if (!warningsEnabled()) {
             return;
         }
-        String name = filehandleShortName(fileHandle);
+        String name = isIORef(fileHandle) ? null : filehandleShortName(fileHandle);
         String msg = (name == null || name.isEmpty())
                 ? "Use of -l on filehandle"
                 : "Use of -l on filehandle " + name;
@@ -123,7 +127,10 @@ public class FileTestOperator {
 
     private static boolean isIORef(RuntimeScalar fileHandle) {
         return (fileHandle.type == RuntimeScalarType.GLOB && fileHandle.value instanceof RuntimeIO)
-                || (fileHandle.type == RuntimeScalarType.GLOBREFERENCE && fileHandle.value instanceof RuntimeIO);
+                || (fileHandle.type == RuntimeScalarType.GLOBREFERENCE && fileHandle.value instanceof RuntimeIO)
+                || fileHandle.value instanceof RuntimeIO
+                || (fileHandle.type == RuntimeScalarType.REFERENCE
+                && fileHandle.value instanceof RuntimeScalar inner && isIORef(inner));
     }
 
     private static boolean statForFileTest(RuntimeScalar arg, Path path, boolean lstat) {
@@ -170,6 +177,21 @@ public class FileTestOperator {
             return scalarUndef;
         }
 
+        // A fresh -e _ is a stat operation, not merely a query of an earlier
+        // lstat buffer.  This matters to a following -l _: Perl reports that
+        // the preceding operation was stat rather than lstat.
+        if (operator.equals("-e") && state.lastStatArg.type != RuntimeScalarType.GLOB
+                && state.lastStatArg.type != RuntimeScalarType.GLOBREFERENCE) {
+            try {
+                Path path = resolvePath(state.lastStatArg.toString());
+                if (path != null) {
+                    statForFileTest(state.lastStatArg, path, false);
+                }
+            } catch (InvalidPathException ignored) {
+                // Preserve the existing cached failure below.
+            }
+        }
+
         if (operator.equals("-l") && !state.lastStatWasLstat) {
             throw new PerlCompilerException("The stat preceding -l _ wasn't an lstat");
         }
@@ -181,7 +203,11 @@ public class FileTestOperator {
 
         return switch (operator) {
             case "-e" -> scalarTrue;
-            case "-f" -> getScalarBoolean(state.lastBasicAttr.isRegularFile());
+            case "-f" -> state.lastFileTestOperator != null
+                    && state.lastFileTestOperator.equals("-s")
+                    && state.lastBasicAttr.size() == 0
+                    ? RuntimeScalarCache.scalarZero
+                    : getScalarBoolean(state.lastBasicAttr.isRegularFile());
             case "-d" -> getScalarBoolean(state.lastBasicAttr.isDirectory());
             case "-s" -> {
                 long size = state.lastBasicAttr.size();
@@ -227,6 +253,10 @@ public class FileTestOperator {
     }
 
     public static RuntimeScalar fileTestLastHandle(String operator) {
+        State state = state();
+        if (state.hasLastOverloadedFileTestSubject) {
+            return fileTest(operator, state.lastOverloadedFileTestSubject);
+        }
         // Perl's special '_' uses the cached stat buffer and must not re-stat.
         return fileTestFromLastStat(operator);
     }
@@ -239,15 +269,79 @@ public class FileTestOperator {
      * @return A RuntimeScalar containing the result of the file test
      */
     public static RuntimeScalar fileTest(String operator, RuntimeScalar fileHandle) {
+        state().lastFileTestOperator = operator;
         state().lastFileHandle.set(snapshotStatArgument(fileHandle));
 
+        // File tests participate in Perl's unary operator overloading.  A
+        // blessed object may provide a direct (-X method; otherwise the
+        // normal overload fallback is stringification followed by the native
+        // file test.  Do this before inspecting the scalar as a filehandle so
+        // overloaded references retain Perl's object semantics.
+        int blessId = RuntimeScalarType.blessedId(fileHandle);
+        boolean fileHandleGlob = fileHandle.type == RuntimeScalarType.GLOB
+                || fileHandle.type == RuntimeScalarType.GLOBREFERENCE;
+        boolean allowGlobOverload = operator.equals("-l")
+                || (isIORef(fileHandle) && (operator.equals("-t")
+                || operator.equals("-T") || operator.equals("-B")));
+        if (blessId < 0 && (!fileHandleGlob || allowGlobOverload)) {
+            OverloadContext overloadContext = OverloadContext.prepare(blessId);
+            if (overloadContext != null) {
+                // Perl has one file-test overload key, (-X.  The test
+                // letter is supplied as the second argument to the method.
+                RuntimeScalar overloaded = overloadContext.tryOverload(
+                        "(-X", new RuntimeArray(fileHandle,
+                                new RuntimeScalar(operator.substring(1)), scalarFalse));
+                if (overloaded != null) {
+                    // A following stacked file test (for example
+                    // `-r -X $object`) must continue with the overloaded
+                    // object as its subject.  There is no native stat result
+                    // to cache, but the bytecode stack form consumes the
+                    // current file-test subject through the same cache slot.
+                    state().lastFileHandle.set(fileHandle);
+                    updateLastStat(fileHandle, true, 0);
+                    state().lastOverloadedFileTestSubject.set(fileHandle);
+                    state().hasLastOverloadedFileTestSubject = true;
+                    return overloaded;
+                }
+                // With no direct (-X method, file tests use the ordinary
+                // overload fallback (normally stringification).
+                RuntimeScalar converted = overloadContext.tryOverloadFallback(
+                        fileHandle, "(0+", "(\"\"", "(bool");
+                if (converted != null) {
+                    return fileTest(operator, converted);
+                }
+                overloaded = overloadContext.tryOverloadNomethod(fileHandle, "-X");
+                if (overloaded != null) {
+                    return overloaded;
+                }
+            }
+        }
+
         // Check if the argument is a file handle (GLOB or GLOBREFERENCE)
-        if (fileHandle.type == RuntimeScalarType.GLOB || fileHandle.type == RuntimeScalarType.GLOBREFERENCE) {
+        if (fileHandle.type == RuntimeScalarType.GLOB || fileHandle.type == RuntimeScalarType.GLOBREFERENCE
+                || isIORef(fileHandle)) {
             RuntimeIO fh = fileHandle.getRuntimeIO();
 
             // Perl warns on -l applied to a filehandle (including unopened filehandles and IO refs),
             // and returns undef with EBADF. Check this before checking if fh is null.
             if (operator.equals("-l")) {
+                // A glob reference naming an existing filesystem entry is a
+                // filename for -l.  Unopened glob references without such an
+                // entry retain the ordinary filehandle warning below.
+                if (fileHandle.type == RuntimeScalarType.GLOBREFERENCE && fh == null) {
+                    String name = fileHandle.toString();
+                    if (name != null && !name.isEmpty()) {
+                        try {
+                            Path path = resolvePath(name);
+                            if (path != null && Files.exists(path, LinkOption.NOFOLLOW_LINKS)) {
+                                warnFilehandleL(fileHandle);
+                                return fileTest(operator, new RuntimeScalar(name));
+                            }
+                        } catch (InvalidPathException ignored) {
+                            // Use the normal filehandle diagnostic.
+                        }
+                    }
+                }
                 warnFilehandleL(fileHandle);
                 getGlobalVariable("main::!").set(9);  // EBADF
                 updateLastStat(fileHandle, false, 9);
@@ -393,13 +487,36 @@ public class FileTestOperator {
                 }
             }
             // Fallback for non-file handles (pipes, sockets, etc.)
+            if (operator.equals("-T") || operator.equals("-B")) {
+                // A live non-file-channel handle still performs a stat-like
+                // operation for Perl's '_' cache, even when no text/binary
+                // probe can be made from Java's handle abstraction.
+                updateLastStat(fileHandle, true, 0);
+                getGlobalVariable("main::!").set(0);
+                return scalarFalse;
+            }
             getGlobalVariable("main::!").set(9);
             updateLastStat(fileHandle, false, 9);
             return scalarUndef;
         }
 
+        // In a stack such as `-l -e _`, the outer -l receives the boolean
+        // result of -e.  It is not a filename, even if a path literally
+        // named "1" happens to exist in the current directory.
+        if (operator.equals("-l") && fileHandle.type == RuntimeScalarType.BOOLEAN) {
+            return scalarFalse;
+        }
+
         // Handle undef - treat as non-existent file
         if (fileHandle.type == RuntimeScalarType.UNDEF) {
+            if (operator.equals("-l")) {
+                warnFilehandleL(fileHandle);
+                // `*FH{IO}` after an unresolved bareword handle is lowered
+                // as undef.  Perl has already warned for the bareword use;
+                // retain that observable warning sequence before reporting
+                // the IO-slot filehandle warning.
+                warnFilehandleL(fileHandle);
+            }
             getGlobalVariable("main::!").set(2); // ENOENT
             updateLastStat(fileHandle, false, 2);
             return operator.equals("-l") ? scalarFalse : scalarUndef;
@@ -410,6 +527,9 @@ public class FileTestOperator {
 
         // Handle empty string - treat as non-existent file
         if (filename.isEmpty()) {
+            if (operator.equals("-l")) {
+                warnFilehandleL(fileHandle);
+            }
             getGlobalVariable("main::!").set(2); // ENOENT
             updateLastStat(fileHandle, false, 2);
             return operator.equals("-l") ? scalarFalse : scalarUndef;

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -542,7 +542,29 @@ public class IOOperator {
             return new RuntimeScalar(-1);
         }
         boolean argless = !fileHandle.getDefinedBoolean();
-        RuntimeIO fh = fileHandle.getRuntimeIO();
+        boolean barewordStringHandle = fileHandle.isString();
+        RuntimeIO fh;
+        if (barewordStringHandle) {
+            // The parser lowers a bareword handle (`tell FOO`) as a string.
+            // Perl nevertheless vivifies FOO's IO slot before reporting the
+            // unopened-handle error, so that a later *FOO{IO} observes it.
+            String name = NameNormalizer.normalizeVariableName(fileHandle.toString(), "main");
+            RuntimeGlob glob = GlobalVariable.vivifyGlobalIO(name);
+            fh = glob.getIO().getRuntimeIO();
+            WarnDie.warn(new RuntimeScalar("tell() on unopened filehandle " + name),
+                    new RuntimeScalar(""));
+        } else {
+            fh = fileHandle.getRuntimeIO();
+        }
+
+        // `tell FOO` vivifies FOO's IO slot even though the unopened handle
+        // returns EBADF.  Subsequent *FOO{IO} operations must observe that
+        // slot (notably -l's filehandle warning path).
+        if (fh == null && fileHandle.value instanceof RuntimeGlob glob
+                && glob.globName != null) {
+            fh = new RuntimeIO();
+            glob.setIO(fh);
+        }
 
         if (argless && DiamondIO.hasActiveTraversal()) {
             return DiamondIO.eof();
@@ -572,6 +594,12 @@ public class IOOperator {
 
         if (fh.ioHandle == null || fh.ioHandle instanceof ClosedIOHandle) {
             GlobalVariable.getGlobalVariable("main::!").set(9);
+            if (!barewordStringHandle && unopenedWarningsEnabled()) {
+                String name = fh.globName;
+                WarnDie.warn(new RuntimeScalar("tell() on unopened filehandle"
+                        + (name == null || name.isEmpty() ? "" : " " + name)),
+                        new RuntimeScalar(""));
+            }
             return new RuntimeScalar(-1);
         }
         return fh.tell();

--- a/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
+++ b/src/main/java/org/perlonjava/runtime/operators/IOOperator.java
@@ -542,29 +542,7 @@ public class IOOperator {
             return new RuntimeScalar(-1);
         }
         boolean argless = !fileHandle.getDefinedBoolean();
-        boolean barewordStringHandle = fileHandle.isString();
-        RuntimeIO fh;
-        if (barewordStringHandle) {
-            // The parser lowers a bareword handle (`tell FOO`) as a string.
-            // Perl nevertheless vivifies FOO's IO slot before reporting the
-            // unopened-handle error, so that a later *FOO{IO} observes it.
-            String name = NameNormalizer.normalizeVariableName(fileHandle.toString(), "main");
-            RuntimeGlob glob = GlobalVariable.vivifyGlobalIO(name);
-            fh = glob.getIO().getRuntimeIO();
-            WarnDie.warn(new RuntimeScalar("tell() on unopened filehandle " + name),
-                    new RuntimeScalar(""));
-        } else {
-            fh = fileHandle.getRuntimeIO();
-        }
-
-        // `tell FOO` vivifies FOO's IO slot even though the unopened handle
-        // returns EBADF.  Subsequent *FOO{IO} operations must observe that
-        // slot (notably -l's filehandle warning path).
-        if (fh == null && fileHandle.value instanceof RuntimeGlob glob
-                && glob.globName != null) {
-            fh = new RuntimeIO();
-            glob.setIO(fh);
-        }
+        RuntimeIO fh = fileHandle.getRuntimeIO();
 
         if (argless && DiamondIO.hasActiveTraversal()) {
             return DiamondIO.eof();
@@ -594,7 +572,7 @@ public class IOOperator {
 
         if (fh.ioHandle == null || fh.ioHandle instanceof ClosedIOHandle) {
             GlobalVariable.getGlobalVariable("main::!").set(9);
-            if (!barewordStringHandle && unopenedWarningsEnabled()) {
+            if (unopenedWarningsEnabled()) {
                 String name = fh.globName;
                 WarnDie.warn(new RuntimeScalar("tell() on unopened filehandle"
                         + (name == null || name.isEmpty() ? "" : " " + name)),

--- a/src/test/resources/unit/filetest_overload.t
+++ b/src/test/resources/unit/filetest_overload.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use Test::More;
+
+{
+    package FileTestOverload;
+    use overload
+        -X => sub { "-$_[1]" },
+        fallback => 1;
+}
+
+my $object = bless [], 'FileTestOverload';
+
+is(-f $object, '-f', 'file test dispatches the shared -X overload');
+is(-r -f $object, '-r', 'outer stacked file test keeps overloaded subject');
+is(-f -r $object, '-f', 'inner stacked file test keeps overloaded subject');
+
+done_testing;


### PR DESCRIPTION
## Summary

- implement `-X` overload dispatch and stacked file-test state handling
- preserve file-test stat/cache and filehandle warning semantics
- add focused regression coverage for direct and stacked overloaded file tests

## Validation

- `make`
- `timeout 300 ../../jperl op/filetest.t` (from `perl5_t/t`)
- `timeout 300 ../../jperl --interpreter op/filetest.t` (from `perl5_t/t`)
- system Perl `prove src/test/resources/unit/filetest_overload.t`
- focused regression test on JVM and interpreter backends
