### PR TITLE
fix: validate package version declarations

### DIFF
--- a/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
+++ b/src/main/java/org/perlonjava/frontend/parser/StatementParser.java
@@ -1154,6 +1154,7 @@ public class StatementParser {
         }
 
         // Parse Version string and store it in the symbol table
+        validatePackageVersion(parser);
         Node version = parseOptionalPackageVersion(parser);
         if (CompilerOptions.DEBUG_ENABLED) parser.ctx.logDebug("package version: " + version);
         if (version != null) {
@@ -1168,8 +1169,11 @@ public class StatementParser {
             if (versionString != null) {
                 // NumberNode retains source precision globally, but package
                 // version scalars use normal numeric stringification.
-                if (versionString.endsWith(".0")) {
-                    versionString = versionString.substring(0, versionString.length() - 2);
+                if (versionString.contains(".")) {
+                    versionString = versionString.replaceFirst("\\.?0+$", "");
+                    if (versionString.isEmpty()) {
+                        versionString = "0";
+                    }
                 }
                 parser.ctx.symbolTable.setPackageVersion(packageName, versionString);
             }
@@ -1488,6 +1492,96 @@ public class StatementParser {
             return parseVstring(parser, TokenUtils.consume(parser).text, parser.tokenIndex);
         }
         return null;
+    }
+
+    /**
+     * Package declarations accept a deliberately narrower version grammar
+     * than ordinary numeric expressions or {@code version->new}.  Validate it
+     * before the general number parser can reinterpret a malformed version as
+     * an octal number, an expression, or a bareword.
+     */
+    private static void validatePackageVersion(Parser parser) {
+        int index = Whitespace.skipWhitespace(parser, parser.tokenIndex, parser.tokens);
+        if (index >= parser.tokens.size()) {
+            return;
+        }
+
+        LexerToken first = parser.tokens.get(index);
+        if ((first.type == LexerTokenType.OPERATOR && (first.text.equals(";") || first.text.equals("{")))
+                || first.type == LexerTokenType.EOF) {
+            return;
+        }
+
+        StringBuilder candidate = new StringBuilder();
+        for (int i = index; i < parser.tokens.size(); i++) {
+            LexerToken token = parser.tokens.get(i);
+            if (token.type == LexerTokenType.WHITESPACE || token.type == LexerTokenType.NEWLINE) {
+                continue;
+            }
+            if (token.type == LexerTokenType.NUMBER || token.type == LexerTokenType.IDENTIFIER
+                    || (token.type == LexerTokenType.OPERATOR && token.text.equals("."))) {
+                candidate.append(token.text);
+                continue;
+            }
+            break;
+        }
+
+        String version = candidate.toString();
+        if (version.isEmpty()) {
+            return;
+        }
+        if (version.matches("(?:0|[1-9]\\d*)(?:\\.\\d+)?")
+                || version.matches("v(?:0|[1-9]\\d*)(?:\\.(?:0|[1-9]\\d{0,2})){2,}")) {
+            return;
+        }
+
+        String diagnostic;
+        if (version.startsWith(".")) {
+            diagnostic = "0 before decimal required";
+        } else if (version.startsWith("v")) {
+            String body = version.substring(1);
+            if (body.contains("_")) {
+                diagnostic = "underscore";
+            } else if (hasLeadingZeroComponent(body)) {
+                diagnostic = "no leading zeros";
+            } else if (!body.matches("\\d+(?:\\.\\d+)*") || body.chars().filter(c -> c == '.').count() < 2) {
+                diagnostic = "dotted-decimal versions require at least three parts";
+            } else if (hasOversizedDottedComponent(body)) {
+                diagnostic = "maximum 3 digits between decimals";
+            } else {
+                diagnostic = "non-numeric data";
+            }
+        } else if (version.matches("\\d+\\.(?:[^\\d].*)?")) {
+            diagnostic = "fractional part required";
+        } else if (version.matches("\\d.*_") || version.matches("\\d.*_.*")) {
+            diagnostic = "underscore";
+        } else if (version.matches("0\\d.*")) {
+            diagnostic = "no leading zeros";
+        } else if (version.matches("\\d+(?:\\.\\d+){2,}")) {
+            diagnostic = "dotted-decimal versions must begin with 'v'";
+        } else {
+            diagnostic = "non-numeric data";
+        }
+        throw new PerlCompilerException(parser.tokenIndex,
+                "Invalid version format (" + diagnostic + ")", parser.ctx.errorUtil);
+    }
+
+    private static boolean hasLeadingZeroComponent(String version) {
+        for (String component : version.split("\\.")) {
+            if (component.length() > 1 && component.startsWith("0")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasOversizedDottedComponent(String version) {
+        for (String component : version.split("\\.")) {
+            if (component.length() > 3) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/org/perlonjava/runtime/perlmodule/Version.java
+++ b/src/main/java/org/perlonjava/runtime/perlmodule/Version.java
@@ -128,6 +128,8 @@ public class Version extends PerlModuleBase {
                 if (version.isEmpty()) {
                     throw new PerlCompilerException("Invalid version format (version required)");
                 }
+
+                validateVersionSyntax(version);
             
                 // Check if original starts with 'v'
                 isVString = version.startsWith("v");
@@ -140,6 +142,14 @@ public class Version extends PerlModuleBase {
                 if (underscoreCount > 1) {
                     throw new PerlCompilerException("Invalid version format (multiple underscores)");
                 }
+
+                // version->new accepts a few lax decimal spellings that are
+                // intentionally forbidden in package declarations.  A
+                // non-numeric fractional part, however, has Perl's specific
+                // "fractional part required" diagnostic.
+                if (version.matches("\\d+\\.[^\\d].*")) {
+                    throw new PerlCompilerException("Invalid version format (fractional part required)");
+                }
             
                 // Validate version format - must contain at least one digit
                 // and be a valid version pattern (digits, dots, underscores, optional v prefix)
@@ -148,7 +158,9 @@ public class Version extends PerlModuleBase {
             
                 // Version must start with a digit and only contain digits and dots
                 // (after removing v prefix and underscores)
-                if (!checkVersion.matches("\\d+(\\.\\d+)*")) {
+                boolean laxDecimal = version.matches("\\.\\d+(?:\\.\\d+)*")
+                        || version.matches("\\d+\\.");
+                if (!laxDecimal && !checkVersion.matches("\\d+(\\.\\d+)*")) {
                     throw new PerlCompilerException("Invalid version format (non-numeric data)");
                 }
             
@@ -179,14 +191,22 @@ public class Version extends PerlModuleBase {
             // For qv(), the original is the v-prefixed version
             originalVersionStr = new RuntimeScalar(version);
         } else if (!version.startsWith("v")) {
-            // Count the number of dots
-            long dotCount = version.chars().filter(ch -> ch == '.').count();
-
-            if (dotCount >= 2) {
-                // Two or more dots means dotted-decimal format (e.g., "0.1.2", "1.2.3")
-                // Perl 5 treats these as v-strings with is_qv=true
+            // A lax leading-dot multi-part value is a dotted decimal with an
+            // implicit zero major component.  Keep it out of the decimal
+            // normalizer, which cannot represent an empty first component.
+            if (version.matches("\\.\\d+(?:\\.\\d+)+")) {
                 isVString = true;
-                version = "v" + version;
+                version = "v0" + version;
+            } else {
+                // Count the number of dots
+                long dotCount = version.chars().filter(ch -> ch == '.').count();
+
+                if (dotCount >= 2) {
+                    // Two or more dots means dotted-decimal format (e.g., "0.1.2", "1.2.3")
+                    // Perl 5 treats these as v-strings with is_qv=true
+                    isVString = true;
+                    version = "v" + version;
+                }
             }
         }
 
@@ -225,6 +245,25 @@ public class Version extends PerlModuleBase {
         ReferenceOperators.bless(blessed, new RuntimeScalar("version"));
 
         return blessed.getList();
+    }
+
+    /** Validate diagnostics that Perl exposes for malformed version strings. */
+    private static void validateVersionSyntax(String version) {
+        if (version.startsWith("v")) {
+            // version->new accepts abbreviated v-strings (v1 and v1.2),
+            // unlike a package declaration.  A bare v or a missing initial
+            // component is not a v-string at all.
+            if (version.equals("v") || version.startsWith("v.")) {
+                throw new PerlCompilerException("Invalid version format (dotted-decimal versions require at least three parts)");
+            }
+            return;
+        }
+        if (version.matches("\\d+\\.[^\\d].*")) {
+            throw new PerlCompilerException("Invalid version format (fractional part required)");
+        }
+        if (version.matches("\\d.*") && (version.endsWith("_") || version.contains("_."))) {
+            throw new PerlCompilerException("Invalid version format (underscore)");
+        }
     }
 
     private static String normalizeDottedVersion(String version) {


### PR DESCRIPTION
## Summary

- validate strict `package NAME VERSION` grammar and diagnostics
- preserve package version numeric stringification
- retain Perl-compatible lax parsing in `version->new`

## Validation

- `make`
- `timeout 180 ../../jperl op/packagev.t` (from `perl5_t/t`)
- `timeout 180 ../../jperl --interpreter op/packagev.t` (from `perl5_t/t`)

Both targeted runs completed all 307 assertions without `not ok` output.

Generated with [Codex](https://openai.com/codex/)
