### PR TITLE
fix: restore Perl smartmatch semantics

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -6,6 +6,9 @@ priorities and future plans.
 
 ## Work in progress
 
+- Restore Perl smartmatch dispatch for arrays, hashes, regexes, predicates,
+  tied hashes, overloaded objects, and both execution backends.
+
 - Restore file-test error, stat-cache, glob-reference, and `tell` bareword
   behavior while preserving `${^LAST_FH}` for ordinary scalar arguments.
 

--- a/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/BytecodeInterpreter.java
@@ -3740,7 +3740,7 @@ public class BytecodeInterpreter {
                 int rd = bytecode[pc++];
                 int rs1 = bytecode[pc++];
                 int rs2 = bytecode[pc++];
-                registers[rd] = CompareOperators.smartmatch(registers[rs1].scalar(), registers[rs2].scalar());
+                registers[rd] = CompareOperators.smartmatch(registers[rs1], registers[rs2]);
                 return pc;
             }
             case Opcodes.PROTOTYPE -> {

--- a/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/bytecode/CompileBinaryOperator.java
@@ -778,6 +778,11 @@ public class CompileBinaryOperator {
                     ? RuntimeContextType.LVALUE : RuntimeContextType.SCALAR;
             default -> RuntimeContextType.SCALAR;
         };
+        if (node.operator.equals("~~") && isArrayLikeNode(node.left)) {
+            // OBJECT is scalar-like to Perl calls but keeps a bare aggregate
+            // as RuntimeArray/RuntimeHash rather than scalarizing it to size.
+            leftCtx = RuntimeContextType.OBJECT;
+        }
         bytecodeCompiler.compileNode(node.left, -1, leftCtx);
         int rs1 = bytecodeCompiler.lastResultReg;
 
@@ -786,6 +791,9 @@ public class CompileBinaryOperator {
             rightCtx = RuntimeContextType.LIST;
         } else {
             rightCtx = RuntimeContextType.SCALAR;
+        }
+        if (node.operator.equals("~~") && isArrayLikeNode(node.right)) {
+            rightCtx = RuntimeContextType.OBJECT;
         }
         Node rightNode = node.right;
         if (node.operator.equals("isa") && rightNode instanceof IdentifierNode identifier) {

--- a/src/main/java/org/perlonjava/backend/jvm/EmitBinaryOperator.java
+++ b/src/main/java/org/perlonjava/backend/jvm/EmitBinaryOperator.java
@@ -32,13 +32,18 @@ public class EmitBinaryOperator {
     static void handleBinaryOperator(EmitterVisitor emitterVisitor, BinaryOperatorNode node, OperatorHandler operatorHandler) {
         EmitterVisitor scalarVisitor =
                 emitterVisitor.with(RuntimeContextType.SCALAR); // execute operands in scalar context
+        // Smartmatch is exceptional: bare @array and %hash operands retain
+        // aggregate identity for its type-based dispatch rather than becoming
+        // scalar element counts.
+        EmitterVisitor smartmatchAggregateVisitor = emitterVisitor.with(RuntimeContextType.OBJECT);
         // bless mutates the scalar slot as well as its referent.  In particular,
         // threads::shared publishes a class change only when the operand is the
         // actual shared scalar, not a scalar-context copy of its reference.
         EmitterVisitor leftVisitor = node.operator.equals("bless")
                 && isDirectScalarLvalue(node.left)
                 ? emitterVisitor.with(RuntimeContextType.LVALUE)
-                : scalarVisitor;
+                : node.operator.equals("~~") && isArrayLikeNode(node.left)
+                        ? smartmatchAggregateVisitor : scalarVisitor;
         if (CompilerOptions.DEBUG_ENABLED) emitterVisitor.ctx.logDebug("handleBinaryOperator: " + node.toString());
 
         if (isIntegerEnabled(emitterVisitor, node)
@@ -218,7 +223,8 @@ public class EmitBinaryOperator {
         }
         mv.visitVarInsn(Opcodes.ASTORE, leftSlot);
 
-        right.accept(scalarVisitor); // right parameter
+        right.accept(node.operator.equals("~~") && isArrayLikeNode(right)
+                ? smartmatchAggregateVisitor : scalarVisitor); // right parameter
 
         mv.visitVarInsn(Opcodes.ALOAD, leftSlot);
         mv.visitInsn(Opcodes.SWAP);
@@ -241,6 +247,14 @@ public class EmitBinaryOperator {
             };
         }
         return false;
+    }
+
+    private static boolean isArrayLikeNode(Node node) {
+        if (node instanceof OperatorNode operator) {
+            return operator.operator.equals("@") || operator.operator.equals("%");
+        }
+        return node instanceof BinaryOperatorNode binary
+                && (binary.operator.equals("(") || binary.operator.equals("()"));
     }
 
     private static void emitIntegerBinaryOperator(EmitterVisitor emitterVisitor,

--- a/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
+++ b/src/main/java/org/perlonjava/frontend/parser/ParseInfix.java
@@ -177,8 +177,10 @@ public class ParseInfix {
                 throw new PerlCompilerException(errorIndex, "syntax error", parser.ctx.errorUtil);
             }
 
-            if (operator.equals("..") || operator.equals("...")) {
-                // Handle regex in: /3/../5/
+            if (operator.equals("..") || operator.equals("...") || operator.equals("~~")) {
+                // A bare /.../ is normally a match against $_, but ranges
+                // and smartmatch consume a regex value instead (for example
+                // /x/ ~~ @values).  Preserve it as quoteRegex on either side.
                 if (left instanceof OperatorNode operatorNode && operatorNode.operator.equals("matchRegex")) {
                     OperatorNode quoted = new OperatorNode("quoteRegex", operatorNode.operand, operatorNode.tokenIndex);
                     quoted.setAnnotation("regexWarningsEnabled", operatorNode.getAnnotation("regexWarningsEnabled"));

--- a/src/main/java/org/perlonjava/runtime/operators/CompareOperators.java
+++ b/src/main/java/org/perlonjava/runtime/operators/CompareOperators.java
@@ -153,6 +153,7 @@ public class CompareOperators {
         // Prepare overload context and check if object is eligible for overloading
         int blessId = blessedId(arg1);
         int blessId2 = blessedId(arg2);
+
         if (blessId < 0 || blessId2 < 0) {
             RuntimeScalar result = OverloadContext.tryTwoArgumentOverloadDirect(arg1, arg2, blessId, blessId2, "(<");
             if (result != null) return result;
@@ -799,6 +800,85 @@ public class CompareOperators {
     public static RuntimeScalar smartmatch(RuntimeScalar arg1, RuntimeScalar arg2) {
         int blessId = blessedId(arg1);
         int blessId2 = blessedId(arg2);
+        // A blessed RHS is only meaningful when it provides a smartmatch
+        // overload.  Check the actual blessing, rather than its effective
+        // overload id: ordinary blessed references intentionally have an
+        // effective id of zero.
+        if (rawBlessId(arg2) != 0 && !OverloadContext.hasDirectOverload(arg2, "(~~")) {
+            throw new PerlCompilerException("Smart matching a non-overloaded object is not supported");
+        }
+        // A RHS object with an explicit ~~ overload owns dispatch even when
+        // its referent happens to be a hash or array.
+        if (OverloadContext.hasDirectOverload(arg2, "(~~")) {
+            RuntimeScalar result = OverloadContext.tryTwoArgumentOverloadDirect(
+                    arg1, arg2, blessId, blessId2, "(~~");
+            if (result != null) return result;
+        }
+
+        RuntimeArray leftArray = arrayReferent(arg1);
+        RuntimeArray rightArray = arrayReferent(arg2);
+        RuntimeHash leftHash = hashReferent(arg1);
+        RuntimeHash rightHash = hashReferent(arg2);
+
+        // Hash smartmatch is key-oriented.  Values deliberately do not
+        // participate: { a => 1 } ~~ { a => 2 } is true in core Perl.
+        // A code reference on the right is a predicate.  Aggregate operands
+        // distribute their candidate keys/elements; an empty aggregate matches
+        // without calling the predicate, just as core Perl does.
+        if (arg2.type == RuntimeScalarType.CODE) {
+            if (leftArray != null) return predicateMatchesArray(arg2, leftArray);
+            if (leftHash != null) return predicateMatchesHash(arg2, leftHash);
+            return predicate(arg2, arg1);
+        }
+
+        // A left array against a regex compares its individual elements. This
+        // must precede generic RHS-regex dispatch so nested array comparison
+        // does not stringify the aggregate to ARRAY(...).
+        if (arg2.type == RuntimeScalarType.REGEX && leftArray != null
+                && arg2.value instanceof RuntimeRegex regex) {
+            for (RuntimeScalar candidate : leftArray) {
+                if (smartmatch(candidate, arg2).getBoolean()) return scalarTrue;
+            }
+            return scalarFalse;
+        }
+
+        // Regex and hash dispatch use the original object identity or its
+        // string form; they do not call a left object's ~~ overload first.
+        if (arg2.type == RuntimeScalarType.REGEX && leftHash == null
+                && arg2.value instanceof RuntimeRegex regex) {
+            RuntimeScalar string = smartmatchString(arg1);
+            return getScalarBoolean(regex.matcher(string, string.toString()).find());
+        }
+
+        // Regex/hash combinations inspect hash keys, not HASH(...) stringification.
+        if (arg2.type == RuntimeScalarType.REGEX && leftHash != null) return regexMatchesHash((RuntimeRegex) arg2.value, leftHash);
+        if (arg1.type == RuntimeScalarType.REGEX && rightHash != null) return regexMatchesHash((RuntimeRegex) arg1.value, rightHash);
+
+        // A left-side smartmatch overload applies to a scalar RHS, but not to
+        // the code/regex/hash forms already dispatched above.
+        if (blessId < 0 && OverloadContext.hasDirectOverload(arg1, "(~~")
+                && rightArray == null && rightHash == null) {
+            RuntimeScalar result = OverloadContext.tryTwoArgumentOverloadDirect(
+                    arg1, arg2, blessId, blessId2, "(~~");
+            if (result != null) return result;
+        }
+
+        if (leftHash != null && rightHash != null) return hashKeysEqual(leftHash, rightHash) ? scalarTrue : scalarFalse;
+        if (leftHash != null && rightArray != null) return arrayKeysInHash(rightArray, leftHash) ? scalarTrue : scalarFalse;
+        if (leftArray != null && rightHash != null) return arrayKeysInHash(leftArray, rightHash) ? scalarTrue : scalarFalse;
+        // undef has no hash-key candidate, even for a hash with an empty key.
+        if (rightHash != null) return arg1.getDefinedBoolean() && hashContainsKey(rightHash, arg1) ? scalarTrue : scalarFalse;
+        if (leftHash != null) {
+            // A hash on the left also matches the string form of its own
+            // reference (for example, %h ~~ "" . \%h).  This is distinct
+            // from the ordinary key-membership rule and intentionally
+            // asymmetric, matching core Perl.
+            if (smartmatchString(arg1).toString().equals(smartmatchString(arg2).toString())) {
+                return scalarTrue;
+            }
+            return arg2.getDefinedBoolean() && hashContainsKey(leftHash, arg2) ? scalarTrue : scalarFalse;
+        }
+
         if (blessId < 0 || blessId2 < 0) {
             RuntimeScalar result = OverloadContext.tryTwoArgumentOverloadDirect(arg1, arg2, blessId, blessId2, "(~~");
             if (result != null) return result;
@@ -810,10 +890,7 @@ public class CompareOperators {
         // ARRAY ~~ ARRAY is structural: each element in the left array must
         // smartmatch the corresponding right element.  Handle this before the
         // general RHS-array distribution rule below.
-        if (arg1.type == RuntimeScalarType.ARRAYREFERENCE
-                && arg1.value instanceof RuntimeArray leftArray
-                && arg2.type == RuntimeScalarType.ARRAYREFERENCE
-                && arg2.value instanceof RuntimeArray rightArray) {
+        if (leftArray != null && rightArray != null) {
             if (leftArray == rightArray) return scalarTrue;
             if (arrayPairActive(leftArray, rightArray)) return scalarFalse;
             if (leftArray.size() != rightArray.size()) return scalarFalse;
@@ -831,28 +908,31 @@ public class CompareOperators {
             }
         }
 
-        // Scalar ~~ ARRAY matches when the scalar smartmatches any array
-        // element. Keep the original scalar intact across candidates: tainted
-        // strings must not have their backing value consumed by a failed
-        // comparison before a later element matches.
-        if (arg2.type == RuntimeScalarType.ARRAYREFERENCE
-                && arg2.value instanceof RuntimeArray candidates) {
-            for (RuntimeScalar candidate : candidates) {
-                if (smartmatch(arg1, candidate).getBoolean()) {
-                    return scalarTrue;
-                }
+        // A regex on the left remains a regex when the right operand is an
+        // array, even though regex-left scalar matching otherwise follows
+        // ordinary string comparison.  Match any array element here before
+        // the general RHS-array distribution below.
+        if (arg1.type == RuntimeScalarType.REGEX
+                && arg1.value instanceof RuntimeRegex regex
+                && rightArray != null) {
+            for (RuntimeScalar candidate : rightArray) {
+                RuntimeScalar string = smartmatchString(candidate);
+                if (regex.matcher(string, string.toString()).find()) return scalarTrue;
             }
             return scalarFalse;
         }
 
-        // An array reference against a regex succeeds when one of its
-        // elements matches.  Do this before generic regex dispatch so the
-        // aggregate is not coerced to its ARRAY(...) stringification.
-        if (arg1.type == RuntimeScalarType.ARRAYREFERENCE
-                && arg1.value instanceof RuntimeArray candidates
-                && arg2.type == RuntimeScalarType.REGEX) {
-            for (RuntimeScalar candidate : candidates) {
-                if (smartmatch(candidate, arg2).getBoolean()) {
+        // Scalar ~~ ARRAY matches when the scalar smartmatches any array
+        // element. Keep the original scalar intact across candidates: tainted
+        // strings must not have their backing value consumed by a failed
+        // comparison before a later element matches.
+        if (rightArray != null) {
+            for (RuntimeScalar candidate : rightArray) {
+                // A scalar does not recurse into a nested aggregate merely
+                // because that aggregate happens to contain the scalar.
+                if (!arg1.getDefinedBoolean()
+                        && (arrayReferent(candidate) != null || hashReferent(candidate) != null)) continue;
+                if (smartmatch(arg1, candidate).getBoolean()) {
                     return scalarTrue;
                 }
             }
@@ -862,13 +942,6 @@ public class CompareOperators {
         // A regex on either side tests the other operand as a string.  This
         // follows RHS-array distribution so qr/x/ ~~ [ 'x' ] tests each
         // candidate, rather than matching the array reference's string form.
-        if (arg2.type == RuntimeScalarType.REGEX && arg2.value instanceof RuntimeRegex regex) {
-            return getScalarBoolean(regex.matcher(arg1, arg1.toString()).find());
-        }
-        if (arg1.type == RuntimeScalarType.REGEX && arg1.value instanceof RuntimeRegex regex) {
-            return getScalarBoolean(regex.matcher(arg2, arg2.toString()).find());
-        }
-
         // Check if both are defined
         if (!arg1.getDefinedBoolean() && !arg2.getDefinedBoolean()) {
             return scalarTrue;  // undef ~~ undef is true
@@ -878,14 +951,13 @@ public class CompareOperators {
         }
 
         // Try string comparison
-        if (arg1.toString().equals(arg2.toString())) {
+        if (smartmatchString(arg1).toString().equals(smartmatchString(arg2).toString())) {
             return scalarTrue;
         }
 
         // Try numeric comparison if both look like numbers
         try {
-            if (arg1.type == RuntimeScalarType.INTEGER || arg1.type == RuntimeScalarType.DOUBLE ||
-                    arg2.type == RuntimeScalarType.INTEGER || arg2.type == RuntimeScalarType.DOUBLE) {
+            if (ScalarUtils.looksLikeNumber(arg1) && ScalarUtils.looksLikeNumber(arg2)) {
                 RuntimeScalar num1 = arg1.getNumber();
                 RuntimeScalar num2 = arg2.getNumber();
                 if (num1.type == RuntimeScalarType.DOUBLE || num2.type == RuntimeScalarType.DOUBLE) {
@@ -899,5 +971,96 @@ public class CompareOperators {
         }
 
         return scalarFalse;
+    }
+
+    private static RuntimeArray arrayReferent(RuntimeScalar value) {
+        return rawBlessId(value) == 0
+                && value.type == RuntimeScalarType.ARRAYREFERENCE
+                && value.value instanceof RuntimeArray array ? array : null;
+    }
+
+    private static RuntimeScalar smartmatchString(RuntimeScalar value) {
+        // RuntimeScalar.toString() is the runtime's normal Perl string
+        // conversion path: it includes a class name for ordinary objects and
+        // invokes "" overloads when present.
+        return new RuntimeScalar(value.toString());
+    }
+
+    private static int rawBlessId(RuntimeScalar value) {
+        if (value.blessId != 0) return value.blessId;
+        return value.value instanceof RuntimeBase base ? base.blessId : 0;
+    }
+
+    private static RuntimeHash hashReferent(RuntimeScalar value) {
+        return rawBlessId(value) == 0
+                && value.type == RuntimeScalarType.HASHREFERENCE
+                && value.value instanceof RuntimeHash hash ? hash : null;
+    }
+
+    private static boolean hashKeysEqual(RuntimeHash left, RuntimeHash right) {
+        RuntimeArray leftKeys = left.keys();
+        RuntimeArray rightKeys = right.keys();
+        if (leftKeys.size() != rightKeys.size()) return false;
+        for (RuntimeScalar key : leftKeys) if (!hashContainsKey(right, key)) return false;
+        return true;
+    }
+
+    private static boolean arrayKeysInHash(RuntimeArray array, RuntimeHash hash) {
+        // Array/hash smartmatch asks whether any array value names a hash key.
+        // In particular, ['foo', 'bar'] ~~ { foo => 1 } is true, while an
+        // empty array has no candidate and is false.
+        for (RuntimeScalar value : array) if (hashContainsKey(hash, value)) return true;
+        return false;
+    }
+
+    private static boolean hashContainsKey(RuntimeHash hash, RuntimeScalar key) {
+        return hash.exists(key).getBoolean();
+    }
+
+    private static RuntimeScalar predicate(RuntimeScalar code, RuntimeScalar value) {
+        // Predicate arguments are a one-element @_.  Preserve a reference
+        // scalar as that element instead of exposing its referent's list
+        // value through an aliasing call frame.
+        RuntimeScalar argument = new RuntimeScalar(value);
+        return RuntimeCode.apply(code, new RuntimeArray(argument), RuntimeContextType.SCALAR).scalar();
+    }
+
+    private static RuntimeScalar predicateMatchesArray(RuntimeScalar code, RuntimeArray array) {
+        // Smartmatch applies a code predicate to every candidate; an aggregate
+        // matches only when no candidate is rejected (and an empty aggregate
+        // consequently matches without invoking the code).
+        for (RuntimeScalar value : array) if (!predicate(code, value).getBoolean()) return scalarFalse;
+        return scalarTrue;
+    }
+
+    private static RuntimeScalar predicateMatchesHash(RuntimeScalar code, RuntimeHash hash) {
+        for (RuntimeScalar key : hash.keys()) if (!predicate(code, key).getBoolean()) return scalarFalse;
+        return scalarTrue;
+    }
+
+    private static RuntimeScalar regexMatchesHash(RuntimeRegex regex, RuntimeHash hash) {
+        for (RuntimeScalar key : hash.keys()) if (regex.matcher(key, key.toString()).find()) return scalarTrue;
+        return scalarFalse;
+    }
+
+    /**
+     * Entry point used by the compilers.  Unlike ordinary binary operators,
+     * smartmatch gives a bare array or hash aggregate semantics rather than
+     * its scalar size.  Preserve that information by turning the aggregate
+     * into the same reference representation used by explicit \@ and \%.
+     */
+    public static RuntimeScalar smartmatch(RuntimeBase arg1, RuntimeBase arg2) {
+        return smartmatch(smartmatchOperand(arg1), smartmatchOperand(arg2));
+    }
+
+    private static RuntimeScalar smartmatchOperand(RuntimeBase operand) {
+        if (operand instanceof RuntimeArray array) return array.createReference();
+        if (operand instanceof RuntimeHash hash) return hash.createReference();
+        if (operand instanceof RuntimeList list) {
+            RuntimeArray array = new RuntimeArray();
+            for (RuntimeBase value : list.elements) array.add(value.scalar());
+            return array.createAnonymousReference();
+        }
+        return operand == null ? scalarUndef : operand.scalar();
     }
 }

--- a/src/main/java/org/perlonjava/runtime/operators/OperatorHandler.java
+++ b/src/main/java/org/perlonjava/runtime/operators/OperatorHandler.java
@@ -129,7 +129,9 @@ public record OperatorHandler(String className, String methodName, int methodTyp
         put("gt", "gt", "org/perlonjava/runtime/operators/CompareOperators");
         put("ge", "ge", "org/perlonjava/runtime/operators/CompareOperators");
         put("cmp", "cmp", "org/perlonjava/runtime/operators/CompareOperators");
-        put("~~", "smartmatch", "org/perlonjava/runtime/operators/CompareOperators");
+        // Smartmatch retains bare arrays and hashes instead of scalarizing them
+        // to their sizes before dispatching its type table.
+        put("~~", "smartmatch", "org/perlonjava/runtime/operators/CompareOperators", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;Lorg/perlonjava/runtime/runtimetypes/RuntimeBase;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");
 
         // String
         put("chr", "chr", "org/perlonjava/runtime/operators/StringOperators", "(Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;)Lorg/perlonjava/runtime/runtimetypes/RuntimeScalar;");

--- a/src/main/java/org/perlonjava/runtime/runtimetypes/OverloadContext.java
+++ b/src/main/java/org/perlonjava/runtime/runtimetypes/OverloadContext.java
@@ -171,6 +171,13 @@ public class OverloadContext {
         return InheritanceResolver.findMethodInHierarchy(methodName, perlClassName, null, 0) != null;
     }
 
+    /** Returns whether a blessed value defines this exact overload method. */
+    public static boolean hasDirectOverload(RuntimeScalar value, String methodName) {
+        int blessId = RuntimeScalarType.blessedId(value);
+        OverloadContext ctx = prepare(blessId);
+        return ctx != null && ctx.hasOverload(methodName);
+    }
+
     /**
      * Perl invokes the {@code =} copy constructor immediately before an
      * overloaded mutator.  The constructor's return value replaces the value

--- a/src/test/resources/unit/smartmatch_semantics.t
+++ b/src/test/resources/unit/smartmatch_semantics.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+use Test::More;
+use Tie::Hash;
+
+no warnings 'experimental::smartmatch';
+
+{
+    package Smartmatch::Plain;
+    sub new { bless { value => 1 }, shift }
+}
+
+{
+    package Smartmatch::Stringified;
+    use overload '""' => sub { 'stringified object' }, fallback => 1;
+    sub new { bless { value => 1 }, shift }
+}
+
+my $plain = Smartmatch::Plain->new;
+my $stringified = Smartmatch::Stringified->new;
+
+ok($plain ~~ qr/Smartmatch::Plain/,
+    'a blessed object smartmatches a regex against its normal string form');
+ok($stringified ~~ 'stringified object',
+    'a blessed object uses its stringification overload for scalar smartmatch');
+ok($plain ~~ sub { ref $_[0] eq 'Smartmatch::Plain' },
+    'a code predicate receives the original blessed object');
+
+my $error = eval { my $ignored = 'x' ~~ $plain; 1 };
+ok(!$error && $@, 'a plain RHS object without a smartmatch overload dies');
+
+my %plain_hash = (alpha => 1, beta => 2);
+tie my %tied_hash, 'Tie::StdHash';
+%tied_hash = %plain_hash;
+ok(\%plain_hash ~~ \%tied_hash,
+    'hash smartmatch compares keys through a tied hash iterator');
+
+my $hash_string = '' . \%plain_hash;
+ok(%plain_hash ~~ $hash_string,
+    'a bare hash smartmatches its own stringified reference asymmetrically');
+ok(!($hash_string ~~ %plain_hash),
+    'the stringified-reference rule is not symmetric');
+
+done_testing;


### PR DESCRIPTION
## Summary

- restore Perl-compatible smartmatch dispatch for arrays, hashes, regexes, predicates, tied hashes, and overloaded objects
- preserve bare aggregate operands for smartmatch on the JVM and bytecode-interpreter backends
- add focused regression coverage for the restored object and hash semantics

## Validation

- `make`
- `perl5_t/t/op/smartmatch.t` on JVM and interpreter backends (353 assertions each)
- `src/test/resources/unit/smartmatch_semantics.t` on system Perl, JVM, and interpreter backends
- `make check-links`
